### PR TITLE
Cancel on-device generation when the app enters the background

### DIFF
--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -21,6 +21,11 @@ final class LocalLLMService: ObservableObject {
     private var modelContainer: ModelContainer?
     private var activeDownloadTask: Task<Void, Error>?
 
+    /// Set when the app enters the background during a generation so the token loop
+    /// can stop before submitting the next Metal command buffer (forbidden in the
+    /// background — see `generate`).
+    private var enteredBackgroundDuringGeneration = false
+
     /// HubClient configured to store models in Application Support (persistent, not purgeable).
     private let hub: HubClient = {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
@@ -222,12 +227,36 @@ final class LocalLLMService: ObservableObject {
         }
         let input = LMInput(text: .init(tokens: .init(tokens)))
 
+        // Watch for backgrounding *during* generation. The pre-check above covers
+        // the already-backgrounded case; this covers the app being sent to the
+        // background mid-stream, where the next per-token Metal eval would crash.
+        enteredBackgroundDuringGeneration = false
+        let bgObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            // Delivered on the main thread; this type is @MainActor.
+            MainActor.assumeIsolated { self?.enteredBackgroundDuringGeneration = true }
+        }
+        defer { NotificationCenter.default.removeObserver(bgObserver) }
+
         // Generate
         let parameters = GenerateParameters(maxTokens: 512, temperature: 0.7, topP: 0.9)
         let stream = try await container.generate(input: input, parameters: parameters)
 
         var output = ""
-        for try await generation in stream {
+        // Drive the stream manually so we can bail out *before* requesting the next
+        // token — i.e. before MLX submits the next Metal command buffer. Stopping
+        // here avoids the uncatchable background-GPU crash; whatever tokens we have
+        // so far are returned (or .backgrounded is thrown if nothing was produced).
+        var iterator = stream.makeAsyncIterator()
+        while true {
+            if enteredBackgroundDuringGeneration || UIApplication.shared.applicationState == .background {
+                if output.isEmpty { throw LocalLLMError.backgrounded }
+                break
+            }
+            guard let generation = await iterator.next() else { break }
             switch generation {
             case .chunk(let text):
                 output += text


### PR DESCRIPTION
Follow-up to the background-GPU crash fix (#20), closing the edge case noted there.

## Gap
#20's pre-check stops the **scheduler** from starting local inference while already backgrounded. But a **foreground-started** generation could still crash if the app was sent to the background **mid-stream** — the next per-token Metal eval hits the forbidden-background-GPU restriction and MLX raises an uncatchable C++ exception.

## Fix
`LocalLLMService.generate` now:
- Observes `UIApplication.didEnterBackgroundNotification` for the duration of the generation (scoped, removed via `defer`).
- Drives the token stream with a **manual iterator**, checking *before* each `next()`. If we've entered the background, it stops **before requesting the next token** (i.e. before MLX submits the next command buffer):
  - returns partial output if any tokens were produced, or
  - throws `LocalLLMError.backgrounded` if nothing was produced (which `AgentScheduler` already treats as a deferral).

## Limitation (now minimal)
This shrinks the crash window to a single in-flight token eval — if backgrounding lands during the exact eval already in flight, it can't be interrupted without MLX-level cancellation hooks. Stopping before the *next* eval covers the realistic case.

## Verification
`xcodebuild … build` (iPhone 17 Pro sim): **BUILD SUCCEEDED**, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)