### PR TITLE
Ray-Ban Display HUD output (Phase 2: notifications + Navigation Assist) + Round 6 plans

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -746,11 +746,13 @@ class AppState: ObservableObject, AppStateProtocol {
             startPermissionRequiringServices()
         }
 
-        // Start proactive calendar alerts — speaks through TTS when events are imminent
+        // Start proactive calendar alerts — speaks through TTS when events are imminent,
+        // and mirrors a richer notification card to the in-lens HUD.
         proactiveAlerts.onAlert = { [weak self] message, urgency in
             guard let self else { return }
+            self.glassesDisplay.showNotification(title: "Reminder", body: message, icon: .calendar)
             Task {
-                await self.speechService.speak(message, urgency: urgency)
+                await self.speechService.speak(message, urgency: urgency, mirrorToHUD: false)
             }
         }
         proactiveAlerts.onMeetingPlaybook = { [weak self] title, notes, steps in
@@ -771,6 +773,7 @@ class AppState: ObservableObject, AppStateProtocol {
 
         // Configure Navigation Assist (Plan J) similarly.
         NavigationAssistService.shared.configure(camera: cameraService, llm: llmService, tts: speechService)
+        NavigationAssistService.shared.glassesDisplay = glassesDisplay
 
         // Field Assist Phase 5 (Plan K2): expert stream bridge for escalations. Transport
         // (MJPEG / WebRTC) is selected in Settings; MJPEG is the working default.
@@ -788,12 +791,14 @@ class AppState: ObservableObject, AppStateProtocol {
         // Pre-fetch Home Assistant entity cache for fuzzy matching
         Task { await HomeAssistantEntityCache.shared.refreshIfNeeded() }
 
-        // Wire geofence alerts — speak via TTS when entering/leaving a region
+        // Wire geofence alerts — speak via TTS when entering/leaving a region, and
+        // mirror a location notification card to the in-lens HUD.
         if let geofenceTool = nativeToolRegistry.tool(named: "geofence") as? GeofenceTool {
             geofenceTool.onAlert = { [weak self] message, urgency in
                 guard let self else { return }
+                self.glassesDisplay.showNotification(title: "Location", body: message, icon: .location)
                 Task {
-                    await self.speechService.speak(message, urgency: urgency)
+                    await self.speechService.speak(message, urgency: urgency, mirrorToHUD: false)
                 }
             }
             geofenceTool.restoreGeofences()

--- a/OpenGlasses/Sources/Resources/Localizable.xcstrings
+++ b/OpenGlasses/Sources/Resources/Localizable.xcstrings
@@ -1,152 +1,15 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "Share Health Data with AI" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gesundheitsdaten mit KI teilen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartir datos de salud con la IA"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Partager les données de santé avec l'IA"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "健康データをAIと共有"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Udostępniaj dane zdrowotne AI"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "与 AI 共享健康数据"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "與 AI 共享健康資料"
-          }
-        }
-      }
-    },
-    "Off by default. When on, the fitness coach may read your Apple Health workout history and send it to your configured AI provider (Anthropic, OpenAI, Google, etc.) so it can discuss your progress. Your Health data leaves the device only while this is enabled. On-device workout tracking, form analysis, and saving workouts to Apple Health work either way." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standardmäßig deaktiviert. Wenn aktiviert, darf der Fitness-Coach deinen Apple-Health-Trainingsverlauf lesen und an deinen konfigurierten KI-Anbieter (Anthropic, OpenAI, Google usw.) senden, um deine Fortschritte zu besprechen. Deine Gesundheitsdaten verlassen das Gerät nur, solange dies aktiviert ist. Trainingsaufzeichnung, Haltungsanalyse und das Speichern von Trainings in Apple Health auf dem Gerät funktionieren in jedem Fall."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desactivado por defecto. Cuando está activado, el entrenador de fitness puede leer tu historial de entrenamientos de Apple Salud y enviarlo a tu proveedor de IA configurado (Anthropic, OpenAI, Google, etc.) para comentar tu progreso. Tus datos de salud salen del dispositivo solo mientras esto esté activado. El seguimiento de entrenamientos, el análisis de la técnica y el guardado de entrenamientos en Apple Salud en el dispositivo funcionan igualmente."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Désactivé par défaut. Lorsqu'il est activé, le coach sportif peut lire votre historique d'entraînements Apple Santé et l'envoyer à votre fournisseur d'IA configuré (Anthropic, OpenAI, Google, etc.) afin de discuter de vos progrès. Vos données de santé ne quittent l'appareil que lorsque cette option est activée. Le suivi des entraînements, l'analyse de la posture et l'enregistrement des entraînements dans Apple Santé sur l'appareil fonctionnent dans tous les cas."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "デフォルトではオフです。オンにすると、フィットネスコーチがApple ヘルスケアのワークアウト履歴を読み取り、設定したAIプロバイダ（Anthropic、OpenAI、Googleなど）に送信して進捗について話せるようになります。健康データがデバイスの外に出るのは、この設定がオンの間だけです。デバイス上でのワークアウト記録、フォーム分析、Apple ヘルスケアへのワークアウト保存は、どちらの場合でも機能します。"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Domyślnie wyłączone. Po włączeniu trener fitness może odczytać historię treningów z Apple Health i wysłać ją do skonfigurowanego dostawcy AI (Anthropic, OpenAI, Google itp.), aby omówić Twoje postępy. Dane zdrowotne opuszczają urządzenie tylko wtedy, gdy ta opcja jest włączona. Śledzenie treningów, analiza formy i zapisywanie treningów w Apple Health na urządzeniu działają niezależnie od tego."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "默认关闭。开启后，健身教练可以读取你的“Apple 健康”锻炼记录，并发送给你配置的 AI 提供商（Anthropic、OpenAI、Google 等）以讨论你的进展。只有在启用此选项时，你的健康数据才会离开设备。设备上的锻炼跟踪、姿势分析以及将锻炼保存到“Apple 健康”在任何情况下都可使用。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "預設關閉。開啟後，健身教練可讀取你的「Apple 健康」鍛鍊記錄，並傳送給你設定的 AI 供應商（Anthropic、OpenAI、Google 等）以討論你的進度。只有在啟用此選項時，你的健康資料才會離開裝置。裝置上的鍛鍊追蹤、姿勢分析以及將鍛鍊儲存到「Apple 健康」在任何情況下都可使用。"
-          }
-        }
-      }
-    },
-    "Bystander Face Blur runs entirely on-device — no images leave your phone. Share Health Data with AI is off by default: Apple Health data is sent to your AI provider only when you turn it on." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Unschärfe für Passantengesichter läuft vollständig auf dem Gerät – es verlassen keine Bilder dein Telefon. „Gesundheitsdaten mit KI teilen“ ist standardmäßig deaktiviert: Apple-Health-Daten werden nur an deinen KI-Anbieter gesendet, wenn du es aktivierst."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El desenfoque de rostros de transeúntes se ejecuta completamente en el dispositivo: ninguna imagen sale de tu teléfono. «Compartir datos de salud con la IA» está desactivado por defecto: los datos de Apple Salud se envían a tu proveedor de IA solo cuando lo activas."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le floutage des visages des passants s'exécute entièrement sur l'appareil — aucune image ne quitte votre téléphone. « Partager les données de santé avec l'IA » est désactivé par défaut : les données Apple Santé ne sont envoyées à votre fournisseur d'IA que lorsque vous l'activez."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "傍観者の顔のぼかしは完全にデバイス上で実行され、画像が端末の外に出ることはありません。「健康データをAIと共有」はデフォルトでオフです。Apple ヘルスケアのデータは、オンにした場合にのみAIプロバイダに送信されます。"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rozmycie twarzy przechodniów działa w całości na urządzeniu — żadne zdjęcia nie opuszczają telefonu. „Udostępniaj dane zdrowotne AI“ jest domyślnie wyłączone: dane Apple Health są wysyłane do dostawcy AI tylko po włączeniu tej opcji."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "旁观者面部模糊完全在设备上运行——不会有图像离开你的手机。“与 AI 共享健康数据”默认关闭：只有在你开启时，“Apple 健康”数据才会发送给你的 AI 提供商。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "旁觀者面部模糊完全在裝置上執行——不會有圖像離開你的手機。「與 AI 共享健康資料」預設關閉：只有在你開啟時，「Apple 健康」資料才會傳送給你的 AI 供應商。"
-          }
-        }
-      }
-    },
     "" : {
 
     },
     "·" : {
       "comment" : "A period used to separate different pieces of text.",
+      "isCommentAutoGenerated" : true
+    },
+    "· Unload" : {
+      "comment" : "A separator between the main text and the secondary text.",
       "isCommentAutoGenerated" : true
     },
     "\"%@\"" : {
@@ -365,6 +228,13 @@
           }
         }
       }
+    },
+    "%@ loaded" : {
+      "comment" : "A label that indicates a model is loaded. The argument is the name of the model.",
+      "isCommentAutoGenerated" : true
+    },
+    "%@ loaded. Tap to unload." : {
+
     },
     "%@ mode: %@" : {
       "comment" : "A label that describes the active mode, optionally prefixed with \"Active\" if the mode is active.",
@@ -667,6 +537,18 @@
       "comment" : "A label displaying the number of skills from ClawHub.ai that match the current search. The",
       "isCommentAutoGenerated" : true
     },
+    "%lld step%@" : {
+      "comment" : "A label that shows the number of steps in a scenario. The argument is the number of steps.",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld step%2$@"
+          }
+        }
+      }
+    },
     "%lld steps" : {
 
     },
@@ -707,6 +589,10 @@
           }
         }
       }
+    },
+    "%lld%%" : {
+      "comment" : "A progress bar showing the percentage of a download. The argument is the percentage of the download.",
+      "isCommentAutoGenerated" : true
     },
     "+ %lld more tools" : {
 
@@ -968,8 +854,9 @@
     "Active Session" : {
 
     },
-    "Adam — deep, American" : {
-
+    "Active vault: %@. Tap to switch." : {
+      "comment" : "A label that describes the active vault.",
+      "isCommentAutoGenerated" : true
     },
     "Add" : {
       "extractionState" : "manual",
@@ -1307,9 +1194,6 @@
     "AirDrop, email, Files, or any installed app" : {
 
     },
-    "Alice — confident, British" : {
-
-    },
     "All %lld tools available" : {
 
     },
@@ -1418,6 +1302,9 @@
     "Appearance" : {
       "comment" : "A section header in the Quick Action Editor that describes the appearance settings.",
       "isCommentAutoGenerated" : true
+    },
+    "Approve" : {
+
     },
     "Ask" : {
       "extractionState" : "manual",
@@ -1724,9 +1611,6 @@
       "comment" : "A label for a badge that indicates the product is the best value.",
       "isCommentAutoGenerated" : true
     },
-    "Bill — strong, American" : {
-
-    },
     "Binaries" : {
 
     },
@@ -1790,9 +1674,6 @@
     "Branches" : {
       "comment" : "A section for the branches of a step.",
       "isCommentAutoGenerated" : true
-    },
-    "Brian — deep, American" : {
-
     },
     "Brightness" : {
 
@@ -1951,13 +1832,57 @@
         }
       }
     },
+    "Bystander Face Blur runs entirely on-device — no images leave your phone. Share Health Data with AI is off by default: Apple Health data is sent to your AI provider only when you turn it on." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Unschärfe für Passantengesichter läuft vollständig auf dem Gerät – es verlassen keine Bilder dein Telefon. „Gesundheitsdaten mit KI teilen“ ist standardmäßig deaktiviert: Apple-Health-Daten werden nur an deinen KI-Anbieter gesendet, wenn du es aktivierst."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El desenfoque de rostros de transeúntes se ejecuta completamente en el dispositivo: ninguna imagen sale de tu teléfono. «Compartir datos de salud con la IA» está desactivado por defecto: los datos de Apple Salud se envían a tu proveedor de IA solo cuando lo activas."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le floutage des visages des passants s'exécute entièrement sur l'appareil — aucune image ne quitte votre téléphone. « Partager les données de santé avec l'IA » est désactivé par défaut : les données Apple Santé ne sont envoyées à votre fournisseur d'IA que lorsque vous l'activez."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "傍観者の顔のぼかしは完全にデバイス上で実行され、画像が端末の外に出ることはありません。「健康データをAIと共有」はデフォルトでオフです。Apple ヘルスケアのデータは、オンにした場合にのみAIプロバイダに送信されます。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rozmycie twarzy przechodniów działa w całości na urządzeniu — żadne zdjęcia nie opuszczają telefonu. „Udostępniaj dane zdrowotne AI“ jest domyślnie wyłączone: dane Apple Health są wysyłane do dostawcy AI tylko po włączeniu tej opcji."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旁观者面部模糊完全在设备上运行——不会有图像离开你的手机。“与 AI 共享健康数据”默认关闭：只有在你开启时，“Apple 健康”数据才会发送给你的 AI 提供商。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "旁觀者面部模糊完全在裝置上執行——不會有圖像離開你的手機。「與 AI 共享健康資料」預設關閉：只有在你開啟時，「Apple 健康」資料才會傳送給你的 AI 供應商。"
+          }
+        }
+      }
+    },
     "Callback source: %@" : {
 
     },
     "Callback URL: %@" : {
-
-    },
-    "Callum — hoarse, American" : {
 
     },
     "CAM" : {
@@ -2236,12 +2161,6 @@
     "Changes take effect next time the camera session starts. Higher settings use more battery." : {
 
     },
-    "Charlie — casual, Australian" : {
-
-    },
-    "Charlotte — English-Swedish" : {
-
-    },
     "Chattiness" : {
 
     },
@@ -2312,9 +2231,6 @@
     "Choose your AI" : {
       "comment" : "A title for the onboarding page where users can choose an AI provider.",
       "isCommentAutoGenerated" : true
-    },
-    "Chris — casual, American" : {
-
     },
     "Clear" : {
       "extractionState" : "manual",
@@ -2442,6 +2358,10 @@
     },
     "Configured" : {
 
+    },
+    "Confirm action" : {
+      "comment" : "A title for a confirmation dialog.",
+      "isCommentAutoGenerated" : true
     },
     "Connect Glasses" : {
       "extractionState" : "manual",
@@ -2988,6 +2908,10 @@
     "Could not load skills from ClawHub. Check your connection and try again." : {
 
     },
+    "Couldn't start session" : {
+      "comment" : "A title for an alert that can't start a Field Assist session.",
+      "isCommentAutoGenerated" : true
+    },
     "Covered by this app" : {
 
     },
@@ -3115,9 +3039,6 @@
       "comment" : "A text field within the \"Wake Word\" section, allowing users to input a custom wake phrase. The text field is pre-populated with the value of the \"wakePhrase\" state variable.",
       "isCommentAutoGenerated" : true
     },
-    "Daniel — deep, British" : {
-
-    },
     "Dark" : {
 
     },
@@ -3135,9 +3056,6 @@
 
     },
     "Data Sent by Category" : {
-
-    },
-    "Dave — conversational, British" : {
 
     },
     "Debug" : {
@@ -3812,9 +3730,6 @@
         }
       }
     },
-    "Dorothy — pleasant, British" : {
-
-    },
     "Double-tap to edit" : {
       "comment" : "A hint that appears when tapping on a persona to edit it.",
       "isCommentAutoGenerated" : true
@@ -3953,9 +3868,6 @@
     "Drag to reorder priority. The app tries gateways top-to-bottom until one responds." : {
       "comment" : "A description of how to reorder gateways.",
       "isCommentAutoGenerated" : true
-    },
-    "Drew — well-rounded, American" : {
-
     },
     "e.g. Check train delays" : {
 
@@ -4162,9 +4074,6 @@
 
     },
     "elevenlabs.io" : {
-
-    },
-    "Emily — calm, American" : {
 
     },
     "Enable" : {
@@ -4980,13 +4889,14 @@
     "Field Assist provides hands-free, domain-grounded guidance for service technicians. When enabled, the `field_session` tool becomes available and an active session injects the relevant knowledge vault into the AI's context." : {
 
     },
+    "Field Assist. %@" : {
+      "comment" : "A row in the persona picker that opens the Field Assist settings. The argument is the string “Unlock for grounded field-engineer guidance” or the string “Tap to enable”.",
+      "isCommentAutoGenerated" : true
+    },
     "Files App" : {
 
     },
     "Filter" : {
-
-    },
-    "Fin — Irish" : {
 
     },
     "For now, use FHIR R4 or Manual Share to export transcripts." : {
@@ -4996,6 +4906,9 @@
 
     },
     "Framework Coverage" : {
+
+    },
+    "Free ElevenLabs accounts may reject public-library voices — load voices from your account, or paste a Voice ID your key can use. The iOS voice is still used as a fallback." : {
 
     },
     "from: %@" : {
@@ -5022,9 +4935,6 @@
     "General" : {
       "comment" : "A section of the gateway edit form.",
       "isCommentAutoGenerated" : true
-    },
-    "George — raspy, British" : {
-
     },
     "Get API Key" : {
       "comment" : "A label that reads \"Get API Key\".",
@@ -5151,6 +5061,10 @@
     },
     "HA URL (e.g. http://192.168.1.100:8123)" : {
 
+    },
+    "Hands-free, domain-grounded guidance for field engineers — load a knowledge vault and run grounded, audited sessions." : {
+      "comment" : "A description of Field Assist.",
+      "isCommentAutoGenerated" : true
     },
     "Hardware" : {
       "comment" : "A section title for the hardware settings.",
@@ -5818,9 +5732,6 @@
         }
       }
     },
-    "James — calm, Australian" : {
-
-    },
     "JSON body. Use {{variable}} to insert values from previous steps." : {
       "comment" : "A description of how to use variables in a JSON body.",
       "isCommentAutoGenerated" : true
@@ -5871,9 +5782,6 @@
     "Later steps can reference this result with {{%@}}." : {
       "comment" : "A message that appears under a step's output variable when it's not empty. The variable is replaced with the step's output variable.",
       "isCommentAutoGenerated" : true
-    },
-    "Liam — American" : {
-
     },
     "License Code" : {
       "comment" : "A label displayed above a text field for entering a license code.",
@@ -5972,9 +5880,6 @@
       }
     },
     "Light" : {
-
-    },
-    "Lily — raspy, British" : {
 
     },
     "Limited RAM — use models under 1 GB" : {
@@ -6249,11 +6154,34 @@
     "LiveAI Mode" : {
 
     },
+    "Load" : {
+      "comment" : "A button to load a model.",
+      "isCommentAutoGenerated" : true
+    },
+    "Load %@" : {
+      "comment" : "A button to load a local machine learning model.",
+      "isCommentAutoGenerated" : true
+    },
     "Load Entities" : {
 
     },
     "Load More" : {
 
+    },
+    "Load My ElevenLabs Voices" : {
+
+    },
+    "Load on-device model %@" : {
+      "comment" : "A button that loads a local machine learning model. The argument is the name of the model.",
+      "isCommentAutoGenerated" : true
+    },
+    "Loaded" : {
+      "comment" : "A label that indicates a model is loaded.",
+      "isCommentAutoGenerated" : true
+    },
+    "Loading %@…" : {
+      "comment" : "A label at the top of the checkout view providing medication instructions. The argument is the instructions for taking the primary medication in the cart.",
+      "isCommentAutoGenerated" : true
     },
     "Loading entities…" : {
       "comment" : "A placeholder text displayed while loading Home Assistant entities.",
@@ -6270,6 +6198,9 @@
     "Loading shortcuts…" : {
       "comment" : "Text displayed while loading a list of Siri Shortcuts.",
       "isCommentAutoGenerated" : true
+    },
+    "Loading Voices…" : {
+
     },
     "Loading…" : {
 
@@ -6341,6 +6272,10 @@
     "Look & Feel" : {
 
     },
+    "Manage Field Assist" : {
+      "comment" : "A label for the settings button in the Field Assist tab.",
+      "isCommentAutoGenerated" : true
+    },
     "Manage Subscription" : {
 
     },
@@ -6348,9 +6283,6 @@
 
     },
     "Manual Sharing Options" : {
-
-    },
-    "Matilda — warm, American" : {
 
     },
     "MCP Server" : {
@@ -6505,8 +6437,16 @@
       "comment" : "A description of what an MCP server is and how it can be used with the app.",
       "isCommentAutoGenerated" : true
     },
+    "Model for this vault" : {
+      "comment" : "A label for the field assist vault model picker.",
+      "isCommentAutoGenerated" : true
+    },
     "Model ID" : {
 
+    },
+    "Model loaded — tap to unload" : {
+      "comment" : "A label for a button that unloads a loaded local LLM model.",
+      "isCommentAutoGenerated" : true
     },
     "Model: %@" : {
 
@@ -6718,9 +6658,6 @@
       "comment" : "A button that selects the next step in a step editor.",
       "isCommentAutoGenerated" : true
     },
-    "Nicole — whisper, American" : {
-
-    },
     "No active Medical Compliance subscription was found for this Apple ID." : {
       "comment" : "A message displayed when the user has not yet purchased the Medical Compliance subscription.",
       "isCommentAutoGenerated" : true
@@ -6807,6 +6744,10 @@
           }
         }
       }
+    },
+    "No guided scenarios in this vault — the assistant still answers grounded questions from its reference files." : {
+      "comment" : "A description of the Field Assist experience when a vault has no scenarios.",
+      "isCommentAutoGenerated" : true
     },
     "No MCP servers configured. Add one to connect external tools." : {
       "comment" : "A message displayed when no MCP servers are configured, encouraging the user to add one.",
@@ -7059,6 +7000,53 @@
     },
     "Off by default. Turn this on if you want the AI to act on its own — running background tasks, scheduling actions, looping through multi-step plans. Tap %@ above for the full list of what it unlocks." : {
 
+    },
+    "Off by default. When on, the fitness coach may read your Apple Health workout history and send it to your configured AI provider (Anthropic, OpenAI, Google, etc.) so it can discuss your progress. Your Health data leaves the device only while this is enabled. On-device workout tracking, form analysis, and saving workouts to Apple Health work either way." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Standardmäßig deaktiviert. Wenn aktiviert, darf der Fitness-Coach deinen Apple-Health-Trainingsverlauf lesen und an deinen konfigurierten KI-Anbieter (Anthropic, OpenAI, Google usw.) senden, um deine Fortschritte zu besprechen. Deine Gesundheitsdaten verlassen das Gerät nur, solange dies aktiviert ist. Trainingsaufzeichnung, Haltungsanalyse und das Speichern von Trainings in Apple Health auf dem Gerät funktionieren in jedem Fall."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivado por defecto. Cuando está activado, el entrenador de fitness puede leer tu historial de entrenamientos de Apple Salud y enviarlo a tu proveedor de IA configurado (Anthropic, OpenAI, Google, etc.) para comentar tu progreso. Tus datos de salud salen del dispositivo solo mientras esto esté activado. El seguimiento de entrenamientos, el análisis de la técnica y el guardado de entrenamientos en Apple Salud en el dispositivo funcionan igualmente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactivé par défaut. Lorsqu'il est activé, le coach sportif peut lire votre historique d'entraînements Apple Santé et l'envoyer à votre fournisseur d'IA configuré (Anthropic, OpenAI, Google, etc.) afin de discuter de vos progrès. Vos données de santé ne quittent l'appareil que lorsque cette option est activée. Le suivi des entraînements, l'analyse de la posture et l'enregistrement des entraînements dans Apple Santé sur l'appareil fonctionnent dans tous les cas."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デフォルトではオフです。オンにすると、フィットネスコーチがApple ヘルスケアのワークアウト履歴を読み取り、設定したAIプロバイダ（Anthropic、OpenAI、Googleなど）に送信して進捗について話せるようになります。健康データがデバイスの外に出るのは、この設定がオンの間だけです。デバイス上でのワークアウト記録、フォーム分析、Apple ヘルスケアへのワークアウト保存は、どちらの場合でも機能します。"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Domyślnie wyłączone. Po włączeniu trener fitness może odczytać historię treningów z Apple Health i wysłać ją do skonfigurowanego dostawcy AI (Anthropic, OpenAI, Google itp.), aby omówić Twoje postępy. Dane zdrowotne opuszczają urządzenie tylko wtedy, gdy ta opcja jest włączona. Śledzenie treningów, analiza formy i zapisywanie treningów w Apple Health na urządzeniu działają niezależnie od tego."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认关闭。开启后，健身教练可以读取你的“Apple 健康”锻炼记录，并发送给你配置的 AI 提供商（Anthropic、OpenAI、Google 等）以讨论你的进展。只有在启用此选项时，你的健康数据才会离开设备。设备上的锻炼跟踪、姿势分析以及将锻炼保存到“Apple 健康”在任何情况下都可使用。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "預設關閉。開啟後，健身教練可讀取你的「Apple 健康」鍛鍊記錄，並傳送給你設定的 AI 供應商（Anthropic、OpenAI、Google 等）以討論你的進度。只有在啟用此選項時，你的健康資料才會離開裝置。裝置上的鍛鍊追蹤、姿勢分析以及將鍛鍊儲存到「Apple 健康」在任何情況下都可使用。"
+          }
+        }
+      }
     },
     "Offline Mode" : {
       "extractionState" : "manual",
@@ -7756,7 +7744,7 @@
         }
       }
     },
-    "Pick a downloaded local model (runs offline) or any configured cloud provider. Local handles fast tool calls; cloud handles complex reasoning." : {
+    "Pick a downloaded local model (runs offline) or any configured cloud provider. Cloud handles all tiers reliably; the on-device model is experimental (see the toggle)." : {
 
     },
     "Pick a provider. You can add more later in Settings." : {
@@ -8212,9 +8200,6 @@
     "Quick Vision" : {
 
     },
-    "Rachel — calm, American" : {
-
-    },
     "Read Text" : {
 
     },
@@ -8649,9 +8634,6 @@
       "comment" : "The title of a view that displays details of each safeguard.",
       "isCommentAutoGenerated" : true
     },
-    "Sarah — soft, American" : {
-
-    },
     "Save" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -8736,6 +8718,10 @@
     },
     "Say this phrase to activate this persona. Add alternatives for common misrecognitions." : {
       "comment" : "A footer for the \"Wake Word\" section in the PersonaEditorView, explaining the purpose of the \"Alternative spellings\" text field.",
+      "isCommentAutoGenerated" : true
+    },
+    "Scenarios — %@" : {
+      "comment" : "A heading for a section of the persona picker that lists scenarios (procedures) in a vault. The argument is the name of the vault.",
       "isCommentAutoGenerated" : true
     },
     "Schedule" : {
@@ -8839,9 +8825,6 @@
       "isCommentAutoGenerated" : true
     },
     "Sends a metadata request to verify the FHIR server is reachable and responds to capability queries." : {
-
-    },
-    "Serena — pleasant, American" : {
 
     },
     "Server" : {
@@ -9014,6 +8997,53 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "設定"
+          }
+        }
+      }
+    },
+    "Share Health Data with AI" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesundheitsdaten mit KI teilen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Compartir datos de salud con la IA"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partager les données de santé avec l'IA"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "健康データをAIと共有"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Udostępniaj dane zdrowotne AI"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "与 AI 共享健康数据"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "與 AI 共享健康資料"
           }
         }
       }
@@ -9307,6 +9337,22 @@
     "Standard" : {
 
     },
+    "Start %@" : {
+      "comment" : "A button that starts a Field Assist session. The argument is the procedure.",
+      "isCommentAutoGenerated" : true
+    },
+    "Start a Field Assist session on %@ and run “%@”." : {
+      "comment" : "A confirmation dialog message that asks the user to start a Field Assist session on a vault and run a specific procedure. The first argument is the name of the vault. The second argument is the title of the",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Start a Field Assist session on %1$@ and run “%2$@”."
+          }
+        }
+      }
+    },
     "Start a Gemini Live session in a specific mode" : {
 
     },
@@ -9533,6 +9579,10 @@
     },
     "Start Session" : {
       "comment" : "A button that starts a Gemini Live session.",
+      "isCommentAutoGenerated" : true
+    },
+    "Start session?" : {
+      "comment" : "A confirmation dialog asking the user to start a session.",
       "isCommentAutoGenerated" : true
     },
     "Start wake word detection and Live Activity" : {
@@ -9972,6 +10022,10 @@
         }
       }
     },
+    "Switch the active knowledge vault. Each vault can link its own model, used only while a session is running. Tap Manage for license, vault editing, and sessions." : {
+      "comment" : "A footer for the Field Assist section of the persona picker.",
+      "isCommentAutoGenerated" : true
+    },
     "Switch to Gemini Live" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -10189,6 +10243,13 @@
       "comment" : "A description of the action to add a new persona.",
       "isCommentAutoGenerated" : true
     },
+    "Tap a model to select it. Tap Load to bring it into memory now (so the first reply is instant) — or Unload to free memory. Swipe left to delete." : {
+
+    },
+    "Tap a scenario to start a Field Assist session running that guided procedure." : {
+      "comment" : "A description of the action to start a Field Assist session.",
+      "isCommentAutoGenerated" : true
+    },
     "Tap a step to configure its type, prompts, conditions, or HTTP requests. Drag to reorder." : {
       "comment" : "A description of the steps of a playbook.",
       "isCommentAutoGenerated" : true
@@ -10357,10 +10418,6 @@
     },
     "Tap to see full response" : {
 
-    },
-    "Tap to select. Swipe left to delete. Models are stored persistently and won't be purged by iOS." : {
-      "comment" : "A footer in the Local Model Manager View, explaining how to interact with the list of models.",
-      "isCommentAutoGenerated" : true
     },
     "Tap to stop" : {
       "extractionState" : "manual",
@@ -10660,7 +10717,7 @@
       "comment" : "A description of the Health Vault.",
       "isCommentAutoGenerated" : true
     },
-    "The phrase that starts a conversation. Silent Mode keeps the assistant fully available via widget, watch, and Action Button — just without the always-listening mic." : {
+    "The phrase that starts a conversation. Push-to-Talk Mode stops the always-listening mic (so it won't fight other audio) — trigger on demand via the Action Button, Siri, widget, or watch." : {
 
     },
     "The reading level used when you ask to simplify text without specifying one." : {
@@ -10786,9 +10843,6 @@
       "isCommentAutoGenerated" : true
     },
     "This will:\n• Require biometric authentication to open the app\n• Encrypt all recordings and transcripts at rest\n• Disable web search and external messaging\n• Exclude clinical data from iCloud backup\n• Enable audit logging of all data access" : {
-
-    },
-    "Thomas — calm, American" : {
 
     },
     "Tier Assignments" : {
@@ -11145,6 +11199,10 @@
       "comment" : "A description for the URL template field in the Custom Tool Editor.",
       "isCommentAutoGenerated" : true
     },
+    "Use current model" : {
+      "comment" : "A label for a picker that lets the user choose a model.",
+      "isCommentAutoGenerated" : true
+    },
     "Used when ElevenLabs is unavailable or quota is exhausted. Download more voices in iOS Settings → Accessibility → Spoken Content → Voices." : {
 
     },
@@ -11383,6 +11441,9 @@
       }
     },
     "Voice Command" : {
+
+    },
+    "Voice ID" : {
 
     },
     "Voice Isolation Mode" : {

--- a/OpenGlasses/Sources/Services/Accessibility/NavigationAssistService.swift
+++ b/OpenGlasses/Sources/Services/Accessibility/NavigationAssistService.swift
@@ -21,6 +21,9 @@ final class NavigationAssistService: ObservableObject {
     private weak var llm: LLMService?
     private weak var tts: TextToSpeechService?
 
+    /// Set by AppState — mirrors guidance to the in-lens HUD (no-op without a display).
+    weak var glassesDisplay: GlassesDisplayService?
+
     private var timer: Timer?
     private var analyzing = false
 
@@ -65,6 +68,7 @@ final class NavigationAssistService: ObservableObject {
         isActive = false
         timer?.invalidate()
         timer = nil
+        glassesDisplay?.clear()
         NSLog("[NavAssist] Stopped")
     }
 
@@ -93,7 +97,11 @@ final class NavigationAssistService: ObservableObject {
         if let last = lastAdvice, Self.isSimilar(advice.advice, last.advice) { return }
 
         lastAdvice = advice
-        await tts.speak(advice.advice, urgency: advice.urgency.speechUrgency)
+        // Mirror to the HUD with an urgency-appropriate icon; suppress the plain TTS
+        // mirror so this richer rendering is what stays on screen.
+        let hudIcon: GlassesDisplayService.HUDIcon = advice.urgency == .high ? .hazard : .navigation
+        glassesDisplay?.showNavigation(advice.advice, icon: hudIcon)
+        await tts.speak(advice.advice, urgency: advice.urgency.speechUrgency, mirrorToHUD: false)
     }
 
     // MARK: - Frame quality (pure, testable)

--- a/OpenGlasses/Sources/Services/GlassesDisplayService.swift
+++ b/OpenGlasses/Sources/Services/GlassesDisplayService.swift
@@ -2,19 +2,22 @@ import Foundation
 import MWDATCore
 import MWDATDisplay
 
-/// Mirrors short text to the Ray-Ban *Display* in-lens HUD (DAT SDK `MWDATDisplay`).
+/// Mirrors short content to the Ray-Ban *Display* in-lens HUD (DAT SDK `MWDATDisplay`).
 ///
-/// Phase 1: surfaces AI responses and the live ambient-caption line. Everything is
-/// additive — the on-phone overlay and TTS are untouched. On glasses without a
-/// display (`Device.supportsDisplay() == false`) every call is a safe no-op and no
-/// `DeviceSession` is ever created, so non-Display Ray-Ban hardware is unaffected.
+/// Producers wired so far:
+/// - Phase 1: AI responses (`TextToSpeechService`) and the live ambient-caption line.
+/// - Phase 2: notifications (proactive/calendar + geofence alerts) and Navigation
+///   Assist guidance, rendered with an icon + heading + body.
+///
+/// Everything is additive — the on-phone overlay and TTS are untouched. On glasses
+/// without a display (`Device.supportsDisplay() == false`) every call is a safe no-op
+/// and no `DeviceSession` is ever created, so non-Display Ray-Ban hardware is unaffected.
 ///
 /// Session ownership: this service manages its own `DeviceSession` (via
 /// `AutoDeviceSelector`), separate from `CameraService`. The SDK allows a single
 /// session per device, so while the HUD session is held the camera falls back to its
 /// existing iPhone-camera path. Unifying the two into one shared `DeviceSession`
-/// (camera + display capabilities on one session) is a tracked follow-up; it is out of
-/// scope for Phase 1 and only affects Display-model hardware with the flag on.
+/// (camera + display capabilities on one session) is a tracked follow-up.
 @MainActor
 final class GlassesDisplayService: ObservableObject {
     /// True once the display capability is started and content is being shown.
@@ -25,20 +28,63 @@ final class GlassesDisplayService: ObservableObject {
     /// Debug event callback (wired to `AppState.addDebugEvent`).
     var onDebugEvent: ((String) -> Void)?
 
+    /// Semantic icon for HUD content. Mapped internally to a `MWDATDisplay.IconName`
+    /// so producers don't need to import the SDK.
+    enum HUDIcon: Equatable {
+        case none
+        case info, success, warning, error
+        case navigation, hazard
+        case calendar, location, reminder, message
+
+        fileprivate var iconName: IconName? {
+            switch self {
+            case .none: return nil
+            case .info: return .iCircle
+            case .success: return .checkmarkCircle
+            case .warning: return .exclamationTriangle
+            case .error: return .exclamationCircle
+            case .navigation: return .compassNorthUpRed
+            case .hazard: return .exclamationTriangle
+            case .calendar: return .calendar
+            case .location: return .house
+            case .reminder: return .bell
+            case .message: return .speechBubble
+            }
+        }
+    }
+
+    /// A single HUD frame: optional heading + body, with an optional leading icon.
+    private struct HUDContent: Equatable {
+        var title: String?
+        var body: String
+        var icon: HUDIcon
+    }
+
+    private enum RenderOp: Equatable {
+        case show(HUDContent)
+        case clear
+    }
+
     /// Lazily initialized after `Wearables.configure()` has been called.
     private lazy var deviceSelector = AutoDeviceSelector(wearables: Wearables.shared)
     private var deviceSession: DeviceSession?
     private var display: Display?
 
-    /// Latest-wins render queue. Rapid caption updates collapse to the most recent
-    /// frame so we never flood the BLE link — only one `send` is ever in flight.
-    private var pendingText: String?
+    /// Latest-wins render queue. Rapid updates collapse to the most recent frame so we
+    /// never flood the BLE link — only one `send` is ever in flight.
+    private var pending: RenderOp?
     private var isRendering = false
-    /// Last text actually pushed to the HUD; identical updates are skipped.
-    private var lastSentText: String?
+    /// The op last pushed to the HUD; identical follow-ups are skipped.
+    private var lastRendered: RenderOp?
 
-    /// Max characters to show on the HUD — kept short for legibility in-lens.
+    /// Generation guard for transient auto-clear, so a newer frame cancels an older
+    /// frame's pending clear.
+    private var autoClearGeneration = 0
+
+    /// Max characters for the body line — kept short for in-lens legibility.
     private static let maxLength = 120
+    /// Max characters for a heading.
+    private static let maxTitleLength = 40
 
     // MARK: - Capability
 
@@ -61,61 +107,86 @@ final class GlassesDisplayService: ObservableObject {
 
     // MARK: - Public API
 
-    /// Show a concise line of text on the HUD. No-op when the feature is off or the
-    /// glasses have no display. Text is trimmed and truncated for legibility.
+    /// Show a concise line of body text. No-op when the feature is off or the glasses
+    /// have no display. Used by the Phase 1 producers (AI replies, ambient captions).
     func showText(_ text: String) {
-        guard isEnabled, deviceSupportsDisplay() else { return }
-        let trimmed = Self.condense(text)
-        guard !trimmed.isEmpty else { return }
-        scheduleRender(trimmed)
+        present(HUDContent(title: nil, body: text, icon: .none), transient: false, duration: 0)
     }
 
-    /// Briefly show text, then clear it after `duration` seconds (if nothing newer
-    /// has been shown in the meantime).
-    func flash(_ text: String, duration: TimeInterval = 4.0) {
-        guard isEnabled, deviceSupportsDisplay() else { return }
-        let trimmed = Self.condense(text)
-        guard !trimmed.isEmpty else { return }
-        scheduleRender(trimmed)
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: UInt64(duration * 1_000_000_000))
-            guard let self else { return }
-            // Only clear if this flash is still the thing on screen.
-            if self.lastSentText == trimmed { self.clear() }
-        }
+    /// Show body text, then auto-clear after `duration` seconds.
+    func flash(_ text: String, duration: TimeInterval = 4) {
+        present(HUDContent(title: nil, body: text, icon: .none), transient: true, duration: duration)
+    }
+
+    /// Show a transient notification (icon + optional heading + body) that auto-clears.
+    func showNotification(title: String?, body: String, icon: HUDIcon = .info, duration: TimeInterval = 5) {
+        present(HUDContent(title: title, body: body, icon: icon), transient: true, duration: duration)
+    }
+
+    /// Show persistent navigation guidance (icon + body). Cleared explicitly via
+    /// `clear()` when guidance stops.
+    func showNavigation(_ text: String, icon: HUDIcon = .navigation) {
+        present(HUDContent(title: nil, body: text, icon: icon), transient: false, duration: 0)
     }
 
     /// Clear the HUD (keeps the session alive for fast subsequent updates).
     func clear() {
         guard isEnabled else { return }
         guard isDisplayActive || display != nil else { return }
-        scheduleRender("")
+        enqueue(.clear)
     }
 
     /// Fully tear down the display session. Call on feature disable / mode switch /
     /// app teardown.
     func shutdown() async {
-        pendingText = nil
+        pending = nil
         await teardownDisplay()
+    }
+
+    // MARK: - Presentation
+
+    private func present(_ content: HUDContent, transient: Bool, duration: TimeInterval) {
+        guard isEnabled, deviceSupportsDisplay() else { return }
+        var shaped = content
+        shaped.body = Self.condense(content.body)
+        shaped.title = content.title.map { Self.condense($0, max: Self.maxTitleLength) }
+        let hasBody = !shaped.body.isEmpty
+        let hasTitle = !(shaped.title?.isEmpty ?? true)
+        guard hasBody || hasTitle else { return }
+
+        let op = RenderOp.show(shaped)
+        enqueue(op)
+        if transient { scheduleAutoClear(for: op, after: duration) }
+    }
+
+    private func scheduleAutoClear(for op: RenderOp, after duration: TimeInterval) {
+        autoClearGeneration += 1
+        let generation = autoClearGeneration
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(max(0, duration) * 1_000_000_000))
+            guard let self, generation == self.autoClearGeneration else { return }
+            // Only clear if this frame is still what's on screen.
+            if self.lastRendered == op { self.clear() }
+        }
     }
 
     // MARK: - Render queue
 
-    private func scheduleRender(_ text: String) {
-        pendingText = text
+    private func enqueue(_ op: RenderOp) {
+        pending = op
         guard !isRendering else { return }
         isRendering = true
         Task { @MainActor [weak self] in
             guard let self else { return }
-            while let next = self.pendingText {
-                self.pendingText = nil
+            while let op = self.pending {
+                self.pending = nil
+                if op == self.lastRendered { continue } // skip redundant identical sends
                 do {
-                    if next.isEmpty {
-                        try await self.renderClear()
-                    } else {
-                        try await self.renderText(next)
+                    switch op {
+                    case .show(let content): try await self.renderContent(content)
+                    case .clear: try await self.renderClear()
                     }
-                    self.lastSentText = next.isEmpty ? nil : next
+                    self.lastRendered = op
                 } catch {
                     self.handleRenderError(error)
                     break
@@ -125,15 +196,39 @@ final class GlassesDisplayService: ObservableObject {
         }
     }
 
-    private func renderText(_ text: String) async throws {
+    private func renderContent(_ content: HUDContent) async throws {
         let display = try await ensureDisplay()
+        let iconName = content.icon.iconName
+        let hasTitle = !(content.title?.isEmpty ?? true)
+
         let view = FlexBox(
             direction: .column,
-            spacing: 4,
+            spacing: 6,
             alignment: .start,
             padding: EdgeInsets(all: 12)
         ) {
-            Text(text, style: .body, color: .primary)
+            if hasTitle, let title = content.title {
+                // Heading row (icon + title), then body underneath.
+                if let iconName {
+                    FlexBox(direction: .row, spacing: 6, alignment: .center) {
+                        Icon(name: iconName)
+                        Text(title, style: .heading, color: .primary)
+                    }
+                } else {
+                    Text(title, style: .heading, color: .primary)
+                }
+                Text(content.body, style: .body, color: .secondary)
+            } else {
+                // Body only — inline with the icon when present.
+                if let iconName {
+                    FlexBox(direction: .row, spacing: 6, alignment: .center) {
+                        Icon(name: iconName)
+                        Text(content.body, style: .body, color: .primary)
+                    }
+                } else {
+                    Text(content.body, style: .body, color: .primary)
+                }
+            }
         }
         try await display.send(view)
     }
@@ -204,7 +299,7 @@ final class GlassesDisplayService: ObservableObject {
         deviceSession?.stop()
         deviceSession = nil
         isDisplayActive = false
-        lastSentText = nil
+        lastRendered = nil
     }
 
     private func handleRenderError(_ error: Error) {
@@ -217,21 +312,22 @@ final class GlassesDisplayService: ObservableObject {
         deviceSession?.stop()
         deviceSession = nil
         isDisplayActive = false
+        lastRendered = nil
     }
 
     // MARK: - Text shaping
 
     /// Collapse whitespace and truncate to a HUD-legible length.
-    private static func condense(_ text: String) -> String {
+    private static func condense(_ text: String, max: Int = maxLength) -> String {
         let collapsed = text
             .replacingOccurrences(of: "\n", with: " ")
             .components(separatedBy: .whitespacesAndNewlines)
             .filter { !$0.isEmpty }
             .joined(separator: " ")
-        guard collapsed.count > maxLength else { return collapsed }
-        let cut = collapsed.prefix(maxLength)
+        guard collapsed.count > max else { return collapsed }
+        let cut = collapsed.prefix(max)
         // Prefer to break on the last space so we don't slice a word in half.
-        if let lastSpace = cut.lastIndex(of: " "), lastSpace > cut.index(cut.startIndex, offsetBy: maxLength / 2) {
+        if let lastSpace = cut.lastIndex(of: " "), lastSpace > cut.index(cut.startIndex, offsetBy: max / 2) {
             return String(cut[..<lastSpace]) + "…"
         }
         return String(cut) + "…"

--- a/OpenGlasses/Sources/Services/TextToSpeechService.swift
+++ b/OpenGlasses/Sources/Services/TextToSpeechService.swift
@@ -137,13 +137,14 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
     /// Multiplier applied to the iOS speech rate for the current utterance (driven by urgency).
     private var activeRateMultiplier: Float = 1.0
 
-    func speak(_ text: String, urgency: SpeechUrgency = .low) async {
+    func speak(_ text: String, urgency: SpeechUrgency = .low, mirrorToHUD: Bool = true) async {
         guard !text.isEmpty else { return }
         activeRateMultiplier = urgency.rateMultiplier
         let text = urgency.prefix + text
 
         // Mirror spoken text to the in-lens HUD (additive; no-op without a display).
-        glassesDisplay?.showText(text)
+        // Callers that render a richer HUD treatment themselves pass mirrorToHUD: false.
+        if mirrorToHUD { glassesDisplay?.showText(text) }
 
         // Silence if glasses-only mode is on and glasses aren't connected
         if Config.glassesOnlyAudio && !glassesConnected {

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -31,6 +31,8 @@ All plans A–M are **built and merged to `main`** to the extent verifiable with
 | U Structured Capture-Flow / Action-Form Schema | 📋 Planned (Round 5 — field) |
 | V Curated MCP Catalogue & Transport Breadth | 📋 Planned (Round 5 — MCP UX) |
 | W Presence-Aware Agent Throttle | 📋 Planned (Round 5 — agentic/battery) |
+| X Interactive HUD — Now/Next Tasks | 📋 Planned (Round 6 — Display Phase 3). Display Phase 1 ✅ merged (#42), Phase 2 on `display/hud-phase2`. |
+| Y Interactive HUD Launcher | 📋 Planned (Round 6 — Display Phase 4) |
 
 Three selectable expert-stream transports: **MJPEG** (same-LAN browser viewer), **Meeting link** (zero-infra — your meeting tool hosts the call; recommended for remote), and **WebRTC** (self-hosted peer-to-peer, needs your own signaling + TURN).
 
@@ -91,6 +93,17 @@ Drafted from a survey of our own idea-source repo `~/Code/qaeros` (its `plans/` 
 **Source-mapping (qaeros → OpenGlasses):** R ← `213`/`200`; S ← `214`/`357`/`192`; T ← `369`; U ← `327`/`366`/`552` (+`547` geofenced preconditions); V ← `575` (concept only); W ← `510`. A work-order/dispatch model (`547`/`421`/`354`) is deliberately **deferred** until T/U land.
 
 **Suggested sequence:** R (safety first) → S (agentic spine) → T (offline) → U (capture schema) → V + W (catalogue + throttle polish).
+
+## Round 6 — interactive display (Ray-Ban Display + Neural Band)
+
+Extends the in-lens HUD line from **read-only** (Display Phase 1 ✅ merged in [#42](https://github.com/straff2002/OpenGlasses/pull/42) — AI responses + ambient captions; Phase 2 on branch `display/hud-phase2` — notifications + Navigation Assist) to **interactive**, driven by the Neural Band. Grounded in the actual `MWDATDisplay` 0.7.0 surface: one-way `Display.send(view)` + `Button`/`onClick`/`onTap` callbacks (no raw gesture stream — firmware owns focus/select). Both plans are mostly a HUD interaction layer over task/launcher models the app already ships.
+
+| Plan | Title | Effort | Reuses | Strategic fit |
+|---|---|---|---|---|
+| [X](X-interactive-hud-now-next-tasks.md) | Interactive HUD — Now/Next Tasks (Display Phase 3) | ~3–4 days | GlassesDisplayService, PlaybookStore, FieldAssist ProcedureRunner, wake-word pipeline | First time the user *acts through* the lens: render the active Playbook/Procedure step as a Now/Next card; band buttons (Done/Skip/Back) drive the existing engine transitions. 📋 Planned |
+| [Y](Y-interactive-hud-launcher.md) | Interactive HUD Launcher (Display Phase 4) | ~4–6 days | Plan X HUDRouter, Config.quickActions, PlaybookStore, ProcedureLibrary, AppMode/Persona | Band-navigable home on the lens — Quick Actions · Workflows · SOPs · Mode/Persona, all in one release. Input: band + voice + phone. 📋 Planned |
+
+**Sequence (agreed):** X first (ships hands-free workflow execution and validates band navigation on one card), then Y (the full launcher reuses X's router).
 
 ## Dependency graph
 

--- a/docs/plans/X-interactive-hud-now-next-tasks.md
+++ b/docs/plans/X-interactive-hud-now-next-tasks.md
@@ -1,0 +1,173 @@
+# Plan X — Interactive HUD: Now / Next Tasks (Display Phase 3)
+
+**Source pattern:** Continues the Ray-Ban **Display** HUD line — Phase 1 (PR #42: AI responses + ambient captions) and Phase 2 (notifications + Navigation Assist, branch `display/hud-phase2`). Phases 1–2 are **read-only** mirrors. Phase 3 is the first time the user *acts through the lens* with the **Neural Band** instead of just reading it.
+
+**Strategic fit:** The app already has two step-based execution engines — **Playbooks** ([PlaybookStore.swift](../../OpenGlasses/Sources/Services/PlaybookStore.swift)) and Field Assist **Procedures** ([ProcedureRunner.swift](../../OpenGlasses/Sources/Services/FieldAssist/ProcedureRunner.swift)). Both already track a current step and a next step. Phase 3 is therefore ~90% a thin **interactive HUD layer** over models that exist, not new task infrastructure: render the active step as a *Now / Next* card and wire four band buttons (`Done / Skip / Next / Back`) to the engine's existing transitions. This is the foundation [Plan Y](Y-interactive-hud-launcher.md) (the launcher) builds on.
+
+**Effort:** ~3–4 days.
+
+---
+
+## SDK reality — what input we actually get
+
+`MWDATDisplay` is **one-way render + callbacks**, confirmed against the 0.7.0 `.swiftinterface`:
+
+- `Display.send(some DisplayableView) async throws` pushes a `FlexBox` tree (the only producer call).
+- Interactivity is **declarative**: `Button(label:style:iconName:onClick:)`, plus `FlexBox.onClick` and `.onTap(handler:)`.
+- There is **no raw band/gesture/focus stream**. The glasses + Neural Band firmware own focus traversal and selection; they invoke our `onClick` closure when the user pinch-selects an element.
+
+So an interactive screen is just *a `FlexBox` of `Button`s with closures*. Selecting one runs the closure; we then `send` the next screen. We manage the nav stack app-side; the band drives focus + select on whatever we last sent.
+
+> ⚠️ **One on-device unknown:** whether the Neural Band can *free-navigate* an arbitrary list of our `Button`s (multi-item focus traversal), or only activate a single primary action. Not visible in the SDK. **Validate first** (see Build order step 0) — the whole interaction model rests on it. Greig has hardware; this can't be checked in the simulator.
+
+---
+
+## Concept
+
+When a Playbook or Procedure is running, the HUD shows a compact card:
+
+```
+┌──────────────────────────────┐
+│ ◔ Step 3 of 7                 │   ← progress (meta)
+│ Torque the manifold bolts     │   ← NOW: step title (heading)
+│ 45 Nm, crosswise, 2 passes    │   ← NOW: instruction (body)
+│ ⚠ De-energize before contact  │   ← safety note (if any)
+│ ─────────────────────────     │
+│ Next: Reconnect the sensor    │   ← NEXT (secondary/dim)
+│ [✓ Done] [↷ Skip] [← Back]    │   ← band-selectable actions
+└──────────────────────────────┘
+```
+
+The band selects an action → we call the task source → re-render with the new now/next. Phase 1/2 ambient producers (AI replies, captions, notifications) are **suppressed or flashed** while a card is held so the task stays on screen (see Open questions).
+
+---
+
+## Files
+
+```
+Sources/Services/Display/
+├── HUDRouter.swift            // interactive screen owner over GlassesDisplayService; ambient⇄interactive mode
+├── HUDScreen.swift            // HUDScreen + HUDItem models + render to FlexBox/Button tree
+├── HUDTaskSource.swift        // protocol: current/next step + complete/skip/advance/back
+├── PlaybookHUDTaskSource.swift   // adapts PlaybookStore / PlaybookSession
+└── ProcedureHUDTaskSource.swift  // adapts FieldAssist ProcedureRunner
+```
+
+Touch:
+- [GlassesDisplayService.swift](../../OpenGlasses/Sources/Services/GlassesDisplayService.swift) — add an **interactive-mode gate**: while `HUDRouter` holds a screen, ambient `showText`/caption producers are suppressed (queued) and notifications become brief flashes that restore the screen. Reuse the existing latest-wins render queue and session.
+- [PlaybookStore.swift](../../OpenGlasses/Sources/Services/PlaybookStore.swift) / [PlaybookTool.swift](../../OpenGlasses/Sources/Services/NativeTools/PlaybookTool.swift) — expose `current`/`next` step + the existing `next/back/skip/add_result` transitions to the adapter (logic already exists; just surface it).
+- [ProcedureRunner.swift](../../OpenGlasses/Sources/Services/FieldAssist/ProcedureRunner.swift) — same: surface `currentStepId`/`nextStepId` + advance/branch for the adapter.
+- [OpenGlassesApp.swift](../../OpenGlasses/Sources/App/OpenGlassesApp.swift) — construct `HUDRouter`, inject `glassesDisplay`, register task sources; auto-present the card when a Playbook/Procedure session starts.
+- [SettingsView.swift](../../OpenGlasses/Sources/App/Views/SettingsView.swift) — interactive HUD is part of the existing **Glasses Display (HUD)** feature; no new top-level toggle needed (gate stays `Config.glassesDisplayEnabled`).
+- Voice bridge: hook the existing wake-word/transcription path so "next / done / skip / back" map to the active source (the **voice** half of the Band+voice+phone input model).
+
+---
+
+## Model
+
+```swift
+struct HUDStep: Equatable {
+    let index: Int          // 0-based
+    let total: Int?         // nil for branching procedures with no fixed length
+    let title: String
+    let instruction: String?
+    let safetyNote: String?
+    let icon: GlassesDisplayService.HUDIcon
+}
+
+/// Source-agnostic adapter so the Now/Next card doesn't care whether it's a
+/// Playbook (linear) or a Field Assist Procedure (branching).
+@MainActor protocol HUDTaskSource: AnyObject {
+    var title: String { get }            // workflow/procedure name
+    var current: HUDStep? { get }        // the NOW step (nil ⇒ finished)
+    var next: HUDStep? { get }           // the NEXT step (nil ⇒ last)
+    var changes: AnyPublisher<Void, Never> { get }  // re-render trigger
+
+    func complete() async   // mark current done → advance
+    func skip() async       // skip current → advance
+    func advance() async    // next without marking (peek-ahead workflows)
+    func back() async       // previous step
+}
+
+struct HUDItem {
+    enum Kind { case action(() async -> Void); case submenu(HUDScreen); case back }
+    let label: String
+    let icon: GlassesDisplayService.HUDIcon
+    let kind: Kind
+}
+
+struct HUDScreen {
+    let title: String?
+    let body: [HUDLine]      // non-interactive content (now/next text, safety)
+    let items: [HUDItem]     // band-selectable buttons
+    let showsBack: Bool
+}
+```
+
+`HUDRouter` owns a `[HUDScreen]` stack, renders the top screen to a `FlexBox` via the existing SDK builders (`Text` heading/body/meta, `Icon`, `Button(onClick:)`, `Background.card`), and routes each button's `onClick` to its `HUDItem.Kind`. For Phase 3 there's effectively **one screen** (the task card); the stack matters for [Plan Y](Y-interactive-hud-launcher.md).
+
+---
+
+## Flow
+
+```
+Playbook/Procedure session starts (phone, voice, or quick action)
+   ▼
+HUDRouter.present(taskCard(for: source))   → HUD enters interactive mode
+   ▼
+band focuses a button, pinch-selects ──► onClick fires
+   │
+   ├─ [✓ Done]  → source.complete()  ┐
+   ├─ [↷ Skip]  → source.skip()      ├─► source.changes emits → re-render card
+   ├─ [← Back]  → source.back()      ┘
+   │  (voice "next/done/skip/back" → same calls)
+   ▼
+source.current == nil  → render "✓ Workflow complete" flash → exit interactive mode
+```
+
+---
+
+## Build order
+
+0. **Spike (½ day, on-device):** send a `FlexBox` with 3–4 `Button`s and log which `onClick`s the band can reach. Confirms free-navigation vs single-action. If single-action only, fall back to a **paged** card (one primary action + band-cycles-the-action) — note it and proceed; the rest of the plan is unaffected.
+1. `HUDScreen` + render-to-`FlexBox`, and the `HUDRouter` interactive-mode gate in `GlassesDisplayService` (ambient suppressed while a screen is held). Unit-test the render mapping (screen → component tree) headlessly.
+2. `HUDTaskSource` + `PlaybookHUDTaskSource` (linear is simplest). Auto-present the card on Playbook start; wire `Done/Skip/Back`.
+3. Voice bridge: "next/done/skip/back" → active source.
+4. `ProcedureHUDTaskSource` (branching: `Done` follows `defaultNext`; a branch step renders its `branches[]` as selectable buttons instead of Done/Skip).
+5. Agent-response coexistence (flash-over-card, then restore) + completion flash.
+6. Settings copy + debug events; Release-config build check.
+
+---
+
+## Tests
+
+- **Render mapping** (pure): `HUDScreen` → expected `FlexBox`/`Button` tree (labels, icons, button count, Back presence). No device.
+- **PlaybookHUDTaskSource**: start → current/next correct; `complete` advances + marks status; `back` returns; last step → `current == nil`.
+- **ProcedureHUDTaskSource**: linear `defaultNext`; a branch step exposes `branches[]` as items; terminal step ends.
+- **Interactive gate**: ambient `showText` is suppressed while a screen is held and flushes the latest on exit; a notification flashes then restores the card.
+- **Voice bridge**: "done"/"skip"/"back"/"next" map to the right source call; ignored when no active source.
+
+---
+
+## Open questions / decisions needed
+
+- **Agent responses vs an active card.** Flash the reply for ~4 s then restore the card, or split the lens into a persistent task region + transient reply line? *Recommendation: flash-and-restore for Phase 3 (simplest, keeps the task authoritative); revisit a two-region layout only if it feels cramped on-device.*
+- **Completion behavior.** On the last `Done`, auto-exit interactive mode after a "✓ Complete" flash, or hold a summary screen? *Recommendation: flash then exit to ambient; a summary screen is a Plan Y launcher concern.*
+- **Voice vocabulary collisions.** "next/done/skip/back" are common words — gate them to only fire while a card is active and the user is in a command window. *Recommendation: only active during an interactive session; require the existing push-to-talk / wake context, not always-listening.*
+- **What presents the card.** Auto-present on Playbook/Procedure start is the default. Also reachable from the [Plan Y](Y-interactive-hud-launcher.md) launcher ("Resume task"). *Recommendation: auto-present on start now; launcher entry lands with Y.*
+
+---
+
+## Dependencies / prereqs
+
+- **Phase 1 + 2 HUD** ([GlassesDisplayService.swift](../../OpenGlasses/Sources/Services/GlassesDisplayService.swift)) — the session, render queue, and `HUDIcon` mapping are reused as-is; Phase 3 adds the interactive layer beside the ambient producers. Phase 2 must be merged first.
+- [PlaybookStore.swift](../../OpenGlasses/Sources/Services/PlaybookStore.swift) + [PlaybookTool.swift](../../OpenGlasses/Sources/Services/NativeTools/PlaybookTool.swift) — primary task source (now/next already modeled via `currentStepIndex`).
+- [FieldAssist/ProcedureRunner.swift](../../OpenGlasses/Sources/Services/FieldAssist/ProcedureRunner.swift) + [Procedure.swift](../../OpenGlasses/Sources/Services/FieldAssist/Procedure.swift) — branching SOP source (see [Plan F](F-field-assist.md)).
+- Wake-word / transcription pipeline (existing) — the voice-command channel.
+- **[Plan Y](Y-interactive-hud-launcher.md)** — consumes `HUDRouter`/`HUDScreen` for the full launcher; X ships standalone value (run a workflow hands-free) before Y exists.
+
+---
+
+## Why this matters
+
+Phases 1–2 made the glasses a second screen you *read*. Phase 3 makes them a surface you *operate* — and it does so over task engines you already shipped, so the new code is a small, well-bounded interaction layer rather than a new subsystem. A field tech (or anyone running a checklist) can keep both hands on the work and tick through a procedure with a pinch. It also de-risks the bigger [launcher](Y-interactive-hud-launcher.md): the band-navigation model, the screen→`FlexBox` renderer, and the ambient⇄interactive arbitration all get proven on one focused card first.

--- a/docs/plans/Y-interactive-hud-launcher.md
+++ b/docs/plans/Y-interactive-hud-launcher.md
@@ -1,0 +1,156 @@
+# Plan Y — Interactive HUD Launcher (Display Phase 4)
+
+**Source pattern:** Builds directly on [Plan X](X-interactive-hud-now-next-tasks.md) (Display Phase 3), which introduces the `HUDRouter` / `HUDScreen` nav stack and proves band navigation on a single Now/Next card. Phase 4 turns that one card into a **navigable launcher**: a hands-free home on the lens for starting and switching everything the app can do.
+
+**Strategic fit:** Every surface the launcher exposes already exists and is already enumerable at runtime — Quick Actions ([Config.swift](../../OpenGlasses/Sources/Utils/Config.swift) `quickActions`), Playbooks ([PlaybookStore.swift](../../OpenGlasses/Sources/Services/PlaybookStore.swift)), Field Assist Procedures ([ProcedureLibrary.swift](../../OpenGlasses/Sources/Services/FieldAssist/ProcedureLibrary.swift)), and Modes/Personas ([Config.swift](../../OpenGlasses/Sources/Utils/Config.swift) `AppMode` / `Persona`). Y is the menu/router glue that makes them reachable from the band without touching the phone.
+
+**Scope decision (agreed):** ship **all four surfaces in one release** — Quick Actions · Workflows · SOPs · Mode/Persona. (Native-tool browse is a natural later add via [NativeToolRegistry.contextualToolNames()](../../OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift) but is **out of scope** for this release to keep the menu shallow.)
+
+**Input model (agreed):** **Band + voice + phone.** Band navigates/selects inside a screen; voice gives parallel commands ("menu", "quick actions", "start <name>", "back"); the phone mirrors the same menu for fallback/setup.
+
+**Effort:** ~4–6 days (on top of X).
+
+---
+
+## What we enable (the four launcher branches)
+
+```
+HUD ROOT  (opened by band gesture / voice "menu" / phone)
+│
+├─ ▶ Resume task            → only when a Playbook/Procedure is active → Plan X card
+├─ ⚡ Quick Actions         → list Config.quickActions → select runs it
+│      • photo / prompt / photo+prompt / Home Assistant / Siri shortcut / open app
+├─ 📋 Workflows             → list Playbooks → start → Plan X Now/Next card
+├─ 🛠 SOPs (Field Assist)   → vault → procedure → start → Plan X card (branching)
+└─ 🎛 Mode / Persona        → switch AppMode / activate a Persona → confirm flash
+```
+
+Each leaf either (a) drops into the [Plan X](X-interactive-hud-now-next-tasks.md) task card (workflows/SOPs), or (b) runs an action and shows a **confirmation flash** then returns to its list. Quick Actions reuse the exact dispatch already behind [QuickActionTool.swift](../../OpenGlasses/Sources/Services/NativeTools/QuickActionTool.swift) / [QuickActionsOverlay.swift](../../OpenGlasses/Sources/App/Views/QuickActionsOverlay.swift); mode/persona switching reuses `AppState.currentMode` / `activePersona`.
+
+---
+
+## How the user interacts
+
+**Inside a screen** — the band traverses focus over the screen's `Button`s and pinch-selects; the SDK fires that button's `onClick` (per [Plan X](X-interactive-hud-now-next-tasks.md) SDK notes). Selecting a category **pushes** a child screen; **Back** (a button on every non-root screen) **pops**.
+
+**Navigation rules (legibility-driven):**
+- **≤ 6 items per screen.** Long lists (many playbooks/quick actions) **paginate** with a "More…" item rather than scroll forever.
+- **≤ 3 levels deep:** root → category → action (SOPs are root → vault → procedure → card = the one 3-deep path).
+- **Short labels** — the HUD condenses to ~120 chars; launcher labels target ≤ ~24 chars (truncated with the existing `condense`).
+- **Always escapable** — Back on every non-root screen; a root "Close" exits to ambient.
+
+**Three input channels (agreed):**
+| Channel | Role |
+|---|---|
+| **Neural Band** | Primary: focus + select within the current screen; Back. |
+| **Voice** | Parallel shortcuts — "menu", "quick actions", "start morning checklist", "switch to <persona>", "back", "close". Resolves against the *current* screen's items + global verbs. |
+| **Phone** | Mirror/fallback — the same `HUDScreen` tree rendered in-app ([QuickActionsOverlay](../../OpenGlasses/Sources/App/Views/QuickActionsOverlay.swift)-style) for setup, or when the band is unpaired. |
+
+---
+
+## Files
+
+```
+Sources/Services/Display/
+├── HUDLauncher.swift          // builds the root + category HUDScreens from live app state
+├── HUDMenuBuilder.swift       // each surface → [HUDItem] (quickActions, playbooks, procedures, personas)
+├── HUDVoiceCommandRouter.swift// transcription → current-screen item match + global verbs
+└── HUDPhoneMirrorView.swift   // SwiftUI mirror of the active HUDScreen stack (fallback/setup)
+```
+
+Reuses from [Plan X](X-interactive-hud-now-next-tasks.md): `HUDRouter` (stack + render), `HUDScreen`/`HUDItem`, the interactive-mode gate in [GlassesDisplayService.swift](../../OpenGlasses/Sources/Services/GlassesDisplayService.swift), and `HUDTaskSource` (workflows/SOPs hand off to the card).
+
+Touch:
+- [OpenGlassesApp.swift](../../OpenGlasses/Sources/App/OpenGlassesApp.swift) — construct `HUDLauncher`; wire open-triggers (band gesture if exposed, voice "menu", a phone Quick Action, lock-screen button).
+- [NativeToolRegistry.swift](../../OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift) — read-only enumeration for any future Tools branch (not wired this release).
+- [SettingsView.swift](../../OpenGlasses/Sources/App/Views/SettingsView.swift) — optional: choose which root branches appear + their order (default: all four).
+
+---
+
+## Model
+
+```swift
+@MainActor final class HUDLauncher {
+    // Live builders — re-evaluated each time a screen is presented so the menu
+    // reflects current state (active session, enabled personas, saved quick actions).
+    func rootScreen() -> HUDScreen
+    func quickActionsScreen(page: Int = 0) -> HUDScreen
+    func workflowsScreen(page: Int = 0) -> HUDScreen
+    func sopVaultsScreen() -> HUDScreen
+    func proceduresScreen(vaultId: String, page: Int = 0) -> HUDScreen
+    func modePersonaScreen() -> HUDScreen
+}
+```
+
+- **Root** is dynamic: "Resume task" only appears when a [Plan X](X-interactive-hud-now-next-tasks.md) `HUDTaskSource` is active; branches with no content (e.g. no vaults installed) are hidden.
+- Each builder maps live model → `[HUDItem]` with the right `HUDIcon` (`.message` prompt, `.location` HA, `.calendar`, etc.) and a handler that runs the action or pushes the next screen.
+- Pagination: when items > 6, append a `More…` submenu item carrying `page + 1`.
+
+---
+
+## Flow
+
+```
+trigger (band gesture | voice "menu" | phone) 
+   ▼
+HUDRouter.present(launcher.rootScreen())     → interactive mode (Plan X gate)
+   ▼
+select "Quick Actions"  → push launcher.quickActionsScreen()
+select "Take photo"     → run QuickActionTool dispatch → "✓ Captured" flash → pop to list
+   … or …
+select "Workflows" → pick "Site walkthrough" → start Playbook
+   → HUDRouter swaps to Plan X Now/Next card (launcher stack retained underneath)
+   ▼
+voice in parallel: "switch to Scout" → HUDVoiceCommandRouter matches modePersona item → activate → flash
+   ▼
+"close" / root Close → exit interactive mode → ambient producers resume
+```
+
+---
+
+## Build order
+
+1. `HUDMenuBuilder` for **Quick Actions** (flattest, instant payoff) + `HUDLauncher.rootScreen`/`quickActionsScreen`; open via a phone Quick Action first (no band-trigger dependency).
+2. Open-trigger matrix: voice "menu"; band gesture **if** the on-device spike ([Plan X](X-interactive-hud-now-next-tasks.md) step 0) shows one is available; keep the phone trigger as guaranteed fallback.
+3. **Workflows** branch → hand off to the [Plan X](X-interactive-hud-now-next-tasks.md) card; "Resume task" root item.
+4. **Mode / Persona** branch (switch + confirm flash).
+5. **SOPs** branch (vault → procedure → card), reusing the branching `ProcedureHUDTaskSource`.
+6. `HUDVoiceCommandRouter` (current-screen item match + global verbs) across all branches.
+7. `HUDPhoneMirrorView` fallback + Settings (branch visibility/order).
+8. Pagination polish; Release-config build check.
+
+---
+
+## Tests
+
+- **Menu builders** (pure): given fixtures (N quick actions, M playbooks, K personas) → expected `HUDScreen` items, icons, pagination (`More…` past 6), and hidden empty branches.
+- **Root dynamism**: "Resume task" present iff a task source is active; vault branch hidden with no vaults.
+- **Routing**: selecting a category pushes the right child; Back pops; leaf action invokes the correct dispatch (mock `QuickActionTool` / persona switch) exactly once.
+- **Voice router**: utterance → correct item on the *current* screen; global verbs ("back/close/menu") always resolve; ambiguous match asks or no-ops (never wrong-fires).
+- **Hand-off**: starting a workflow/SOP from the launcher presents the [Plan X](X-interactive-hud-now-next-tasks.md) card and preserves the launcher stack for return.
+
+---
+
+## Open questions / decisions needed
+
+- **Band open-gesture availability.** Can our app claim a band "home" gesture, or does the system own it (so we open only via voice/phone)? Resolved by the [Plan X](X-interactive-hud-now-next-tasks.md) on-device spike. *Recommendation: design for voice + phone triggers as guaranteed; treat a band gesture as a bonus if exposed.*
+- **List length in the field.** Power users may have many quick actions/playbooks. *Recommendation: paginate at 6 with `More…`; later add a "Favorites" subset pinned to the root for the field.*
+- **Mode switch safety.** Switching to Gemini/OpenAI Realtime from the lens starts a live session (mic/network). *Recommendation: require a second confirm item for mode switches that open a realtime session; persona swaps (same mode) are one-tap.*
+- **Notification interruptions mid-menu.** A geofence/proactive alert arriving while a menu is open. *Recommendation: brief flash badge, never steal focus from an open launcher screen (reuse the [Plan X](X-interactive-hud-now-next-tasks.md) flash-and-restore).*
+- **Agent-mode gating.** Anything that can *act* autonomously stays behind [agentModeEnabled](../../.claude/projects/-Users-greig-Code-OpenGlasses/memory/feedback_agentic_toggle.md); the launcher itself is user-initiated, so it isn't gated, but agentic quick actions inside it inherit that gate.
+
+---
+
+## Dependencies / prereqs
+
+- **[Plan X](X-interactive-hud-now-next-tasks.md) must land first** — Y reuses its `HUDRouter`, `HUDScreen`/`HUDItem`, the interactive-mode gate, and `HUDTaskSource`. (Agreed sequencing: Phase 3 → Phase 4.)
+- [Config.swift](../../OpenGlasses/Sources/Utils/Config.swift) — `quickActions`, `AppMode`, `Persona` enumeration.
+- [QuickActionTool.swift](../../OpenGlasses/Sources/Services/NativeTools/QuickActionTool.swift) / [QuickActionsOverlay.swift](../../OpenGlasses/Sources/App/Views/QuickActionsOverlay.swift) — existing action dispatch + a phone-mirror reference.
+- [PlaybookStore.swift](../../OpenGlasses/Sources/Services/PlaybookStore.swift) + [ProcedureLibrary.swift](../../OpenGlasses/Sources/Services/FieldAssist/ProcedureLibrary.swift) — workflow/SOP listings.
+- Wake-word / transcription pipeline — the voice channel.
+
+---
+
+## Why this matters
+
+The launcher is what makes the Display glasses a *control surface*, not just a notification screen — start a workflow, fire a quick action, switch persona, all without reaching for the phone. Because every branch maps to a capability the app already ships and enumerates, Phase 4 is mostly menu-building over [Plan X](X-interactive-hud-now-next-tasks.md)'s proven router. The shallow ≤6-item / ≤3-level discipline keeps it glanceable in the field, and the three-channel input (band + voice + phone) means it degrades gracefully when the band is unavailable instead of stranding the user.


### PR DESCRIPTION
## Summary

Phase 2 of in-lens HUD support for **Ray-Ban Display** glasses, continuing [#42](https://github.com/straff2002/OpenGlasses/pull/42) (Phase 1: AI responses + ambient captions). Phases 1–2 are **read-only** mirrors; this adds two new producers and richer rendering. Still additive and capability-gated exactly as Phase 1 — every call is a safe no-op when `Config.glassesDisplayEnabled` is off or the glasses have no display, so non-Display hardware is unaffected.

Also bundles the **Round 6 plan docs** (interactive HUD design, Phases 3–4) as a separate commit — markdown only, no code impact.

## What changed (Phase 2 — commit `e1d3b6b`)

- **`GlassesDisplayService`** — generalize the latest-wins render queue from plain text to a `RenderOp` (`show(HUDContent)` / `clear`). New:
  - `showNotification(title:body:icon:duration:)` — icon + optional heading + body, auto-clearing.
  - `showNavigation(_:icon:)` — persistent guidance (icon + body), cleared explicitly.
  - Typed **`HUDIcon`** enum mapped to `MWDATDisplay.IconName` so producers don't import the SDK.
  - Auto-clear is **generation-guarded** so a newer frame cancels an older frame's pending clear.
- **`TextToSpeechService.speak`** — new `mirrorToHUD: Bool = true`; callers that render their own richer HUD card pass `false` to suppress the plain-text mirror (default preserves Phase 1 behavior).
- **Producers wired** in `OpenGlassesApp`:
  - `ProactiveAlertService` → reminder cards (`.calendar`).
  - `GeofenceTool` → location cards (`.location`).
  - `NavigationAssistService` → turn-by-turn guidance, `.hazard` icon on high urgency, clears the HUD when guidance stops.
- **`Localizable.xcstrings`** — Xcode string-catalog re-extraction + added de/es/fr/ja/pl/zh translations for pre-existing strings (noise, no HUD-specific keys).

## Round 6 plan docs (commit `8b8fb15`)

- `docs/plans/X-interactive-hud-now-next-tasks.md` — **Phase 3**: Now/Next task card driven by the Neural Band (Done/Skip/Back), source-agnostic over Playbooks and Field Assist Procedures.
- `docs/plans/Y-interactive-hud-launcher.md` — **Phase 4**: band-navigable launcher (Quick Actions · Workflows · SOPs · Mode/Persona) with band + voice + phone input.
- `docs/plans/README.md` — new "Round 6 — interactive display" section + status rows.

Both grounded in the actual `MWDATDisplay` 0.7.0 surface: one-way `Display.send(view)` + `Button`/`onClick`/`onTap` callbacks (no raw band/gesture stream — firmware owns focus/select).

## API notes

No new SDK dependency or product — Phase 2 reuses the `MWDATDisplay` product declared in Phase 1. All `IconName` cases used (`compassNorthUpRed`, `house`, `bell`, `speechBubble`, `calendar`, `exclamationTriangle`, …), `TextStyle.heading`, `TextColor.secondary`, and `Icon(name:)` verified against the 0.7.0 `.swiftinterface`.

## Build / verify

Rebased clean onto current `main` (includes #43 native-brain + #44 Round-5 docs).

- `./Scripts/generate-xcodeproj.sh`
- ✅ Debug — `xcodebuild -project OpenGlasses.xcodeproj -scheme OpenGlasses -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`
- ✅ Release — `xcodebuild ... -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)