### PR TITLE
security: scrub leaked Meta credentials + Apple Team ID from tracked config

### DIFF
--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -14,6 +14,6 @@
     <key>signingStyle</key>
     <string>automatic</string>
     <key>teamID</key>
-    <string>B9L8ANZQZX</string>
+    <string>YOUR_APPLE_TEAM_ID</string>
 </dict>
 </plist>

--- a/OpenGlasses/Info.plist
+++ b/OpenGlasses/Info.plist
@@ -25,7 +25,7 @@
 		<dict>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>mwdat-688603774243722</string>
+				<string>mwdat-YOUR_META_APP_ID</string>
 				<string>openglasses</string>
 			</array>
 		</dict>
@@ -94,9 +94,9 @@
 		<key>AppLinkURLScheme</key>
 		<string>openglasses://</string>
 		<key>ClientToken</key>
-		<string>AR|688603774243722|906db0d1b28450fdb718401ca16b9d60</string>
+		<string>AR|YOUR_META_APP_ID|YOUR_CLIENT_TOKEN_HASH</string>
 		<key>MetaAppID</key>
-		<string>688603774243722</string>
+		<string>YOUR_META_APP_ID</string>
 		<key>TeamID</key>
 		<string>$(DEVELOPMENT_TEAM)</string>
 	</dict>

--- a/docs/plans/E-mcp-server-mode.md
+++ b/docs/plans/E-mcp-server-mode.md
@@ -1,6 +1,6 @@
 # Plan E — Claude Code MCP Server Mode
 
-**Strategic fit:** Developer-only feature. Lets a Claude Code session on a Mac "see through" OpenGlasses by exposing camera frames + display broadcast as MCP tools. Gated behind existing `agentModeEnabled` toggle (per [Agentic Toggle memory](../../.claude/projects/-Users-greig-Code-OpenGlasses/memory/feedback_agentic_toggle.md) pattern).
+**Strategic fit:** Developer-only feature. Lets a Claude Code session on a Mac "see through" OpenGlasses by exposing camera frames + display broadcast as MCP tools. Gated behind existing `agentModeEnabled` toggle (per Agentic Toggle memory pattern).
 
 **Effort:** ~2 days
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -33,6 +33,7 @@ All plans A–M are **built and merged to `main`** to the extent verifiable with
 | W Presence-Aware Agent Throttle | 📋 Planned (Round 5 — agentic/battery) |
 | X Interactive HUD — Now/Next Tasks | 🚧 In progress on `display/hud-phase3` — foundation + band card + voice bridge + Playbook/Procedure sources shipped; 30 headless tests, Debug+Release green. Display Phases 1–2 ✅ merged (#42, #45). |
 | Y Interactive HUD Launcher | 📋 Planned (Round 6 — Display Phase 4) |
+| Z Shortcuts Catalog | 📋 Planned (auto-surface Siri Shortcuts to the agent) |
 
 Three selectable expert-stream transports: **MJPEG** (same-LAN browser viewer), **Meeting link** (zero-infra — your meeting tool hosts the call; recommended for remote), and **WebRTC** (self-hosted peer-to-peer, needs your own signaling + TURN).
 

--- a/docs/plans/S-plan-then-execute-and-safety-supervisor.md
+++ b/docs/plans/S-plan-then-execute-and-safety-supervisor.md
@@ -12,7 +12,7 @@
 
 - Single-shot today: the LLM loop in [LLMService.swift](../../OpenGlasses/Sources/Services/LLMService.swift) (and the realtime path in `GeminiLiveSessionManager.swift`) feeds tool results straight back to the model — fine for "what's the weather", weak for "find the open work order, photo the gauge, log it, and message my lead".
 - The veto seam already exists: `ToolConfirmationCoordinator.requestConfirmation` ([:33](../../OpenGlasses/Sources/Services/ToolConfirmationCoordinator.swift)) + `onSpeakPrompt` ([:28](../../OpenGlasses/Sources/Services/ToolConfirmationCoordinator.swift)) already suspend a call for spoken approval. The supervisor reuses this for veto → confirm.
-- Gated behind `Config.agentModeEnabled`, per the [Agentic Toggle memory](../../.claude/projects/-Users-greig-Code-OpenGlasses/memory/feedback_agentic_toggle.md). When agent mode is off, behavior is exactly as today (single-shot).
+- Gated behind `Config.agentModeEnabled`, per the Agentic Toggle memory. When agent mode is off, behavior is exactly as today (single-shot).
 
 ---
 

--- a/docs/plans/T-offline-field-queue-and-sync.md
+++ b/docs/plans/T-offline-field-queue-and-sync.md
@@ -112,7 +112,7 @@ Reachability.isOnline ──rising edge──▶ SyncEngine.flush()
 ---
 
 ## Open questions / decisions needed
-- **Offline LLM grounding:** queue the *question* for an online answer, or attempt on-device MLX immediately (no connectivity needed)? *Recommendation: try MLX first when present (instant, offline), queue for a stronger cloud answer only if the tech opts in — and note per the [Local Model Background memory](../../.claude/projects/-Users-greig-Code-OpenGlasses/memory/project_local_model_background.md) MLX can't run backgrounded, so foreground-only.*
+- **Offline LLM grounding:** queue the *question* for an online answer, or attempt on-device MLX immediately (no connectivity needed)? *Recommendation: try MLX first when present (instant, offline), queue for a stronger cloud answer only if the tech opts in — and note per the Local Model Background memory MLX can't run backgrounded, so foreground-only.*
 - **Photo durability vs storage:** keep all captured photos until synced (disk pressure) or cap? *Recommendation: keep until `done`, then move to a capped cache; warn at a disk threshold.*
 - **Sync target:** flush to the OpenClaw gateway, a customer endpoint, or just local export until a backend exists? *Recommendation: pluggable sink — local export is the v1 sink, gateway/customer endpoint slot in behind the same interface.*
 - **Multi-device:** one technician, one phone in v1 — defer true multi-writer reconciliation. *Recommendation: single-writer assumption; document it.*

--- a/docs/plans/W-presence-aware-agent-throttle.md
+++ b/docs/plans/W-presence-aware-agent-throttle.md
@@ -18,7 +18,7 @@ qaeros throttles server-side agent cycles by operator tab-focus. We don't have a
 | Voice activity | existing wake-word / transcription pipeline | recent spoken interaction |
 | Time since last command | app state | how long since the user engaged |
 | Glasses connectivity | DAT session state | are the glasses even on the face |
-| Foreground | app lifecycle (+ [Local Model Background memory](../../.claude/projects/-Users-greig-Code-OpenGlasses/memory/project_local_model_background.md): MLX can't run backgrounded) | local inference only runs foreground |
+| Foreground | app lifecycle (+ Local Model Background memory: MLX can't run backgrounded) | local inference only runs foreground |
 
 These fuse into `engagement ∈ [0,1]`: ~1.0 actively talking/looking, ~0.3 connected-but-idle, ~0.0 disconnected/backgrounded.
 
@@ -115,7 +115,7 @@ held recommendations are spoken: "While you were idle: 2 suggestions."
 - Wake-word / transcription pipeline (existing) — the voice-activity signal source.
 - DAT `DeviceSession` state (existing) — connectivity signal.
 - **[Plan S](S-plan-then-execute-and-safety-supervisor.md)** — the autonomy-ceiling consumer; W is most valuable once S's agent loop exists, but the loop-throttle half ships value immediately on `LiveCoachService`.
-- Note the [Local Model Background memory](../../.claude/projects/-Users-greig-Code-OpenGlasses/memory/project_local_model_background.md): MLX inference is foreground-only, so `away`/backgrounded ⇒ paused is also a correctness constraint, not just an optimization.
+- Note the Local Model Background memory: MLX inference is foreground-only, so `away`/backgrounded ⇒ paused is also a correctness constraint, not just an optimization.
 
 ---
 

--- a/docs/plans/Y-interactive-hud-launcher.md
+++ b/docs/plans/Y-interactive-hud-launcher.md
@@ -137,7 +137,7 @@ voice in parallel: "switch to Scout" → HUDVoiceCommandRouter matches modePerso
 - **List length in the field.** Power users may have many quick actions/playbooks. *Recommendation: paginate at 6 with `More…`; later add a "Favorites" subset pinned to the root for the field.*
 - **Mode switch safety.** Switching to Gemini/OpenAI Realtime from the lens starts a live session (mic/network). *Recommendation: require a second confirm item for mode switches that open a realtime session; persona swaps (same mode) are one-tap.*
 - **Notification interruptions mid-menu.** A geofence/proactive alert arriving while a menu is open. *Recommendation: brief flash badge, never steal focus from an open launcher screen (reuse the [Plan X](X-interactive-hud-now-next-tasks.md) flash-and-restore).*
-- **Agent-mode gating.** Anything that can *act* autonomously stays behind [agentModeEnabled](../../.claude/projects/-Users-greig-Code-OpenGlasses/memory/feedback_agentic_toggle.md); the launcher itself is user-initiated, so it isn't gated, but agentic quick actions inside it inherit that gate.
+- **Agent-mode gating.** Anything that can *act* autonomously stays behind agentModeEnabled; the launcher itself is user-initiated, so it isn't gated, but agentic quick actions inside it inherit that gate.
 
 ---
 

--- a/docs/plans/Z-shortcuts-catalog.md
+++ b/docs/plans/Z-shortcuts-catalog.md
@@ -1,0 +1,80 @@
+# Plan Z — Shortcuts Catalog: auto-surface Siri Shortcuts to the agent
+
+**Source pattern:** The agent can already *run* Apple Shortcuts — generically by name ([SiriShortcutsTool.swift](../../OpenGlasses/Sources/Services/NativeTools/SiriShortcutsTool.swift) `run_shortcut`, fire-and-forget) and as first-class result-returning tools ([CustomToolWrapper.swift](../../OpenGlasses/Sources/Services/NativeTools/CustomToolWrapper.swift) via `shortcuts://x-callback-url` + [ShortcutCallbackManager](../../OpenGlasses/Sources/Services/ShortcutCallbackManager.swift)). What it lacks is a **live menu of what exists** — and iOS exposes **no API to enumerate all Shortcuts**. The closest is `INVoiceShortcutCenter`, which returns only the shortcuts the user has *"Added to Siri"*. [DiscoverCapabilitiesTool](../../OpenGlasses/Sources/Services/NativeTools/DiscoverCapabilitiesTool.swift) already pulls that subset on demand; this plan folds it into the system prompt automatically so the agent has a current menu without the user naming shortcuts.
+
+**Effort:** ~half a day.
+
+---
+
+## Concept
+
+A small `ShortcutsCatalog` caches the user's Siri-added shortcuts and feeds a compact block into the prompt builders, refreshed when the app foregrounds. The agent then knows which shortcut names are real (and can call `run_shortcut` confidently), without us pretending we can see the full Shortcuts library — the block states the limit plainly.
+
+---
+
+## Files
+
+```
+Sources/Services/ShortcutsCatalog.swift   // wraps INVoiceShortcutCenter; caches [(phrase, title)]; refresh()
+```
+
+Touch:
+- [LLMService.swift](../../OpenGlasses/Sources/Services/LLMService.swift) + [GeminiLiveSessionManager.swift](../../OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift) — inject an `Available Siri Shortcuts:` block (the two prompt builders, same spot the custom-tool list is assembled).
+- [OpenGlassesApp.swift](../../OpenGlasses/Sources/App/OpenGlassesApp.swift) (`AppState`) — `refresh()` on `scenePhase`/`didBecomeActive`, and after a Custom Tool is saved.
+- Prompt Inspector (transparency) — show the block, since it's data going to the model.
+
+---
+
+## Model
+
+```swift
+@MainActor final class ShortcutsCatalog: ObservableObject {
+    struct Entry: Equatable { let phrase: String; let title: String }
+    @Published private(set) var entries: [Entry] = []   // cached, persisted to UserDefaults
+
+    func refresh() async        // INVoiceShortcutCenter.getAllVoiceShortcuts → entries
+    func promptBlock(max: Int = 25) -> String?  // nil when empty; capped + truncated
+}
+```
+
+`promptBlock` example:
+
+```
+Available Siri Shortcuts (ones the user added to Siri — call run_shortcut by name):
+- "log water" → Log Water
+- "start focus" → Start Focus
+(There may be more Shortcuts not listed here; iOS only exposes Siri-added ones.)
+```
+
+---
+
+## Build order
+
+1. `ShortcutsCatalog.refresh()` + `promptBlock` (pure formatter) + UserDefaults cache.
+2. Inject `promptBlock` into `LLMService` and `GeminiLiveSessionManager` prompt assembly (only when non-empty).
+3. Refresh triggers: app foreground + after Custom Tool save.
+4. Surface the block in the Prompt Inspector.
+
+---
+
+## Tests
+- `promptBlock` (pure): N entries → expected formatting, cap/truncation at `max`, `nil` when empty, the iOS-limit caveat line present.
+- Catalog: synthetic entries → dedup/sort stable; cache round-trips through UserDefaults.
+- Prompt assembly: block present when entries exist, absent when empty (no dangling header).
+
+---
+
+## Open questions / decisions
+- **Cap size.** 25 shortcuts is plenty for a HUD-era prompt; more just burns tokens. *Recommendation: cap 25, newest/most-recently-used first if that ordering is available, else alphabetical.*
+- **Privacy.** Shortcut names can be personal. *Recommendation: it's local-only and only the Siri-added subset; still, gate it behind the existing Tools/transparency surface and show it in the Prompt Inspector.*
+
+---
+
+## Dependencies / prereqs
+- `INVoiceShortcutCenter` (Intents framework) — already used by [DiscoverCapabilitiesTool](../../OpenGlasses/Sources/Services/NativeTools/DiscoverCapabilitiesTool.swift) and [QuickActionTool](../../OpenGlasses/Sources/Services/NativeTools/QuickActionTool.swift).
+- The two prompt builders (`LLMService`, `GeminiLiveSessionManager`) — the injection points (they already assemble the custom-tool list).
+
+---
+
+## Why this matters
+Today the agent runs shortcuts "blind" — it guesses a name or relies on the user to say it. Folding the Siri-added catalog into the prompt gives it a real, current menu so `run_shortcut` lands on names that exist, while being honest (in the prompt itself) that iOS hides the rest — for which **Custom Tools** remain the reliable, result-returning path.


### PR DESCRIPTION
## Summary

A leak audit (requested) turned up personal credentials/identifiers committed in **tracked, public** files. This scrubs them to the placeholders the README already documents — real values live in the **gitignored** overlay (`Config/Info/Info.personal.plist` + `project.local.yml`), which the local build already uses, so **nothing changes for the maintainer's build or CI**.

## Scrubbed

| File | Was | Now |
|---|---|---|
| `OpenGlasses/Info.plist` | Meta App ID `688603774243722`, `ClientToken AR\|…`, `mwdat-<id>` scheme | `YOUR_META_APP_ID` / `YOUR_CLIENT_TOKEN_HASH` |
| `ExportOptions.plist` | Apple Team ID `B9L8ANZQZX` | `YOUR_APPLE_TEAM_ID` |
| `docs/plans/{E,S,T,W,Y}.md` | links embedding `/Users/greig/…` | label text (leaked the username; broken links anyway) |

## ⚠️ Action required (maintainer)

The Meta **ClientToken was public**, so scrubbing HEAD isn't sufficient — **rotate it in the Meta developer dashboard**. It also remains in git history; rotation is the real fix (history rewrite via `git filter-repo`/BFG is optional).

## Intentionally NOT changed

`.well-known/apple-app-site-association` and `index.html` keep their real Team ID / App ID — they're **served live by GitHub Pages** (`pages.yml` deploys repo root) and **must** be real for universal links to work. An AASA is **inherently public** by design (Apple fetches it over HTTPS to verify the app↔domain association), so the Team ID there isn't a removable leak.

## Also bundled

`docs/plans/Z-shortcuts-catalog.md` — the spec to auto-surface Siri Shortcuts into the agent's system prompt (the "keep the list updated" follow-up).

## Verification

- Local build unaffected: `project.local.yml` overrides `INFOPLIST_FILE → Config/Info/Info.personal.plist` (which has the real creds, gitignored).
- CI unaffected: `app-store-upload.yml` writes its own `ExportOptions.plist` to `$RUNNER_TEMP`.
- Post-scrub grep: 0 occurrences of the ClientToken / Team ID in build config; 0 username path-leaks in docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)