### PR TITLE
Fix gemma-4 (Local Gemini) crash: 2D token input, not 1D

### DIFF
--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import HuggingFace
+import MLX
 import MLXHuggingFace
 import MLXLLM
 import MLXLMCommon
@@ -234,7 +235,12 @@ final class LocalLLMService: ObservableObject {
             fallbackMessages.append(["role": "user", "content": combinedUserMessage])
             tokens = try tokenizer.applyChatTemplate(messages: fallbackMessages)
         }
-        let input = LMInput(text: .init(tokens: .init(tokens)))
+        // Build a 2D (1, L) batch, not a 1D (L,) array. The Gemma 4 / 3n forward pass
+        // indexes x.dim(2) and fatally crashes ("SmallVector out of range") on 1D input —
+        // its prepare() path doesn't expand 1D internally (ml-explore/mlx-swift-lm#240).
+        // Other models accept (1, L) fine, so this is safe across the board.
+        let tokenIDs = MLXArray(tokens).expandedDimensions(axis: 0)
+        let input = LMInput(text: .init(tokens: tokenIDs))
 
         // Watch for backgrounding *during* generation. The pre-check above covers
         // the already-backgrounded case; this covers the app being sent to the


### PR DESCRIPTION
**The actual root cause of the on-device gemma-4 crash, found via the upstream issue tracker.**

## Crash
`MLX … Fatal error: SmallVector out of range` (mlx-c `array.cpp:335`) on every Local Gemini query — uncatchable, terminates the app.

## Root cause
`LocalLLMService.generate()` built `LMInput` from `MLXArray(tokens)` where `tokens` is `[Int]` — a **1D `(L,)` array**. The Gemma 4 / 3n forward pass indexes `x.dim(2)` (it expects `(B, L)` tokens → `(B, L, D)` hidden states). On 1D input the embedding produces a 2D `(L, D)` tensor and `dim(2)` is **out of range** → fatal crash. Standard models' `prepare()` expands 1D internally; the Gemma 4 path does **not** — documented upstream in [ml-explore/mlx-swift-lm#240](https://github.com/ml-explore/mlx-swift-lm/issues/240) ("Gemma 4 VLM: crash … 1D input shape").

## Fix
Build a 2D batch:
```swift
let tokenIDs = MLXArray(tokens).expandedDimensions(axis: 0)   // (1, L)
let input = LMInput(text: .init(tokens: tokenIDs))
```
This is exactly the fix the upstream issue recommends. `(1, L)` is accepted by every local model, so it's safe across the board. Adds `import MLX`.

## Confidence / verification
High confidence — directly matches the documented upstream cause and explains the exact error, unlike the earlier RoPE-bypass hypothesis (#31, harmless but not the cause). **Cannot run on the Simulator** (no MLX/Metal), so please confirm on-device: select **Local Gemini** and ask a question — it should now answer instead of crashing.

`xcodebuild … build` (iPhone 17 Pro sim): **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)