### PR TITLE
Swift 6 LicenseService fix + quiet Xcode recommended-settings nag

### DIFF
--- a/OpenGlasses/Sources/Services/LicenseService.swift
+++ b/OpenGlasses/Sources/Services/LicenseService.swift
@@ -18,10 +18,13 @@ final class LicenseService: ObservableObject {
 
     /// Vendor's production public key (base64, Curve25519 raw representation). The private half is
     /// held only by the vendor and never ships in the app.
-    static let productionPublicKeyBase64 = "KJyr5gDejBhxO2zpXbaBgvOeSjs9b3I93PJgauHubhY="
+    ///
+    /// `nonisolated` so it can be used as the default argument of `init` (default-argument
+    /// expressions evaluate in a nonisolated context) — required under the Swift 6 language mode.
+    nonisolated static let productionPublicKeyBase64 = "KJyr5gDejBhxO2zpXbaBgvOeSjs9b3I93PJgauHubhY="
 
     /// Feature identifier a license must name to unlock Field Assist.
-    static let featureId = "field_assist"
+    nonisolated static let featureId = "field_assist"
 
     /// The verifying key in use. Overridable so tests can sign with an ephemeral keypair.
     let publicKeyBase64: String

--- a/project.base.yml
+++ b/project.base.yml
@@ -13,7 +13,9 @@ options:
   deploymentTarget:
     iOS: "26.0"
     watchOS: "26.0"
-  xcodeVersion: "26.0"
+  # Sets LastUpgradeCheck (26.5 -> 2650). Keep in step with the project's Xcode
+  # baseline so Xcode's "Update to recommended settings" validation stays quiet.
+  xcodeVersion: "26.5"
   generateEmptyDirectories: true
   developmentLanguage: en
   knownRegions:


### PR DESCRIPTION
Two small follow-ups that were pushed to the #15 branch *after* it merged, so they never made it into `main`. Re-landing them here.

## Changes
1. **`LicenseService` Swift 6 fix** — `productionPublicKeyBase64` (and `featureId`) made `nonisolated`. They're used as a default argument of `init`, whose expression evaluates in a nonisolated context; referencing the `@MainActor` static there is a hard error under the Swift 6 language mode. Both are immutable `Sendable` constants, so `nonisolated` is correct.
2. **Quiet "Update to recommended settings"** — `options.xcodeVersion` → `26.5` so XcodeGen emits `LastUpgradeCheck = 2650` (matches Xcode 26.5 and survives project regeneration). Attribute-only.

## Verification
- `xcodebuild … build` (iPhone 17 Pro sim): **BUILD SUCCEEDED**, LicenseService compiles with no actor-isolation diagnostic.
- Regenerated project confirms `LastUpgradeCheck = 2650`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)