### PR TITLE
Fix near-silent TTS volume on iPhone speaker when glasses disconnected

### DIFF
--- a/OpenGlasses/Sources/Services/WakeWordService.swift
+++ b/OpenGlasses/Sources/Services/WakeWordService.swift
@@ -120,9 +120,19 @@ class WakeWordService: NSObject, ObservableObject {
         let options: AVAudioSession.CategoryOptions = useGlassesMic
             ? [.allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
             : [.defaultToSpeaker]
-        try? session.setCategory(.playAndRecord, mode: .measurement, options: options)
+        // .default (NOT .measurement): .measurement disables system audio processing/gain,
+        // which makes TTS playback extremely quiet on the iPhone speaker. The wake-word /
+        // command capture works fine in .default (see resumeOtherAudio, which already does this).
+        try? session.setCategory(.playAndRecord, mode: .default, options: options)
         try? session.setActive(true)
-        print("🎤 Pausing other audio for active listening")
+        // Belt-and-suspenders: when not on a Bluetooth (glasses) route, force the main
+        // speaker so playback never ends up stuck on the receiver/earpiece.
+        let onBluetooth = session.currentRoute.outputs.contains {
+            [.bluetoothHFP, .bluetoothA2DP, .bluetoothLE].contains($0.portType)
+        }
+        if !onBluetooth { try? session.overrideOutputAudioPort(.speaker) }
+        let outRoute = session.currentRoute.outputs.map { $0.portType.rawValue }.joined(separator: ",")
+        print("🎤 Pausing other audio for active listening — output route: \(outRoute)")
     }
 
     /// Restore other audio (podcasts, music) after active listening ends.


### PR DESCRIPTION
## Problem

When the Ray-Ban Meta glasses aren't connected and the app falls back to the iPhone speaker, TTS played at an extremely low volume from the built-in speakers (audible from both speakers, but very quiet).

## Cause

`WakeWordService.pauseOtherAudio()` — invoked whenever a conversation goes active (and via TTS's `beginPause`) — configured the shared `AVAudioSession` with `mode: .measurement`. That mode disables system audio processing/gain, which makes media playback very quiet. `resumeOtherAudio()` already uses `.default` for the always-on listener for exactly this reason.

## Fix

- Use `.default` mode in `pauseOtherAudio()` too (wake-word / command capture works fine in `.default`), restoring normal playback volume.
- Force the main speaker via `overrideOutputAudioPort(.speaker)` when not on a Bluetooth route, so output never sticks on the receiver/earpiece.

## Testing

Verified on-device (iPhone 16 Pro Max, iOS 26): with glasses disconnected, TTS now plays at full volume from the iPhone speakers instead of near-silent.
