### PR TITLE
Plan P — page & section citations for Document RAG

### DIFF
--- a/OpenGlasses/Sources/Services/NativeTools/DocumentRAGTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/DocumentRAGTool.swift
@@ -84,10 +84,19 @@ struct DocumentRAGTool: NativeTool {
         }
 
         let body = passages.enumerated().map { i, p in
-            "[\(i + 1)] From \"\(p.documentName)\" (chunk \(p.chunkIndex), score \(String(format: "%.2f", p.similarity))):\n\(p.text)"
+            "[\(i + 1)] From \"\(p.documentName)\" (\(locator(for: p)), score \(String(format: "%.2f", p.similarity))):\n\(p.text)"
         }.joined(separator: "\n\n")
 
-        return "Relevant passages for '\(query)' — answer using only these, and cite the document name:\n\n\(body)"
+        return "Relevant passages for '\(query)' — answer using only these, and cite the document name and (when shown) the page/section:\n\n\(body)"
+    }
+
+    /// A speakable source locator for a passage: prefers page + section, degrades to whichever is
+    /// present, and falls back to the chunk index when the document carried no page/heading markers.
+    private func locator(for p: DocumentStore.Passage) -> String {
+        var parts: [String] = []
+        if let page = p.page { parts.append("page \(page)") }
+        if let section = p.section, !section.isEmpty { parts.append(section) }
+        return parts.isEmpty ? "chunk \(p.chunkIndex)" : parts.joined(separator: ", ")
     }
 
     private func ingestText(_ args: [String: Any], store: DocumentStore) async -> String {

--- a/OpenGlasses/Sources/Services/RAG/DocumentChunker.swift
+++ b/OpenGlasses/Sources/Services/RAG/DocumentChunker.swift
@@ -7,6 +7,11 @@ import NaturalLanguage
 /// chunks are packed up to `targetChars`, and each new chunk re-includes trailing sentences
 /// from the previous one (up to `overlapChars`) so a passage that straddles a boundary stays
 /// retrievable. A single sentence longer than `maxChars` is hard-split as a last resort.
+///
+/// Each chunk also carries the page number and nearest section heading active at its first
+/// sentence, so retrieval can cite a locatable source ("§5.3, page 42"). Pages are detected
+/// from form feeds and "Page N" / "- N -" markers; sections from numbered/Chapter/ALL-CAPS
+/// heading lines. Unpaginated input (e.g. a single OCR'd scan) leaves `page` nil.
 struct DocumentChunker {
 
     /// Soft target size — packing starts a new chunk once adding the next sentence would exceed this.
@@ -28,33 +33,46 @@ struct DocumentChunker {
     struct Chunk: Equatable {
         let index: Int
         let text: String
+        let page: Int?
+        let section: String?
+    }
+
+    /// A sentence tagged with the page/section context active where it appears.
+    private struct Sentence {
+        let text: String
+        let page: Int?
+        let section: String?
     }
 
     func chunk(_ raw: String) -> [Chunk] {
         let text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return [] }
 
-        let sentences = Self.sentences(in: text)
-        var chunks: [String] = []
-        var current: [String] = []
+        let sentences = Self.taggedSentences(in: text)
+        var chunks: [(text: String, page: Int?, section: String?)] = []
+        var current: [Sentence] = []
         var currentLen = 0
 
         func flush() {
             guard !current.isEmpty else { return }
-            let joined = current.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
-            if !joined.isEmpty { chunks.append(joined) }
+            let joined = current.map(\.text).joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !joined.isEmpty, let first = current.first else { return }
+            chunks.append((joined, first.page, first.section))
         }
 
         for sentence in sentences {
-            let s = sentence.trimmingCharacters(in: .whitespacesAndNewlines)
+            let s = sentence.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !s.isEmpty else { continue }
 
             // A single sentence too big to ever fit: flush what we have, then hard-split it.
+            // The split pieces inherit the oversized sentence's page/section.
             if s.count > maxChars {
                 flush()
                 current = []
                 currentLen = 0
-                for piece in Self.hardSplit(s, maxChars: maxChars) { chunks.append(piece) }
+                for piece in Self.hardSplit(s, maxChars: maxChars) {
+                    chunks.append((piece, sentence.page, sentence.section))
+                }
                 continue
             }
 
@@ -63,39 +81,150 @@ struct DocumentChunker {
             if currentLen + s.count + 1 > targetChars && !current.isEmpty {
                 flush()
                 current = Self.overlapTail(current, overlapChars: overlapChars)
-                currentLen = current.reduce(0) { $0 + $1.count + 1 }
+                currentLen = current.reduce(0) { $0 + $1.text.count + 1 }
             }
 
-            current.append(s)
+            current.append(Sentence(text: s, page: sentence.page, section: sentence.section))
             currentLen += s.count + 1
         }
         flush()
 
-        return chunks.enumerated().map { Chunk(index: $0.offset, text: $0.element) }
+        return chunks.enumerated().map {
+            Chunk(index: $0.offset, text: $0.element.text, page: $0.element.page, section: $0.element.section)
+        }
     }
 
-    // MARK: - Helpers
+    // MARK: - Sentence tagging
 
-    static func sentences(in text: String) -> [String] {
+    /// Tokenise into sentences, each tagged with the page/section context where it starts.
+    private static func taggedSentences(in text: String) -> [Sentence] {
+        let (breaks, paginated) = pageHeadingBreakpoints(in: text)
+
         let tokenizer = NLTokenizer(unit: .sentence)
         tokenizer.string = text
-        var result: [String] = []
+        var result: [Sentence] = []
+        var bpIdx = 0
+        var page = 1            // content before any marker is page 1 (only surfaced when paginated)
+        var section: String? = nil
+
         tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
+            let offset = text.distance(from: text.startIndex, to: range.lowerBound)
+            while bpIdx < breaks.count && breaks[bpIdx].offset <= offset {
+                page = breaks[bpIdx].page
+                section = breaks[bpIdx].section
+                bpIdx += 1
+            }
             let s = String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)
-            if !s.isEmpty { result.append(s) }
+            if !s.isEmpty {
+                result.append(Sentence(text: s, page: paginated ? page : nil, section: section))
+            }
             return true
         }
+
         // Fall back to the whole text if the tokenizer found nothing usable.
-        return result.isEmpty ? [text] : result
+        if result.isEmpty { return [Sentence(text: text, page: nil, section: nil)] }
+        return result
     }
 
+    /// A point in the text from which a new (page, section) state applies.
+    private struct Breakpoint { let offset: Int; let page: Int; let section: String? }
+
+    /// Single pass producing offset-keyed (page, section) state changes, plus whether the document
+    /// showed any pagination evidence at all (form feed or "Page N"). Without evidence, callers
+    /// treat page as nil — a lone scanned image isn't "page 1 of N".
+    private static func pageHeadingBreakpoints(in text: String) -> (breaks: [Breakpoint], paginated: Bool) {
+        var breaks: [Breakpoint] = []
+        var page = 1
+        var section: String? = nil
+        var paginated = false
+
+        var offset = 0
+        var lineStart = 0
+        var line = ""
+
+        func endLine() {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let n = pageNumber(in: trimmed) {
+                page = n
+                paginated = true
+                breaks.append(Breakpoint(offset: lineStart, page: page, section: section))
+            } else if let heading = detectHeading(trimmed) {
+                section = heading
+                breaks.append(Breakpoint(offset: lineStart, page: page, section: section))
+            }
+            line = ""
+        }
+
+        for ch in text {
+            if ch == "\n" {
+                endLine()
+                offset += 1
+                lineStart = offset
+            } else if ch == "\u{0C}" {           // form feed → new page
+                endLine()
+                page += 1
+                paginated = true
+                offset += 1
+                lineStart = offset
+                breaks.append(Breakpoint(offset: offset, page: page, section: section))
+            } else {
+                line.append(ch)
+                offset += 1
+            }
+        }
+        endLine()
+
+        return (breaks, paginated)
+    }
+
+    // MARK: - Detection (ported from qaeros documentChunker.js)
+
+    /// A line that reads as a section heading → its text, else nil.
+    /// Matches numbered sections ("5.3 Safety"), Chapter/Part/Section/Article N, and ALL-CAPS lines.
+    static func detectHeading(_ line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 4, trimmed.count < 200 else { return nil }
+
+        if trimmed.range(of: #"^\d+(\.\d+)*\s+\S"#, options: .regularExpression) != nil {
+            return trimmed
+        }
+        if trimmed.range(of: #"^(chapter|part|section|article)\s+\d"#, options: [.regularExpression, .caseInsensitive]) != nil {
+            return trimmed
+        }
+        if trimmed.range(of: #"^[A-Z0-9\s.,;:()&/-]+$"#, options: .regularExpression) != nil {
+            let uppercase = trimmed.filter { $0.isLetter && $0.isUppercase }
+            if uppercase.count >= 4 { return trimmed }
+        }
+        return nil
+    }
+
+    /// The page number a marker line denotes ("Page 42" or "- 42 -"), else nil.
+    static func pageNumber(in line: String) -> Int? {
+        if line.range(of: #"^\s*page\s+\d"#, options: [.regularExpression, .caseInsensitive]) != nil,
+           let n = firstInt(in: line), n > 0, n < 10000 {
+            return n
+        }
+        if line.range(of: #"^\s*-\s*\d+\s*-\s*$"#, options: .regularExpression) != nil,
+           let n = firstInt(in: line), n > 0, n < 10000 {
+            return n
+        }
+        return nil
+    }
+
+    private static func firstInt(in s: String) -> Int? {
+        guard let r = s.range(of: #"\d+"#, options: .regularExpression) else { return nil }
+        return Int(s[r])
+    }
+
+    // MARK: - Packing helpers
+
     /// Trailing sentences whose cumulative length fits within `overlapChars`, in original order.
-    private static func overlapTail(_ sentences: [String], overlapChars: Int) -> [String] {
+    private static func overlapTail(_ sentences: [Sentence], overlapChars: Int) -> [Sentence] {
         guard overlapChars > 0 else { return [] }
-        var tail: [String] = []
+        var tail: [Sentence] = []
         var len = 0
         for sentence in sentences.reversed() {
-            let next = len + sentence.count + 1
+            let next = len + sentence.text.count + 1
             if next > overlapChars && !tail.isEmpty { break }
             tail.append(sentence)
             len = next

--- a/OpenGlasses/Sources/Services/RAG/DocumentStore.swift
+++ b/OpenGlasses/Sources/Services/RAG/DocumentStore.swift
@@ -28,6 +28,8 @@ final class DocumentStore: ObservableObject {
         let chunkIndex: Int
         let text: String
         let similarity: Float
+        let page: Int?
+        let section: String?
     }
 
     // MARK: - Published
@@ -83,7 +85,7 @@ final class DocumentStore: ObservableObject {
         for chunk in chunks {
             let embedding = embedder.embed(chunk.text)
             insertChunk(documentId: docId, index: chunk.index, text: chunk.text,
-                        embedding: embedding.map(vecToData), createdAt: now)
+                        embedding: embedding.map(vecToData), page: chunk.page, section: chunk.section, createdAt: now)
             progress?(chunk.index + 1, chunks.count)
             await Task.yield()
         }
@@ -105,7 +107,8 @@ final class DocumentStore: ObservableObject {
             let sim = Embedder.cosineSimilarity(qv, emb)
             guard sim > minSimilarity else { return nil }
             return Passage(documentId: row.documentId, documentName: row.documentName,
-                           chunkIndex: row.chunkIndex, text: row.text, similarity: sim)
+                           chunkIndex: row.chunkIndex, text: row.text, similarity: sim,
+                           page: row.page, section: row.section)
         }
         return Array(scored.sorted { $0.similarity > $1.similarity }.prefix(limit))
     }
@@ -155,9 +158,15 @@ final class DocumentStore: ObservableObject {
             chunk_index INTEGER NOT NULL,
             text TEXT NOT NULL,
             embedding BLOB,
+            page INTEGER,
+            section TEXT,
             created_at REAL NOT NULL
         )
         """)
+        // Bring pre-existing databases (created before page/section citations) up to schema.
+        // ALTER fails harmlessly if the column already exists; exec swallows the error.
+        exec("ALTER TABLE doc_chunks ADD COLUMN page INTEGER")
+        exec("ALTER TABLE doc_chunks ADD COLUMN section TEXT")
         exec("CREATE INDEX IF NOT EXISTS idx_chunk_doc ON doc_chunks(document_id)")
         exec("CREATE INDEX IF NOT EXISTS idx_doc_ns ON documents(namespace)")
     }
@@ -180,8 +189,9 @@ final class DocumentStore: ObservableObject {
         _ = sqlite3_step(stmt)
     }
 
-    private func insertChunk(documentId: String, index: Int, text: String, embedding: Data?, createdAt: Double) {
-        let sql = "INSERT INTO doc_chunks (id, document_id, chunk_index, text, embedding, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+    private func insertChunk(documentId: String, index: Int, text: String, embedding: Data?,
+                             page: Int?, section: String?, createdAt: Double) {
+        let sql = "INSERT INTO doc_chunks (id, document_id, chunk_index, text, embedding, page, section, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
         defer { sqlite3_finalize(stmt) }
@@ -194,7 +204,9 @@ final class DocumentStore: ObservableObject {
         } else {
             sqlite3_bind_null(stmt, 5)
         }
-        sqlite3_bind_double(stmt, 6, createdAt)
+        if let page { sqlite3_bind_int(stmt, 6, Int32(page)) } else { sqlite3_bind_null(stmt, 6) }
+        if let section { sqlite3_bind_text(stmt, 7, section, -1, SQLITE_TRANSIENT) } else { sqlite3_bind_null(stmt, 7) }
+        sqlite3_bind_double(stmt, 8, createdAt)
         _ = sqlite3_step(stmt)
     }
 
@@ -206,11 +218,13 @@ final class DocumentStore: ObservableObject {
         let chunkIndex: Int
         let text: String
         let embedding: [Float]?
+        let page: Int?
+        let section: String?
     }
 
     private func fetchChunks(namespace: String?, documentIds: [String]?) -> [ChunkRow] {
         var sql = """
-        SELECT c.document_id, d.name, c.chunk_index, c.text, c.embedding
+        SELECT c.document_id, d.name, c.chunk_index, c.text, c.embedding, c.page, c.section
         FROM doc_chunks c JOIN documents d ON c.document_id = d.id
         """
         var clauses: [String] = []
@@ -235,7 +249,10 @@ final class DocumentStore: ObservableObject {
                 let len = sqlite3_column_bytes(stmt, 4)
                 emb = dataToVec(Data(bytes: ptr, count: Int(len)))
             }
-            rows.append(ChunkRow(documentId: docId, documentName: name, chunkIndex: idx, text: text, embedding: emb))
+            let page = sqlite3_column_type(stmt, 5) != SQLITE_NULL ? Int(sqlite3_column_int(stmt, 5)) : nil
+            let section = sqlite3_column_type(stmt, 6) != SQLITE_NULL ? String(cString: sqlite3_column_text(stmt, 6)) : nil
+            rows.append(ChunkRow(documentId: docId, documentName: name, chunkIndex: idx, text: text,
+                                 embedding: emb, page: page, section: section))
         }
         return rows
     }

--- a/OpenGlassesTests/DocumentChunkerTests.swift
+++ b/OpenGlassesTests/DocumentChunkerTests.swift
@@ -65,4 +65,54 @@ final class DocumentChunkerTests: XCTestCase {
         let text = (1...15).map { "Repeatable sentence \($0)." }.joined(separator: " ")
         XCTAssertEqual(chunker.chunk(text), chunker.chunk(text))
     }
+
+    // MARK: - Heading & page detection
+
+    func testDetectHeadingRecognisesSectionForms() {
+        XCTAssertEqual(DocumentChunker.detectHeading("5.3 Safety Requirements"), "5.3 Safety Requirements")
+        XCTAssertEqual(DocumentChunker.detectHeading("12.1.2 Procedures"), "12.1.2 Procedures")
+        XCTAssertEqual(DocumentChunker.detectHeading("Chapter 12"), "Chapter 12")
+        XCTAssertEqual(DocumentChunker.detectHeading("SAFETY PROCEDURES"), "SAFETY PROCEDURES")
+    }
+
+    func testDetectHeadingRejectsOrdinaryAndTooShortLines() {
+        XCTAssertNil(DocumentChunker.detectHeading("This is a normal sentence."))
+        XCTAssertNil(DocumentChunker.detectHeading("abc"))                 // < 4 chars
+        XCTAssertNil(DocumentChunker.detectHeading("the quick brown fox")) // lowercase, unnumbered
+    }
+
+    func testPageNumberDetection() {
+        XCTAssertEqual(DocumentChunker.pageNumber(in: "Page 42"), 42)
+        XCTAssertEqual(DocumentChunker.pageNumber(in: "- 7 -"), 7)
+        XCTAssertNil(DocumentChunker.pageNumber(in: "Page of contents"))
+        XCTAssertNil(DocumentChunker.pageNumber(in: "ordinary text"))
+    }
+
+    func testUnpaginatedTextLeavesPageAndSectionNil() {
+        let chunks = DocumentChunker().chunk("Just some plain text. No pages here at all.")
+        XCTAssertEqual(chunks.count, 1)
+        XCTAssertNil(chunks[0].page)
+        XCTAssertNil(chunks[0].section)
+    }
+
+    func testFormFeedAdvancesPageNumber() {
+        let chunker = DocumentChunker(targetChars: 50, maxChars: 90, overlapChars: 0)
+        let p1 = (1...4).map { "Page one sentence \($0)." }.joined(separator: " ")
+        let p2 = (1...4).map { "Page two sentence \($0)." }.joined(separator: " ")
+        let chunks = chunker.chunk(p1 + "\u{0C}" + p2)
+
+        XCTAssertGreaterThan(chunks.count, 1)
+        XCTAssertEqual(chunks.first?.page, 1)
+        XCTAssertTrue(chunks.contains { $0.page == 2 }, "A chunk from the second page should be tagged page 2")
+        // Paginated document → every chunk gets a page number, none nil.
+        XCTAssertNil(chunks.first { $0.page == nil })
+    }
+
+    func testSectionHeadingTagsFollowingChunks() {
+        let chunker = DocumentChunker(targetChars: 60, maxChars: 100, overlapChars: 0)
+        let text = "5.3 Safety Requirements\nAll staff must wear helmets at all times. Visitors must sign in."
+        let chunks = chunker.chunk(text)
+        XCTAssertTrue(chunks.contains { $0.section == "5.3 Safety Requirements" },
+                      "Content under a heading should carry that section")
+    }
 }

--- a/docs/plans/P-chunk-citations.md
+++ b/docs/plans/P-chunk-citations.md
@@ -1,0 +1,46 @@
+# Plan P — Page & section citations for Document RAG
+
+**Builds on:** [`DocumentChunker`](../../OpenGlasses/Sources/Services/RAG/DocumentChunker.swift), [`DocumentStore`](../../OpenGlasses/Sources/Services/RAG/DocumentStore.swift), and [`DocumentRAGTool`](../../OpenGlasses/Sources/Services/NativeTools/DocumentRAGTool.swift) — all shipped in Plan O. The retrieval path works; what it can't do is tell the user *where* in a document an answer came from.
+
+**Strategic fit:** Voice-first. A glasses assistant that says *"that's in §5.3 of the safety manual, page 42"* is far more useful hands-free than one that cites an opaque chunk index. Pairs with Field Assist (Plan F) and accessibility (scan a leaflet, ask about it) — both benefit from grounded, locatable answers. Cross-pollinated from the qaeros RAG chunker (`server/core/data/documentChunker.js`), which already tracks page + heading per chunk; this ports that idea back into the Swift on-device path. Pattern reuse only.
+
+**Effort:** ~half a day.
+
+---
+
+## What already exists (reuse, do not rebuild)
+
+- **Sentence-aware packing:** `DocumentChunker` packs whole sentences (NLTokenizer), with sentence-aligned overlap and word/char hard-split fallback. Keep all of it — this plan layers metadata on top, it does not touch packing behaviour.
+- **Storage + retrieval:** `DocumentStore` (SQLite, `Embedder` sentence vectors, cosine top-k, namespaces) and `Passage` are the surfaces that carry attribution back to the tool.
+- **Citation surface:** `DocumentRAGTool.runQuery` renders each `Passage` into the tool-result string the LLM grounds on — today `(chunk N, score X)`.
+
+## The gap
+
+Chunks carry only `chunk_index`. A chunk index spoken aloud is meaningless. qaeros's chunker detects page boundaries (form-feed `\f`, "Page N" / "- N -") and section headings (numbered `5.3 …`, `Chapter/Part/Section/Article N`, ALL-CAPS lines) and records, per chunk, the page of its first word and the nearest heading. We have none of that. PDFs and multi-page extracted text carry exactly these markers; OCR'd glasses scans (single image) carry none — so detection must degrade gracefully to `nil`.
+
+## New work
+
+**1. `DocumentChunker` — tag chunks with page + section**
+`Chunk` gains `page: Int?` and `section: String?`.
+- One pass over the (trimmed) text builds offset-keyed breakpoints: form-feed and "Page N" / "- N -" → page number; heading lines (`detectHeading`, ported from qaeros) → current section.
+- Tokenise sentences with their start offsets (new internal `taggedSentences`), look up the active page/heading at each sentence's offset.
+- A chunk's `page`/`section` = the values active at its **first** sentence (matches qaeros semantics). Packing, overlap, and hard-split are unchanged; overlap tail carries tagged sentences. Plain text with no markers → both `nil`, identical chunk text to today (existing tests stay green).
+- `detectHeading` is pure → add table-driven cases to the chunker tests (numbered §, Chapter N, ALL-CAPS, and negatives like a normal sentence).
+
+**2. `DocumentStore` — persist & return the metadata**
+- `doc_chunks` gains `page INTEGER` and `section TEXT`. New install: add to `CREATE TABLE`. Existing install: guarded `ALTER TABLE doc_chunks ADD COLUMN …` (ignore the duplicate-column error via the existing silent `exec`) so a doc indexed under Plan O isn't lost.
+- `insertChunk` binds page (nullable int) / section (nullable text); `ChunkRow` + `fetchChunks` SELECT them; `Passage` gains `page: Int?`, `section: String?` and `query` threads them through.
+
+**3. `DocumentRAGTool` — speakable citations**
+`runQuery` attribution becomes locator-aware, degrading cleanly:
+- page + section → `From "Safety Manual" (page 42, §5.3 Safety Requirements, score 0.81)`
+- page only → `(page 42, score …)`; section only → `(§5.3 …, score …)`; neither → `(chunk N, score …)` as today.
+Update the trailing instruction so the model is told it may cite the page/section when present.
+
+**4. No new tool, no registry change, no system-prompt edit**
+This extends an existing tool's output only — `document_knowledge`'s schema and registration are unchanged, so steps 3–4 of CLAUDE.md "Adding a New Tool" don't apply. XcodeGen auto-includes the edited files; no `.pbxproj` work.
+
+## Out of scope
+- No re-chunk/migration of already-ingested docs — new metadata applies on next ingest; old chunks simply return `nil` page/section and fall back to chunk-index citation. Flag a follow-up if re-indexing proves worthwhile.
+- No embedding/retrieval changes — purely the chunk-production + attribution path.
+- BM25/hybrid retrieval stays out (the qaeros direction); OpenGlasses' on-device semantic path is deliberate.


### PR DESCRIPTION
## What

Document RAG chunks now carry the **page number** and **nearest section heading** active at their first sentence, so the agent can cite a locatable source — *"per §5.3 of the safety manual, page 42"* — instead of an opaque chunk index. For a voice-first glasses assistant, a spoken page/section reference is far more useful than a chunk number.

Implements [`docs/plans/P-chunk-citations.md`](docs/plans/P-chunk-citations.md). Detection logic is cross-pollinated from the qaeros RAG chunker (which already tracked page + heading); this ports that idea into the Swift on-device path.

## Changes

- **`DocumentChunker`** — single offset-keyed pass detects page boundaries (form feed, `Page N`, `- N -`) and section headings (numbered `5.3 …`, `Chapter/Part/Section/Article N`, ALL-CAPS), tagging each `Chunk` with `page`/`section`. Packing, sentence-aligned overlap, and hard-split are unchanged. Unpaginated input (e.g. a single OCR'd scan) leaves `page` nil — no misleading "page 1".
- **`DocumentStore`** — `page`/`section` columns on `doc_chunks` (`CREATE` + guarded `ALTER` so documents indexed under Plan O survive), bound on insert, selected on fetch, threaded through `Passage`.
- **`DocumentRAGTool`** — citation string degrades cleanly: `page + section` → page-only → section-only → chunk index (old behaviour).
- **Tests** — `detectHeading`/`pageNumber` cases, form-feed page advance, heading→section tagging, unpaginated→nil.

## Scope notes

- No re-chunk/migration of already-ingested docs — new metadata applies on next ingest; old chunks fall back to chunk-index citation.
- No embedding/retrieval changes; purely chunk-production + attribution.
- No new tool / registry / system-prompt changes (extends an existing tool's output only).

## Testing

- `DocumentChunkerTests`: **12/12 pass** (6 pre-existing + 6 new).
- Full app build green: `xcodebuild -project OpenGlasses.xcodeproj -scheme OpenGlasses -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)