### PR TITLE
Smart connect: hand audio + wake word to glasses when they come on

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -388,6 +388,23 @@ class AppState: ObservableObject, AppStateProtocol {
                 speechService.stopSpeaking()
 
                 NSLog("[Privacy] Glasses disconnected — stopped mic, sessions, camera. Agent continues.")
+            } else if isConnected && !oldValue {
+                // Smart connect: glasses just came on (e.g. mid text-only session). Hand
+                // audio + wake word off to them — the mirror of the teardown above. iOS
+                // routes audio output to the Bluetooth device automatically, but the
+                // wake-word listener has to be (re)started on the glasses mic explicitly.
+                speechService.playConnectTone()
+                NSLog("[SmartConnect] Glasses connected — switching audio + wake word to glasses")
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    // Let the Bluetooth audio link settle before grabbing the mic.
+                    try? await Task.sleep(nanoseconds: 2_500_000_000)
+                    guard self.isConnected else { return }  // bail if it dropped again
+                    self.wakeWordService.reconfigureAudioSessionIfNeeded()
+                    if self.listeningEnabled && !self.isListening {
+                        try? await self.wakeWordService.startListening()
+                    }
+                }
             }
         }
     }

--- a/OpenGlasses/Sources/Services/TextToSpeechService.swift
+++ b/OpenGlasses/Sources/Services/TextToSpeechService.swift
@@ -283,6 +283,14 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
         }
     }
 
+    /// Ascending "glasses connected" cue (counterpart to playDisconnectTone).
+    func playConnectTone() {
+        playTone(frequency: 660, duration: 0.10)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) { [weak self] in
+            self?.playTone(frequency: 990, duration: 0.14)
+        }
+    }
+
     private func playTone(frequency: Double, duration: Double) {
         do {
             let toneData = try Self.generateToneData(frequency: frequency, duration: duration, sampleRate: 44100)


### PR DESCRIPTION
Answers "is there smart connect — start a session, put the glasses on, and everything switches?" It now does.

## Before
The `isConnected` didSet only handled **disconnect** (tear down mic/camera/sessions). The **connect** transition just flipped the flag. So if you started a text-only session and then put the glasses on:
- the wake-word listener (stopped on disconnect, or never started without glasses) was **not** restarted on the glasses mic,
- there was no audible confirmation,
- only iOS's automatic audio-output routing followed the Bluetooth device.

## After
Added a connect branch mirroring the teardown:
- Plays an ascending **"connected" cue** (new `TextToSpeechService.playConnectTone`).
- After a short delay to let the Bluetooth link settle, **reconfigures the audio session and (re)starts the wake-word listener on the glasses mic** — only if the master listening switch is on and we're not already listening. Bails if the glasses dropped again during the delay.

So putting the glasses on mid-session genuinely switches input + wake word over to them, not just audio output.

## Verification
`xcodebuild … build` (iPhone 17 Pro sim): **BUILD SUCCEEDED**. Real behaviour (BT mic switch, cue) needs a device + glasses to confirm.

## Scope notes
- Independent of #25 (widget) — different files.
- Does not migrate an *in-flight* realtime stream; it sets up wake word + audio so the next interaction uses the glasses. Resuming camera streaming on connect was left out deliberately (privacy: don't silently start the camera).

🤖 Generated with [Claude Code](https://claude.com/claude-code)