### PR TITLE
Field Assist quick action + chunky, always-visible Lock Screen buttons

### DIFF
--- a/GlassesActivityWidget/GlassesActivityWidget.swift
+++ b/GlassesActivityWidget/GlassesActivityWidget.swift
@@ -133,21 +133,17 @@ struct GlassesActivityWidget: Widget {
                 }
             }
 
-            // Quick-launch buttons or Connect button
-            if context.state.isConnected {
-                actionButtons(for: context.state, compact: false)
-            } else {
+            // Quick actions — always shown so the Lock Screen stays useful even when the
+            // glasses are disconnected (most actions just open the app via deep link).
+            actionButtons(for: context.state, compact: false)
+            if !context.state.isConnected {
                 Link(destination: URL(string: "openglasses://connect")!) {
-                    Label {
-                        Text("Connect & Talk")
-                    } icon: {
-                        LogoIcon(size: 16)
-                    }
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 8)
-                    .background(.green.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
+                    Label("Connect Glasses", systemImage: "antenna.radiowaves.left.and.right")
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.white.opacity(0.7))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6)
+                        .background(.white.opacity(0.10), in: Capsule())
                 }
             }
         }
@@ -157,55 +153,95 @@ struct GlassesActivityWidget: Widget {
 
     // MARK: - Action Buttons
 
-    /// Shows persona buttons if available, otherwise quick action buttons.
+    /// A resolved button for the Live Activity (quick action, persona, or fallback).
+    private struct ActionItem: Identifiable {
+        let id: String
+        let label: String
+        let icon: String
+        let url: URL
+        let accent: Bool   // coral-tinted (AI/Field Assist) vs neutral
+    }
+
+    /// Quick actions take priority (incl. the built-in Field Assist action), then personas,
+    /// then a generic Ask/Photo fallback. Capped at 4 for the chunky grid.
+    private func actionItems(for state: GlassesActivityAttributes.ContentState) -> [ActionItem] {
+        if !state.quickActionButtons.isEmpty {
+            return state.quickActionButtons.prefix(4).map {
+                ActionItem(id: $0.id, label: $0.label, icon: $0.icon,
+                           url: URL(string: "openglasses://quickaction/\($0.id)")!,
+                           accent: $0.id == "field-assist")
+            }
+        } else if !state.personaButtons.isEmpty {
+            return state.personaButtons.prefix(4).map {
+                ActionItem(id: $0.id, label: $0.name, icon: "person.fill",
+                           url: URL(string: "openglasses://persona/\($0.id)")!, accent: false)
+            }
+        } else {
+            return [
+                ActionItem(id: "ask", label: "Ask", icon: "mic.fill",
+                           url: URL(string: "openglasses://action/ask")!, accent: true),
+                ActionItem(id: "photo", label: "Photo", icon: "camera.fill",
+                           url: URL(string: "openglasses://action/photo")!, accent: false),
+            ]
+        }
+    }
+
     @ViewBuilder
     private func actionButtons(for state: GlassesActivityAttributes.ContentState, compact: Bool) -> some View {
-        let fontSize: Font = compact ? .caption2.weight(.medium) : .caption.weight(.medium)
-        let vPadding: CGFloat = compact ? 4 : 6
-        let cornerRadius: CGFloat = compact ? 6 : 8
-
-        HStack(spacing: compact ? 6 : 8) {
-            if !state.personaButtons.isEmpty {
-                ForEach(state.personaButtons, id: \.id) { persona in
-                    Link(destination: URL(string: "openglasses://persona/\(persona.id)")!) {
-                        Text(persona.name)
-                            .font(fontSize)
+        let items = actionItems(for: state)
+        if compact {
+            // Dynamic Island: slim single row (space-constrained).
+            HStack(spacing: 6) {
+                ForEach(items.prefix(3)) { item in
+                    Link(destination: item.url) {
+                        Label(item.label, systemImage: item.icon)
+                            .font(.caption2.weight(.semibold))
                             .foregroundStyle(.white)
                             .frame(maxWidth: .infinity)
-                            .padding(.vertical, vPadding)
-                            .background(.white.opacity(0.15), in: RoundedRectangle(cornerRadius: cornerRadius))
+                            .padding(.vertical, 5)
+                            .background((item.accent ? AccentColors.aiCoral : .white).opacity(0.22), in: Capsule())
                     }
-                }
-            } else if !state.quickActionButtons.isEmpty {
-                ForEach(state.quickActionButtons, id: \.id) { action in
-                    Link(destination: URL(string: "openglasses://quickaction/\(action.id)")!) {
-                        Label(action.label, systemImage: action.icon)
-                            .font(fontSize)
-                            .foregroundStyle(.white)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, vPadding)
-                            .background(.white.opacity(0.15), in: RoundedRectangle(cornerRadius: cornerRadius))
-                    }
-                }
-            } else {
-                // Fallback: generic actions
-                Link(destination: URL(string: "openglasses://action/ask")!) {
-                    Label("Ask", systemImage: "mic.fill")
-                        .font(fontSize)
-                        .foregroundStyle(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, vPadding)
-                        .background(.white.opacity(0.15), in: RoundedRectangle(cornerRadius: cornerRadius))
-                }
-                Link(destination: URL(string: "openglasses://action/photo")!) {
-                    Label("Photo", systemImage: "camera.fill")
-                        .font(fontSize)
-                        .foregroundStyle(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, vPadding)
-                        .background(.white.opacity(0.15), in: RoundedRectangle(cornerRadius: cornerRadius))
                 }
             }
+        } else {
+            // Lock Screen: chunky capsule buttons, two per row.
+            VStack(spacing: 8) {
+                HStack(spacing: 8) {
+                    if items.indices.contains(0) { chunkyButton(items[0]) }
+                    if items.indices.contains(1) { chunkyButton(items[1]) }
+                }
+                if items.count > 2 {
+                    HStack(spacing: 8) {
+                        chunkyButton(items[2])
+                        if items.indices.contains(3) {
+                            chunkyButton(items[3])
+                        } else {
+                            Color.clear.frame(maxWidth: .infinity)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func chunkyButton(_ item: ActionItem) -> some View {
+        let tint: Color = item.accent ? AccentColors.aiCoral : .white
+        Link(destination: item.url) {
+            HStack(spacing: 7) {
+                Image(systemName: item.icon)
+                    .font(.callout.weight(.semibold))
+                Text(item.label)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+            }
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .padding(.horizontal, 10)
+            .background(tint.opacity(item.accent ? 0.30 : 0.16), in: Capsule())
+            .overlay(Capsule().strokeBorder(tint.opacity(item.accent ? 0.55 : 0.18), lineWidth: 1))
         }
     }
 

--- a/GlassesActivityWidget/GlassesActivityWidget.swift
+++ b/GlassesActivityWidget/GlassesActivityWidget.swift
@@ -137,14 +137,10 @@ struct GlassesActivityWidget: Widget {
             // glasses are disconnected (most actions just open the app via deep link).
             actionButtons(for: context.state, compact: false)
             if !context.state.isConnected {
-                Link(destination: URL(string: "openglasses://connect")!) {
-                    Label("Connect Glasses", systemImage: "antenna.radiowaves.left.and.right")
-                        .font(.caption2.weight(.medium))
-                        .foregroundStyle(.white.opacity(0.7))
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 6)
-                        .background(.white.opacity(0.10), in: Capsule())
-                }
+                chunkyLink(label: "Connect Glasses",
+                           icon: "antenna.radiowaves.left.and.right",
+                           url: URL(string: "openglasses://connect")!,
+                           tint: .green, strong: true)
             }
         }
         .padding(16)
@@ -226,12 +222,18 @@ struct GlassesActivityWidget: Widget {
 
     @ViewBuilder
     private func chunkyButton(_ item: ActionItem) -> some View {
-        let tint: Color = item.accent ? AccentColors.aiCoral : .white
-        Link(destination: item.url) {
+        chunkyLink(label: item.label, icon: item.icon, url: item.url,
+                   tint: item.accent ? AccentColors.aiCoral : .white, strong: item.accent)
+    }
+
+    /// Shared full-width, ~44pt-tall capsule button (used by quick actions and Connect).
+    @ViewBuilder
+    private func chunkyLink(label: String, icon: String, url: URL, tint: Color, strong: Bool) -> some View {
+        Link(destination: url) {
             HStack(spacing: 7) {
-                Image(systemName: item.icon)
+                Image(systemName: icon)
                     .font(.callout.weight(.semibold))
-                Text(item.label)
+                Text(label)
                     .font(.subheadline.weight(.semibold))
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
@@ -240,8 +242,8 @@ struct GlassesActivityWidget: Widget {
             .frame(maxWidth: .infinity)
             .padding(.vertical, 12)
             .padding(.horizontal, 10)
-            .background(tint.opacity(item.accent ? 0.30 : 0.16), in: Capsule())
-            .overlay(Capsule().strokeBorder(tint.opacity(item.accent ? 0.55 : 0.18), lineWidth: 1))
+            .background(tint.opacity(strong ? 0.30 : 0.16), in: Capsule())
+            .overlay(Capsule().strokeBorder(tint.opacity(strong ? 0.55 : 0.18), lineWidth: 1))
         }
     }
 

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -88,6 +88,18 @@ struct QuickAction: Codable, Identifiable {
         ),
     ]
 
+    /// Built-in Field Assist quick action. Injected at the front of `Config.quickActions`
+    /// whenever Field Assist is active (see `withFieldAssistAction`) — it is never persisted,
+    /// so it appears/disappears with the entitlement. A `.prompt` action so it routes through
+    /// the existing pipeline and the AI starts the session via the `field_session` tool.
+    static let fieldAssist = QuickAction(
+        id: "field-assist",
+        label: "Field Assist",
+        icon: "wrench.and.screwdriver.fill",
+        type: .prompt,
+        promptText: "Start a Field Assist session on my default vault. Briefly confirm you're ready and what you can help me troubleshoot."
+    )
+
     static let defaults: [QuickAction] = [
         QuickAction(id: "describe", label: "Describe", icon: "eye", type: .photoThenPrompt,
                     promptText: "Describe what you see in this image in detail."),
@@ -1578,6 +1590,7 @@ struct Config {
     // MARK: - Quick Actions
 
     static var quickActions: [QuickAction] {
+        let base: [QuickAction]
         if let data = UserDefaults.standard.data(forKey: "quickActions"),
            let actions = try? JSONDecoder().decode([QuickAction].self, from: data),
            !actions.isEmpty {
@@ -1585,9 +1598,19 @@ struct Config {
             if merged.count != actions.count {
                 setQuickActions(merged)
             }
-            return merged
+            base = merged
+        } else {
+            base = QuickAction.defaults
         }
-        return QuickAction.defaults
+        return withFieldAssistAction(base)
+    }
+
+    /// Surface the built-in Field Assist quick action (first) when the feature is active.
+    /// Recomputed each read so it tracks the entitlement/toggle: any stale/persisted copy is
+    /// stripped, then re-added only when active — so it never lingers after a lapsed license.
+    private static func withFieldAssistAction(_ actions: [QuickAction]) -> [QuickAction] {
+        let base = actions.filter { $0.id != QuickAction.fieldAssist.id }
+        return fieldAssistActive ? [QuickAction.fieldAssist] + base : base
     }
 
     static func setQuickActions(_ actions: [QuickAction]) {


### PR DESCRIPTION
Makes Field Assist callable from a button and fixes the Lock Screen quick-action buttons.

## Field Assist — now a quick action
Previously Field Assist was **voice-only** (no button). Added a built-in `QuickAction.fieldAssist` — a `.prompt` action that asks the AI to start a field session on the default vault, so it routes through the existing pipeline (no enum surgery). `Config.quickActions`:
- **injects it at the front when `fieldAssistActive`** (entitled *and* switched on), and
- **strips any stale/persisted copy when inactive**, so it appears/disappears with the entitlement and never lingers after a lapsed license.

It shows in the in-app quick-actions grid **and** on the Lock Screen.

## Lock Screen buttons — fixed + chunky
**Root cause of "I'm not seeing any buttons":** the action row was gated behind `context.state.isConnected`. With glasses disconnected (the common case), the Live Activity only showed "Connect & Talk" — persona/quick-action buttons never rendered.

Changes:
- Quick actions now render **regardless of connection** (most just open the app via deep link); a slim "Connect Glasses" affordance appears below when disconnected.
- **Quick actions prioritised over personas** (per request), capped at 4.
- Restyled as **chunky capsule buttons, two per row** (icon + label, ~44pt tall). Field Assist gets the **coral AI accent**; others a neutral tint. Dynamic Island keeps a slim row.

## How to use Field Assist (answering the original question)
1. Unlock it in **Settings → Field Assist** (license code or IAP).
2. It then appears as a **coral "Field Assist" button** on the Lock Screen Live Activity and in the in-app grid. Tap → starts a grounded field session.
3. (Voice still works too: "start a field session on the refrigeration vault".)

## Verification
`xcodebuild … build` (iPhone 17 Pro sim): **BUILD SUCCEEDED**.

## Note
The Field Assist button only appears when Field Assist is **unlocked + enabled** — if it's locked you won't see it (by design; it's the paid feature). Lock Screen text/preview strings here are English-only; can localise in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)