### PR TITLE
Add iPhone back-camera fallback for photo capture when glasses unavailable

### DIFF
--- a/OpenGlasses/Sources/Services/CameraService.swift
+++ b/OpenGlasses/Sources/Services/CameraService.swift
@@ -59,6 +59,9 @@ class CameraService: ObservableObject {
     /// Number of consecutive stall recoveries (for diagnostics).
     private var stallRecoveryCount = 0
 
+    /// iPhone back-camera fallback, used when the glasses camera is unavailable.
+    private let phoneSource = PhoneCameraSource()
+
     /// Name of the Photos album where glasses photos are saved.
     private nonisolated static let albumName = "Glasses"
 
@@ -287,6 +290,24 @@ class CameraService: ObservableObject {
     /// Capture a photo from the glasses camera. Returns JPEG data.
     /// Reuses the persistent session — starts it if needed, does NOT stop it after capture.
     func capturePhoto() async throws -> Data {
+        // Glasses are usable for the camera only once fully registered (state 3). When
+        // they're offline / not connected / not registered, capture from the iPhone back
+        // camera instead so the vision tools keep working without glasses.
+        if Wearables.shared.registrationState.rawValue < 3 {
+            NSLog("[Camera] Glasses not registered (state < 3) — capturing from iPhone back camera")
+            return try await phoneSource.capturePhoto()
+        }
+        do {
+            return try await captureFromGlasses()
+        } catch {
+            NSLog("[Camera] Glasses capture failed (%@) — falling back to iPhone back camera",
+                  error.localizedDescription)
+            return try await phoneSource.capturePhoto()
+        }
+    }
+
+    /// Capture a photo from the glasses camera. Returns JPEG data.
+    private func captureFromGlasses() async throws -> Data {
         isCaptureInProgress = true
         defer { isCaptureInProgress = false }
 

--- a/OpenGlasses/Sources/Services/PhoneCameraSource.swift
+++ b/OpenGlasses/Sources/Services/PhoneCameraSource.swift
@@ -1,0 +1,106 @@
+import AVFoundation
+import UIKit
+
+/// Headless iPhone back-camera capture, used as a fallback for the AI vision tools when
+/// the glasses camera is unavailable (glasses offline / not connected / not registered).
+///
+/// Unlike `PhoneCameraController` (which drives a visible preview sheet so the user can
+/// aim), this captures with no UI: it starts the back camera on demand, grabs a single
+/// still, and stops — so the camera indicator is only lit during the brief capture.
+///
+/// Not @MainActor: AVCaptureSession config/start/stop run on `sessionQueue`. The single
+/// in-flight capture continuation is set and resumed on the main queue for thread safety
+/// (same discipline as PhoneCameraController).
+final class PhoneCameraSource: NSObject, @unchecked Sendable {
+    private let session = AVCaptureSession()
+    private let photoOutput = AVCapturePhotoOutput()
+    private let sessionQueue = DispatchQueue(label: "com.openglasses.phone-camera.source")
+    private var configured = false
+    private var photoContinuation: CheckedContinuation<Data, Error>?
+
+    /// Capture a single still from the iPhone back camera as JPEG data.
+    func capturePhoto() async throws -> Data {
+        try await ensureRunning()
+        // Let auto-exposure / focus settle so the first frame isn't dark/blurry.
+        try? await Task.sleep(nanoseconds: 350_000_000)
+        let data: Data = try await withCheckedThrowingContinuation { cont in
+            DispatchQueue.main.async { [self] in
+                photoContinuation = cont
+                sessionQueue.async { [self] in
+                    photoOutput.capturePhoto(with: AVCapturePhotoSettings(), delegate: self)
+                }
+            }
+        }
+        stop()
+        NSLog("[PhoneCamera] Captured %d bytes from iPhone back camera", data.count)
+        return data
+    }
+
+    func stop() {
+        sessionQueue.async { [self] in
+            if session.isRunning { session.stopRunning() }
+        }
+    }
+
+    private func ensureRunning() async throws {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .notDetermined:
+            let granted = await AVCaptureDevice.requestAccess(for: .video)
+            if !granted { throw CameraError.permissionDenied }
+        case .denied, .restricted:
+            throw CameraError.permissionDenied
+        default:
+            break
+        }
+
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            sessionQueue.async { [self] in
+                if session.isRunning { cont.resume(); return }
+                if !configured {
+                    // Don't let the capture session tear down the app's playAndRecord audio
+                    // session (wake word / TTS).
+                    session.automaticallyConfiguresApplicationAudioSession = false
+                    session.beginConfiguration()
+                    if session.canSetSessionPreset(.photo) { session.sessionPreset = .photo }
+                    guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back)
+                            ?? AVCaptureDevice.default(for: .video),
+                          let input = try? AVCaptureDeviceInput(device: device),
+                          session.canAddInput(input) else {
+                        session.commitConfiguration()
+                        cont.resume(throwing: CameraError.captureFailed)
+                        return
+                    }
+                    session.addInput(input)
+                    if session.canAddOutput(photoOutput) { session.addOutput(photoOutput) }
+                    session.commitConfiguration()
+                    configured = true
+                }
+                session.startRunning()
+                cont.resume()
+            }
+        }
+    }
+}
+
+extension PhoneCameraSource: AVCapturePhotoCaptureDelegate {
+    func photoOutput(_ output: AVCapturePhotoOutput,
+                     didFinishProcessingPhoto photo: AVCapturePhoto,
+                     error: Error?) {
+        let raw = photo.fileDataRepresentation()
+        DispatchQueue.main.async { [self] in
+            let cont = photoContinuation
+            photoContinuation = nil
+            if let error {
+                cont?.resume(throwing: error)
+                return
+            }
+            // Normalize to JPEG so it matches the glasses path (capturePhoto returns JPEG)
+            // regardless of the device's default photo codec (HEIC).
+            guard let raw, let jpeg = UIImage(data: raw)?.jpegData(compressionQuality: 0.85) else {
+                cont?.resume(throwing: CameraError.captureFailed)
+                return
+            }
+            cont?.resume(returning: jpeg)
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`CameraService.capturePhoto()` is glasses-only (MWDATCamera stream), so the AI vision tools (what's-this, Smart Capture, money / medication / color identifier, reading & document scan, accessibility, etc.) all fail with "make sure the glasses are connected" whenever the glasses are offline.

## Change

Add a headless `PhoneCameraSource` that captures a single still from the iPhone back camera (`builtInWideAngleCamera`, `.back`) as JPEG:

- No preview UI — camera indicator is lit only during the brief capture.
- Sets `automaticallyConfiguresApplicationAudioSession = false` so it doesn't disturb the wake-word / TTS audio session.

`capturePhoto()` routes to it when the glasses aren't fully registered (`registrationState < 3`), and as a fallback if a glasses capture throws — fixing every vision tool at the single choke point.

## Status

Phase 1 of a no-glasses camera fallback (photo / vision). Live preview/streaming and video recording would follow in separate PRs.

Opened as a **draft**: builds clean, but on-device runtime verification is still in progress. (There's an existing manual-preview phone fallback, `PhoneCameraView`, for the voice "take a photo & ask" flow; this wires a headless equivalent into the tool path.)
