### PR TITLE
Fix Xcode Cloud package resolution (post-clone resolve + lockfile sync)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c149056df5876ff3eb5c8ea35fa69dec00ab9fb3abe135d4d5ee8452b7cde6cc",
+  "originHash" : "18e3260711c0130c5c74b2ecf73b3387b67fb41621ecbcb8aa9eb73917aefae6",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -143,6 +143,15 @@
       "state" : {
         "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
         "version" : "1.2.1"
+      }
+    },
+    {
+      "identity" : "webrtc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stasel/WebRTC.git",
+      "state" : {
+        "revision" : "3edaa8f0ddae889ad8ea236023de88672f6a16ec",
+        "version" : "120.0.0"
       }
     },
     {

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -10,3 +10,11 @@ if ! command -v xcodegen >/dev/null 2>&1; then
   exit 1
 fi
 ./Scripts/generate-xcodeproj.sh
+
+# The .xcodeproj is generated (and gitignored), so no Package.resolved is committed
+# at its path. Xcode Cloud runs the build/archive action with automatic package
+# resolution disabled and fails unless a resolved file already exists there. Resolve
+# explicitly here (post-clone has network) so the file is in place before the build.
+xcodebuild -resolvePackageDependencies \
+  -project OpenGlasses.xcodeproj \
+  -scheme OpenGlasses


### PR DESCRIPTION
Fixes the failing Xcode Cloud **Archive - iOS** build. These two commits were pushed to the #16 branch *after* it merged, so they never reached `main`.

## The failure
Xcode Cloud runs the archive action with automatic package resolution disabled and errors with *"a resolved file is required …"* for `swift-transformers` / `SystemNotification`. The `OpenGlasses.xcodeproj` is generated by XcodeGen (and gitignored), so no `Package.resolved` is ever committed at its path, and the existing `ci_post_clone.sh` generated the project but never resolved packages.

## Changes
1. **`ci_post_clone.sh`** — after generating the project, run `xcodebuild -resolvePackageDependencies`. Post-clone has network, so this writes a complete resolved file (all 20 pins) before the build action. Self-healing: new dependencies resolve automatically, no committed lockfile to maintain.
2. **Root `Package.resolved`** — synced with `Package.swift`, which declares WebRTC but whose pin was missing. `swift package resolve` adds exactly the `webrtc` 120.0.0 pin (no version bumps, no `mlx-swift-lm` branch churn). This is the SwiftPM build/test graph's lockfile, distinct from the app `.xcodeproj` resolved file from change 1.

## Verification
- `xcodebuild -resolvePackageDependencies … -scheme OpenGlasses`: exit 0, all 20 packages resolved, file written.
- `sh -n ci_post_clone.sh`: passes.
- `swift package resolve` diff: +webrtc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)