### PR TITLE
Fix: XcodeGen migration follow-ups (setup default + README conflict)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,13 +277,8 @@ Professional-grade safeguards for clinical recordings, available as an in-app su
 
 ## Requirements
 
-<<<<<<< XcodeGen_migration
-- **iOS 17+** (built targeting iOS 26)
-- **Xcode 15+** and **[XcodeGen](https://github.com/yonaskolb/XcodeGen)** (`brew install xcodegen`)
-=======
 - **iOS 26+**
-- **Xcode 26+**
->>>>>>> main
+- **Xcode 26+** and **[XcodeGen](https://github.com/yonaskolb/XcodeGen)** (`brew install xcodegen`)
 - **Physical iPhone** (Bluetooth, camera, microphone required)
 - **Ray-Ban Meta smart glasses** (paired via Meta AI app)
 - At least one LLM: API key (Anthropic, OpenAI, Gemini, etc.) OR a downloaded local model

--- a/Scripts/setup-local-dev.sh
+++ b/Scripts/setup-local-dev.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-DEFAULT_COMMIT=e5bbe7946af05411c3081785b9893a9eac4a7381
+# Last commit that still tracked OpenGlasses.xcodeproj (with DEVELOPMENT_TEAM + entitlements),
+# i.e. the merge right before the XcodeGen migration. `--from-commit` recovers personal
+# signing config from here. Stays valid permanently (git history is immutable).
+DEFAULT_COMMIT=4a7011f70ab74c2ad5924aadb39b1cae357243be
 
 development_team_from_commit() {
   local commit="$1"


### PR DESCRIPTION
Two follow-up fixes to the XcodeGen migration (#9):

### 1. `setup-local-dev.sh` DEFAULT_COMMIT pointed at a nonexistent SHA
It shipped with a fork-specific commit that doesn't exist here, so `./Scripts/setup-local-dev.sh --from-commit` (no arg) errored before recovering the team + personal entitlements/Info. Pinned to `4a7011f` — the last merge that still tracked `OpenGlasses.xcodeproj` (with `DEVELOPMENT_TEAM` + entitlements). Immutable, so it stays valid.

### 2. Leftover merge conflict marker in README
The migration carried an unresolved `<<<<<<< / >>>>>>>` block into the Requirements section. Resolved to iOS 26+ / Xcode 26+ + the XcodeGen prerequisite.

## Verification
- [x] `./Scripts/setup-local-dev.sh --from-commit` (no arg) restores `project.local.yml` (team B9L8ANZQZX) + personal config and generates the project
- [x] `BUILD SUCCEEDED` with the recovered personal signing config
- [x] No conflict markers remain (`git grep '<<<<<<<'` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)