### PR TITLE
Ray-Ban Display HUD output (Phase 1: AI responses + ambient captions)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -458,6 +458,7 @@ class AppState: ObservableObject, AppStateProtocol {
     let locationService = LocationService()
     let proactiveAlerts = ProactiveAlertService()
     let ambientCaptions = AmbientCaptionService()
+    let glassesDisplay = GlassesDisplayService()
     let faceRecognition = FaceRecognitionService()
     let memoryRewind = MemoryRewindService()
     let privacyFilter = PrivacyFilterService()
@@ -599,8 +600,16 @@ class AppState: ObservableObject, AppStateProtocol {
         // same reference-counted hold that the active-listening flow uses.
         speechService.wakeWordService = wakeWordService
 
+        // Mirror spoken AI responses + ambient captions to the in-lens HUD (no-op on
+        // glasses without a display, and gated behind Config.glassesDisplayEnabled).
+        speechService.glassesDisplay = glassesDisplay
+        glassesDisplay.onDebugEvent = { [weak self] message in
+            Task { @MainActor in self?.addDebugEvent(message) }
+        }
+
         // Wire Tier 1 services
         ambientCaptions.wakeWordService = wakeWordService
+        ambientCaptions.glassesDisplay = glassesDisplay
         memoryRewind.wakeWordService = wakeWordService
         videoRecorder.wakeWordService = wakeWordService
         videoRecorder.ambientCaptionService = ambientCaptions

--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -940,6 +940,19 @@ struct HardwarePrivacyView: View {
                     info: "Disables camera video streaming from the glasses. Voice commands still work but vision features (photo capture, live video analysis) are unavailable. Significantly extends glasses battery life."
                 )
                 InfoToggle(
+                    title: "Glasses Display (HUD)",
+                    isOn: Binding(
+                        get: { Config.glassesDisplayEnabled },
+                        set: { newValue in
+                            Config.setGlassesDisplayEnabled(newValue)
+                            if !newValue {
+                                Task { await appState.glassesDisplay.shutdown() }
+                            }
+                        }
+                    ),
+                    info: "Mirrors AI responses and live captions to the in-lens display on Ray-Ban Display glasses. Has no effect on glasses without a built-in display."
+                )
+                InfoToggle(
                     title: "Use Phone Mic for Translation",
                     isOn: Binding(
                         get: { Config.usePhoneMicForTranslation },

--- a/OpenGlasses/Sources/Services/AmbientCaptionService.swift
+++ b/OpenGlasses/Sources/Services/AmbientCaptionService.swift
@@ -24,6 +24,10 @@ class AmbientCaptionService: ObservableObject {
     /// Reference to the wake word service for audio buffer forwarding
     weak var wakeWordService: WakeWordService?
 
+    /// Set by AppState — the live caption line is mirrored to the in-lens HUD when the
+    /// Glasses Display feature is on. No-ops on glasses without a display.
+    weak var glassesDisplay: GlassesDisplayService?
+
     /// Previous buffer forwarder (if transcription was using it)
     private var previousForwarder: ((AVAudioPCMBuffer) -> Void)?
 
@@ -60,6 +64,7 @@ class AmbientCaptionService: ObservableObject {
         isActive = false
         stopRecognitionSession()
         currentCaption = ""
+        glassesDisplay?.clear()
         print("🎙️ Ambient captions stopped")
     }
 
@@ -91,6 +96,7 @@ class AmbientCaptionService: ObservableObject {
                 if let result = result {
                     let text = result.bestTranscription.formattedString
                     self.currentCaption = text
+                    self.glassesDisplay?.showText(text)
                     self.resetSilenceTimer()
 
                     if result.isFinal {

--- a/OpenGlasses/Sources/Services/GlassesDisplayService.swift
+++ b/OpenGlasses/Sources/Services/GlassesDisplayService.swift
@@ -1,0 +1,251 @@
+import Foundation
+import MWDATCore
+import MWDATDisplay
+
+/// Mirrors short text to the Ray-Ban *Display* in-lens HUD (DAT SDK `MWDATDisplay`).
+///
+/// Phase 1: surfaces AI responses and the live ambient-caption line. Everything is
+/// additive — the on-phone overlay and TTS are untouched. On glasses without a
+/// display (`Device.supportsDisplay() == false`) every call is a safe no-op and no
+/// `DeviceSession` is ever created, so non-Display Ray-Ban hardware is unaffected.
+///
+/// Session ownership: this service manages its own `DeviceSession` (via
+/// `AutoDeviceSelector`), separate from `CameraService`. The SDK allows a single
+/// session per device, so while the HUD session is held the camera falls back to its
+/// existing iPhone-camera path. Unifying the two into one shared `DeviceSession`
+/// (camera + display capabilities on one session) is a tracked follow-up; it is out of
+/// scope for Phase 1 and only affects Display-model hardware with the flag on.
+@MainActor
+final class GlassesDisplayService: ObservableObject {
+    /// True once the display capability is started and content is being shown.
+    @Published private(set) var isDisplayActive = false
+    /// Whether the currently-active glasses report an in-lens display.
+    @Published private(set) var hasDisplayCapability = false
+
+    /// Debug event callback (wired to `AppState.addDebugEvent`).
+    var onDebugEvent: ((String) -> Void)?
+
+    /// Lazily initialized after `Wearables.configure()` has been called.
+    private lazy var deviceSelector = AutoDeviceSelector(wearables: Wearables.shared)
+    private var deviceSession: DeviceSession?
+    private var display: Display?
+
+    /// Latest-wins render queue. Rapid caption updates collapse to the most recent
+    /// frame so we never flood the BLE link — only one `send` is ever in flight.
+    private var pendingText: String?
+    private var isRendering = false
+    /// Last text actually pushed to the HUD; identical updates are skipped.
+    private var lastSentText: String?
+
+    /// Max characters to show on the HUD — kept short for legibility in-lens.
+    private static let maxLength = 120
+
+    // MARK: - Capability
+
+    /// Whether the active glasses expose an in-lens display. Cheap, synchronous, and
+    /// safe to call frequently. Updates `hasDisplayCapability` as a side effect.
+    @discardableResult
+    func deviceSupportsDisplay() -> Bool {
+        let supported: Bool = {
+            guard let id = deviceSelector.activeDevice,
+                  let device = Wearables.shared.deviceForIdentifier(id) else {
+                return false
+            }
+            return device.supportsDisplay()
+        }()
+        if hasDisplayCapability != supported { hasDisplayCapability = supported }
+        return supported
+    }
+
+    private var isEnabled: Bool { Config.glassesDisplayEnabled }
+
+    // MARK: - Public API
+
+    /// Show a concise line of text on the HUD. No-op when the feature is off or the
+    /// glasses have no display. Text is trimmed and truncated for legibility.
+    func showText(_ text: String) {
+        guard isEnabled, deviceSupportsDisplay() else { return }
+        let trimmed = Self.condense(text)
+        guard !trimmed.isEmpty else { return }
+        scheduleRender(trimmed)
+    }
+
+    /// Briefly show text, then clear it after `duration` seconds (if nothing newer
+    /// has been shown in the meantime).
+    func flash(_ text: String, duration: TimeInterval = 4.0) {
+        guard isEnabled, deviceSupportsDisplay() else { return }
+        let trimmed = Self.condense(text)
+        guard !trimmed.isEmpty else { return }
+        scheduleRender(trimmed)
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
+            guard let self else { return }
+            // Only clear if this flash is still the thing on screen.
+            if self.lastSentText == trimmed { self.clear() }
+        }
+    }
+
+    /// Clear the HUD (keeps the session alive for fast subsequent updates).
+    func clear() {
+        guard isEnabled else { return }
+        guard isDisplayActive || display != nil else { return }
+        scheduleRender("")
+    }
+
+    /// Fully tear down the display session. Call on feature disable / mode switch /
+    /// app teardown.
+    func shutdown() async {
+        pendingText = nil
+        await teardownDisplay()
+    }
+
+    // MARK: - Render queue
+
+    private func scheduleRender(_ text: String) {
+        pendingText = text
+        guard !isRendering else { return }
+        isRendering = true
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            while let next = self.pendingText {
+                self.pendingText = nil
+                do {
+                    if next.isEmpty {
+                        try await self.renderClear()
+                    } else {
+                        try await self.renderText(next)
+                    }
+                    self.lastSentText = next.isEmpty ? nil : next
+                } catch {
+                    self.handleRenderError(error)
+                    break
+                }
+            }
+            self.isRendering = false
+        }
+    }
+
+    private func renderText(_ text: String) async throws {
+        let display = try await ensureDisplay()
+        let view = FlexBox(
+            direction: .column,
+            spacing: 4,
+            alignment: .start,
+            padding: EdgeInsets(all: 12)
+        ) {
+            Text(text, style: .body, color: .primary)
+        }
+        try await display.send(view)
+    }
+
+    private func renderClear() async throws {
+        // Nothing to clear if we never started a session.
+        guard let display else { return }
+        let empty = FlexBox(direction: .column) {}
+        try await display.send(empty)
+    }
+
+    // MARK: - Session lifecycle
+
+    private func ensureDisplay() async throws -> Display {
+        // Reuse a live display/session.
+        if let display, deviceSession?.state == .started {
+            return display
+        }
+        // Drop stale references if the session died underneath us.
+        if deviceSession?.state == .stopped || deviceSession?.state == .idle {
+            display = nil
+            deviceSession = nil
+            isDisplayActive = false
+        }
+
+        guard deviceSupportsDisplay() else { throw GlassesDisplayError.noDisplay }
+
+        let session: DeviceSession
+        if let existing = deviceSession {
+            session = existing
+        } else {
+            session = try Wearables.shared.createSession(deviceSelector: deviceSelector)
+            deviceSession = session
+        }
+
+        if session.state != .started {
+            try session.start()
+            let deadline = ContinuousClock.now + .seconds(10)
+            while ContinuousClock.now < deadline {
+                if session.state == .started || session.state == .stopped { break }
+                try await Task.sleep(nanoseconds: 200_000_000)
+            }
+        }
+        guard session.state == .started else { throw GlassesDisplayError.sessionUnavailable }
+
+        let display: Display
+        if let existing = self.display {
+            display = existing
+        } else {
+            // We exclusively own this session, so the display capability can't already
+            // be active. `addDisplay()` throws DeviceSessionError; surface failures via
+            // the render-error path (which tears down and rebuilds a fresh session).
+            display = try session.addDisplay()
+            self.display = display
+        }
+
+        await display.start()
+        isDisplayActive = true
+        onDebugEvent?("HUD display started")
+        return display
+    }
+
+    private func teardownDisplay() async {
+        if let display {
+            await display.stop()
+        }
+        display = nil
+        deviceSession?.stop()
+        deviceSession = nil
+        isDisplayActive = false
+        lastSentText = nil
+    }
+
+    private func handleRenderError(_ error: Error) {
+        // Don't spam logs for the expected "no display" no-op path.
+        if case GlassesDisplayError.noDisplay = error { return }
+        NSLog("[Display] HUD render failed: %@", String(describing: error))
+        onDebugEvent?("HUD error: \(String(describing: error))")
+        // Drop references so the next render rebuilds the session from scratch.
+        display = nil
+        deviceSession?.stop()
+        deviceSession = nil
+        isDisplayActive = false
+    }
+
+    // MARK: - Text shaping
+
+    /// Collapse whitespace and truncate to a HUD-legible length.
+    private static func condense(_ text: String) -> String {
+        let collapsed = text
+            .replacingOccurrences(of: "\n", with: " ")
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        guard collapsed.count > maxLength else { return collapsed }
+        let cut = collapsed.prefix(maxLength)
+        // Prefer to break on the last space so we don't slice a word in half.
+        if let lastSpace = cut.lastIndex(of: " "), lastSpace > cut.index(cut.startIndex, offsetBy: maxLength / 2) {
+            return String(cut[..<lastSpace]) + "…"
+        }
+        return String(cut) + "…"
+    }
+}
+
+enum GlassesDisplayError: LocalizedError {
+    case noDisplay
+    case sessionUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .noDisplay: return "Connected glasses have no in-lens display"
+        case .sessionUnavailable: return "Display session unavailable"
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/TextToSpeechService.swift
+++ b/OpenGlasses/Sources/Services/TextToSpeechService.swift
@@ -88,6 +88,10 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
     weak var wakeWordService: WakeWordService?
     private var didHoldPause = false
 
+    /// Set by AppState — spoken text is mirrored to the in-lens HUD when the Glasses
+    /// Display feature is on. The service no-ops on glasses without a display.
+    weak var glassesDisplay: GlassesDisplayService?
+
     private func beginPause() {
         guard !didHoldPause else { return }
         wakeWordService?.pauseOtherAudio()
@@ -137,6 +141,9 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
         guard !text.isEmpty else { return }
         activeRateMultiplier = urgency.rateMultiplier
         let text = urgency.prefix + text
+
+        // Mirror spoken text to the in-lens HUD (additive; no-op without a display).
+        glassesDisplay?.showText(text)
 
         // Silence if glasses-only mode is on and glasses aren't connected
         if Config.glassesOnlyAudio && !glassesConnected {

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -2131,6 +2131,18 @@ struct Config {
         UserDefaults.standard.set(enabled, forKey: "audioOnlyMode")
     }
 
+    // MARK: - Glasses Display (in-lens HUD)
+
+    /// When enabled, AI responses and ambient captions are mirrored to the
+    /// Ray-Ban Display in-lens HUD. No-ops on glasses without a display.
+    static var glassesDisplayEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "glassesDisplayEnabled")
+    }
+
+    static func setGlassesDisplayEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: "glassesDisplayEnabled")
+    }
+
     // MARK: - WebRTC Streaming
 
     static var webRTCSignalingURL: String {

--- a/project.base.yml
+++ b/project.base.yml
@@ -118,6 +118,8 @@ targets:
         product: MWDATCore
       - package: meta-wearables-dat-ios
         product: MWDATCamera
+      - package: meta-wearables-dat-ios
+        product: MWDATDisplay
       - package: HaishinKit
         product: HaishinKit
       - package: HaishinKit


### PR DESCRIPTION
## Summary

Phase 1 of in-lens HUD support for **Ray-Ban Display** glasses. The app previously used only `MWDATCore` + `MWDATCamera`; this wires in the `MWDATDisplay` module (already present in the resolved SDK at 0.7.0 but never declared as a dependency) and mirrors two producers to the HUD, behind a feature flag with a graceful no-op on glasses that have no display.

- **AI responses** — every `TextToSpeechService.speak(...)` utterance is mirrored to the HUD.
- **Ambient captions** — the live caption line from `AmbientCaptionService` is mirrored as it updates.

Both are **additive**: the on-phone overlay and TTS audio behavior are untouched.

## What changed

- **`project.base.yml`** — declare `MWDATDisplay` as an SPM product on the OpenGlasses target. Project regenerated with `./Scripts/generate-xcodeproj.sh` (no hand-edited `project.pbxproj`).
- **`Config.swift`** — `glassesDisplayEnabled` UserDefaults flag (default **off**), following the `audioOnlyMode` pattern.
- **`GlassesDisplayService.swift`** (new) — `@MainActor` service:
  - Capability check via `Device.supportsDisplay()` — when false (or flag off), every call is a pure no-op and **no `DeviceSession` is ever created**.
  - Renders short text with `FlexBox { Text(...) }` over `DeviceSession.addDisplay()` → `Display.start()` → `display.send(view)`.
  - Latest-wins coalescing render queue (one `send` in flight at a time) so rapid partial captions don't flood the BLE link; text is whitespace-collapsed and truncated (~120 chars) for in-lens legibility.
  - `showText` / `clear` / `flash(_:duration:)` / `shutdown()`; typed `do/catch` error handling that tears down and rebuilds the session on failure.
- **`TextToSpeechService.swift` / `AmbientCaptionService.swift`** — weak `glassesDisplay` reference (same pattern as the existing `wakeWordService` wiring) + one mirror call each.
- **`OpenGlassesApp.swift`** — instantiate the service and wire the two producers + debug events.
- **`SettingsView.swift`** — "Glasses Display (HUD)" toggle under **Hardware**, next to Audio-Only Mode; turning it off tears down the HUD session.

## API notes (0.7.0 vs 0.5 reference docs)

The 0.7.0 `MWDATDisplay.swiftinterface` does **not** follow the `*Session` + config + selector shape the 0.5 reference docs / DAT conventions suggest. Actual surface used:

- `DeviceSession.addDisplay() throws(DeviceSessionError) -> Display` (extension) — the display is a **capability added to an existing `DeviceSession`**, not a standalone session created with a config + selector.
- `Display` conforms to `MWDATCore.Capability` (`capabilityState`), with `start()`, `stop()`, `send(some DisplayableView)`, `sendVideoStop()`.
- Views are a declarative `FlexBox`/`Text`/`Icon`/`Image`/`Button` tree built with a result builder; `FlexBox` is the `DisplayableView` we send.
- Capability is best detected from the hardware via `Device.supportsDisplay()` (used here) rather than the runtime `capabilityState`.

Implemented against the actual `.swiftinterface`, per the task's "follow the actual interface" guidance.

> Minor: a `catch DeviceSessionError.<case>` pattern-match on the typed-throws `addDisplay()` reproducibly crashed the Swift 6.2.3 frontend (SILGenCleanup ownership verification). Worked around by not special-casing that catch — we exclusively own the session, so the display capability can't already be active.

## Known limitation / follow-up

The HUD uses its **own** `DeviceSession`, separate from `CameraService`. The SDK allows a single session per device, so while the HUD session is held the camera uses its existing iPhone-camera fallback path. This only affects **Display-model hardware with the flag on** — non-Display glasses never create a session, so the camera is unaffected. Unifying camera + display onto one shared `DeviceSession` (both as capabilities) is a tracked follow-up, out of scope for Phase 1. Navigation/notification HUD output are also follow-up PRs.

## Build / verify

- `./Scripts/generate-xcodeproj.sh`
- ✅ Debug — `xcodebuild -project OpenGlasses.xcodeproj -scheme OpenGlasses -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`
- ✅ Release — `xcodebuild ... -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`

No tool/system-prompt wording changed, so no `GeminiLiveSessionManager.swift` mirroring needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)