### PR TITLE
Guard model loading against background GPU work (second crash path)

### DIFF
--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -143,7 +143,16 @@ final class LocalLLMService: ObservableObject {
     /// Uses LLMModelFactory for text models, VLMModelFactory for vision models.
     func loadModel(_ modelId: String) async throws {
         if loadedModelId == modelId && isModelLoaded {
-            return  // Already loaded
+            return  // Already loaded — no GPU work needed, safe even in background
+        }
+
+        // Loading materializes model weights on the GPU via Metal (same restriction
+        // as generate()), which iOS forbids in the background. The model is unloaded
+        // when the app backgrounds, so a backgrounded scheduled task would otherwise
+        // try to reload here and crash. Refuse early with a catchable error so callers
+        // can defer.
+        guard UIApplication.shared.applicationState != .background else {
+            throw LocalLLMError.backgrounded
         }
 
         unloadModel()


### PR DESCRIPTION
The background-GPU crash recurred, but via a **different path** than #20/#21 fixed.

## What happened
```
📱 App moved to background …
[AgentScheduler] Running morning briefing
🤖 Using model: Local Gemini (…gemma-4…)
🔄 Local model unloaded
IOGPUMetalError: Insufficient Permission (to submit GPU work from background)
```
Note: **no `✅ Local model loaded`** — the crash is during **loading**, not generation. When the app backgrounds, the on-device model is unloaded to free memory, so the backgrounded scheduled task hit `loadModel()` first. `loadContainer` materializes the quantized weights on the **GPU via Metal**, which iOS forbids in the background → crash before `generate()`'s guard could run.

## Fix
Add the same `applicationState == .background` pre-check to `loadModel`, placed:
- **after** the already-loaded early return (a cached model needs no GPU work, safe in background), and
- **before** any `loadContainer` call.

It throws the catchable `LocalLLMError.backgrounded`, which propagates through `sendLocal` (the `loadModel` call is outside its inner `do/catch`) to `AgentScheduler`, which **defers** — exactly like the `generate()` path that already worked in testing.

## Verification
`xcodebuild … build` (iPhone 17 Pro sim): **BUILD SUCCEEDED**. Error propagation is proven by the prior run, where `generate()`'s `.backgrounded` reached the scheduler and logged "deferred" — `loadModel` exits `sendLocal` as the same error type via the same path.

Together with #20/#21 this closes both on-device Metal entry points (load + generate) for the background case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)