### PR TITLE
Plan Z: surface the user's Siri Shortcuts in the agent prompt

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -275,6 +275,9 @@ struct OpenGlassesApp: App {
             case .active:
                 print("📱 App became active")
                 appState.restoreFromBackground()
+                // Refresh the Siri Shortcuts catalog — the user may have added shortcuts
+                // while away — so the agent's run_shortcut menu stays current (Plan Z).
+                Task { await ShortcutsCatalog.shared.refresh() }
                 if appState.conversationStore.isLocked {
                     Task { await appState.conversationStore.unlock() }
                 }
@@ -2307,6 +2310,7 @@ class AppState: ObservableObject, AppStateProtocol {
                     memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext() : nil,
                     playbookContext: classification.relevantSections.contains(.playbook) ? playbookStore.playbookContext() : nil,
                     nowPlayingContext: nowPlayingAtStart?.promptContext,
+                    shortcutsContext: ShortcutsCatalog.shared.promptBlock(),
                     promptSections: classification.relevantSections
                 )
             }
@@ -2399,7 +2403,8 @@ class AppState: ObservableObject, AppStateProtocol {
                 locationContext: locationService.locationContext,
                 imageData: image,
                 memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext() : nil,
-                playbookContext: playbookStore.playbookContext()
+                playbookContext: playbookStore.playbookContext(),
+                shortcutsContext: ShortcutsCatalog.shared.promptBlock()
             )
 
             let response = Config.userMemoryEnabled ? userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse

--- a/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift
+++ b/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift
@@ -507,6 +507,11 @@ class GeminiLiveSessionManager: ObservableObject {
                 for ct in customTools {
                     toolSection += "\n            - \(ct.name): \(ct.description)"
                 }
+
+                // Inject the user's Siri Shortcuts so run_shortcut targets real names (Plan Z)
+                if let shortcuts = ShortcutsCatalog.shared.promptBlock() {
+                    toolSection += "\n\n            \(shortcuts.replacingOccurrences(of: "\n", with: "\n            "))"
+                }
             }
 
             if hasOpenClaw {

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -164,7 +164,7 @@ class LLMService: ObservableObject {
     /// Build the full system prompt, optionally including location, tools, memory, and vision context.
     /// When `promptSections` is provided (from the ConversationClassifier), irrelevant sections are
     /// stripped to reduce token count. When nil, all sections are included (backward compatible).
-    private static func buildSystemPrompt(locationContext: String?, includeTools: Bool, includeOpenClaw: Bool, hasImage: Bool, nativeToolNames: [String] = [], gatewayToolNames: [String] = [], memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil) async -> String {
+    private static func buildSystemPrompt(locationContext: String?, includeTools: Bool, includeOpenClaw: Bool, hasImage: Bool, nativeToolNames: [String] = [], gatewayToolNames: [String] = [], memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil) async -> String {
         // Agent personality mode: soul.md + skills.md + memory.md replace the standard prompt
         var prompt: String
         if Config.agentModeEnabled, let agentContext, !agentContext.isEmpty {
@@ -286,6 +286,11 @@ class LLMService: ObservableObject {
                 let customTools = Config.customTools.filter { Config.isToolEnabled($0.name) }
                 for ct in customTools {
                     toolSection += "\n            - \(ct.name): \(ct.description)"
+                }
+
+                // Inject the user's Siri Shortcuts so run_shortcut targets real names (Plan Z)
+                if let shortcuts = shortcutsContext {
+                    toolSection += "\n\n            \(shortcuts.replacingOccurrences(of: "\n", with: "\n            "))"
                 }
 
                 // Inject Home Assistant device list so LLM uses real entity IDs (skip if classifier says not needed)
@@ -424,7 +429,7 @@ class LLMService: ObservableObject {
         return PromptInjectionPolicy.wrap(toolName: toolName, content: content)
     }
 
-    func sendMessage(_ text: String, locationContext: String? = nil, imageData: Data? = nil, memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil) async throws -> String {
+    func sendMessage(_ text: String, locationContext: String? = nil, imageData: Data? = nil, memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil) async throws -> String {
         isProcessing = true
         defer { isProcessing = false }
 
@@ -446,7 +451,7 @@ class LLMService: ObservableObject {
         let includeTools = hasNativeTools || includeOpenClaw
         let nativeToolNames = nativeToolRouter?.registry.toolNames ?? []
         let gatewayToolNames = openClawBridge?.availableToolNames ?? []
-        let fullPrompt = await Self.buildSystemPrompt(locationContext: locationContext, includeTools: includeTools, includeOpenClaw: includeOpenClaw, hasImage: imageData != nil, nativeToolNames: nativeToolNames, gatewayToolNames: gatewayToolNames, memoryContext: memoryContext, agentContext: agentContext, playbookContext: playbookContext, nowPlayingContext: nowPlayingContext, promptSections: promptSections)
+        let fullPrompt = await Self.buildSystemPrompt(locationContext: locationContext, includeTools: includeTools, includeOpenClaw: includeOpenClaw, hasImage: imageData != nil, nativeToolNames: nativeToolNames, gatewayToolNames: gatewayToolNames, memoryContext: memoryContext, agentContext: agentContext, playbookContext: playbookContext, nowPlayingContext: nowPlayingContext, shortcutsContext: shortcutsContext, promptSections: promptSections)
 
         var toolsLabel = ""
         if hasNativeTools { toolsLabel += " [NativeTools]" }

--- a/OpenGlasses/Sources/Services/ShortcutsCatalog.swift
+++ b/OpenGlasses/Sources/Services/ShortcutsCatalog.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Intents
+
+/// Caches the user's Siri-added shortcuts and formats them into a compact prompt block
+/// (Plan Z). iOS exposes no API to enumerate *all* Shortcuts — only the ones the user
+/// "Added to Siri" via `INVoiceShortcutCenter` — so this surfaces that subset to the
+/// agent (for `run_shortcut`) and says so plainly in the block itself.
+@MainActor
+final class ShortcutsCatalog: ObservableObject {
+    static let shared = ShortcutsCatalog()
+
+    struct Entry: Codable, Equatable, Sendable {
+        let phrase: String
+        let title: String
+    }
+
+    @Published private(set) var entries: [Entry] = []
+
+    /// `nonisolated` so it can be used as a default argument and from off-actor helpers
+    /// without a main-actor-isolation warning (immutable Sendable constant).
+    nonisolated static let maxEntries = 25
+
+    private let storageKey = "shortcutsCatalog"
+
+    init() { load() }
+
+    /// Re-query Siri shortcuts and update the cache. Cheap; safe to call on foreground.
+    func refresh() async {
+        let normalized = Self.normalize(await Self.fetchVoiceShortcuts(), max: Self.maxEntries)
+        guard normalized != entries else { return }
+        entries = normalized
+        save()
+    }
+
+    /// Compact prompt block for the current cache, or nil when empty.
+    func promptBlock() -> String? { Self.promptBlock(for: entries) }
+
+    // MARK: - Pure helpers (testable without a device)
+
+    /// Dedup by phrase (case-insensitive), sort alphabetically, cap to `max`.
+    nonisolated static func normalize(_ raw: [Entry], max: Int) -> [Entry] {
+        var seen = Set<String>()
+        let deduped = raw
+            .sorted { $0.phrase.localizedCaseInsensitiveCompare($1.phrase) == .orderedAscending }
+            .filter { seen.insert($0.phrase.lowercased()).inserted }
+        return Array(deduped.prefix(max))
+    }
+
+    nonisolated static func promptBlock(for entries: [Entry], max: Int = maxEntries) -> String? {
+        guard !entries.isEmpty else { return nil }
+        let lines = entries.prefix(max).map { "- \"\($0.phrase)\" → \($0.title)" }
+        return """
+        Available Siri Shortcuts (the user added these to Siri — call run_shortcut with the exact name):
+        \(lines.joined(separator: "\n"))
+        (There may be more Shortcuts the user created that iOS does not expose here.)
+        """
+    }
+
+    // MARK: - INVoiceShortcutCenter
+
+    nonisolated private static func fetchVoiceShortcuts() async -> [Entry] {
+        await withCheckedContinuation { (cont: CheckedContinuation<[Entry], Never>) in
+            INVoiceShortcutCenter.shared.getAllVoiceShortcuts { shortcuts, _ in
+                let entries: [Entry] = (shortcuts ?? []).compactMap { vs in
+                    let phrase = vs.invocationPhrase.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !phrase.isEmpty else { return nil }
+                    let title = vs.shortcut.intent?.description
+                        ?? vs.shortcut.userActivity?.title
+                        ?? phrase
+                    return Entry(phrase: phrase, title: title)
+                }
+                cont.resume(returning: entries)
+            }
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func save() {
+        if let data = try? JSONEncoder().encode(entries) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+        }
+    }
+
+    private func load() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode([Entry].self, from: data) else { return }
+        entries = decoded
+    }
+}

--- a/OpenGlassesTests/ShortcutsCatalogTests.swift
+++ b/OpenGlassesTests/ShortcutsCatalogTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for the Siri Shortcuts catalog (Plan Z). The `INVoiceShortcutCenter` fetch
+/// can't run headlessly, so the device-independent logic — normalize + prompt-block
+/// formatting + persistence — is factored into pure static helpers and tested here.
+final class ShortcutsCatalogTests: XCTestCase {
+    private typealias Entry = ShortcutsCatalog.Entry
+
+    func testNormalizeSortsAndDedupesCaseInsensitively() {
+        let raw = [
+            Entry(phrase: "Start Focus", title: "Focus"),
+            Entry(phrase: "log water", title: "Water"),
+            Entry(phrase: "LOG WATER", title: "Water dup"),   // case-insensitive duplicate
+            Entry(phrase: "Arrive Home", title: "Home"),
+        ]
+        let out = ShortcutsCatalog.normalize(raw, max: 10)
+        XCTAssertEqual(out.count, 3)   // duplicate collapsed
+        XCTAssertEqual(out.map { $0.phrase.lowercased() }, ["arrive home", "log water", "start focus"])
+    }
+
+    func testNormalizeCapsAtMax() {
+        let raw = (1...30).map { Entry(phrase: "p\($0)", title: "t\($0)") }
+        XCTAssertEqual(ShortcutsCatalog.normalize(raw, max: 25).count, 25)
+    }
+
+    func testPromptBlockFormatsAndIncludesCaveat() throws {
+        let entries = [Entry(phrase: "log water", title: "Log Water"),
+                       Entry(phrase: "start focus", title: "Start Focus")]
+        let block = try XCTUnwrap(ShortcutsCatalog.promptBlock(for: entries))
+        XCTAssertTrue(block.contains("- \"log water\" → Log Water"))
+        XCTAssertTrue(block.contains("- \"start focus\" → Start Focus"))
+        XCTAssertTrue(block.contains("run_shortcut"))                       // tells the model how to use them
+        XCTAssertTrue(block.lowercased().contains("more shortcuts"))        // the iOS-limit caveat
+    }
+
+    func testPromptBlockNilWhenEmpty() {
+        XCTAssertNil(ShortcutsCatalog.promptBlock(for: []))
+    }
+
+    func testPromptBlockRespectsMax() throws {
+        let entries = (1...10).map { Entry(phrase: "p\($0)", title: "t\($0)") }
+        let block = try XCTUnwrap(ShortcutsCatalog.promptBlock(for: entries, max: 3))
+        let bullets = block.split(separator: "\n").filter { $0.hasPrefix("- \"") }
+        XCTAssertEqual(bullets.count, 3)
+    }
+
+    func testEntryCodableRoundTrips() throws {
+        let entries = [Entry(phrase: "a", title: "A"), Entry(phrase: "b", title: "B")]
+        let decoded = try JSONDecoder().decode([Entry].self, from: JSONEncoder().encode(entries))
+        XCTAssertEqual(decoded, entries)
+    }
+}

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -31,9 +31,9 @@ All plans A–M are **built and merged to `main`** to the extent verifiable with
 | U Structured Capture-Flow / Action-Form Schema | 📋 Planned (Round 5 — field) |
 | V Curated MCP Catalogue & Transport Breadth | 📋 Planned (Round 5 — MCP UX) |
 | W Presence-Aware Agent Throttle | 📋 Planned (Round 5 — agentic/battery) |
-| X Interactive HUD — Now/Next Tasks | 🚧 In progress on `display/hud-phase3` — foundation + band card + voice bridge + Playbook/Procedure sources shipped; 30 headless tests, Debug+Release green. Display Phases 1–2 ✅ merged (#42, #45). |
+| X Interactive HUD — Now/Next Tasks | ✅ Shipped (#46) — foundation + band card + voice bridge + Playbook/Procedure sources; 30 headless tests. Display Phases 1–3 merged (#42, #45, #46). |
 | Y Interactive HUD Launcher | 📋 Planned (Round 6 — Display Phase 4) |
-| Z Shortcuts Catalog | 📋 Planned (auto-surface Siri Shortcuts to the agent) |
+| Z Shortcuts Catalog | ✅ Shipped on `feat/shortcuts-catalog` — Siri-added shortcuts injected into the agent prompt; 6 tests. |
 
 Three selectable expert-stream transports: **MJPEG** (same-LAN browser viewer), **Meeting link** (zero-infra — your meeting tool hosts the call; recommended for remote), and **WebRTC** (self-hosted peer-to-peer, needs your own signaling + TURN).
 

--- a/docs/plans/Z-shortcuts-catalog.md
+++ b/docs/plans/Z-shortcuts-catalog.md
@@ -4,6 +4,8 @@
 
 **Effort:** ~half a day.
 
+**Status:** ✅ Shipped on `feat/shortcuts-catalog` — `ShortcutsCatalog` service (cached, refreshed on app foreground) injects a compact block into both prompt builders (`LLMService` + `GeminiLiveSessionManager`); 6 headless tests. Follow-up: surface the block in the Prompt Inspector (it doesn't reconstruct via `buildSystemPrompt`, so it isn't auto-shown there yet).
+
 ---
 
 ## Concept


### PR DESCRIPTION
## Summary

The agent could already *run* Apple Shortcuts by name, but had no live menu of which exist — and iOS exposes **no API to enumerate all Shortcuts**. This folds the **Siri-added subset** (`INVoiceShortcutCenter`) into the system prompt so `run_shortcut` targets names that actually exist, refreshed automatically when the app foregrounds.

## What it does

- **`ShortcutsCatalog`** — caches the user's voice shortcuts (`[(phrase, title)]`), persisted to UserDefaults, refreshed on `scenePhase .active`. The device-independent logic (dedup/sort/cap + prompt-block formatting) is in **pure static helpers** so it's testable without hardware.
- **Prompt injection** — `LLMService.buildSystemPrompt`/`sendMessage` gain a `shortcutsContext`; the block is injected into the tool section beside custom tools and the HA summary. `GeminiLiveSessionManager` injects the same.
- **Honest about the limit** — the block ends with *"there may be more Shortcuts iOS does not expose here."* **Custom Tools** remain the path for full, **result-returning** coverage.

Example block:
```
Available Siri Shortcuts (the user added these to Siri — call run_shortcut with the exact name):
- "log water" → Log Water
- "start focus" → Start Focus
(There may be more Shortcuts the user created that iOS does not expose here.)
```

## Tests

6 headless tests: normalize (case-insensitive dedup, sort, cap at 25), prompt-block formatting + the iOS-limit caveat, nil-when-empty, max cap, `Entry` Codable round-trip. **Debug + Release green.**

## Follow-up

The Prompt Inspector doesn't reconstruct the prompt via `buildSystemPrompt`, so the block isn't auto-shown there yet — noted in `docs/plans/Z-…`.

*(Also marks Plan X as ✅ shipped in the plan index — it was stale after #46 merged.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)