### PR TITLE
Also skip macro validation in ci_pre_xcodebuild (belt-and-suspenders)

### DIFF
--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+# Belt-and-suspenders for the mlx-swift-lm Swift macro (MLXHuggingFaceMacros, used
+# by LocalLLMService). ci_post_clone.sh already sets these, but re-assert them right
+# before each xcodebuild invocation in case the build step doesn't inherit the
+# post-clone defaults. Without this, Xcode Cloud's fresh environment fails the
+# archive with "Macro … must be enabled before it can be used" (it can't show the
+# interactive Trust & Enable prompt). Safe — dependencies are ours and pinned via
+# the committed Package.resolved.
+defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES


### PR DESCRIPTION
Follow-up safety net to #22. That PR sets `IDESkipMacroFingerprintValidation` in `ci_post_clone.sh`; this re-asserts the same defaults in **`ci_pre_xcodebuild.sh`**, which runs immediately before each `xcodebuild` invocation — covering the case where the build step doesn't inherit the post-clone defaults.

Script committed with executable mode (`100755`), as Xcode Cloud requires.

## Recommended order
**Re-run the workflow with #22 alone first.** If the macro-trust error is gone, post-clone was sufficient and this PR can be closed as unneeded. If it resurfaces, merge this — the pre-xcodebuild hook is the closest point to the build and should close any remaining gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)