### PR TITLE
Field Assist Modes panel: vault switcher + scenarios from selected vault

### DIFF
--- a/OpenGlasses/Sources/App/Views/PersonaPickerSheet.swift
+++ b/OpenGlasses/Sources/App/Views/PersonaPickerSheet.swift
@@ -292,6 +292,7 @@ struct PersonaPickerTab: View {
                 ForEach(unlockedVaults, id: \.id) { manifest in
                     Button {
                         faVaultId = manifest.id
+                        applyVaultModel(manifest.id)
                     } label: {
                         if faVaultId == manifest.id {
                             Label(manifest.name, systemImage: "checkmark")
@@ -322,6 +323,23 @@ struct PersonaPickerTab: View {
             }
             .accessibilityLabel("Active vault: \(current?.name ?? "none"). Tap to switch.")
 
+            // Per-vault model — this vault remembers its model; switching vaults applies it.
+            Picker("Model for this vault", selection: Binding(
+                get: { Config.fieldAssistVaultModelId(for: faVaultId) ?? "" },
+                set: { newId in
+                    Config.setFieldAssistVaultModelId(newId.isEmpty ? nil : newId, for: faVaultId)
+                    if !newId.isEmpty {
+                        Config.setActiveModelId(newId)
+                        appState.llmService.refreshActiveModel()
+                    }
+                }
+            )) {
+                Text("Use current model").tag("")
+                ForEach(Config.savedModels) { model in
+                    Text(model.name).tag(model.id)
+                }
+            }
+
             NavigationLink {
                 FieldAssistSettingsView()
             } label: {
@@ -330,7 +348,7 @@ struct PersonaPickerTab: View {
         } header: {
             Text("Field Assist")
         } footer: {
-            Text("Switch the active knowledge vault. Tap Manage for license, vault editing, and sessions.")
+            Text("Switch the active knowledge vault — each vault remembers its own model and applies it when selected. Tap Manage for license, vault editing, and sessions.")
         }
 
         if let current {
@@ -365,6 +383,14 @@ struct PersonaPickerTab: View {
                 Text("Guided, step-by-step procedures in this vault. Start one hands-free during a session: \u{201C}start the \u{2039}name\u{203A} procedure.\u{201D}")
             }
         }
+    }
+
+    /// Apply a vault's linked model (if any) to the active model.
+    private func applyVaultModel(_ vaultId: String) {
+        guard let modelId = Config.fieldAssistVaultModelId(for: vaultId),
+              Config.savedModels.contains(where: { $0.id == modelId }) else { return }
+        Config.setActiveModelId(modelId)
+        appState.llmService.refreshActiveModel()
     }
 
     private func activatePersona(_ persona: Persona) {

--- a/OpenGlasses/Sources/App/Views/PersonaPickerSheet.swift
+++ b/OpenGlasses/Sources/App/Views/PersonaPickerSheet.swift
@@ -132,6 +132,8 @@ struct PersonaPickerTab: View {
     @ObservedObject var appState: AppState
 
     @State private var editingPersona: Persona? = nil
+    @AppStorage("fieldAssistEnabled") private var faEnabled: Bool = false
+    @AppStorage("fieldAssistDefaultVaultId") private var faVaultId: String = "refrigeration"
 
     var body: some View {
         List {
@@ -228,48 +230,141 @@ struct PersonaPickerTab: View {
     /// Field Assist screen (license/paywall, master toggle, vault picker, sessions).
     @ViewBuilder
     private var fieldAssistSection: some View {
+        if !Config.fieldAssistUnlocked {
+            Section {
+                fieldAssistLink(subtitle: "Unlock for grounded field-engineer guidance", locked: true)
+            } header: {
+                Text("Field Assist")
+            } footer: {
+                Text("Hands-free, domain-grounded guidance for field engineers — load a knowledge vault and run grounded, audited sessions.")
+            }
+        } else if !faEnabled {
+            Section {
+                fieldAssistLink(subtitle: "Tap to enable", locked: false)
+            } header: {
+                Text("Field Assist")
+            }
+        } else {
+            fieldAssistActivePanel
+        }
+    }
+
+    /// Header row that opens the full Field Assist screen.
+    @ViewBuilder
+    private func fieldAssistLink(subtitle: String, locked: Bool) -> some View {
+        NavigationLink {
+            FieldAssistSettingsView()
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "wrench.and.screwdriver.fill")
+                    .font(.title3)
+                    .foregroundStyle(AccentColors.aiCoral)
+                    .frame(width: 32)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Field Assist")
+                        .font(.body.weight(.medium))
+                        .foregroundStyle(Color(.label))
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if locked {
+                    Image(systemName: "lock.fill")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .accessibilityLabel("Field Assist. \(subtitle)")
+    }
+
+    /// Active panel: quick vault switcher + the selected vault's scenarios (procedures).
+    @ViewBuilder
+    private var fieldAssistActivePanel: some View {
+        let unlockedVaults = VaultRegistry.shared.allManifests.filter { VaultRegistry.shared.isUnlocked($0) }
+        let current = VaultRegistry.shared.manifest(id: faVaultId)
+
         Section {
-            NavigationLink {
-                FieldAssistSettingsView()
+            // Quick vault switcher
+            Menu {
+                ForEach(unlockedVaults, id: \.id) { manifest in
+                    Button {
+                        faVaultId = manifest.id
+                    } label: {
+                        if faVaultId == manifest.id {
+                            Label(manifest.name, systemImage: "checkmark")
+                        } else {
+                            Text(manifest.name)
+                        }
+                    }
+                }
             } label: {
                 HStack(spacing: 12) {
                     Image(systemName: "wrench.and.screwdriver.fill")
                         .font(.title3)
                         .foregroundStyle(AccentColors.aiCoral)
                         .frame(width: 32)
-                        .accessibilityHidden(true)
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Field Assist")
                             .font(.body.weight(.medium))
                             .foregroundStyle(Color(.label))
-                        Text(fieldAssistSubtitle)
+                        Text(current?.name ?? "Choose a vault")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
-                    if Config.fieldAssistActive {
-                        Text("On")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(.green)
-                    } else if !Config.fieldAssistUnlocked {
-                        Image(systemName: "lock.fill")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
-            .accessibilityLabel("Field Assist. \(fieldAssistSubtitle)")
+            .accessibilityLabel("Active vault: \(current?.name ?? "none"). Tap to switch.")
+
+            NavigationLink {
+                FieldAssistSettingsView()
+            } label: {
+                Label("Manage Field Assist", systemImage: "gearshape")
+            }
         } header: {
             Text("Field Assist")
         } footer: {
-            Text("Hands-free, domain-grounded guidance for field engineers — load a knowledge vault and run grounded, audited sessions.")
+            Text("Switch the active knowledge vault. Tap Manage for license, vault editing, and sessions.")
         }
-    }
 
-    private var fieldAssistSubtitle: String {
-        if !Config.fieldAssistUnlocked { return "Unlock for grounded field-engineer guidance" }
-        if Config.fieldAssistActive { return "On — manage vaults & sessions" }
-        return "Tap to enable"
+        if let current {
+            let procedures = ProcedureLibrary(store: VaultRegistry.shared.store(for: current)).all
+            Section {
+                if procedures.isEmpty {
+                    Text("No guided scenarios in this vault — the assistant still answers grounded questions from its reference files.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(procedures) { proc in
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(proc.title)
+                                .font(.body.weight(.medium))
+                                .foregroundStyle(Color(.label))
+                            if let desc = proc.description, !desc.isEmpty {
+                                Text(desc)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                            }
+                            Text("\(proc.steps.count) step\(proc.steps.count == 1 ? "" : "s")")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            } header: {
+                Text("Scenarios — \(current.name)")
+            } footer: {
+                Text("Guided, step-by-step procedures in this vault. Start one hands-free during a session: \u{201C}start the \u{2039}name\u{203A} procedure.\u{201D}")
+            }
+        }
     }
 
     private func activatePersona(_ persona: Persona) {

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -2346,6 +2346,26 @@ struct Config {
         UserDefaults.standard.set(id, forKey: "fieldAssistDefaultVaultId")
     }
 
+    // MARK: - Per-vault model linking
+
+    /// The model a given Field Assist vault is linked to (a savedModel id). nil = use
+    /// whatever the current active model is. Lets each vault carry its own model so
+    /// switching vaults switches the model.
+    static func fieldAssistVaultModelId(for vaultId: String) -> String? {
+        let map = UserDefaults.standard.dictionary(forKey: "fieldAssistVaultModels") as? [String: String] ?? [:]
+        return map[vaultId]
+    }
+
+    static func setFieldAssistVaultModelId(_ modelId: String?, for vaultId: String) {
+        var map = UserDefaults.standard.dictionary(forKey: "fieldAssistVaultModels") as? [String: String] ?? [:]
+        if let modelId, !modelId.isEmpty {
+            map[vaultId] = modelId
+        } else {
+            map.removeValue(forKey: vaultId)
+        }
+        UserDefaults.standard.set(map, forKey: "fieldAssistVaultModels")
+    }
+
     /// Optional webhook (Slack-compatible) paged when a technician escalates to a human expert.
     /// Empty = local notification only.
     static var expertWebhookURL: String {


### PR DESCRIPTION
Per request: the **Field Assist panel on the Modes tab** (not the settings screen) should show the **scenarios from the selected vault** and let you **quickly change vaults**.

## What
When Field Assist is active, the Modes-tab section becomes a real panel:
- **Quick vault switcher** — a Menu over unlocked vaults, bound to `fieldAssistDefaultVaultId`. Switch the active vault inline; the scenarios update immediately.
- **Scenarios** — lists the selected vault's procedures (title, description, step count) — the guided step-by-step flows that vault ships.
- **Manage Field Assist** — link to the full screen (license, vault editing, sessions).

Locked → unlock link; unlocked-but-disabled → enable link (unchanged).

## Verification
`xcodebuild … build` (iPhone 17 Pro sim): **BUILD SUCCEEDED**.

## Open question (the "maybe")
You mentioned "maybe linked model connections?" — I held off because it's ambiguous. See my follow-up; tell me what you mean and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)