### PR TITLE
Fix chat Send button blocked by keyboard Done toolbar

### DIFF
--- a/OpenGlasses/Sources/App/Views/VoiceTab.swift
+++ b/OpenGlasses/Sources/App/Views/VoiceTab.swift
@@ -301,15 +301,6 @@ struct ChatInputBar: View {
                     .padding(.vertical, 8)
                     .glassEffect(in: .rect(cornerRadius: 20))
                     .onSubmit { sendMessage() }
-                    .toolbar {
-                        ToolbarItemGroup(placement: .keyboard) {
-                            Spacer()
-                            Button("Done") {
-                                isTextFieldFocused = false
-                                showChatInput = false
-                            }
-                        }
-                    }
 
                 // Send button
                 Button {


### PR DESCRIPTION
## Summary
The text-input `Done` button (a `.keyboard`-placement toolbar on the message `TextField` in `ChatInputBar`) overlaid the **Send** button — both anchor just above the keyboard, so `Done` sat on top of Send and intercepted the tap.

Removed the toolbar. It was redundant: the **mic button** already closes the chat input (exactly what `Done` did), and the keyboard dismisses on send / swipe-down. Send is now tappable.

## Test plan
- [ ] Open chat input, focus the text field
- [ ] Confirm the Send (↑) button is tappable and sends
- [ ] Confirm the mic button still closes chat input / dismisses the keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)