### PR TITLE
Skip macro fingerprint validation in Xcode Cloud

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -2,6 +2,15 @@
 set -eu
 cd "${CI_PRIMARY_REPOSITORY_PATH:-$(dirname "$0")/..}"
 
+# mlx-swift-lm ships a Swift macro (MLXHuggingFaceMacros, used by LocalLLMService).
+# Since Xcode 15, macros must be trusted before the build can use them — locally you
+# do that once via Xcode's "Trust & Enable" prompt, but Xcode Cloud is a fresh
+# environment that never trusted it, so `xcodebuild archive` fails with
+# "Macro … must be enabled before it can be used" (exit 65). Skip macro/plugin
+# fingerprint validation for the headless build — we control these dependencies.
+defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
+
 if ! command -v xcodegen >/dev/null 2>&1 && command -v brew >/dev/null 2>&1; then
   brew install xcodegen
 fi


### PR DESCRIPTION
Next Xcode Cloud gate after package resolution started succeeding. Archive failed with:
```
Macro "MLXHuggingFaceMacros" from package "mlx-swift-lm" must be enabled before it can be used
xcodebuild archive … Command exited with non-zero exit-code: 65
```

## Cause
`mlx-swift-lm` ships a Swift macro (`MLXHuggingFaceMacros`, used by `LocalLLMService`). Since Xcode 15, macros must be **trusted** before a build can use them. Locally that happens once via Xcode's "Trust & Enable" prompt and is cached per-user — but **Xcode Cloud is a fresh environment** that has never trusted it, and there's no interactive prompt in CI, so the archive bails.

## Fix
`ci_post_clone.sh` now sets the build defaults that bypass interactive macro trust:
```sh
defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
```
This is the standard Xcode Cloud workaround for macro/plugin trust. Safe here — the dependency set is ours and pinned via the committed `Package.resolved`.

## Note
I can't reproduce the Xcode Cloud environment locally (macros are already trusted on the dev Mac, so the error doesn't occur here). `sh -n` passes on the script. This is the documented fix for this exact error; please re-run the workflow after merge to confirm it clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)