### PR TITLE
Push-to-Talk mode (reliable) + gentler always-listen audio

### DIFF
--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -58,7 +58,7 @@ struct SettingsView: View {
                 }
 
                 InfoToggle(
-                    title: "Silent Mode",
+                    title: "Push-to-Talk Mode",
                     isOn: Binding(
                         get: { Config.silentMode },
                         set: { newValue in
@@ -71,12 +71,12 @@ struct SettingsView: View {
                             }
                         }
                     ),
-                    info: "Turns off the always-listening wake word detector. The assistant is still fully functional via the Apple Watch, home screen widget, Action Button, and manual mic tap. Useful in meetings or quiet environments."
+                    info: "Turns off the always-on wake-word listener so the mic isn't held in the background — fixes conflicts with music/podcasts playing at the same time. Start a conversation on demand instead: the iPhone Action Button (\"Ask OpenGlasses\"), Siri, the home screen widget, the Apple Watch, or a manual mic tap."
                 )
             } header: {
                 Text("Voice")
             } footer: {
-                Text("The phrase that starts a conversation. Silent Mode keeps the assistant fully available via widget, watch, and Action Button — just without the always-listening mic.")
+                Text("The phrase that starts a conversation. Push-to-Talk Mode stops the always-listening mic (so it won't fight other audio) — trigger on demand via the Action Button, Siri, widget, or watch.")
             }
 
             // MARK: AI Models

--- a/OpenGlasses/Sources/Services/WakeWordService.swift
+++ b/OpenGlasses/Sources/Services/WakeWordService.swift
@@ -140,7 +140,10 @@ class WakeWordService: NSObject, ObservableObject {
         let options: AVAudioSession.CategoryOptions = useGlassesMic
             ? [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
             : [.mixWithOthers, .defaultToSpeaker]
-        try? session.setCategory(.playAndRecord, mode: .measurement, options: options)
+        // .default (not .measurement) so concurrent music/podcasts keep playing cleanly
+        // while the wake-word listener runs — .measurement disables system audio
+        // processing and fights other audio even with .mixWithOthers.
+        try? session.setCategory(.playAndRecord, mode: .default, options: options)
         // notifyOthersOnDeactivation tells paused apps (Music, Podcasts) they can resume.
         try? session.setActive(true, options: .notifyOthersOnDeactivation)
         print("🎤 Restored audio mix — other apps can resume")
@@ -172,7 +175,9 @@ class WakeWordService: NSObject, ObservableObject {
                 let options: AVAudioSession.CategoryOptions = useGlassesMic
                     ? [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
                     : [.mixWithOthers, .defaultToSpeaker]
-                try audioSession.setCategory(.playAndRecord, mode: .measurement, options: options)
+                // .default (not .measurement) so other audio coexists cleanly with the
+                // always-on listener — see resumeOtherAudio for the same rationale.
+                try audioSession.setCategory(.playAndRecord, mode: .default, options: options)
                 try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
                 audioSessionConfigured = true
                 print("🎤 Mic source: \(useGlassesMic ? "glasses (Bluetooth)" : "phone (built-in)")")
@@ -293,6 +298,15 @@ class WakeWordService: NSObject, ObservableObject {
 
     func startListening() async throws {
         guard !isListening else { return }
+        // Push-to-Talk (Silent Mode): never run the always-on wake-word listener.
+        // This is the single chokepoint — every auto-start path (launch, foreground,
+        // glasses connect, returnToWakeWord, autoStart) funnels through here, so the
+        // mic is never held for constant listening. On-demand triggers (Action Button →
+        // startDirectTranscription) bypass this and still work.
+        if Config.silentMode {
+            print("🎤 Push-to-Talk mode — skipping always-on wake-word listener")
+            return
+        }
         stopFired = false
         wakeWordFired = false
         silentBufferCount = 0


### PR DESCRIPTION
Addresses "constant listening was a problem with other audio playing" + "I'd like to toggle push-to-talk on/off". Both done.

## 1. Reliable Push-to-Talk toggle
There was already a **Silent Mode** toggle meant to disable the always-on listener — but `Config.silentMode` was only checked in **3 scattered places**, so other paths still started the constant listener and leaked the mic back on (foreground, glasses connect — including the new smart-connect hand-off — `returnToWakeWord`, `autoStart`).

Fix: move the gate to the **single chokepoint** `WakeWordService.startListening()` — if `Config.silentMode`, skip the always-on listener entirely. Every auto-start funnels through here, so it's now airtight. On-demand triggers (Action Button → `startDirectTranscription`, Siri, widget, watch, mic tap) bypass it and still work.

Relabelled the toggle **"Push-to-Talk Mode"** (storage key `silentMode` unchanged) with copy explaining it stops the always-on mic and how to trigger on demand.

## 2. Gentler always-listen audio
Constant listening used `.playAndRecord` + **`.measurement`** mode, which disables iOS audio processing and attenuates/fights concurrent music/podcasts even with `.mixWithOthers`. Switched the always-on config (`configureAudioSession` + `resumeOtherAudio`) to **`.default`** mode so other audio keeps playing cleanly. The deliberate `pauseOtherAudio` path (which interrupts audio *during* active command capture, by design) is unchanged.

## Action Button (answering the earlier question)
Already wired: bind iOS Settings → Action Button → Shortcut → **"Ask OpenGlasses"** (`AskOpenGlassesIntent`) — skips the wake word and starts transcribing. With Push-to-Talk on, that's the primary trigger.

## Verification
`xcodebuild … build` (iPhone 17 Pro sim): **BUILD SUCCEEDED**.

## ⚠️ Device-only
Audio-session behaviour (music coexistence, mic) can't be exercised on the Simulator. Please verify on-device:
1. Push-to-Talk ON → play music → confirm it keeps playing and no wake-word mic is held; Action Button still starts a conversation.
2. Push-to-Talk OFF + music playing → confirm music coexists with the always-on listener (the `.measurement`→`.default` change) and ducks/pauses only during an active command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)