### PR TITLE
Fix Xcode Cloud: commit Package.resolved instead of resolving in post-clone

### DIFF
--- a/Scripts/update-package-resolved.sh
+++ b/Scripts/update-package-resolved.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Refresh ci_scripts/Package.resolved — the committed SwiftPM lockfile that
+# Xcode Cloud copies into the generated .xcodeproj (it won't resolve packages
+# itself). Run this whenever you add, remove, or bump an SPM dependency, then
+# commit the result, so the cloud build keeps a complete, in-sync resolved file.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SRC="OpenGlasses.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+
+if [[ ! -f "$SRC" ]]; then
+  echo "No resolved file at $SRC." >&2
+  echo "Generate + resolve first:" >&2
+  echo "  ./Scripts/generate-xcodeproj.sh" >&2
+  echo "  xcodebuild -resolvePackageDependencies -project OpenGlasses.xcodeproj -scheme OpenGlasses" >&2
+  exit 1
+fi
+
+cp "$SRC" ci_scripts/Package.resolved
+echo "Updated ci_scripts/Package.resolved ($(grep -c '"identity"' ci_scripts/Package.resolved) pins). Commit it."

--- a/ci_scripts/Package.resolved
+++ b/ci_scripts/Package.resolved
@@ -1,0 +1,186 @@
+{
+  "originHash" : "50e6823178dffaf6d63142658698a0f686e94bf3e3f3cdcb1723f590455da805",
+  "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "haishinkit.swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/shogo4405/HaishinKit.swift.git",
+      "state" : {
+        "revision" : "dc880cb540b8feeb98f64e8b7dcfaaf320b6b2bd",
+        "version" : "2.2.5"
+      }
+    },
+    {
+      "identity" : "logboard",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/shogo4405/Logboard.git",
+      "state" : {
+        "revision" : "8f41c63afb903040b77049ee2efa8c257b8c0d50",
+        "version" : "2.6.0"
+      }
+    },
+    {
+      "identity" : "meta-wearables-dat-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/facebook/meta-wearables-dat-ios.git",
+      "state" : {
+        "revision" : "c40db3978a76b97504b85ed9f082be5549c5a486",
+        "version" : "0.7.0"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "state" : {
+        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
+        "version" : "3.31.3"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
+        "version" : "2.3.6"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers.git",
+      "state" : {
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "systemnotification",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/danielsaidi/SystemNotification.git",
+      "state" : {
+        "revision" : "69c2fa246dabd8d19c7ee62250d0a489a721660f",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "webrtc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/stasel/WebRTC.git",
+      "state" : {
+        "revision" : "3edaa8f0ddae889ad8ea236023de88672f6a16ec",
+        "version" : "120.0.0"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -11,10 +11,14 @@ if ! command -v xcodegen >/dev/null 2>&1; then
 fi
 ./Scripts/generate-xcodeproj.sh
 
-# The .xcodeproj is generated (and gitignored), so no Package.resolved is committed
-# at its path. Xcode Cloud runs the build/archive action with automatic package
-# resolution disabled and fails unless a resolved file already exists there. Resolve
-# explicitly here (post-clone has network) so the file is in place before the build.
-xcodebuild -resolvePackageDependencies \
-  -project OpenGlasses.xcodeproj \
-  -scheme OpenGlasses
+# Xcode Cloud requires a committed Package.resolved and will NOT resolve packages
+# itself — automatic resolution is disabled in its environment, and even
+# `xcodebuild -resolvePackageDependencies` fails there (exit 74). Because the
+# .xcodeproj is generated (and gitignored), no resolved file is committed at its
+# path, so copy our tracked copy into place before the build/archive action runs.
+#
+# Keep ci_scripts/Package.resolved in sync after adding/updating an SPM dependency:
+#   ./Scripts/update-package-resolved.sh
+RESOLVED_DST="OpenGlasses.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
+mkdir -p "$RESOLVED_DST"
+cp ci_scripts/Package.resolved "$RESOLVED_DST/Package.resolved"


### PR DESCRIPTION
Follow-up to #17, whose approach was wrong. The Xcode Cloud build still failed — this time in `ci_post_clone.sh` itself (exit 74).

## Why #17 didn't work
Xcode Cloud **disables automatic package resolution**, and that policy also blocks `xcodebuild -resolvePackageDependencies` — so the post-clone resolve step errored with *"a resolved file is required … 'swift-huggingface'"*. It worked locally only because local resolution isn't disabled. Xcode Cloud requires a **committed** `Package.resolved`; it will not resolve packages itself.

## Fix
Because `OpenGlasses.xcodeproj` is generated (gitignored), there's no committed resolved file at its path. So:
1. Commit the complete app lockfile at **`ci_scripts/Package.resolved`** (20 pins — includes `swift-huggingface`, `swift-transformers`, `SystemNotification`, `WebRTC`, …).
2. **`ci_post_clone.sh`** now *copies* it into `OpenGlasses.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/` after generating the project — no resolution attempted.
3. **`Scripts/update-package-resolved.sh`** refreshes the committed copy after any SPM dependency change (run it + commit).

## Verification
Reproduced the cloud condition locally: a full `xcodebuild -disableAutomaticPackageResolution build` (iPhone 17 Pro sim) **succeeds** with **no** "a resolved file is required" / "Running resolver because" — the committed file satisfies the package graph without re-resolution. `sh -n` / `bash -n` pass on both scripts.

## Maintenance note
`ci_scripts/Package.resolved` must be refreshed (via the new script) whenever dependencies change, or the cloud build will fail again with "<dep> was added". That's inherent to committing a lockfile for a generated project under Xcode Cloud's no-resolve policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)