### PR TITLE
Plan X polish: AI replies flash over the task card + refreshed Settings copy

### DIFF
--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -950,7 +950,7 @@ struct HardwarePrivacyView: View {
                             }
                         }
                     ),
-                    info: "Mirrors AI responses and live captions to the in-lens display on Ray-Ban Display glasses. Has no effect on glasses without a built-in display."
+                    info: "Shows AI responses, live captions, notifications and turn-by-turn guidance on the in-lens display, and runs interactive task cards you complete hands-free with the Neural Band or voice (\"next\", \"done\", \"skip\", \"back\"). Ray-Ban Display glasses only — no effect on glasses without a built-in display."
                 )
                 InfoToggle(
                     title: "Use Phone Mic for Translation",

--- a/OpenGlasses/Sources/Services/GlassesDisplayService.swift
+++ b/OpenGlasses/Sources/Services/GlassesDisplayService.swift
@@ -153,8 +153,17 @@ final class GlassesDisplayService: ObservableObject {
 
     /// Show a concise line of body text. No-op when the feature is off or the glasses
     /// have no display. Used by the Phase 1 producers (AI replies, ambient captions).
-    func showText(_ text: String) {
-        present(HUDContent(title: nil, body: text, icon: .none), transient: false, duration: 0)
+    ///
+    /// `flashWhileInteractive`: when a task card is held, AI replies pass `true` so the
+    /// reply briefly flashes over the card and the card is then restored — rather than
+    /// being suppressed. Ambient captions leave it `false` (suppressed while a card is
+    /// up, to avoid spamming the task).
+    func showText(_ text: String, flashWhileInteractive: Bool = false) {
+        if flashWhileInteractive && isInteractive {
+            present(HUDContent(title: nil, body: text, icon: .none), transient: true, duration: 5)
+        } else {
+            present(HUDContent(title: nil, body: text, icon: .none), transient: false, duration: 0)
+        }
     }
 
     /// Show body text, then auto-clear after `duration` seconds.
@@ -188,14 +197,17 @@ final class GlassesDisplayService: ObservableObject {
         screenSelectionHandler = onSelect
         currentScreen = screen
         isInteractive = true
+        onDebugEvent?("HUD task card: \(screen.title ?? "menu")")
         enqueue(.screen(screen))
     }
 
     /// Leave interactive mode and clear the HUD so ambient producers resume.
     func endInteractive() {
+        guard isInteractive else { return }
         isInteractive = false
         currentScreen = nil
         screenSelectionHandler = nil
+        onDebugEvent?("HUD interactive ended")
         enqueue(.op(.clear))
     }
 

--- a/OpenGlasses/Sources/Services/TextToSpeechService.swift
+++ b/OpenGlasses/Sources/Services/TextToSpeechService.swift
@@ -144,7 +144,7 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
 
         // Mirror spoken text to the in-lens HUD (additive; no-op without a display).
         // Callers that render a richer HUD treatment themselves pass mirrorToHUD: false.
-        if mirrorToHUD { glassesDisplay?.showText(text) }
+        if mirrorToHUD { glassesDisplay?.showText(text, flashWhileInteractive: true) }
 
         // Silence if glasses-only mode is on and glasses aren't connected
         if Config.glassesOnlyAudio && !glassesConnected {

--- a/OpenGlassesTests/GlassesDisplayInteractiveTests.swift
+++ b/OpenGlassesTests/GlassesDisplayInteractiveTests.swift
@@ -71,6 +71,17 @@ final class GlassesDisplayInteractiveTests: XCTestCase {
         XCTAssertEqual(frames, [])
     }
 
+    func testAIReplyFlashesOverCardWhileCaptionSuppressed() async {
+        svc.present(screen: card("Card")) { _ in }
+        await settle()
+        frames.removeAll()
+        // A caption (default showText) stays suppressed; an AI reply flashes over the card.
+        svc.showText("a caption line")                          // suppressed
+        svc.showText("the AI answer", flashWhileInteractive: true)  // flashes
+        await settle()
+        XCTAssertEqual(frames, [.content(body: "the AI answer", title: nil, icon: .none)])
+    }
+
     func testNotificationFlashesThenRestoresScreenWhileInteractive() async {
         let screen = card("Card")
         svc.present(screen: screen) { _ in }

--- a/docs/plans/X-interactive-hud-now-next-tasks.md
+++ b/docs/plans/X-interactive-hud-now-next-tasks.md
@@ -6,7 +6,7 @@
 
 **Effort:** ~3–4 days.
 
-**Status (branch `display/hud-phase3`):** ✅ Build-order steps 1–4 shipped and tested — interactive foundation, `PlaybookHUDTaskSource` (linear) and `ProcedureHUDTaskSource` (branching SOPs with choice buttons), and the voice bridge ("next/done/skip/back"). 30 headless tests pass; Debug + Release green. Remaining: step 5 (agent replies currently *suppressed* while a card is held — heard via TTS, card stays authoritative; flash-during-task is an optional refinement) and step 6 (Settings copy).
+**Status:** ✅ **Complete.** Steps 1–4 shipped in #46 (interactive foundation, `PlaybookHUDTaskSource` linear + `ProcedureHUDTaskSource` branching SOPs, voice bridge). Step 5 (AI replies now *flash* over the card and restore it, while ambient captions stay suppressed) and step 6 (Settings copy + interactive debug events) followed on `feat/hud-polish`. 31 headless tests; Debug + Release green.
 
 ---
 


### PR DESCRIPTION
## Summary

The two follow-ups noted in [#46](https://github.com/straff2002/OpenGlasses/pull/46), closing out Plan X.

- **AI replies flash over the task card.** `GlassesDisplayService.showText` gains `flashWhileInteractive`: while a Now/Next card is held, AI replies (TTS) now briefly flash over the card and the card is restored, instead of being suppressed. **Ambient captions keep the default** (suppressed during a task, to avoid spamming it).
- **Settings copy refresh.** The "Glasses Display (HUD)" toggle blurb only mentioned Phase-1 mirroring; it now covers notifications, navigation, and the interactive task cards (Neural Band + voice).
- **Interactive debug events** (present card / end interactive); `endInteractive` guards on `isInteractive` so a stray call can't wipe ambient content.

## Tests

1 new headless test (AI reply flashes while a caption stays suppressed) — **31 HUD tests pass; Debug + Release green.**

Plan X is now complete (status updated in `docs/plans/X-…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)