### PR TITLE
Fix Push-to-Talk: stop button, phone-only tap-to-talk, audible Action Button

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -1791,8 +1791,18 @@ class AppState: ObservableObject, AppStateProtocol {
         Task {
             // Configure audio (uses glasses mic if connected, phone mic otherwise)
             wakeWordService.configureAudioSession()
-            await handleWakeWordDetected()
+            // manual: true — this is an explicit user trigger (Action Button / Siri / tap),
+            // so the reply speaks through the phone speaker even with no glasses connected.
+            await handleWakeWordDetected(manual: true)
         }
+    }
+
+    /// End the current voice session immediately — backs the in-app "Tap to stop"
+    /// button and any explicit Push-to-Talk end. Stops the recorder (which otherwise
+    /// only ends on silence) and resets conversation state.
+    func endListeningSession() {
+        transcriptionService.stopRecording()
+        Task { await returnToWakeWord() }
     }
 
     /// Whether the current conversation was started by an explicit user tap (not wake word).

--- a/OpenGlasses/Sources/App/Views/BottomControlBar.swift
+++ b/OpenGlasses/Sources/App/Views/BottomControlBar.swift
@@ -141,8 +141,20 @@ struct BottomControlBar: View {
             ) {
                 appState.cancelCurrentResponse()
             }
-        } else if !appState.isConnected {
-            // Disconnected — one tap to reconnect + start listening
+        } else if appState.isListening {
+            // Active voice session — explicit End button. Shown regardless of glasses
+            // connection so Push-to-Talk / phone-only sessions can always be stopped.
+            ActionCapsule(
+                icon: "stop.circle.fill",
+                label: "Tap to stop",
+                isActive: true,
+                color: .orange,
+                showMuteBadge: appState.micMuted
+            ) {
+                appState.endListeningSession()
+            }
+        } else if !appState.isConnected && !Config.silentMode {
+            // Disconnected and not in Push-to-Talk — one tap to reconnect + start listening
             ActionCapsule(
                 icon: "OpenGlassesLogo",
                 label: "Connect & Talk",
@@ -153,21 +165,17 @@ struct BottomControlBar: View {
                 }
             }
         } else {
+            // Idle — tap to talk. Works phone-only (Push-to-Talk) or through the glasses.
             ActionCapsule(
-                icon: appState.isListening ? "waveform.circle.fill" : "mic.fill",
-                label: appState.isListening ? "Listening..." : "Tap to talk",
-                isActive: appState.isListening,
+                icon: "mic.fill",
+                label: "Tap to talk",
                 color: accent,
                 showMuteBadge: appState.micMuted
             ) {
                 Task {
-                    if appState.isListening {
-                        await appState.returnToWakeWord()
-                    } else {
-                        appState.wakeWordService.stopListening()
-                        try? await Task.sleep(nanoseconds: 100_000_000)
-                        await appState.handleWakeWordDetected(manual: true)
-                    }
+                    appState.wakeWordService.stopListening()
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                    await appState.handleWakeWordDetected(manual: true)
                 }
             }
         }


### PR DESCRIPTION
Fixes the real-device Push-to-Talk problems: no end button, no in-app way to talk without glasses, and a silent Action Button.

## Root causes
The hero button's if-chain checked **`!isConnected` before `isListening`**, so with glasses off:
- an active phone-only session showed **"Connect & Talk"**, never a stop control — and the recorder only ends on silence, so there was **no way to end a session**;
- idle showed only "Connect & Talk" (connect glasses) — **no phone-only tap-to-talk**.

And `startDirectTranscription()` (the Action Button path) called `handleWakeWordDetected()` with **`manual: false`**, so with no glasses the reply never spoke through the phone — the Action Button "did nothing".

## Fixes
1. **Explicit Stop.** Active session now always shows an orange **"Tap to stop"** (checked before the connection branch, so it works with or without glasses). Backed by new `AppState.endListeningSession()` — stops the recorder (`transcriptionService.stopRecording()`) and resets state via `returnToWakeWord()`.
2. **Phone-only Tap-to-talk.** Idle now shows **"Tap to talk"** in Push-to-Talk mode (or when connected) and starts a manual session on the phone mic; **"Connect & Talk"** only appears when disconnected *and* not in Push-to-Talk.
3. **Audible Action Button.** `startDirectTranscription` passes `manual: true`, so the reply speaks through the phone speaker even with no glasses.

## Verification
`xcodebuild … build` (iPhone 17 Pro sim): **BUILD SUCCEEDED**. On-device check: PTT on, glasses off → "Tap to talk" starts a session, "Tap to stop" ends it, Action Button ("Ask OpenGlasses") starts an audible session.

## Note on the Action Button setup
The button still has to be assigned in iOS Settings → Action Button → Shortcut → "Ask OpenGlasses" (or Siri). This PR makes the resulting session actually work end-to-end; it can't auto-assign the hardware button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)