### PR TITLE
Interactive HUD — Now/Next task card + band/voice control (Display Phase 3 / Plan X)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2035,6 +2035,20 @@ class AppState: ObservableObject, AppStateProtocol {
         speechService.playEndListeningTone()
         print("📝 Transcription: \(text)")
 
+        // HUD task control (Display Phase 3 / Plan X): while a Now/Next card is on the
+        // glasses, "next/done/skip/back" drive the task instead of going to the LLM.
+        // Checked before intent classification so these short commands aren't filtered.
+        if await hudRouter.handleVoiceCommand(text) {
+            print("🎯 HUD task command handled: \(text)")
+            if inConversation {
+                isListening = true
+                transcriptionService.startRecording()
+            } else {
+                await returnToWakeWord()
+            }
+            return
+        }
+
         // Will be updated below if persona detected in text
         var query = text
 

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -472,6 +472,7 @@ class AppState: ObservableObject, AppStateProtocol {
     /// glasses from the active Playbook, navigable with the Neural Band.
     lazy var hudRouter = HUDRouter(display: glassesDisplay)
     lazy var playbookHUDSource = PlaybookHUDTaskSource(store: playbookStore)
+    lazy var procedureHUDSource = ProcedureHUDTaskSource()
     let hipaaService = HIPAAComplianceService()
     let medicalExportService = MedicalExportService()
 
@@ -963,6 +964,16 @@ class AppState: ObservableObject, AppStateProtocol {
                 self.hudRouter.startTask(self.playbookHUDSource)
             }
         cancellables.append(playbookHUDToken)
+
+        // Auto-present the interactive HUD task card when a Field Assist procedure starts.
+        let procedureHUDToken = FieldSessionService.shared.$activeProcedureId
+            .map { $0 != nil }
+            .removeDuplicates()
+            .sink { [weak self] active in
+                guard let self, active else { return }
+                self.hudRouter.startTask(self.procedureHUDSource)
+            }
+        cancellables.append(procedureHUDToken)
 
         wakeWordService.onWakeWordDetected = { [weak self] matchedPhrase in
             Task { @MainActor in

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -468,6 +468,10 @@ class AppState: ObservableObject, AppStateProtocol {
     let agentScheduler = AgentScheduler()
     let agentNotificationQueue = AgentNotificationQueue()
     let playbookStore = PlaybookStore()
+    /// Interactive HUD (Display Phase 3 / Plan X): drives a Now/Next task card on the
+    /// glasses from the active Playbook, navigable with the Neural Band.
+    lazy var hudRouter = HUDRouter(display: glassesDisplay)
+    lazy var playbookHUDSource = PlaybookHUDTaskSource(store: playbookStore)
     let hipaaService = HIPAAComplianceService()
     let medicalExportService = MedicalExportService()
 
@@ -948,6 +952,17 @@ class AppState: ObservableObject, AppStateProtocol {
                 self?.applyFieldSessionModel(for: session)
             }
         cancellables.append(fieldSessionToken)
+
+        // Auto-present the interactive HUD task card (Display Phase 3 / Plan X) when a
+        // Playbook session starts; the router self-dismisses when the workflow ends.
+        let playbookHUDToken = playbookStore.$activeSession
+            .map { $0 != nil }
+            .removeDuplicates()
+            .sink { [weak self] active in
+                guard let self, active else { return }
+                self.hudRouter.startTask(self.playbookHUDSource)
+            }
+        cancellables.append(playbookHUDToken)
 
         wakeWordService.onWakeWordDetected = { [weak self] matchedPhrase in
             Task { @MainActor in

--- a/OpenGlasses/Sources/Services/Display/HUDRouter.swift
+++ b/OpenGlasses/Sources/Services/Display/HUDRouter.swift
@@ -63,6 +63,21 @@ final class HUDRouter: ObservableObject {
         item.action()
     }
 
+    /// Voice leg of the band+voice+phone input model: while a task card is active,
+    /// "next/done/skip/back" drive the source. Returns `true` if it consumed the
+    /// utterance (so the caller doesn't also send it to the LLM). No-op otherwise.
+    @discardableResult
+    func handleVoiceCommand(_ text: String) async -> Bool {
+        guard isPresentingTask, let source = taskSource,
+              let command = HUDVoiceCommand.parse(text) else { return false }
+        switch command {
+        case .complete: await source.complete()
+        case .skip: await source.skip()
+        case .back: await source.back()
+        }
+        return true
+    }
+
     // MARK: - Card layout
 
     /// Build the Now/Next card. `static` and pure so it's unit-testable without a device.

--- a/OpenGlasses/Sources/Services/Display/HUDRouter.swift
+++ b/OpenGlasses/Sources/Services/Display/HUDRouter.swift
@@ -97,17 +97,29 @@ final class HUDRouter: ObservableObject {
             lines.append(HUDLine("Next: \(next.title)", emphasis: .meta))
         }
 
-        let items: [HUDItem] = [
-            HUDItem(id: "done", label: "Done", icon: .success, style: .primary) {
-                Task { await source.complete() }
-            },
-            HUDItem(id: "skip", label: "Skip", style: .secondary) {
-                Task { await source.skip() }
-            },
-            HUDItem(id: "back", label: "Back", style: .outline) {
-                Task { await source.back() }
-            },
-        ]
+        // A decision step renders one button per branch (+ Back); a linear step
+        // renders Done / Skip / Back.
+        let choices = source.choices
+        var items: [HUDItem]
+        if choices.isEmpty {
+            items = [
+                HUDItem(id: "done", label: "Done", icon: .success, style: .primary) {
+                    Task { await source.complete() }
+                },
+                HUDItem(id: "skip", label: "Skip", style: .secondary) {
+                    Task { await source.skip() }
+                },
+            ]
+        } else {
+            items = choices.map { choice in
+                HUDItem(id: "choice:\(choice.id)", label: choice.label, style: .primary) {
+                    Task { await source.choose(choice.id) }
+                }
+            }
+        }
+        items.append(HUDItem(id: "back", label: "Back", style: .outline) {
+            Task { await source.back() }
+        })
 
         return HUDScreen(title: current.title, lines: lines, items: items)
     }

--- a/OpenGlasses/Sources/Services/Display/HUDRouter.swift
+++ b/OpenGlasses/Sources/Services/Display/HUDRouter.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Combine
+
+/// Owns the interactive HUD (Display Phase 3 / Plan X): given a `HUDTaskSource`, it
+/// renders the Now/Next card, routes Neural-Band selections back to the source, and
+/// re-renders whenever the source changes. The full launcher ([Plan Y](../../../docs/plans/Y-interactive-hud-launcher.md))
+/// will reuse this router with a screen *stack*; Phase 3 is a single task card.
+@MainActor
+final class HUDRouter: ObservableObject {
+    private let display: GlassesDisplayService
+
+    private var taskSource: HUDTaskSource?
+    private var currentScreen: HUDScreen?
+    private var cancellable: AnyCancellable?
+
+    /// Whether a task card is currently being driven on the HUD.
+    @Published private(set) var isPresentingTask = false
+
+    init(display: GlassesDisplayService) {
+        self.display = display
+    }
+
+    // MARK: - Task presentation
+
+    /// Begin driving `source` as a Now/Next card. Re-renders on every source change.
+    func startTask(_ source: HUDTaskSource) {
+        taskSource = source
+        cancellable = source.changes.sink { [weak self] _ in
+            // Defer to the next main-actor tick so the source reflects the new step.
+            Task { @MainActor in self?.refresh() }
+        }
+        isPresentingTask = true
+        refresh()
+    }
+
+    /// Stop driving the current task and return the HUD to its ambient producers.
+    func stopTask() {
+        cancellable = nil
+        taskSource = nil
+        currentScreen = nil
+        isPresentingTask = false
+        display.endInteractive()
+    }
+
+    private func refresh() {
+        guard let source = taskSource else { return }
+        guard let current = source.current else {
+            // Workflow finished → confirmation flash, then back to ambient.
+            let title = source.title
+            stopTask()
+            display.flash("✓ \(title) complete")
+            return
+        }
+        let screen = Self.taskCard(source: source, current: current, next: source.next)
+        currentScreen = screen
+        display.present(screen: screen) { [weak self] id in
+            self?.handleSelection(id)
+        }
+    }
+
+    private func handleSelection(_ id: String) {
+        guard let item = currentScreen?.items.first(where: { $0.id == id }) else { return }
+        item.action()
+    }
+
+    // MARK: - Card layout
+
+    /// Build the Now/Next card. `static` and pure so it's unit-testable without a device.
+    static func taskCard(source: HUDTaskSource, current: HUDStep, next: HUDStep?) -> HUDScreen {
+        var lines: [HUDLine] = []
+
+        if let total = current.total {
+            lines.append(HUDLine("Step \(current.index + 1) of \(total)", emphasis: .meta))
+        }
+        if let instruction = current.instruction, !instruction.isEmpty {
+            lines.append(HUDLine(instruction, emphasis: .secondary))
+        }
+        if let safety = current.safetyNote, !safety.isEmpty {
+            lines.append(HUDLine(safety, icon: .hazard, emphasis: .secondary))
+        }
+        if let next {
+            lines.append(HUDLine("Next: \(next.title)", emphasis: .meta))
+        }
+
+        let items: [HUDItem] = [
+            HUDItem(id: "done", label: "Done", icon: .success, style: .primary) {
+                Task { await source.complete() }
+            },
+            HUDItem(id: "skip", label: "Skip", style: .secondary) {
+                Task { await source.skip() }
+            },
+            HUDItem(id: "back", label: "Back", style: .outline) {
+                Task { await source.back() }
+            },
+        ]
+
+        return HUDScreen(title: current.title, lines: lines, items: items)
+    }
+}

--- a/OpenGlasses/Sources/Services/Display/HUDScreen.swift
+++ b/OpenGlasses/Sources/Services/Display/HUDScreen.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// SDK-free description of one interactive HUD screen (Display Phase 3 / Plan X).
+///
+/// A screen is a heading + some non-interactive content lines + a list of
+/// band-selectable items. `GlassesDisplayService` renders it to a `MWDATDisplay`
+/// `FlexBox`/`Button` tree; nothing here imports the SDK, so screens are pure data
+/// and unit-testable headlessly. `HUDIcon` is reused from `GlassesDisplayService`.
+
+/// Text emphasis for a content line, mapped to the SDK's `TextStyle`/`TextColor`
+/// inside `GlassesDisplayService`.
+enum HUDEmphasis: Equatable {
+    case primary    // body / primary colour
+    case secondary  // body / secondary colour
+    case meta       // small meta / secondary colour
+}
+
+/// Button prominence, mapped to the SDK's `ButtonStyle` inside `GlassesDisplayService`.
+enum HUDButtonStyle: Equatable {
+    case primary
+    case secondary
+    case outline
+}
+
+/// A non-interactive content line (optional leading icon + text).
+struct HUDLine: Equatable {
+    let text: String
+    let icon: GlassesDisplayService.HUDIcon
+    let emphasis: HUDEmphasis
+
+    init(_ text: String, icon: GlassesDisplayService.HUDIcon = .none, emphasis: HUDEmphasis = .primary) {
+        self.text = text
+        self.icon = icon
+        self.emphasis = emphasis
+    }
+}
+
+/// A band-selectable action. `id` is stable and Sendable so the SDK `onClick`
+/// callback can route back by id; `action` is invoked on the main actor by `HUDRouter`.
+struct HUDItem: Identifiable {
+    let id: String
+    let label: String
+    let icon: GlassesDisplayService.HUDIcon
+    let style: HUDButtonStyle
+    let action: () -> Void
+
+    init(id: String,
+         label: String,
+         icon: GlassesDisplayService.HUDIcon = .none,
+         style: HUDButtonStyle = .secondary,
+         action: @escaping () -> Void) {
+        self.id = id
+        self.label = label
+        self.icon = icon
+        self.style = style
+        self.action = action
+    }
+}
+
+/// One renderable interactive screen.
+struct HUDScreen {
+    let title: String?
+    let lines: [HUDLine]
+    let items: [HUDItem]
+
+    init(title: String? = nil, lines: [HUDLine] = [], items: [HUDItem] = []) {
+        self.title = title
+        self.lines = lines
+        self.items = items
+    }
+
+    /// Stable key over the *visible* content, used to skip redundant re-renders
+    /// (the render queue collapses identical screens). Excludes closures.
+    var renderKey: String {
+        let head = title ?? ""
+        let body = lines.map { "\($0.emphasis):\($0.icon):\($0.text)" }.joined(separator: "¦")
+        let acts = items.map { "\($0.id):\($0.style):\($0.icon):\($0.label)" }.joined(separator: "¦")
+        return "\(head)|\(body)|\(acts)"
+    }
+}

--- a/OpenGlasses/Sources/Services/Display/HUDTaskSource.swift
+++ b/OpenGlasses/Sources/Services/Display/HUDTaskSource.swift
@@ -27,21 +27,37 @@ struct HUDStep: Equatable {
     }
 }
 
+/// A branch choice at a decision step (Field Assist procedures). Linear sources
+/// (Playbooks) expose none.
+struct HUDChoice: Equatable, Identifiable {
+    let id: String
+    let label: String
+}
+
 /// Adapter a step-based engine implements so `HUDRouter` can render and drive it from
-/// the Neural Band. Conformers: `PlaybookHUDTaskSource` (Plan X) and, later, a
-/// Field Assist `ProcedureRunner` adapter.
+/// the Neural Band. Conformers: `PlaybookHUDTaskSource` (linear) and
+/// `ProcedureHUDTaskSource` (branching Field Assist SOPs).
 @MainActor
 protocol HUDTaskSource: AnyObject {
     /// Workflow / procedure name (rendered as the card heading).
     var title: String { get }
     /// The NOW step, or nil when the workflow has finished.
     var current: HUDStep? { get }
-    /// The NEXT step (preview), or nil when on the last step.
+    /// The NEXT step (preview), or nil when on the last/branching step.
     var next: HUDStep? { get }
-    /// Emits whenever `current`/`next` may have changed, so the card re-renders.
+    /// Branch options at a decision step. Empty ⇒ a linear Done/Skip/Back card;
+    /// non-empty ⇒ the card renders one button per choice (+ Back).
+    var choices: [HUDChoice] { get }
+    /// Emits whenever `current`/`next`/`choices` may have changed, so the card re-renders.
     var changes: AnyPublisher<Void, Never> { get }
 
-    func complete() async   // mark current done → advance
-    func skip() async       // skip current → advance
-    func back() async       // previous step
+    func complete() async        // mark current done → advance
+    func skip() async            // skip current → advance
+    func back() async            // previous step
+    func choose(_ id: String) async   // take a specific branch
+}
+
+extension HUDTaskSource {
+    var choices: [HUDChoice] { [] }
+    func choose(_ id: String) async {}
 }

--- a/OpenGlasses/Sources/Services/Display/HUDTaskSource.swift
+++ b/OpenGlasses/Sources/Services/Display/HUDTaskSource.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Combine
+
+/// One step of a workflow/SOP as the HUD needs it — source-agnostic so the Now/Next
+/// card doesn't care whether it's a linear Playbook or a branching Field Assist
+/// Procedure.
+struct HUDStep: Equatable {
+    let index: Int           // 0-based
+    let total: Int?          // nil for branching procedures with no fixed length
+    let title: String
+    let instruction: String?
+    let safetyNote: String?
+    let icon: GlassesDisplayService.HUDIcon
+
+    init(index: Int,
+         total: Int?,
+         title: String,
+         instruction: String? = nil,
+         safetyNote: String? = nil,
+         icon: GlassesDisplayService.HUDIcon = .none) {
+        self.index = index
+        self.total = total
+        self.title = title
+        self.instruction = instruction
+        self.safetyNote = safetyNote
+        self.icon = icon
+    }
+}
+
+/// Adapter a step-based engine implements so `HUDRouter` can render and drive it from
+/// the Neural Band. Conformers: `PlaybookHUDTaskSource` (Plan X) and, later, a
+/// Field Assist `ProcedureRunner` adapter.
+@MainActor
+protocol HUDTaskSource: AnyObject {
+    /// Workflow / procedure name (rendered as the card heading).
+    var title: String { get }
+    /// The NOW step, or nil when the workflow has finished.
+    var current: HUDStep? { get }
+    /// The NEXT step (preview), or nil when on the last step.
+    var next: HUDStep? { get }
+    /// Emits whenever `current`/`next` may have changed, so the card re-renders.
+    var changes: AnyPublisher<Void, Never> { get }
+
+    func complete() async   // mark current done → advance
+    func skip() async       // skip current → advance
+    func back() async       // previous step
+}

--- a/OpenGlasses/Sources/Services/Display/HUDVoiceCommand.swift
+++ b/OpenGlasses/Sources/Services/Display/HUDVoiceCommand.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Maps a spoken phrase to a HUD task action (Display Phase 3 / Plan X). These are
+/// common words, so the match is deliberately **strict** — only tight whole-phrase
+/// matches fire, and the caller (`HUDRouter`) only consults this while a Now/Next card
+/// is actually on the glasses. A leading filler ("ok", "hey", …) is tolerated.
+enum HUDVoiceCommand: Equatable {
+    case complete   // "done" / "next" / "complete" / "finished"
+    case skip       // "skip"
+    case back       // "back" / "previous"
+
+    static func parse(_ text: String) -> HUDVoiceCommand? {
+        // Lowercase, strip punctuation, collapse whitespace.
+        let stripped = text.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.union(.whitespaces).inverted)
+            .joined()
+        let words = stripped.split(separator: " ").map(String.init).filter { !$0.isEmpty }
+        let filler: Set<String> = ["ok", "okay", "hey", "please", "uh", "um", "yeah", "yep", "now"]
+        let core = words.drop(while: { filler.contains($0) }).joined(separator: " ")
+
+        switch core {
+        case "done", "next", "complete", "completed", "finish", "finished",
+             "next step", "mark done", "mark complete", "done with this", "next one":
+            return .complete
+        case "skip", "skip this", "skip step", "skip this step":
+            return .skip
+        case "back", "go back", "previous", "previous step", "step back":
+            return .back
+        default:
+            return nil
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/Display/PlaybookHUDTaskSource.swift
+++ b/OpenGlasses/Sources/Services/Display/PlaybookHUDTaskSource.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Combine
+
+/// Adapts the linear [PlaybookStore](PlaybookStore.swift) workflow engine to the HUD's
+/// `HUDTaskSource`, so a running Playbook renders as a Now/Next card the Neural Band
+/// can drive. Pure glue — all step logic stays in `PlaybookStore`.
+@MainActor
+final class PlaybookHUDTaskSource: HUDTaskSource {
+    private let store: PlaybookStore
+
+    init(store: PlaybookStore) {
+        self.store = store
+    }
+
+    /// `PlaybookStore` is an `ObservableObject`; its `objectWillChange` fires on every
+    /// session mutation. `HUDRouter` defers the actual read to the next main-actor tick,
+    /// by which point `activeSession` reflects the new step.
+    var changes: AnyPublisher<Void, Never> {
+        store.objectWillChange.map { _ in () }.eraseToAnyPublisher()
+    }
+
+    private var session: PlaybookSession? { store.activeSession }
+    private var playbook: Playbook? { session.flatMap { store.playbook(byId: $0.playbookId) } }
+
+    var title: String { playbook?.name ?? "Workflow" }
+
+    var current: HUDStep? { step(at: session?.currentStepIndex, instruction: true) }
+
+    var next: HUDStep? { step(at: session.map { $0.currentStepIndex + 1 }, instruction: false) }
+
+    private func step(at index: Int?, instruction: Bool) -> HUDStep? {
+        guard let index, let pb = playbook, index >= 0, index < pb.steps.count else { return nil }
+        let step = pb.steps[index]
+        let detail = step.detail.trimmingCharacters(in: .whitespacesAndNewlines)
+        return HUDStep(
+            index: index,
+            total: pb.steps.count,
+            title: step.title,
+            instruction: (instruction && !detail.isEmpty) ? detail : nil,
+            safetyNote: nil,          // Playbooks have no safety notes (that's Field Assist)
+            icon: .none
+        )
+    }
+
+    func complete() async { _ = store.nextStep() }            // marks current complete + advances
+    func skip() async { _ = store.skipCurrentStep(reason: "Skipped from HUD") }
+    func back() async { _ = store.previousStep() }
+}

--- a/OpenGlasses/Sources/Services/Display/ProcedureHUDTaskSource.swift
+++ b/OpenGlasses/Sources/Services/Display/ProcedureHUDTaskSource.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Combine
+
+/// The slice of `FieldSessionService` the HUD procedure source needs. Abstracted to a
+/// protocol so the adapter is unit-testable without standing up a full vault + session.
+@MainActor
+protocol ProcedureHosting: AnyObject {
+    var activeProcedureStep: Procedure.Step? { get }
+    var activeProcedureTitle: String? { get }
+    var objectWillChange: ObservableObjectPublisher { get }
+    @discardableResult func advanceProcedure(choice: String?) throws -> ProcedureRunner.Transition
+    @discardableResult func procedureBack() throws -> Procedure.Step
+}
+
+extension FieldSessionService: ProcedureHosting {}
+
+/// Adapts a running Field Assist **Procedure** (branching SOP) to the HUD's
+/// `HUDTaskSource`, so it renders as a Now/Next card with per-branch choice buttons.
+/// Pure glue — the step graph and audit logging stay in `ProcedureRunner`.
+@MainActor
+final class ProcedureHUDTaskSource: HUDTaskSource {
+    private let host: ProcedureHosting
+
+    init(host: ProcedureHosting = FieldSessionService.shared) {
+        self.host = host
+    }
+
+    var changes: AnyPublisher<Void, Never> {
+        host.objectWillChange.map { _ in () }.eraseToAnyPublisher()
+    }
+
+    private var step: Procedure.Step? { host.activeProcedureStep }
+
+    var title: String { host.activeProcedureTitle ?? "Procedure" }
+
+    var current: HUDStep? {
+        guard let step else { return nil }
+        let instruction = step.instruction.trimmingCharacters(in: .whitespacesAndNewlines)
+        return HUDStep(
+            index: 0,
+            total: nil,                              // branching graph — no fixed length
+            title: step.title,
+            instruction: instruction.isEmpty ? nil : instruction,
+            safetyNote: step.safetyNote,
+            icon: step.terminal ? .success : .navigation
+        )
+    }
+
+    /// Branching procedures have no single linear "next" to preview.
+    var next: HUDStep? { nil }
+
+    var choices: [HUDChoice] {
+        (step?.branches ?? []).map { HUDChoice(id: $0.id, label: $0.condition) }
+    }
+
+    func complete() async { _ = try? host.advanceProcedure(choice: nil) }   // follow default_next / finish terminal
+    func skip() async { _ = try? host.advanceProcedure(choice: nil) }       // procedures don't skip — treat as advance
+    func back() async { _ = try? host.procedureBack() }
+    func choose(_ id: String) async { _ = try? host.advanceProcedure(choice: id) }
+}

--- a/OpenGlasses/Sources/Services/GlassesDisplayService.swift
+++ b/OpenGlasses/Sources/Services/GlassesDisplayService.swift
@@ -100,10 +100,31 @@ final class GlassesDisplayService: ObservableObject {
     private var currentScreen: HUDScreen?
     private var screenSelectionHandler: ((String) -> Void)?
 
+    // MARK: - Testing seam
+    //
+    // No Ray-Ban *Display* hardware is available in CI/sim, so the interactive logic
+    // (capability gate, ambient suppression, render-key dedup, flash-then-restore) is
+    // validated headlessly. `testCapabilityOverride` bypasses the hardware capability
+    // check; `testRenderSink`, when set, captures the frame the queue *would* send
+    // instead of hitting the SDK. Both are nil in production — the real SDK path is
+    // untouched. The Neural Band itself is simulated in tests by invoking the
+    // `onClick` of the buttons produced by `makeScreenView(_:)`.
+    var testCapabilityOverride: Bool?
+    var testRenderSink: ((HUDFrame) -> Void)?
+
+    /// A frame the render queue resolved to — the test observation point.
+    enum HUDFrame: Equatable {
+        case content(body: String, title: String?, icon: HUDIcon)
+        case screen(renderKey: String)
+        case clear
+    }
+
     /// Max characters for the body line — kept short for in-lens legibility.
-    private static let maxLength = 120
+    /// `nonisolated` so `condense`'s default argument can reference it without a
+    /// Swift 6 main-actor-isolation warning (it's an immutable Sendable constant).
+    private nonisolated static let maxLength = 120
     /// Max characters for a heading.
-    private static let maxTitleLength = 40
+    private nonisolated static let maxTitleLength = 40
 
     // MARK: - Capability
 
@@ -111,6 +132,10 @@ final class GlassesDisplayService: ObservableObject {
     /// safe to call frequently. Updates `hasDisplayCapability` as a side effect.
     @discardableResult
     func deviceSupportsDisplay() -> Bool {
+        if let testCapabilityOverride {
+            if hasDisplayCapability != testCapabilityOverride { hasDisplayCapability = testCapabilityOverride }
+            return testCapabilityOverride
+        }
         let supported: Bool = {
             guard let id = deviceSelector.activeDevice,
                   let device = Wearables.shared.deviceForIdentifier(id) else {
@@ -209,9 +234,9 @@ final class GlassesDisplayService: ObservableObject {
             // Only act if this frame is still what's on screen.
             guard self.lastRendered == op else { return }
             if self.isInteractive, let screen = self.currentScreen {
-                self.enqueue(.screen(screen))   // restore the held screen after the flash
+                self.enqueue(.screen(screen))     // restore the held screen after the flash
             } else {
-                self.clear()
+                self.enqueue(.op(.clear))         // auto-clear the just-shown transient frame
             }
         }
     }
@@ -230,15 +255,23 @@ final class GlassesDisplayService: ObservableObject {
                     switch frame {
                     case .op(let op):
                         if op == self.lastRendered { continue } // skip redundant identical sends
-                        switch op {
-                        case .show(let content): try await self.renderContent(content)
-                        case .clear: try await self.renderClear()
+                        if let sink = self.testRenderSink {
+                            sink(Self.descriptor(for: op))
+                        } else {
+                            switch op {
+                            case .show(let content): try await self.renderContent(content)
+                            case .clear: try await self.renderClear()
+                            }
                         }
                         self.lastRendered = op
                         self.lastScreenKey = nil
                     case .screen(let screen):
                         if screen.renderKey == self.lastScreenKey { continue }
-                        try await self.renderScreen(screen)
+                        if let sink = self.testRenderSink {
+                            sink(.screen(renderKey: screen.renderKey))
+                        } else {
+                            try await self.renderScreen(screen)
+                        }
                         self.lastScreenKey = screen.renderKey
                         self.lastRendered = nil
                     }
@@ -297,39 +330,70 @@ final class GlassesDisplayService: ObservableObject {
 
     private func renderScreen(_ screen: HUDScreen) async throws {
         let display = try await ensureDisplay()
-        let view = FlexBox(
+        try await display.send(makeScreenView(screen))
+    }
+
+    private static func descriptor(for op: RenderOp) -> HUDFrame {
+        switch op {
+        case .show(let content): return .content(body: content.body, title: content.title, icon: content.icon)
+        case .clear: return .clear
+        }
+    }
+
+    /// Build the interactive `FlexBox` for `screen`. Internal and free of SDK session
+    /// state so tests can inspect the component tree and invoke each Button's `onClick`
+    /// to simulate a Neural-Band selection.
+    func makeScreenView(_ screen: HUDScreen) -> FlexBox {
+        // Pre-shape all text and presentation here (MainActor context) so the
+        // result-builder closure below never references the MainActor-isolated
+        // `condense`/`maxLength`. Each button model carries only Sendable values —
+        // never the HUDItem, whose `action` closure isn't Sendable; selection routes
+        // back by id.
+        let headingText = screen.title.flatMap { $0.isEmpty ? nil : Self.condense($0, max: Self.maxTitleLength) }
+        let lineModels = screen.lines.map { line in
+            (text: Self.condense(line.text), iconName: line.icon.iconName,
+             style: line.emphasis.textStyle, color: line.emphasis.textColor)
+        }
+        let buttonModels = screen.items.map { item in
+            (id: item.id, label: Self.condense(item.label, max: Self.maxTitleLength),
+             style: item.style.buttonStyle, iconName: item.icon.iconName)
+        }
+
+        return FlexBox(
             direction: .column,
             spacing: 6,
             alignment: .start,
             padding: EdgeInsets(all: 12)
         ) {
-            if let title = screen.title, !title.isEmpty {
-                Text(Self.condense(title, max: Self.maxTitleLength), style: .heading, color: .primary)
+            if let headingText {
+                Text(headingText, style: .heading, color: .primary)
             }
-            for line in screen.lines {
-                let text = Self.condense(line.text)
-                if let iconName = line.icon.iconName {
+            for line in lineModels {
+                if let iconName = line.iconName {
                     FlexBox(direction: .row, spacing: 6, alignment: .center) {
                         Icon(name: iconName)
-                        Text(text, style: line.emphasis.textStyle, color: line.emphasis.textColor)
+                        Text(line.text, style: line.style, color: line.color)
                     }
                 } else {
-                    Text(text, style: line.emphasis.textStyle, color: line.emphasis.textColor)
+                    Text(line.text, style: line.style, color: line.color)
                 }
             }
-            for item in screen.items {
-                // Capture only Sendable values (id + presentation) — never the HUDItem,
-                // whose `action` closure isn't Sendable. Selection routes back by id.
-                let id = item.id
-                let label = Self.condense(item.label, max: Self.maxTitleLength)
-                let style = item.style.buttonStyle
-                let iconName = item.icon.iconName
-                Button(label: label, style: style, iconName: iconName, onClick: { [weak self] in
+            for button in buttonModels {
+                let id = button.id
+                Button(label: button.label, style: button.style, iconName: button.iconName, onClick: { [weak self] in
                     Task { @MainActor in self?.screenSelectionHandler?(id) }
                 })
             }
         }
-        try await display.send(view)
+    }
+
+    /// Test helper: the `onClick` actions of the interactive buttons in `screen`'s
+    /// rendered tree, in order, so a test can simulate Neural-Band selections without
+    /// importing the SDK. Each fires exactly the routing the real button would.
+    func testInteractiveButtonActions(for screen: HUDScreen) -> [() -> Void] {
+        makeScreenView(screen).children
+            .compactMap { ($0 as? Button)?.onClick }
+            .map { onClick in { onClick() } }
     }
 
     // MARK: - Session lifecycle

--- a/OpenGlasses/Sources/Services/GlassesDisplayService.swift
+++ b/OpenGlasses/Sources/Services/GlassesDisplayService.swift
@@ -65,6 +65,14 @@ final class GlassesDisplayService: ObservableObject {
         case clear
     }
 
+    /// A unit of work for the render queue: an ambient content/clear op, or a full
+    /// interactive screen (Plan X). Screens carry closures, so they're deduped by
+    /// `renderKey` rather than `Equatable`.
+    private enum Frame {
+        case op(RenderOp)
+        case screen(HUDScreen)
+    }
+
     /// Lazily initialized after `Wearables.configure()` has been called.
     private lazy var deviceSelector = AutoDeviceSelector(wearables: Wearables.shared)
     private var deviceSession: DeviceSession?
@@ -72,14 +80,25 @@ final class GlassesDisplayService: ObservableObject {
 
     /// Latest-wins render queue. Rapid updates collapse to the most recent frame so we
     /// never flood the BLE link — only one `send` is ever in flight.
-    private var pending: RenderOp?
+    private var pending: Frame?
     private var isRendering = false
-    /// The op last pushed to the HUD; identical follow-ups are skipped.
+    /// The ambient op last pushed to the HUD; identical follow-ups are skipped.
     private var lastRendered: RenderOp?
+    /// The interactive screen last pushed (by `renderKey`); identical screens are skipped.
+    private var lastScreenKey: String?
 
     /// Generation guard for transient auto-clear, so a newer frame cancels an older
     /// frame's pending clear.
     private var autoClearGeneration = 0
+
+    // MARK: - Interactive (Plan X)
+
+    /// True while an interactive screen (task card / menu) is held on the HUD. Ambient
+    /// *persistent* producers (AI replies, captions, navigation) are suppressed while
+    /// set; transient notifications flash over the screen and then restore it.
+    @Published private(set) var isInteractive = false
+    private var currentScreen: HUDScreen?
+    private var screenSelectionHandler: ((String) -> Void)?
 
     /// Max characters for the body line — kept short for in-lens legibility.
     private static let maxLength = 120
@@ -133,7 +152,26 @@ final class GlassesDisplayService: ObservableObject {
     func clear() {
         guard isEnabled else { return }
         guard isDisplayActive || display != nil else { return }
-        enqueue(.clear)
+        enqueue(.op(.clear))
+    }
+
+    /// Present an interactive screen (task card / menu). Drives the HUD into interactive
+    /// mode; band selections route back via `onSelect(itemID)`. No-op when the feature is
+    /// off or the glasses have no display.
+    func present(screen: HUDScreen, onSelect: @escaping (String) -> Void) {
+        guard isEnabled, deviceSupportsDisplay() else { return }
+        screenSelectionHandler = onSelect
+        currentScreen = screen
+        isInteractive = true
+        enqueue(.screen(screen))
+    }
+
+    /// Leave interactive mode and clear the HUD so ambient producers resume.
+    func endInteractive() {
+        isInteractive = false
+        currentScreen = nil
+        screenSelectionHandler = nil
+        enqueue(.op(.clear))
     }
 
     /// Fully tear down the display session. Call on feature disable / mode switch /
@@ -147,6 +185,9 @@ final class GlassesDisplayService: ObservableObject {
 
     private func present(_ content: HUDContent, transient: Bool, duration: TimeInterval) {
         guard isEnabled, deviceSupportsDisplay() else { return }
+        // While an interactive screen is held, suppress persistent ambient frames;
+        // transient notifications still flash (and restore the screen on auto-clear).
+        if isInteractive && !transient { return }
         var shaped = content
         shaped.body = Self.condense(content.body)
         shaped.title = content.title.map { Self.condense($0, max: Self.maxTitleLength) }
@@ -155,7 +196,7 @@ final class GlassesDisplayService: ObservableObject {
         guard hasBody || hasTitle else { return }
 
         let op = RenderOp.show(shaped)
-        enqueue(op)
+        enqueue(.op(op))
         if transient { scheduleAutoClear(for: op, after: duration) }
     }
 
@@ -165,28 +206,42 @@ final class GlassesDisplayService: ObservableObject {
         Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(max(0, duration) * 1_000_000_000))
             guard let self, generation == self.autoClearGeneration else { return }
-            // Only clear if this frame is still what's on screen.
-            if self.lastRendered == op { self.clear() }
+            // Only act if this frame is still what's on screen.
+            guard self.lastRendered == op else { return }
+            if self.isInteractive, let screen = self.currentScreen {
+                self.enqueue(.screen(screen))   // restore the held screen after the flash
+            } else {
+                self.clear()
+            }
         }
     }
 
     // MARK: - Render queue
 
-    private func enqueue(_ op: RenderOp) {
-        pending = op
+    private func enqueue(_ frame: Frame) {
+        pending = frame
         guard !isRendering else { return }
         isRendering = true
         Task { @MainActor [weak self] in
             guard let self else { return }
-            while let op = self.pending {
+            while let frame = self.pending {
                 self.pending = nil
-                if op == self.lastRendered { continue } // skip redundant identical sends
                 do {
-                    switch op {
-                    case .show(let content): try await self.renderContent(content)
-                    case .clear: try await self.renderClear()
+                    switch frame {
+                    case .op(let op):
+                        if op == self.lastRendered { continue } // skip redundant identical sends
+                        switch op {
+                        case .show(let content): try await self.renderContent(content)
+                        case .clear: try await self.renderClear()
+                        }
+                        self.lastRendered = op
+                        self.lastScreenKey = nil
+                    case .screen(let screen):
+                        if screen.renderKey == self.lastScreenKey { continue }
+                        try await self.renderScreen(screen)
+                        self.lastScreenKey = screen.renderKey
+                        self.lastRendered = nil
                     }
-                    self.lastRendered = op
                 } catch {
                     self.handleRenderError(error)
                     break
@@ -238,6 +293,43 @@ final class GlassesDisplayService: ObservableObject {
         guard let display else { return }
         let empty = FlexBox(direction: .column) {}
         try await display.send(empty)
+    }
+
+    private func renderScreen(_ screen: HUDScreen) async throws {
+        let display = try await ensureDisplay()
+        let view = FlexBox(
+            direction: .column,
+            spacing: 6,
+            alignment: .start,
+            padding: EdgeInsets(all: 12)
+        ) {
+            if let title = screen.title, !title.isEmpty {
+                Text(Self.condense(title, max: Self.maxTitleLength), style: .heading, color: .primary)
+            }
+            for line in screen.lines {
+                let text = Self.condense(line.text)
+                if let iconName = line.icon.iconName {
+                    FlexBox(direction: .row, spacing: 6, alignment: .center) {
+                        Icon(name: iconName)
+                        Text(text, style: line.emphasis.textStyle, color: line.emphasis.textColor)
+                    }
+                } else {
+                    Text(text, style: line.emphasis.textStyle, color: line.emphasis.textColor)
+                }
+            }
+            for item in screen.items {
+                // Capture only Sendable values (id + presentation) — never the HUDItem,
+                // whose `action` closure isn't Sendable. Selection routes back by id.
+                let id = item.id
+                let label = Self.condense(item.label, max: Self.maxTitleLength)
+                let style = item.style.buttonStyle
+                let iconName = item.icon.iconName
+                Button(label: label, style: style, iconName: iconName, onClick: { [weak self] in
+                    Task { @MainActor in self?.screenSelectionHandler?(id) }
+                })
+            }
+        }
+        try await display.send(view)
     }
 
     // MARK: - Session lifecycle
@@ -300,6 +392,7 @@ final class GlassesDisplayService: ObservableObject {
         deviceSession = nil
         isDisplayActive = false
         lastRendered = nil
+        lastScreenKey = nil
     }
 
     private func handleRenderError(_ error: Error) {
@@ -313,6 +406,7 @@ final class GlassesDisplayService: ObservableObject {
         deviceSession = nil
         isDisplayActive = false
         lastRendered = nil
+        lastScreenKey = nil
     }
 
     // MARK: - Text shaping
@@ -342,6 +436,33 @@ enum GlassesDisplayError: LocalizedError {
         switch self {
         case .noDisplay: return "Connected glasses have no in-lens display"
         case .sessionUnavailable: return "Display session unavailable"
+        }
+    }
+}
+
+// MARK: - HUD model → SDK mapping (Plan X)
+
+fileprivate extension HUDEmphasis {
+    var textStyle: TextStyle {
+        switch self {
+        case .primary, .secondary: return .body
+        case .meta: return .meta
+        }
+    }
+    var textColor: TextColor {
+        switch self {
+        case .primary: return .primary
+        case .secondary, .meta: return .secondary
+        }
+    }
+}
+
+fileprivate extension HUDButtonStyle {
+    var buttonStyle: ButtonStyle {
+        switch self {
+        case .primary: return .primary
+        case .secondary: return .secondary
+        case .outline: return .outline
         }
     }
 }

--- a/OpenGlassesTests/GlassesDisplayInteractiveTests.swift
+++ b/OpenGlassesTests/GlassesDisplayInteractiveTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Headless tests for the interactive HUD layer in `GlassesDisplayService` (Display
+/// Phase 3 / Plan X). No Ray-Ban Display hardware exists in CI, so we drive the real
+/// queue/gate/dedup/flash-restore logic through the test seam: `testCapabilityOverride`
+/// fakes a display-capable device, `testRenderSink` captures the frame each render
+/// *would* send, and the Neural Band is simulated by firing the rendered buttons'
+/// `onClick`. These tests are the only validation this code gets — keep them thorough.
+@MainActor
+final class GlassesDisplayInteractiveTests: XCTestCase {
+
+    private var svc: GlassesDisplayService!
+    private var frames: [GlassesDisplayService.HUDFrame] = []
+    private var savedFlag = false
+
+    override func setUp() {
+        super.setUp()
+        savedFlag = Config.glassesDisplayEnabled
+        Config.setGlassesDisplayEnabled(true)
+        frames = []
+        svc = GlassesDisplayService()
+        svc.testCapabilityOverride = true
+        svc.testRenderSink = { [weak self] frame in self?.frames.append(frame) }
+    }
+
+    override func tearDown() {
+        Config.setGlassesDisplayEnabled(savedFlag)
+        svc = nil
+        super.tearDown()
+    }
+
+    /// Let the render queue's drain Task run (it's spawned, not synchronous).
+    private func settle(_ ms: UInt64 = 40) async {
+        try? await Task.sleep(nanoseconds: ms * 1_000_000)
+    }
+
+    private func card(_ key: String, items: [String] = ["done"]) -> HUDScreen {
+        HUDScreen(title: key, items: items.map { id in HUDItem(id: id, label: id.capitalized) {} })
+    }
+
+    // MARK: - Presentation & interactive mode
+
+    func testPresentScreenEntersInteractiveAndRenders() async {
+        let screen = card("Card")
+        svc.present(screen: screen) { _ in }
+        await settle()
+        XCTAssertTrue(svc.isInteractive)
+        XCTAssertEqual(frames, [.screen(renderKey: screen.renderKey)])
+    }
+
+    func testEndInteractiveClearsAndExits() async {
+        svc.present(screen: card("Card")) { _ in }
+        await settle()
+        frames.removeAll()
+        svc.endInteractive()
+        await settle()
+        XCTAssertFalse(svc.isInteractive)
+        XCTAssertEqual(frames, [.clear])
+    }
+
+    // MARK: - Ambient suppression gate
+
+    func testPersistentAmbientTextSuppressedWhileInteractive() async {
+        svc.present(screen: card("Card")) { _ in }
+        await settle()
+        frames.removeAll()
+        svc.showText("an AI reply")          // persistent ambient → suppressed
+        svc.showNavigation("turn left")      // persistent ambient → suppressed
+        await settle()
+        XCTAssertEqual(frames, [])
+    }
+
+    func testNotificationFlashesThenRestoresScreenWhileInteractive() async {
+        let screen = card("Card")
+        svc.present(screen: screen) { _ in }
+        await settle()
+        frames.removeAll()
+
+        svc.showNotification(title: nil, body: "ping", icon: .message, duration: 0.05)
+        await settle(25)                     // before the flash auto-clears
+        XCTAssertEqual(frames, [.content(body: "ping", title: nil, icon: .message)])
+
+        await settle(120)                    // after the flash duration
+        XCTAssertEqual(frames.last, .screen(renderKey: screen.renderKey))   // screen restored
+    }
+
+    // MARK: - Ambient behaviour when NOT interactive
+
+    func testAmbientTextRendersWhenNotInteractive() async {
+        svc.showText("hello there")
+        await settle()
+        XCTAssertEqual(frames, [.content(body: "hello there", title: nil, icon: .none)])
+    }
+
+    func testNonInteractiveFlashAutoClears() async {
+        svc.flash("brief", duration: 0.05)
+        await settle(25)
+        XCTAssertEqual(frames, [.content(body: "brief", title: nil, icon: .none)])
+        await settle(120)
+        XCTAssertEqual(frames.last, .clear)
+    }
+
+    // MARK: - Dedup (latest-wins / render-key collapse)
+
+    func testIdenticalScreenRendersOnce() async {
+        let screen = card("Card")
+        svc.present(screen: screen) { _ in }
+        svc.present(screen: screen) { _ in }
+        await settle()
+        XCTAssertEqual(frames, [.screen(renderKey: screen.renderKey)])
+    }
+
+    func testIdenticalAmbientContentRendersOnce() async {
+        svc.showText("same line")
+        svc.showText("same line")
+        await settle()
+        XCTAssertEqual(frames, [.content(body: "same line", title: nil, icon: .none)])
+    }
+
+    // MARK: - Capability / feature-flag guards
+
+    func testNoDisplayCapabilitySuppressesEverything() async {
+        svc.testCapabilityOverride = false
+        svc.present(screen: card("Card")) { _ in }
+        svc.showText("x")
+        await settle()
+        XCTAssertFalse(svc.isInteractive)
+        XCTAssertEqual(frames, [])
+    }
+
+    func testFeatureFlagOffSuppressesEverything() async {
+        Config.setGlassesDisplayEnabled(false)
+        svc.present(screen: card("Card")) { _ in }
+        svc.showText("x")
+        await settle()
+        XCTAssertEqual(frames, [])
+    }
+
+    // MARK: - Simulated Neural-Band selection
+
+    func testBandSelectionRoutesToHandlerById() async {
+        let screen = card("Card", items: ["done", "skip", "back"])
+        var received: [String] = []
+        svc.present(screen: screen) { received.append($0) }
+        await settle()
+
+        let actions = svc.testInteractiveButtonActions(for: screen)
+        XCTAssertEqual(actions.count, 3)
+        for fire in actions { fire() }       // simulate pinch-select on each button
+        await settle()
+
+        XCTAssertEqual(received, ["done", "skip", "back"])
+    }
+}

--- a/OpenGlassesTests/HUDInteractionTests.swift
+++ b/OpenGlassesTests/HUDInteractionTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+import Combine
+@testable import OpenGlasses
+
+/// Tests for the interactive HUD foundation (Display Phase 3 / Plan X): the Playbook
+/// task-source adapter, the Now/Next card layout, and screen render-key dedup. All
+/// headless — no device or SDK needed.
+@MainActor
+final class HUDInteractionTests: XCTestCase {
+
+    // MARK: - PlaybookHUDTaskSource
+
+    private func makeStartedSource(id: String) -> (PlaybookStore, PlaybookHUDTaskSource) {
+        let store = PlaybookStore()
+        let pb = Playbook(id: id, name: "HUD Test", steps: [
+            PlaybookStep(title: "Step A", detail: "Do A"),
+            PlaybookStep(title: "Step B", detail: "Do B"),
+            PlaybookStep(title: "Step C", detail: "Do C"),
+        ])
+        store.add(pb)
+        _ = store.startPlaybook(pb.id)
+        return (store, PlaybookHUDTaskSource(store: store))
+    }
+
+    func testSourceReportsCurrentAndNext() {
+        let (store, source) = makeStartedSource(id: "hud-cn")
+        defer { _ = store.finishPlaybook() }
+
+        XCTAssertEqual(source.title, "HUD Test")
+        XCTAssertEqual(source.current?.index, 0)
+        XCTAssertEqual(source.current?.total, 3)
+        XCTAssertEqual(source.current?.title, "Step A")
+        XCTAssertEqual(source.current?.instruction, "Do A")
+        XCTAssertNil(source.current?.safetyNote)            // Playbooks carry no safety notes
+        XCTAssertEqual(source.next?.index, 1)
+        XCTAssertEqual(source.next?.title, "Step B")
+        XCTAssertNil(source.next?.instruction)              // next is a preview — title only
+    }
+
+    func testCompleteAdvancesAndBackReturns() async {
+        let (store, source) = makeStartedSource(id: "hud-cb")
+        defer { _ = store.finishPlaybook() }
+
+        await source.complete()
+        XCTAssertEqual(source.current?.index, 1)
+        XCTAssertEqual(source.current?.title, "Step B")
+
+        await source.back()
+        XCTAssertEqual(source.current?.index, 0)
+    }
+
+    func testSkipAdvances() async {
+        let (store, source) = makeStartedSource(id: "hud-skip")
+        defer { _ = store.finishPlaybook() }
+
+        await source.skip()
+        XCTAssertEqual(source.current?.index, 1)
+    }
+
+    func testCompletingLastStepEndsWorkflow() async {
+        let (store, source) = makeStartedSource(id: "hud-end")
+        defer { _ = store.finishPlaybook() }
+
+        await source.complete()   // → B
+        await source.complete()   // → C
+        await source.complete()   // → finished
+        XCTAssertNil(source.current)
+        XCTAssertNil(store.activeSession)
+    }
+
+    // MARK: - Card layout
+
+    func testTaskCardLayout() {
+        let source = FakeTaskSource()
+        let current = HUDStep(index: 0, total: 3, title: "Torque bolts", instruction: "45 Nm, 2 passes")
+        let next = HUDStep(index: 1, total: 3, title: "Reconnect sensor")
+        let screen = HUDRouter.taskCard(source: source, current: current, next: next)
+
+        XCTAssertEqual(screen.title, "Torque bolts")
+        XCTAssertTrue(screen.lines.contains { $0.text == "Step 1 of 3" })
+        XCTAssertTrue(screen.lines.contains { $0.text == "45 Nm, 2 passes" })
+        XCTAssertTrue(screen.lines.contains { $0.text == "Next: Reconnect sensor" })
+        XCTAssertEqual(screen.items.map(\.id), ["done", "skip", "back"])
+    }
+
+    func testTaskCardShowsSafetyNoteWithHazardIcon() {
+        let source = FakeTaskSource()
+        let current = HUDStep(index: 2, total: 7, title: "Contact terminals",
+                              instruction: "Check continuity", safetyNote: "De-energize first")
+        let screen = HUDRouter.taskCard(source: source, current: current, next: nil)
+
+        let safety = screen.lines.first { $0.text == "De-energize first" }
+        XCTAssertNotNil(safety)
+        XCTAssertEqual(safety?.icon, .hazard)
+        XCTAssertFalse(screen.lines.contains { $0.text.hasPrefix("Next:") })  // no next on last step
+    }
+
+    func testTaskCardButtonsInvokeSource() async {
+        let source = FakeTaskSource()
+        let screen = HUDRouter.taskCard(
+            source: source,
+            current: HUDStep(index: 0, total: 1, title: "Only step"),
+            next: nil
+        )
+        screen.items.first { $0.id == "done" }?.action()
+        screen.items.first { $0.id == "skip" }?.action()
+        screen.items.first { $0.id == "back" }?.action()
+        // Actions launch detached tasks; let them run.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(source.completeCount, 1)
+        XCTAssertEqual(source.skipCount, 1)
+        XCTAssertEqual(source.backCount, 1)
+    }
+
+    // MARK: - Render-key dedup
+
+    func testRenderKeyStableForIdenticalContent() {
+        let a = HUDScreen(title: "T", lines: [HUDLine("x", emphasis: .meta)],
+                          items: [HUDItem(id: "i", label: "Go") {}])
+        let b = HUDScreen(title: "T", lines: [HUDLine("x", emphasis: .meta)],
+                          items: [HUDItem(id: "i", label: "Go") {}])
+        XCTAssertEqual(a.renderKey, b.renderKey)
+    }
+
+    func testRenderKeyDiffersWhenLabelChanges() {
+        let a = HUDScreen(title: "T", items: [HUDItem(id: "i", label: "Go") {}])
+        let b = HUDScreen(title: "T", items: [HUDItem(id: "i", label: "Stop") {}])
+        XCTAssertNotEqual(a.renderKey, b.renderKey)
+    }
+}
+
+/// In-memory `HUDTaskSource` double for layout/wiring tests.
+@MainActor
+private final class FakeTaskSource: HUDTaskSource {
+    var title = "Fake"
+    var current: HUDStep?
+    var next: HUDStep?
+    private let subject = PassthroughSubject<Void, Never>()
+    var changes: AnyPublisher<Void, Never> { subject.eraseToAnyPublisher() }
+
+    var completeCount = 0
+    var skipCount = 0
+    var backCount = 0
+
+    func complete() async { completeCount += 1 }
+    func skip() async { skipCount += 1 }
+    func back() async { backCount += 1 }
+}

--- a/OpenGlassesTests/HUDInteractionTests.swift
+++ b/OpenGlassesTests/HUDInteractionTests.swift
@@ -113,6 +113,58 @@ final class HUDInteractionTests: XCTestCase {
         XCTAssertEqual(source.backCount, 1)
     }
 
+    // MARK: - Router lifecycle (with the real GlassesDisplayService via its test seam)
+
+    private func makeDisplay() -> (GlassesDisplayService, () -> [GlassesDisplayService.HUDFrame]) {
+        let svc = GlassesDisplayService()
+        svc.testCapabilityOverride = true
+        var frames: [GlassesDisplayService.HUDFrame] = []
+        svc.testRenderSink = { frames.append($0) }
+        return (svc, { frames })
+    }
+
+    func testRouterPresentsCardOnStart() async {
+        let saved = Config.glassesDisplayEnabled
+        Config.setGlassesDisplayEnabled(true)
+        defer { Config.setGlassesDisplayEnabled(saved) }
+
+        let (display, frames) = makeDisplay()
+        let router = HUDRouter(display: display)
+        let source = FakeTaskSource()
+        source.current = HUDStep(index: 0, total: 2, title: "First")
+        source.next = HUDStep(index: 1, total: 2, title: "Second")
+
+        router.startTask(source)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(router.isPresentingTask)
+        XCTAssertEqual(frames().count, 1)
+        guard case .screen? = frames().first else { return XCTFail("expected a screen frame") }
+    }
+
+    func testRouterFlashesCompleteAndStopsWhenSourceFinishes() async {
+        let saved = Config.glassesDisplayEnabled
+        Config.setGlassesDisplayEnabled(true)
+        defer { Config.setGlassesDisplayEnabled(saved) }
+
+        let (display, frames) = makeDisplay()
+        let router = HUDRouter(display: display)
+        let source = FakeTaskSource()
+        source.current = HUDStep(index: 0, total: 1, title: "Only")
+        router.startTask(source)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        source.current = nil          // workflow done
+        source.emitChange()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertFalse(router.isPresentingTask)
+        XCTAssertTrue(frames().contains {
+            if case .content(let body, _, _) = $0 { return body.contains("complete") }
+            return false
+        })
+    }
+
     // MARK: - Render-key dedup
 
     func testRenderKeyStableForIdenticalContent() {
@@ -146,4 +198,6 @@ private final class FakeTaskSource: HUDTaskSource {
     func complete() async { completeCount += 1 }
     func skip() async { skipCount += 1 }
     func back() async { backCount += 1 }
+
+    func emitChange() { subject.send(()) }
 }

--- a/OpenGlassesTests/HUDInteractionTests.swift
+++ b/OpenGlassesTests/HUDInteractionTests.swift
@@ -165,6 +165,59 @@ final class HUDInteractionTests: XCTestCase {
         })
     }
 
+    // MARK: - Voice bridge
+
+    func testVoiceParserMatchesStrictly() {
+        XCTAssertEqual(HUDVoiceCommand.parse("done"), .complete)
+        XCTAssertEqual(HUDVoiceCommand.parse("Done."), .complete)
+        XCTAssertEqual(HUDVoiceCommand.parse("next"), .complete)
+        XCTAssertEqual(HUDVoiceCommand.parse("okay next"), .complete)
+        XCTAssertEqual(HUDVoiceCommand.parse("next step"), .complete)
+        XCTAssertEqual(HUDVoiceCommand.parse("skip"), .skip)
+        XCTAssertEqual(HUDVoiceCommand.parse("skip this step"), .skip)
+        XCTAssertEqual(HUDVoiceCommand.parse("back"), .back)
+        XCTAssertEqual(HUDVoiceCommand.parse("go back"), .back)
+        XCTAssertEqual(HUDVoiceCommand.parse("previous"), .back)
+    }
+
+    func testVoiceParserRejectsNonCommands() {
+        XCTAssertNil(HUDVoiceCommand.parse("what's the weather"))
+        XCTAssertNil(HUDVoiceCommand.parse("next time we meet"))
+        XCTAssertNil(HUDVoiceCommand.parse("back to the office"))
+        XCTAssertNil(HUDVoiceCommand.parse("I'm done with the weather"))
+        XCTAssertNil(HUDVoiceCommand.parse(""))
+    }
+
+    func testRouterHandlesVoiceOnlyWhenTaskActive() async {
+        let saved = Config.glassesDisplayEnabled
+        Config.setGlassesDisplayEnabled(true)
+        defer { Config.setGlassesDisplayEnabled(saved) }
+
+        let (display, _) = makeDisplay()
+        let router = HUDRouter(display: display)
+        let source = FakeTaskSource()
+        source.current = HUDStep(index: 0, total: 2, title: "First")
+
+        // No active task → not consumed, source untouched.
+        var consumed = await router.handleVoiceCommand("done")
+        XCTAssertFalse(consumed)
+        XCTAssertEqual(source.completeCount, 0)
+
+        router.startTask(source)
+        try? await Task.sleep(nanoseconds: 40_000_000)
+
+        consumed = await router.handleVoiceCommand("next")
+        XCTAssertTrue(consumed); XCTAssertEqual(source.completeCount, 1)
+        consumed = await router.handleVoiceCommand("skip")
+        XCTAssertTrue(consumed); XCTAssertEqual(source.skipCount, 1)
+        consumed = await router.handleVoiceCommand("go back")
+        XCTAssertTrue(consumed); XCTAssertEqual(source.backCount, 1)
+
+        // Non-command while active → not consumed (falls through to the LLM).
+        consumed = await router.handleVoiceCommand("tell me a joke")
+        XCTAssertFalse(consumed)
+    }
+
     // MARK: - Render-key dedup
 
     func testRenderKeyStableForIdenticalContent() {

--- a/OpenGlassesTests/HUDInteractionTests.swift
+++ b/OpenGlassesTests/HUDInteractionTests.swift
@@ -165,6 +165,72 @@ final class HUDInteractionTests: XCTestCase {
         })
     }
 
+    // MARK: - Branching procedures (choices)
+
+    func testBranchStepRendersChoiceButtonsNotDoneSkip() {
+        let source = FakeTaskSource()
+        source.stubChoices = [HUDChoice(id: "low", label: "Pressure is low"),
+                              HUDChoice(id: "ok", label: "Pressure is normal")]
+        let screen = HUDRouter.taskCard(
+            source: source,
+            current: HUDStep(index: 0, total: nil, title: "Check pressure"),
+            next: nil
+        )
+        XCTAssertEqual(screen.items.map(\.id), ["choice:low", "choice:ok", "back"])
+        XCTAssertFalse(screen.items.contains { $0.id == "done" || $0.id == "skip" })
+    }
+
+    func testChoiceButtonInvokesChoose() async {
+        let source = FakeTaskSource()
+        source.stubChoices = [HUDChoice(id: "low", label: "Low")]
+        let screen = HUDRouter.taskCard(source: source,
+                                        current: HUDStep(index: 0, total: nil, title: "X"),
+                                        next: nil)
+        screen.items.first { $0.id == "choice:low" }?.action()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(source.chooseCount, 1)
+        XCTAssertEqual(source.lastChoice, "low")
+    }
+
+    // MARK: - ProcedureHUDTaskSource (Field Assist adapter)
+
+    func testProcedureSourceMapsStepAndBranches() {
+        let host = FakeProcedureHost()
+        host.activeProcedureTitle = "Diagnose No Cooling"
+        host.activeProcedureStep = Procedure.Step(
+            id: "s1", title: "Check suction pressure",
+            instruction: "Read the gauge", safetyNote: "Wear gloves",
+            branches: [Procedure.Branch(id: "low", condition: "Below 20 psi", next: "s2"),
+                       Procedure.Branch(id: "ok", condition: "20 psi or above", next: "s3")]
+        )
+        let source = ProcedureHUDTaskSource(host: host)
+        XCTAssertEqual(source.title, "Diagnose No Cooling")
+        XCTAssertEqual(source.current?.title, "Check suction pressure")
+        XCTAssertEqual(source.current?.instruction, "Read the gauge")
+        XCTAssertEqual(source.current?.safetyNote, "Wear gloves")
+        XCTAssertNil(source.next)
+        XCTAssertEqual(source.choices.map(\.id), ["low", "ok"])
+        XCTAssertEqual(source.choices.map(\.label), ["Below 20 psi", "20 psi or above"])
+    }
+
+    func testProcedureSourceDelegatesActions() async {
+        let host = FakeProcedureHost()
+        host.activeProcedureStep = Procedure.Step(id: "s1", title: "S", instruction: "i")
+        let source = ProcedureHUDTaskSource(host: host)
+        await source.choose("low")
+        await source.complete()
+        await source.back()
+        XCTAssertEqual(host.advanceChoices, ["low", nil])   // choose(low), then complete(nil)
+        XCTAssertEqual(host.backCount, 1)
+    }
+
+    func testProcedureSourceNilWhenNoStep() {
+        let source = ProcedureHUDTaskSource(host: FakeProcedureHost())
+        XCTAssertNil(source.current)
+        XCTAssertEqual(source.title, "Procedure")
+        XCTAssertTrue(source.choices.isEmpty)
+    }
+
     // MARK: - Voice bridge
 
     func testVoiceParserMatchesStrictly() {
@@ -247,10 +313,33 @@ private final class FakeTaskSource: HUDTaskSource {
     var completeCount = 0
     var skipCount = 0
     var backCount = 0
+    var chooseCount = 0
+    var lastChoice: String?
+    var stubChoices: [HUDChoice] = []
+    var choices: [HUDChoice] { stubChoices }
 
     func complete() async { completeCount += 1 }
     func skip() async { skipCount += 1 }
     func back() async { backCount += 1 }
+    func choose(_ id: String) async { chooseCount += 1; lastChoice = id }
 
     func emitChange() { subject.send(()) }
+}
+
+/// In-memory `ProcedureHosting` double for `ProcedureHUDTaskSource` tests.
+@MainActor
+private final class FakeProcedureHost: ObservableObject, ProcedureHosting {
+    var activeProcedureStep: Procedure.Step?
+    var activeProcedureTitle: String?
+    var advanceChoices: [String?] = []
+    var backCount = 0
+
+    func advanceProcedure(choice: String?) throws -> ProcedureRunner.Transition {
+        advanceChoices.append(choice)
+        return .moved(activeProcedureStep ?? Procedure.Step(id: "x", title: "x", instruction: ""))
+    }
+    func procedureBack() throws -> Procedure.Step {
+        backCount += 1
+        return activeProcedureStep ?? Procedure.Step(id: "x", title: "x", instruction: "")
+    }
 }

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -31,7 +31,7 @@ All plans A–M are **built and merged to `main`** to the extent verifiable with
 | U Structured Capture-Flow / Action-Form Schema | 📋 Planned (Round 5 — field) |
 | V Curated MCP Catalogue & Transport Breadth | 📋 Planned (Round 5 — MCP UX) |
 | W Presence-Aware Agent Throttle | 📋 Planned (Round 5 — agentic/battery) |
-| X Interactive HUD — Now/Next Tasks | 📋 Planned (Round 6 — Display Phase 3). Display Phase 1 ✅ merged (#42), Phase 2 on `display/hud-phase2`. |
+| X Interactive HUD — Now/Next Tasks | 🚧 In progress on `display/hud-phase3` — foundation + band card + voice bridge + Playbook/Procedure sources shipped; 30 headless tests, Debug+Release green. Display Phases 1–2 ✅ merged (#42, #45). |
 | Y Interactive HUD Launcher | 📋 Planned (Round 6 — Display Phase 4) |
 
 Three selectable expert-stream transports: **MJPEG** (same-LAN browser viewer), **Meeting link** (zero-infra — your meeting tool hosts the call; recommended for remote), and **WebRTC** (self-hosted peer-to-peer, needs your own signaling + TURN).

--- a/docs/plans/X-interactive-hud-now-next-tasks.md
+++ b/docs/plans/X-interactive-hud-now-next-tasks.md
@@ -6,6 +6,8 @@
 
 **Effort:** ~3–4 days.
 
+**Status (branch `display/hud-phase3`):** ✅ Build-order steps 1–4 shipped and tested — interactive foundation, `PlaybookHUDTaskSource` (linear) and `ProcedureHUDTaskSource` (branching SOPs with choice buttons), and the voice bridge ("next/done/skip/back"). 30 headless tests pass; Debug + Release green. Remaining: step 5 (agent replies currently *suppressed* while a card is held — heard via TTS, card stays authoritative; flash-during-task is an optional refinement) and step 6 (Settings copy).
+
 ---
 
 ## SDK reality — what input we actually get

--- a/docs/plans/X-interactive-hud-now-next-tasks.md
+++ b/docs/plans/X-interactive-hud-now-next-tasks.md
@@ -18,7 +18,7 @@
 
 So an interactive screen is just *a `FlexBox` of `Button`s with closures*. Selecting one runs the closure; we then `send` the next screen. We manage the nav stack app-side; the band drives focus + select on whatever we last sent.
 
-> ⚠️ **One on-device unknown:** whether the Neural Band can *free-navigate* an arbitrary list of our `Button`s (multi-item focus traversal), or only activate a single primary action. Not visible in the SDK. **Validate first** (see Build order step 0) — the whole interaction model rests on it. Greig has hardware; this can't be checked in the simulator.
+> ⚠️ **One unverifiable assumption:** whether the Neural Band can *free-navigate* an arbitrary list of our `Button`s (multi-item focus traversal) versus only activating a single primary action. Not visible in the SDK, and **no Ray-Ban Display hardware is available to confirm it** — so this is a documented risk, not a checked fact. The interaction logic is instead validated entirely by **headless tests** that simulate the band by invoking each rendered button's `onClick` (`GlassesDisplayService.testInteractiveButtonActions(for:)`). If a device ever becomes available, run the spike below; if the band turns out to be single-action only, the fallback is a **paged** card (one primary action, band cycles which action is armed) — the rest of the design is unaffected.
 
 ---
 
@@ -129,7 +129,7 @@ source.current == nil  → render "✓ Workflow complete" flash → exit interac
 
 ## Build order
 
-0. **Spike (½ day, on-device):** send a `FlexBox` with 3–4 `Button`s and log which `onClick`s the band can reach. Confirms free-navigation vs single-action. If single-action only, fall back to a **paged** card (one primary action + band-cycles-the-action) — note it and proceed; the rest of the plan is unaffected.
+0. **(Deferred — no hardware.)** The on-device band-navigation spike can't run without a Display device. Until one exists, the band is simulated in tests (fire each rendered button's `onClick`) and free-navigation is a documented assumption (see *SDK reality*). Every other step proceeds test-first.
 1. `HUDScreen` + render-to-`FlexBox`, and the `HUDRouter` interactive-mode gate in `GlassesDisplayService` (ambient suppressed while a screen is held). Unit-test the render mapping (screen → component tree) headlessly.
 2. `HUDTaskSource` + `PlaybookHUDTaskSource` (linear is simplest). Auto-present the card on Playbook start; wire `Done/Skip/Back`.
 3. Voice bridge: "next/done/skip/back" → active source.

--- a/docs/plans/X-interactive-hud-now-next-tasks.md
+++ b/docs/plans/X-interactive-hud-now-next-tasks.md
@@ -24,6 +24,17 @@ So an interactive screen is just *a `FlexBox` of `Button`s with closures*. Selec
 
 ---
 
+## Visibility, colour & brand
+
+`MWDATDisplay` exposes **no raw colour API** (verified against 0.7.0 — no RGB / hex / tint / opacity / brightness). Styling is *semantic tokens only*: `TextColor.primary/.secondary`, `TextStyle.heading/.body/.meta`, `ButtonStyle.primary/.secondary/.outline`, `Background.none/.card`, `IconStyle.filled/.outline`. Meta's on-device design system maps those to the actual colour/contrast/anti-aliasing tuned for the waveguide — so **on-glass legibility and brand consistency are owned by the device, not us**, and we can't ship a low-contrast or off-brand frame even by accident.
+
+Implications:
+- The app's coral brand accent (`#F08A4B`; never cyan/violet) stays on the **phone UI** — the lens inherits Meta's palette. Our identity on the HUD is **icon choice, copy tone, and restraint**, not colour.
+- The visibility levers we *do* control: **hierarchy** (heading/primary for the step title, body for the instruction, meta/secondary for "Step x of y" / "Next: …"), **`Background.card`** to lift high-attention frames, **icons** (hazard for safety, compass for nav, …), **brevity** (`condense` → ≤120 body / ≤40 title, whitespace-collapsed), and the **latest-wins render queue** (one frame in flight, identical frames deduped — no clutter or flicker).
+- **Subtlety:** default to `.secondary`/`.meta` + `Background.none` for ambient mirrors; escalate to `.primary` + `card` + icon only for safety notes and the active task. Ambient AI replies/captions are suppressed while a card is held so the task stays authoritative.
+
+**Device-less validation** (no Display hardware): the test seam asserts the semantic-token choice per frame; the **phone mirror preview** ([Plan Y](Y-interactive-hud-launcher.md) `HUDPhoneMirrorView`) renders the same `HUDScreen` with a Meta-like green-on-dark treatment to eyeball hierarchy/density/brand on the phone; and any hard content limits from Meta's HMI guidance get baked into `condense`.
+
 ## Concept
 
 When a Playbook or Procedure is running, the HUD shows a compact card:


### PR DESCRIPTION
## Summary

Phase 3 of the Ray-Ban **Display** HUD — the first **interactive** layer over the read-only Phase 1/2 mirrors ([#42](https://github.com/straff2002/OpenGlasses/pull/42), [#45](https://github.com/straff2002/OpenGlasses/pull/45)). A running workflow is shown as a **Now/Next card** the user drives with the **Neural Band** (Done/Skip/Back, or branch choices) **or by voice** ("next/done/skip/back"). Additive and capability-gated exactly as before: a safe no-op when `Config.glassesDisplayEnabled` is off or the glasses have no display.

Grounded in the actual `MWDATDisplay` 0.7.0 surface: one-way `Display.send(view)` + `Button`/`onClick` callbacks — the firmware owns focus/select; there is **no raw gesture stream**.

## What's in it

- **`HUDScreen` / `HUDItem` / `HUDLine`** — SDK-free screen model + a `renderKey` for render dedup.
- **`HUDTaskSource`** — source-agnostic step adapter (`current`/`next`, `complete`/`skip`/`back`, optional `choices`/`choose` for branch steps, a change publisher).
  - **`PlaybookHUDTaskSource`** — linear workflows over the existing `PlaybookStore` (now/next from `currentStepIndex`).
  - **`ProcedureHUDTaskSource`** — branching Field Assist SOPs via a small `ProcedureHosting` protocol (`FieldSessionService` conforms); a decision step renders one button per branch.
- **`HUDRouter`** — owns the card, routes band selections, re-renders on change, flashes "✓ complete" and self-dismisses at the end.
- **`HUDVoiceCommand` + `HUDRouter.handleVoiceCommand`** — strict phrase matcher; intercepts in `handleTranscription` *before* intent classification (so short commands aren't filtered), consumed commands don't reach the LLM. Only fires while a card is active.
- **`GlassesDisplayService`** interactive layer — `present(screen:onSelect:)` / `endInteractive()`; the render queue gains a screen frame; persistent ambient frames are suppressed while a card is held; transient notifications flash-and-restore.
- **`AppState`** — auto-presents the card when a Playbook *or* a Field Assist procedure starts.

## No hardware → tests are the validation gate

There's no Ray-Ban Display device to validate against, so the interactive logic is verified **entirely headlessly**:
- A **test seam** (`testCapabilityOverride`, `testRenderSink`) runs the real queue/gate/dedup/flash-restore logic with no device.
- The **Neural Band is simulated** by invoking each rendered button's `onClick` (`testInteractiveButtonActions`).
- **30 tests** cover: task-source transitions, card layout (linear + branch), ambient suppression, notification flash-then-restore, dedup, capability/flag guards, band-selection routing by id, router lifecycle, voice parse + gating, and the procedure adapter.

The on-device band-navigation spike is **deferred (documented assumption)**; see the Plan X doc.

## Visibility, colour & brand

`MWDATDisplay` has **no raw colour API** — styling is semantic tokens only (`TextColor.primary/.secondary`, `TextStyle.heading/.body/.meta`, `ButtonStyle`, `Background`). Meta's renderer owns on-glass contrast/colour/brand, so we can't ship a low-contrast or off-brand frame. Our levers are hierarchy, `Background.card`, icons, brevity (`condense`), and the latest-wins queue. The coral brand accent stays on the phone UI; the lens inherits Meta's palette. Documented in `docs/plans/X-…` along with the device-less validation path (test seam + the Plan Y phone mirror preview).

## Remaining (follow-up)

- Agent-reply *flash*-during-task (currently suppressed — heard via TTS, card stays authoritative).
- Settings copy / debug-event labels.

## Build / verify

- ✅ Debug — 30 HUD tests pass (`platform=iOS Simulator,id=…`)
- ✅ Release — `xcodebuild ... -configuration Release -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`, no warnings (also fixed a pre-existing Swift 6 main-actor-isolation warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)