### PR TITLE
NSLog diagnostics for the gemma-4 crash (survive fatal MLX error)

### DIFF
--- a/OpenGlasses/Sources/Services/Gemma4Text.swift
+++ b/OpenGlasses/Sources/Services/Gemma4Text.swift
@@ -194,7 +194,7 @@ nonisolated class Gemma4ProportionalRoPE: Module, OffsetLayer {
 
         if !Self.didLogShapes {
             Self.didLogShapes = true
-            print("🔬 Gemma4 RoPE: x.shape=\(x.shape) dims=\(dims) rotatedDims=\(rotatedDims) half=\(dims / 2) offset=\(offset)")
+            NSLog("🔬 Gemma4 RoPE x.shape=%@ dims=%d rotatedDims=%d offset=%d", "\(x.shape)", dims, rotatedDims, offset)
         }
 
         // Full rotary (rotatedDims == dims): the split/concat path below produces
@@ -372,7 +372,7 @@ nonisolated class Gemma4Attention: Module {
             let maskLen = maskArray.shape.last ?? keysSeqLen
             if !Self.didLogAttn {
                 Self.didLogAttn = true
-                print("🔬 Gemma4 attn: B=\(B) L=\(L) keys.shape=\(keys.shape) queries.shape=\(queries.shape) maskLen=\(maskLen) keysSeqLen=\(keysSeqLen)")
+                NSLog("🔬 Gemma4 attn B=%d L=%d keys.shape=%@ queries.shape=%@ maskLen=%d keysSeqLen=%d", B, L, "\(keys.shape)", "\(queries.shape)", maskLen, keysSeqLen)
             }
             // Only trim when the mask is LONGER than the key sequence — slicing
             // 0..<keysSeqLen when keysSeqLen exceeds the mask's last dim would itself

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -240,6 +240,9 @@ final class LocalLLMService: ObservableObject {
         // its prepare() path doesn't expand 1D internally (ml-explore/mlx-swift-lm#240).
         // Other models accept (1, L) fine, so this is safe across the board.
         let tokenIDs = MLXArray(tokens).expandedDimensions(axis: 0)
+        // NSLog (not print) so it survives the fatal MLX crash in the unified log,
+        // confirming the 2D fix is live and what shape reaches the model.
+        NSLog("🔬 LocalLLM.generate model=%@ tokenIDs.shape=%@ count=%d", loadedModelId ?? "?", "\(tokenIDs.shape)", tokens.count)
         let input = LMInput(text: .init(tokens: tokenIDs))
 
         // Watch for backgrounding *during* generation. The pre-check above covers


### PR DESCRIPTION
Crash-surviving NSLog so the next on-device run is definitive: confirms whether the #32 2D-token fix is in the running build (`🔬 LocalLLM.generate … tokenIDs.shape=[1, N]`) and, if it still crashes, the exact shapes at the RoPE/attention site. Logging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)