### PR TITLE
Candidate fix for gemma-4 MLX crash (SmallVector out of range) + logging

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -1791,8 +1791,18 @@ class AppState: ObservableObject, AppStateProtocol {
         Task {
             // Configure audio (uses glasses mic if connected, phone mic otherwise)
             wakeWordService.configureAudioSession()
-            await handleWakeWordDetected()
+            // manual: true — this is an explicit user trigger (Action Button / Siri / tap),
+            // so the reply speaks through the phone speaker even with no glasses connected.
+            await handleWakeWordDetected(manual: true)
         }
+    }
+
+    /// End the current voice session immediately — backs the in-app "Tap to stop"
+    /// button and any explicit Push-to-Talk end. Stops the recorder (which otherwise
+    /// only ends on silence) and resets conversation state.
+    func endListeningSession() {
+        transcriptionService.stopRecording()
+        Task { await returnToWakeWord() }
     }
 
     /// Whether the current conversation was started by an explicit user tap (not wake word).

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2147,13 +2147,27 @@ class AppState: ObservableObject, AppStateProtocol {
         var originalModelId: String?
         var useLocalAgent = false
 
-        // Route fast-tier queries to on-device Gemma 4 when agentic mode is on + model downloaded
+        // Route fast-tier queries to the agent model when agentic mode is on + model ready.
+        // If the agent model is the on-device MLX model, only do so when the user has
+        // opted in (localAgentEnabled, default off) — that path can fatally crash. Cloud
+        // agent models route normally.
+        let agentIsCloud = Config.savedModels.contains(where: { $0.id == Config.agentModelId })
         if classification.modelTier == .fast,
            Config.agentModeEnabled,
            Config.agentModelDownloaded,
+           (agentIsCloud || Config.localAgentEnabled),
            !isPhotoCommand(query) {
             useLocalAgent = true
-            print("🧠 Routing to local agent (fast tier, agentic mode)")
+            print("🧠 Routing to agent model (fast tier, agentic mode)\(agentIsCloud ? " [cloud]" : " [on-device]")")
+        } else if classification.modelTier == .fast, Config.agentModeEnabled, Config.agentModelDownloaded, !isPhotoCommand(query) {
+            print("🧠 Skipping on-device agent (localAgentEnabled off) — routing to cloud instead")
+            if Config.autoModelRoutingEnabled,
+               let tierModel = Config.modelForTier(classification.modelTier),
+               tierModel.id != Config.activeModelId {
+                originalModelId = Config.activeModelId
+                Config.setActiveModelId(tierModel.id)
+                llmService.refreshActiveModel()
+            }
         } else if Config.autoModelRoutingEnabled,
            let tierModel = Config.modelForTier(classification.modelTier),
            tierModel.id != Config.activeModelId {

--- a/OpenGlasses/Sources/App/Views/AgenticFeaturesView.swift
+++ b/OpenGlasses/Sources/App/Views/AgenticFeaturesView.swift
@@ -119,10 +119,19 @@ struct AgenticFeaturesView: View {
                             .font(.caption)
                             .foregroundStyle(.red)
                     }
+
+                    InfoToggle(
+                        title: "Run On-Device Model (experimental)",
+                        isOn: Binding(
+                            get: { Config.localAgentEnabled },
+                            set: { Config.setLocalAgentEnabled($0) }
+                        ),
+                        info: "Off by default. The bundled on-device (MLX) model is experimental and can crash during inference on some queries. When off, fast queries route to a cloud model instead even if an on-device model is selected. Turn on to use the on-device model for fast, offline tool calls — at the risk of instability."
+                    )
                 } header: {
                     Text("Agent Model")
                 } footer: {
-                    Text("Pick a downloaded local model (runs offline) or any configured cloud provider. Local handles fast tool calls; cloud handles complex reasoning.")
+                    Text("Pick a downloaded local model (runs offline) or any configured cloud provider. Cloud handles all tiers reliably; the on-device model is experimental (see the toggle).")
                 }
 
                 // Chattiness

--- a/OpenGlasses/Sources/App/Views/BottomControlBar.swift
+++ b/OpenGlasses/Sources/App/Views/BottomControlBar.swift
@@ -141,8 +141,20 @@ struct BottomControlBar: View {
             ) {
                 appState.cancelCurrentResponse()
             }
-        } else if !appState.isConnected {
-            // Disconnected — one tap to reconnect + start listening
+        } else if appState.isListening {
+            // Active voice session — explicit End button. Shown regardless of glasses
+            // connection so Push-to-Talk / phone-only sessions can always be stopped.
+            ActionCapsule(
+                icon: "stop.circle.fill",
+                label: "Tap to stop",
+                isActive: true,
+                color: .orange,
+                showMuteBadge: appState.micMuted
+            ) {
+                appState.endListeningSession()
+            }
+        } else if !appState.isConnected && !Config.silentMode {
+            // Disconnected and not in Push-to-Talk — one tap to reconnect + start listening
             ActionCapsule(
                 icon: "OpenGlassesLogo",
                 label: "Connect & Talk",
@@ -153,21 +165,17 @@ struct BottomControlBar: View {
                 }
             }
         } else {
+            // Idle — tap to talk. Works phone-only (Push-to-Talk) or through the glasses.
             ActionCapsule(
-                icon: appState.isListening ? "waveform.circle.fill" : "mic.fill",
-                label: appState.isListening ? "Listening..." : "Tap to talk",
-                isActive: appState.isListening,
+                icon: "mic.fill",
+                label: "Tap to talk",
                 color: accent,
                 showMuteBadge: appState.micMuted
             ) {
                 Task {
-                    if appState.isListening {
-                        await appState.returnToWakeWord()
-                    } else {
-                        appState.wakeWordService.stopListening()
-                        try? await Task.sleep(nanoseconds: 100_000_000)
-                        await appState.handleWakeWordDetected(manual: true)
-                    }
+                    appState.wakeWordService.stopListening()
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                    await appState.handleWakeWordDetected(manual: true)
                 }
             }
         }

--- a/OpenGlasses/Sources/Services/Gemma4Text.swift
+++ b/OpenGlasses/Sources/Services/Gemma4Text.swift
@@ -187,8 +187,32 @@ nonisolated class Gemma4ProportionalRoPE: Module, OffsetLayer {
         super.init()
     }
 
+    nonisolated(unsafe) private static var didLogShapes = false
+
     func callAsFunction(_ x: MLXArray, offset: Int) -> MLXArray {
         guard rotatedDims > 0 else { return x }
+
+        if !Self.didLogShapes {
+            Self.didLogShapes = true
+            print("🔬 Gemma4 RoPE: x.shape=\(x.shape) dims=\(dims) rotatedDims=\(rotatedDims) half=\(dims / 2) offset=\(offset)")
+        }
+
+        // Full rotary (rotatedDims == dims): the split/concat path below produces
+        // zero-length slices — left[(rotatedDims/2)...] etc. — and concatenating empty
+        // arrays crashes mlx-c with "SmallVector out of range". Apply RoPE to the whole
+        // rotated span directly; this is mathematically identical to the split/concat
+        // when rotatedDims == dims, just without the empty slices.
+        if rotatedDims >= dims {
+            let head = x[.ellipsis, 0 ..< dims]
+            let rotated = MLXFast.RoPE(
+                head, dimensions: rotatedDims, traditional: traditional,
+                base: nil, scale: 1.0, offset: offset, freqs: _freqs
+            )
+            if x.shape.last! > dims {
+                return concatenated([rotated, x[.ellipsis, dims...]], axis: -1)
+            }
+            return rotated
+        }
 
         let head = x[.ellipsis, 0 ..< dims]
         let half = dims / 2
@@ -304,6 +328,8 @@ nonisolated class Gemma4Attention: Module {
         super.init()
     }
 
+    nonisolated(unsafe) private static var didLogAttn = false
+
     func callAsFunction(
         _ x: MLXArray,
         mask: MLXFast.ScaledDotProductAttentionMaskMode? = nil,
@@ -343,7 +369,15 @@ nonisolated class Gemma4Attention: Module {
         var adjustedMask = mask
         if case .array(let maskArray) = mask {
             let keysSeqLen = keys.dim(2)
-            if maskArray.shape.last! != keysSeqLen {
+            let maskLen = maskArray.shape.last ?? keysSeqLen
+            if !Self.didLogAttn {
+                Self.didLogAttn = true
+                print("🔬 Gemma4 attn: B=\(B) L=\(L) keys.shape=\(keys.shape) queries.shape=\(queries.shape) maskLen=\(maskLen) keysSeqLen=\(keysSeqLen)")
+            }
+            // Only trim when the mask is LONGER than the key sequence — slicing
+            // 0..<keysSeqLen when keysSeqLen exceeds the mask's last dim would itself
+            // be out of range. If it's shorter/equal, pass it through unchanged.
+            if maskLen > keysSeqLen {
                 adjustedMask = .array(maskArray[.ellipsis, 0 ..< keysSeqLen].asType(queries.dtype))
             } else {
                 adjustedMask = .array(maskArray.asType(queries.dtype))

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -2596,6 +2596,18 @@ struct Config {
     static func setAgentModelDownloaded(_ value: Bool) {
         UserDefaults.standard.set(value, forKey: "agentModelDownloaded")
     }
+
+    /// Whether fast-tier queries may run on the *on-device* MLX agent model.
+    /// Default off: the bundled gemma-4 MLX path can fatally crash during inference
+    /// ("SmallVector out of range"), and that crash is uncatchable, so we don't route
+    /// to it unless the user explicitly opts in. Cloud agent models are unaffected.
+    static var localAgentEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "localAgentEnabled")
+    }
+
+    static func setLocalAgentEnabled(_ value: Bool) {
+        UserDefaults.standard.set(value, forKey: "localAgentEnabled")
+    }
 }
 
 // MARK: - App Mode Enum


### PR DESCRIPTION
Follow-up to the routing guard (#30) — the actual on-device gemma-4 crash.

## Diagnosis
`SmallVector out of range` (mlx-c `array.cpp:335`) localized to the custom **`Gemma4ProportionalRoPE`** partial-rotary split/concat ([Gemma4Text.swift](OpenGlasses/Sources/Services/Gemma4Text.swift)). When a "proportional" RoPE layer has **`partialRotaryFactor == 1.0`**, `rotatedDims == dims`, so:
```swift
left[.ellipsis, (rotatedDims / 2)...]   // zero-length
right[.ellipsis, (rotatedDims / 2)...]  // zero-length
```
…and concatenating empty arrays crashes mlx-c.

## Candidate fix
- **Full-rotary fast path:** when `rotatedDims >= dims`, apply `MLXFast.RoPE` to the whole span directly — provably identical to the split/concat in that case, minus the empty slices. Partial-rotary path (factor < 1) untouched.
- **Mask hardening:** only trim the attention mask when it's *longer* than the key sequence (the old `0..<keysSeqLen` could itself go out of range if `keysSeqLen` exceeded the mask).
- **One-shot 🔬 shape logging** in the RoPE + attention so an on-device run confirms the fix or points elsewhere.

## ⚠️ Unverified — needs on-device test
MLX/Metal don't run on the Simulator, so I can't exercise this. To test:
1. Merge **#30** first (adds the `localAgentEnabled` toggle).
2. Enable **Agentic Features → Agent Model → "Run On-Device Model (experimental)"** and set the agent model to gemma-4.
3. Ask a fast query → it should answer instead of crashing. Watch the log for `🔬 Gemma4 RoPE:` / `🔬 Gemma4 attn:` — if it still crashes, those shapes tell us the real op.

`xcodebuild … build` (iPhone 17 Pro sim): **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)