### PR TITLE
Fix: add keyboard-dismiss button to chat input

### DIFF
--- a/OpenGlasses/Sources/App/Views/VoiceTab.swift
+++ b/OpenGlasses/Sources/App/Views/VoiceTab.swift
@@ -258,6 +258,23 @@ struct ChatInputBar: View {
 
             // Input row
             HStack(spacing: 10) {
+                // Keyboard dismiss — only while editing. Lives in the bar (not the keyboard
+                // toolbar, which overlays the Send button) and sits leading so it never
+                // collides with the trailing Send control.
+                if isTextFieldFocused {
+                    Button {
+                        isTextFieldFocused = false
+                    } label: {
+                        Image(systemName: "keyboard.chevron.compact.down")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(Color(.label))
+                            .frame(width: 36, height: 36)
+                            .glassEffect(in: .circle)
+                    }
+                    .accessibilityLabel("Dismiss keyboard")
+                    .transition(.opacity)
+                }
+
                 // Close button
                 Button {
                     showChatInput = false


### PR DESCRIPTION
## Summary

Removing the keyboard-toolbar **Done** button (PR #5, because it overlaid **Send**) left no way to dismiss the keyboard once the chat text field was focused.

This adds an in-bar **`keyboard.chevron.compact.down`** button that:
- appears **only while editing** (`isTextFieldFocused`),
- sits on the **leading** side of the input row, so it never collides with the trailing Send control (the root problem with the old toolbar Done button — the keyboard toolbar overlays the whole custom input bar),
- resigns focus on tap, keeping the chat field visible.

One file, +17 lines. Independent of PRs #6 (Document RAG) and #7 (tap-to-talk).

## Test plan
- [x] App target compiles (`BUILD SUCCEEDED`, iPhone 17 Pro simulator)
- [x] Focus the chat field → chevron-down appears leading → tap dismisses keyboard, field stays
- [x] Send button still reachable/unobstructed while the keyboard is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)