### PR TITLE
Run scheme launches the app, not the widget extension

### DIFF
--- a/project.base.yml
+++ b/project.base.yml
@@ -178,6 +178,11 @@ schemes:
       config: Debug
       debugEnabled: true
       askForAppToLaunch: false
-      launchAutomaticallySubstyle: 2
+      # Launch the app, not the widget. Without an explicit executable, XcodeGen
+      # made the first buildable target the runnable — GlassesActivityWidget sorts
+      # before OpenGlasses — and launchAutomaticallySubstyle: 2 turned the run
+      # action into a WidgetKit "show widget" launch via SpringBoard, which fails
+      # on a locked device ("Failed to show Widget … device was not unlocked").
+      executable: OpenGlasses
     archive:
       config: Release


### PR DESCRIPTION
## The bug
Running the **OpenGlasses** scheme failed with:
> Failed to show Widget 'com.openglasses.app.GlassesActivityWidget' … The request to open "com.apple.springboard" failed … device was not, or could not be, unlocked.

It reads like a transient locked-device issue, but it's deterministic: the scheme's run action was launching the **widget extension** through SpringBoard, not the app — and showing a widget requires an unlocked device.

## Root cause
In `project.base.yml` the `OpenGlasses` scheme had `launchAutomaticallySubstyle: 2` and **no explicit `executable`**. XcodeGen then:
- picked the first buildable target as the runnable — `GlassesActivityWidget` sorts before `OpenGlasses`, so the widget won; and
- with substyle 2, emitted a `RemoteRunnable` (`BundleIdentifier = com.apple.springboard`, `GlassesActivityWidget.appex`) — i.e. a WidgetKit "show widget" launch.

So the source looked fine; the generated scheme was wrong.

## Fix
Set `executable: OpenGlasses` and remove `launchAutomaticallySubstyle: 2`. Regenerated scheme now launches the app via a normal `BuildableProductRunnable` (`OpenGlasses.app`) — no substyle, no RemoteRunnable. To debug the widget itself, use a dedicated widget scheme rather than the app scheme.

## Verification
Regenerated `OpenGlasses.xcscheme` LaunchAction:
```
<BuildableProductRunnable>
   BuildableName = "OpenGlasses.app"
   BlueprintName = "OpenGlasses"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)