### PR TITLE
Live HUD mirror (Display Phase 4) + Keychain secret storage + fork-harvest plan

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -133,6 +133,9 @@ struct OpenGlassesApp: App {
     @State private var isHipaaLocked = Config.hipaaMode
 
     init() {
+        // Move any plaintext provider secrets out of UserDefaults and into the
+        // Keychain. Must run before anything reads a secret (AppState, LLM, TTS…).
+        Config.migrateSecretsToKeychainIfNeeded()
         // Defer Wearables SDK (Bluetooth permission) until after onboarding
         if Config.hasCompletedOnboarding {
             configureWearables()

--- a/OpenGlasses/Sources/App/Views/HUDMirrorView.swift
+++ b/OpenGlasses/Sources/App/Views/HUDMirrorView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Live on-phone mirror of the in-lens HUD (Display Phase 4 / Plan Y). Observes the
+/// router's current interactive screen and renders it through `HUDPreviewView`, so you
+/// can watch the real HUD — task cards and launcher menus — on the phone in real time,
+/// with or without Display glasses. (The router sets its `currentScreen` regardless of
+/// whether the glasses actually render, so this works device-less.)
+///
+/// View-only: drive the HUD with the Neural Band or voice; this just reflects it.
+struct HUDMirrorView: View {
+    @ObservedObject var router: HUDRouter
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if let screen = router.currentScreen {
+                HUDPreviewView(screen: screen)
+                    .padding(.horizontal)
+                Text("Live — this is what's on the lens.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                ContentUnavailableView(
+                    "HUD idle",
+                    systemImage: "eyeglasses",
+                    description: Text("Start a workflow or say \u{201C}menu\u{201D} to drive the HUD — it mirrors here in real time.")
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.vertical)
+        .navigationTitle("HUD Mirror")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -952,6 +952,11 @@ struct HardwarePrivacyView: View {
                     ),
                     info: "Shows AI responses, live captions, notifications and turn-by-turn guidance on the in-lens display, and runs interactive task cards you complete hands-free with the Neural Band or voice (\"next\", \"done\", \"skip\", \"back\"). Ray-Ban Display glasses only — no effect on glasses without a built-in display."
                 )
+                NavigationLink {
+                    HUDMirrorView(router: appState.hudRouter)
+                } label: {
+                    Label("HUD Mirror (phone preview)", systemImage: "eyeglasses")
+                }
                 InfoToggle(
                     title: "Use Phone Mic for Translation",
                     isOn: Binding(

--- a/OpenGlasses/Sources/Services/Display/HUDRouter.swift
+++ b/OpenGlasses/Sources/Services/Display/HUDRouter.swift
@@ -10,7 +10,9 @@ final class HUDRouter: ObservableObject {
     private let display: GlassesDisplayService
 
     private var taskSource: HUDTaskSource?
-    private var currentScreen: HUDScreen?
+    /// The interactive screen the router is currently driving (task card or menu), or
+    /// nil when none. Published so the on-phone live mirror (`HUDMirrorView`) tracks it.
+    @Published private(set) var currentScreen: HUDScreen?
     private var cancellable: AnyCancellable?
 
     /// Whether a task card is currently being driven on the HUD.

--- a/OpenGlasses/Sources/Services/KeychainService.swift
+++ b/OpenGlasses/Sources/Services/KeychainService.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Security
+
+/// Thin wrapper around the iOS Keychain for storing small secrets — provider
+/// API keys, auth tokens, and secret-bearing config blobs (e.g. the saved-model
+/// list, whose `apiKey` fields would otherwise sit in plaintext UserDefaults and
+/// land in unencrypted device backups).
+///
+/// Items use `kSecClassGenericPassword`, scoped to this device only and readable
+/// `AfterFirstUnlock`. That means background LLM/TTS requests can still read keys
+/// while the device is locked (after the first post-boot unlock), but the secrets
+/// never sync to iCloud and never leave the device in an iTunes/Finder backup.
+///
+/// This mirrors the Keychain pattern already used by `ConversationEncryptionService`
+/// (same `service` identifier, distinct accounts). API-key items intentionally use a
+/// looser accessibility class than the conversation key (no `.userPresence`) so they
+/// work unattended.
+enum KeychainService {
+
+    /// Shared service identifier for all OpenGlasses Keychain items.
+    private static let service = "OpenGlasses"
+
+    /// Accessibility: readable after the first unlock following a reboot, this
+    /// device only (never backed up, never synced to iCloud).
+    private static let accessible = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+    // MARK: - Data
+
+    /// Read raw data for a key, or `nil` if the item does not exist.
+    static func data(for key: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else {
+            if status != errSecItemNotFound {
+                NSLog("[Keychain] read failed for %@: %d", key, Int(status))
+            }
+            return nil
+        }
+        return result as? Data
+    }
+
+    /// Store raw data for a key. Passing `nil` or empty data deletes the item.
+    /// Returns `true` on success (including the delete-on-empty case).
+    @discardableResult
+    static func setData(_ data: Data?, for key: String) -> Bool {
+        // Delete first so a re-set always replaces cleanly (matches the pattern
+        // in ConversationEncryptionService and avoids errSecDuplicateItem).
+        delete(key)
+        guard let data, !data.isEmpty else { return true }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: accessible,
+        ]
+        let status = SecItemAdd(query as CFDictionary, nil)
+        if status != errSecSuccess {
+            NSLog("[Keychain] write failed for %@: %d", key, Int(status))
+        }
+        return status == errSecSuccess
+    }
+
+    // MARK: - String
+
+    /// Read a UTF-8 string for a key, or `nil` if the item does not exist.
+    static func string(for key: String) -> String? {
+        guard let data = data(for: key) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    /// Store a UTF-8 string for a key. Passing `nil` or an empty string deletes
+    /// the item (matching the "empty means cleared" semantics of the old
+    /// UserDefaults-backed getters). Returns `true` on success.
+    @discardableResult
+    static func setString(_ value: String?, for key: String) -> Bool {
+        guard let value, !value.isEmpty else { return delete(key) }
+        return setData(Data(value.utf8), for: key)
+    }
+
+    // MARK: - Delete
+
+    /// Remove the item for a key. Returns `true` if it was removed or did not exist.
+    @discardableResult
+    static func delete(_ key: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -361,9 +361,9 @@ struct CustomToolDefinition: Codable, Identifiable, Equatable {
 
 /// App configuration and API keys
 struct Config {
-    /// Anthropic API key for Claude
+    /// Anthropic API key for Claude. Stored in the Keychain (see `KeychainService`).
     static var anthropicAPIKey: String {
-        if let key = UserDefaults.standard.string(forKey: "anthropicAPIKey"), !key.isEmpty {
+        if let key = KeychainService.string(for: "anthropicAPIKey"), !key.isEmpty {
             return key
         }
         // No API key configured - set one via Settings
@@ -371,7 +371,81 @@ struct Config {
     }
 
     static func setAnthropicAPIKey(_ key: String) {
-        UserDefaults.standard.set(key, forKey: "anthropicAPIKey")
+        KeychainService.setString(key, for: "anthropicAPIKey")
+    }
+
+    // MARK: - Secret Storage Migration
+
+    /// UserDefaults flag recording that the one-time secret migration has run.
+    private static let secretsMigratedKey = "secretsMigratedToKeychain_v1"
+
+    /// Plain-string secrets that historically lived in UserDefaults and now live in the Keychain.
+    /// The UserDefaults key name is reused verbatim as the Keychain account.
+    private static let migratableStringSecretKeys = [
+        "anthropicAPIKey",
+        "openAIAPIKey",
+        "elevenLabsAPIKey",
+        "perplexityAPIKey",
+        "openClawGatewayToken",
+        "homeAssistantToken",
+        "broadcastStreamKey",
+        "expertTurnCredential",
+    ]
+
+    /// JSON `Data` blobs that embed secrets (provider API keys, gateway tokens, MCP
+    /// auth headers) and so must also move out of plaintext UserDefaults.
+    private static let migratableDataSecretKeys = [
+        modelsKey,        // "savedModelConfigs" — ModelConfig.apiKey
+        "savedGateways",  // GatewayConfig.token
+        "mcpServers",     // MCPServerConfig.headers (Authorization)
+    ]
+
+    /// One-time migration of plaintext secrets from UserDefaults into the Keychain.
+    ///
+    /// Copies any existing values into the Keychain, then removes the plaintext copy
+    /// from UserDefaults so it no longer lands in unencrypted device backups. Only
+    /// secrets move — non-secret prefs (toggles, onboarding flags, URLs, model names)
+    /// stay in UserDefaults. Idempotent: the body runs at most once, and a value is
+    /// removed from UserDefaults only after its Keychain write succeeds, so an
+    /// interrupted/failed write is retried on the next launch rather than losing data.
+    ///
+    /// Call this once, early in app launch (before any secret is read).
+    static func migrateSecretsToKeychainIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: secretsMigratedKey) else { return }
+
+        var allMigrated = true
+
+        for key in migratableStringSecretKeys {
+            guard let value = defaults.string(forKey: key), !value.isEmpty else {
+                defaults.removeObject(forKey: key)  // nothing/empty to migrate — clean up
+                continue
+            }
+            if KeychainService.setString(value, for: key) {
+                defaults.removeObject(forKey: key)
+            } else {
+                allMigrated = false  // keep plaintext until a later launch succeeds
+            }
+        }
+
+        for key in migratableDataSecretKeys {
+            guard let data = defaults.data(forKey: key), !data.isEmpty else {
+                defaults.removeObject(forKey: key)
+                continue
+            }
+            if KeychainService.setData(data, for: key) {
+                defaults.removeObject(forKey: key)
+            } else {
+                allMigrated = false
+            }
+        }
+
+        if allMigrated {
+            defaults.set(true, forKey: secretsMigratedKey)
+            NSLog("[Config] Migrated provider secrets from UserDefaults to Keychain")
+        } else {
+            NSLog("[Config] Secret migration incomplete — will retry on next launch")
+        }
     }
 
     // MARK: - Onboarding
@@ -458,16 +532,16 @@ struct Config {
 
     // MARK: - OpenAI-compatible
 
-    /// OpenAI-compatible API key
+    /// OpenAI-compatible API key. Stored in the Keychain (see `KeychainService`).
     static var openAIAPIKey: String {
-        if let key = UserDefaults.standard.string(forKey: "openAIAPIKey"), !key.isEmpty {
+        if let key = KeychainService.string(for: "openAIAPIKey"), !key.isEmpty {
             return key
         }
         return ""
     }
 
     static func setOpenAIAPIKey(_ key: String) {
-        UserDefaults.standard.set(key, forKey: "openAIAPIKey")
+        KeychainService.setString(key, for: "openAIAPIKey")
     }
 
     /// OpenAI-compatible base URL (supports OpenAI, Groq, Together, Ollama, etc.)
@@ -594,9 +668,10 @@ struct Config {
     private static let modelsKey = "savedModelConfigs"
     private static let activeModelKey = "activeModelId"
 
-    /// All saved model configurations
+    /// All saved model configurations. Persisted in the Keychain because each
+    /// `ModelConfig` embeds a provider `apiKey` (see `KeychainService`).
     static var savedModels: [ModelConfig] {
-        guard let data = UserDefaults.standard.data(forKey: modelsKey),
+        guard let data = KeychainService.data(for: modelsKey),
               var models = try? JSONDecoder().decode([ModelConfig].self, from: data),
               !models.isEmpty else {
             // Migrate from legacy single-provider config
@@ -631,7 +706,7 @@ struct Config {
 
     static func setSavedModels(_ models: [ModelConfig]) {
         if let data = try? JSONEncoder().encode(models) {
-            UserDefaults.standard.set(data, forKey: modelsKey)
+            KeychainService.setData(data, for: modelsKey)
         }
     }
 
@@ -1507,16 +1582,16 @@ struct Config {
 
     // MARK: - ElevenLabs TTS
 
-    /// ElevenLabs API key for natural TTS voices
+    /// ElevenLabs API key for natural TTS voices. Stored in the Keychain (see `KeychainService`).
     static var elevenLabsAPIKey: String {
-        if let key = UserDefaults.standard.string(forKey: "elevenLabsAPIKey"), !key.isEmpty {
+        if let key = KeychainService.string(for: "elevenLabsAPIKey"), !key.isEmpty {
             return key
         }
         return ""
     }
 
     static func setElevenLabsAPIKey(_ key: String) {
-        UserDefaults.standard.set(key, forKey: "elevenLabsAPIKey")
+        KeychainService.setString(key, for: "elevenLabsAPIKey")
     }
 
     /// ElevenLabs voice ID - default is "Rachel" (warm, conversational female voice)
@@ -1687,15 +1762,16 @@ struct Config {
         UserDefaults.standard.set(host, forKey: "openClawTunnelHost")
     }
 
+    /// OpenClaw gateway auth token. Stored in the Keychain (see `KeychainService`).
     static var openClawGatewayToken: String {
-        if let token = UserDefaults.standard.string(forKey: "openClawGatewayToken"), !token.isEmpty {
+        if let token = KeychainService.string(for: "openClawGatewayToken"), !token.isEmpty {
             return token
         }
         return ""
     }
 
     static func setOpenClawGatewayToken(_ token: String) {
-        UserDefaults.standard.set(token, forKey: "openClawGatewayToken")
+        KeychainService.setString(token, for: "openClawGatewayToken")
     }
 
     static var isOpenClawConfigured: Bool {
@@ -1705,9 +1781,10 @@ struct Config {
 
     // MARK: - Multi-Gateway Configuration
 
-    /// All configured gateways, sorted by priority (lower = first).
+    /// All configured gateways, sorted by priority (lower = first). Persisted in the
+    /// Keychain because each `GatewayConfig` embeds an auth `token` (see `KeychainService`).
     static var savedGateways: [GatewayConfig] {
-        guard let data = UserDefaults.standard.data(forKey: "savedGateways"),
+        guard let data = KeychainService.data(for: "savedGateways"),
               let gateways = try? JSONDecoder().decode([GatewayConfig].self, from: data) else {
             // Auto-migrate legacy single-gateway config on first access
             if openClawEnabled && !openClawGatewayToken.isEmpty {
@@ -1735,7 +1812,7 @@ struct Config {
 
     static func setSavedGateways(_ gateways: [GatewayConfig]) {
         guard let data = try? JSONEncoder().encode(gateways) else { return }
-        UserDefaults.standard.set(data, forKey: "savedGateways")
+        KeychainService.setData(data, for: "savedGateways")
     }
 
     /// Enabled gateways only, in priority order.
@@ -1910,8 +1987,10 @@ struct Config {
 
     // MARK: - MCP Servers
 
+    /// Persisted in the Keychain because each `MCPServerConfig` embeds auth `headers`
+    /// (e.g. `Authorization: Bearer …`) — see `KeychainService`.
     static var mcpServers: [MCPServerConfig] {
-        guard let data = UserDefaults.standard.data(forKey: "mcpServers"),
+        guard let data = KeychainService.data(for: "mcpServers"),
               let servers = try? JSONDecoder().decode([MCPServerConfig].self, from: data) else {
             return []
         }
@@ -1920,7 +1999,7 @@ struct Config {
 
     static func setMCPServers(_ servers: [MCPServerConfig]) {
         if let data = try? JSONEncoder().encode(servers) {
-            UserDefaults.standard.set(data, forKey: "mcpServers")
+            KeychainService.setData(data, for: "mcpServers")
         }
     }
 
@@ -1934,12 +2013,13 @@ struct Config {
         UserDefaults.standard.set(url, forKey: "homeAssistantURL")
     }
 
+    /// Home Assistant long-lived access token. Stored in the Keychain (see `KeychainService`).
     static var homeAssistantToken: String {
-        UserDefaults.standard.string(forKey: "homeAssistantToken") ?? ""
+        KeychainService.string(for: "homeAssistantToken") ?? ""
     }
 
     static func setHomeAssistantToken(_ token: String) {
-        UserDefaults.standard.set(token, forKey: "homeAssistantToken")
+        KeychainService.setString(token, for: "homeAssistantToken")
     }
 
     // MARK: - Live Broadcast
@@ -1960,12 +2040,13 @@ struct Config {
         UserDefaults.standard.set(url, forKey: "broadcastRTMPURL")
     }
 
+    /// RTMP broadcast stream key (a publishing credential). Stored in the Keychain (see `KeychainService`).
     static var broadcastStreamKey: String {
-        UserDefaults.standard.string(forKey: "broadcastStreamKey") ?? ""
+        KeychainService.string(for: "broadcastStreamKey") ?? ""
     }
 
     static func setBroadcastStreamKey(_ key: String) {
-        UserDefaults.standard.set(key, forKey: "broadcastStreamKey")
+        KeychainService.setString(key, for: "broadcastStreamKey")
     }
 
     static var isBroadcastConfigured: Bool {
@@ -1995,15 +2076,16 @@ struct Config {
 
     // MARK: - Perplexity Search
 
+    /// Perplexity API key. Stored in the Keychain (see `KeychainService`).
     static var perplexityAPIKey: String {
-        if let key = UserDefaults.standard.string(forKey: "perplexityAPIKey"), !key.isEmpty {
+        if let key = KeychainService.string(for: "perplexityAPIKey"), !key.isEmpty {
             return key
         }
         return ""
     }
 
     static func setPerplexityAPIKey(_ key: String) {
-        UserDefaults.standard.set(key, forKey: "perplexityAPIKey")
+        KeychainService.setString(key, for: "perplexityAPIKey")
     }
 
     static var isPerplexityConfigured: Bool {
@@ -2430,10 +2512,11 @@ struct Config {
     }
     static func setExpertTurnUsername(_ v: String) { UserDefaults.standard.set(v, forKey: "expertTurnUsername") }
 
+    /// TURN server credential (a password). Stored in the Keychain (see `KeychainService`).
     static var expertTurnCredential: String {
-        UserDefaults.standard.string(forKey: "expertTurnCredential") ?? ""
+        KeychainService.string(for: "expertTurnCredential") ?? ""
     }
-    static func setExpertTurnCredential(_ v: String) { UserDefaults.standard.set(v, forKey: "expertTurnCredential") }
+    static func setExpertTurnCredential(_ v: String) { KeychainService.setString(v, for: "expertTurnCredential") }
 
     /// Default session mode for Field Assist ("ai_only" or "human_assisted").
     /// Human-assisted requires Phase 5 work to ship; UI should grey it out until then.

--- a/OpenGlassesTests/ConfigTests.swift
+++ b/OpenGlassesTests/ConfigTests.swift
@@ -16,20 +16,29 @@ final class ConfigTests: XCTestCase {
         "geminiLiveModel",
     ]
 
+    // Secrets now live in the Keychain (see KeychainService), so they must be
+    // cleared there too — clearing UserDefaults alone would leave them set.
+    private let keychainTestKeys = [
+        "openClawGatewayToken",
+    ]
+
     override func setUp() {
         super.setUp()
-        // Clear all test keys before each test
-        for key in testKeys {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
+        clearTestState()
     }
 
     override func tearDown() {
-        // Clean up after each test
+        clearTestState()
+        super.tearDown()
+    }
+
+    private func clearTestState() {
         for key in testKeys {
             UserDefaults.standard.removeObject(forKey: key)
         }
-        super.tearDown()
+        for key in keychainTestKeys {
+            KeychainService.delete(key)
+        }
     }
 
     // MARK: - AppMode

--- a/OpenGlassesTests/HUDLauncherTests.swift
+++ b/OpenGlassesTests/HUDLauncherTests.swift
@@ -97,6 +97,25 @@ final class HUDLauncherTests: XCTestCase {
         XCTAssertEqual(frames.last, .clear)
     }
 
+    func testRouterPublishesCurrentScreenForMirror() async {
+        let saved = Config.glassesDisplayEnabled
+        Config.setGlassesDisplayEnabled(true)
+        defer { Config.setGlassesDisplayEnabled(saved) }
+
+        let display = GlassesDisplayService()
+        display.testCapabilityOverride = true
+        display.testRenderSink = { _ in }
+        let router = HUDRouter(display: display)
+
+        XCTAssertNil(router.currentScreen)
+        router.openLauncher(HUDScreen(title: "Root"))
+        await settle()
+        XCTAssertEqual(router.currentScreen?.title, "Root")   // the live mirror binds to this
+        router.dismiss()
+        await settle()
+        XCTAssertNil(router.currentScreen)
+    }
+
     func testPopFromRootDismisses() async {
         let saved = Config.glassesDisplayEnabled
         Config.setGlassesDisplayEnabled(true)

--- a/OpenGlassesTests/KeychainServiceTests.swift
+++ b/OpenGlassesTests/KeychainServiceTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import OpenGlasses
+
+final class KeychainServiceTests: XCTestCase {
+
+    // A key unlikely to collide with any real secret.
+    private let testKey = "test.keychain.roundtrip"
+
+    override func setUp() {
+        super.setUp()
+        KeychainService.delete(testKey)
+    }
+
+    override func tearDown() {
+        KeychainService.delete(testKey)
+        super.tearDown()
+    }
+
+    // MARK: - String round-trip
+
+    func testStringRoundTrip() {
+        XCTAssertNil(KeychainService.string(for: testKey))
+        XCTAssertTrue(KeychainService.setString("sk-secret-123", for: testKey))
+        XCTAssertEqual(KeychainService.string(for: testKey), "sk-secret-123")
+    }
+
+    func testOverwriteReplacesValue() {
+        KeychainService.setString("first", for: testKey)
+        KeychainService.setString("second", for: testKey)
+        XCTAssertEqual(KeychainService.string(for: testKey), "second")
+    }
+
+    func testEmptyStringDeletesItem() {
+        KeychainService.setString("value", for: testKey)
+        XCTAssertTrue(KeychainService.setString("", for: testKey))
+        XCTAssertNil(KeychainService.string(for: testKey))
+    }
+
+    func testNilStringDeletesItem() {
+        KeychainService.setString("value", for: testKey)
+        XCTAssertTrue(KeychainService.setString(nil, for: testKey))
+        XCTAssertNil(KeychainService.string(for: testKey))
+    }
+
+    // MARK: - Data round-trip
+
+    func testDataRoundTrip() {
+        let payload = Data("{\"k\":\"v\"}".utf8)
+        XCTAssertNil(KeychainService.data(for: testKey))
+        XCTAssertTrue(KeychainService.setData(payload, for: testKey))
+        XCTAssertEqual(KeychainService.data(for: testKey), payload)
+    }
+
+    func testEmptyDataDeletesItem() {
+        KeychainService.setData(Data("x".utf8), for: testKey)
+        XCTAssertTrue(KeychainService.setData(Data(), for: testKey))
+        XCTAssertNil(KeychainService.data(for: testKey))
+    }
+
+    // MARK: - Delete
+
+    func testDeleteMissingKeySucceeds() {
+        XCTAssertTrue(KeychainService.delete(testKey))
+    }
+}
+
+final class SecretMigrationTests: XCTestCase {
+
+    private let migrationFlagKey = "secretsMigratedToKeychain_v1"
+    // A real migratable string secret, exercised end-to-end through Config.
+    private let secretKey = "broadcastStreamKey"
+
+    override func setUp() {
+        super.setUp()
+        resetState()
+    }
+
+    override func tearDown() {
+        resetState()
+        // Leave the flag set so the host app's already-migrated state is respected.
+        UserDefaults.standard.set(true, forKey: migrationFlagKey)
+        super.tearDown()
+    }
+
+    private func resetState() {
+        UserDefaults.standard.removeObject(forKey: migrationFlagKey)
+        UserDefaults.standard.removeObject(forKey: secretKey)
+        KeychainService.delete(secretKey)
+    }
+
+    /// A plaintext secret in UserDefaults is copied into the Keychain and then
+    /// removed from UserDefaults, and remains readable through the Config getter.
+    func testMigrationMovesPlaintextSecretToKeychain() {
+        UserDefaults.standard.set("rtmp-stream-key", forKey: secretKey)
+
+        Config.migrateSecretsToKeychainIfNeeded()
+
+        XCTAssertNil(UserDefaults.standard.string(forKey: secretKey),
+                     "plaintext copy should be removed from UserDefaults")
+        XCTAssertEqual(KeychainService.string(for: secretKey), "rtmp-stream-key",
+                       "secret should now live in the Keychain")
+        XCTAssertEqual(Config.broadcastStreamKey, "rtmp-stream-key",
+                       "Config getter should read the migrated value transparently")
+    }
+
+    /// Migration runs only once — re-running after the flag is set is a no-op and
+    /// must not clobber a value written through the normal (Keychain) setter.
+    func testMigrationIsOneTime() {
+        Config.migrateSecretsToKeychainIfNeeded()   // sets the flag, nothing to migrate
+
+        // Simulate a later write via the public setter (goes straight to Keychain),
+        // plus a stray plaintext value that a second migration must NOT pick up.
+        Config.setBroadcastStreamKey("written-via-setter")
+        UserDefaults.standard.set("stale-plaintext", forKey: secretKey)
+
+        Config.migrateSecretsToKeychainIfNeeded()   // flag already set → no-op
+
+        XCTAssertEqual(Config.broadcastStreamKey, "written-via-setter")
+        XCTAssertEqual(UserDefaults.standard.string(forKey: secretKey), "stale-plaintext",
+                       "a one-time-completed migration should not run again")
+    }
+}

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -106,6 +106,16 @@ Extends the in-lens HUD line from **read-only** (Display Phase 1 ✅ merged in [
 
 **Sequence (agreed):** X first (ships hands-free workflow execution and validates band navigation on one card), then Y (the full launcher reuses X's router).
 
+## Round 7 — community fork harvest
+
+Drafted from a survey of seven community forks of the upstream `Intent-Lab/VisionClaw` sample (the Meta-wearables `CameraAccess` app our DAT/OpenClaw lineage shares). Extracts only what's net-new and a genuine fit; records what to skip. The single highest-value item (a phone-side renderer of the `MWDATDisplay` DSL) was **already harvested** as `HUDPreviewView` on `display/hud-phase4`.
+
+| Plan | Title | Effort | Reuses | Strategic fit |
+|---|---|---|---|---|
+| [Community Fork Harvest](community-fork-harvest.md) | VisionClaw-family features worth lifting | ~0.5–4 days each | TextToSpeechService, Config/Keychain, GlassesDisplayService + CameraService, BrainStore, WakeWordService | Kokoro on-device TTS (offline + backgroundable), API keys → Keychain, shared camera+display `DeviceSession`, BrainStore `needs`. Conditional: alternative hands-free triggers (accessibility), multi-user profiles + PIN. Deferred: declarative HUD widget board. 📋 Planned |
+
+**Suggested sequence:** HUDPreviewView snapshot tests → API keys → Keychain → Kokoro TTS → shared `DeviceSession` → BrainStore `needs` → (if accessibility) alternative triggers → (if shared-device) profiles+PIN → (deferred) widget board.
+
 ## Dependency graph
 
 ```

--- a/docs/plans/community-fork-harvest.md
+++ b/docs/plans/community-fork-harvest.md
@@ -1,0 +1,161 @@
+# Community Fork Harvest — VisionClaw-family features worth lifting
+
+**Source:** A survey of seven community forks of [`Intent-Lab/VisionClaw`](https://github.com/Intent-Lab/VisionClaw) (the Meta-wearables `CameraAccess` sample our DAT/OpenClaw lineage shares). Each fork explored a different direction; this plan extracts only what's net-new and a genuine fit for OpenGlasses, and explicitly records what to skip.
+
+**Forks reviewed:**
+
+| Fork | Headline | Net-new to us |
+|---|---|---|
+| [`mediclaw-ai/HoloClaw`](https://github.com/Intent-Lab/VisionClaw/compare/main...mediclaw-ai:HoloClaw:main) | Phone-side renderer of the `MWDATDisplay` DSL + declarative widget board | Renderer **already harvested** (see below); widget board is a Phase-4+ concept |
+| [`FortisRiders/VisionClaw`](https://github.com/Intent-Lab/VisionClaw/compare/main...FortisRiders:VisionClaw:main) | "Jarvis" rebrand: PTT voice mode, **Kokoro on-device TTS**, multi-user profiles + PIN, Keychain | **Kokoro TTS**, **Keychain secrets**, profiles (conditional) |
+| [`benkraus/VisionClaw`](https://github.com/Intent-Lab/VisionClaw/compare/main...benkraus:VisionClaw:main) | Grok voice + a `DisplayHUDManager` with a **shared `DeviceSession`** + tailnet OAuth broker | The shared-session pattern (our standing TODO) |
+| [`wert-yunsub/VisionClaw`](https://github.com/Intent-Lab/VisionClaw/compare/main...wert-yunsub:VisionClaw:main) | Swap OpenClaw → a self-hosted "Jarvis Memory API" (typed people/meeting/memory/**needs** tools) | The `needs`/follow-ups concept for our brain |
+| [`Vamiko234/VisionClaw`](https://github.com/Intent-Lab/VisionClaw/compare/main...Vamiko234:VisionClaw:main) | Hands-free **alternative triggers** (volume button, shake, cough, AirPod stem) + Gemini reliability tuning | **Alternative triggers** (accessibility); reliability we already have |
+| [`chisince1991-debug/VisionClaw`](https://github.com/Intent-Lab/VisionClaw/compare/main...chisince1991-debug:VisionClaw:main) | Bug-fixes/perf to the sample's audio/TTS/vision + a DirectSession debug overlay | **Nothing to port** — all handled more robustly here; one TTS-cancellation gotcha noted |
+| [`AppToptoptop/VisionClaw`](https://github.com/Intent-Lab/VisionClaw) | — | **Nothing** — 0 ahead / 80 behind upstream (stale mirror) |
+
+> **Naming note:** "Jarvis" appears in three of these forks and means a *different thing each time* — a rebrand, a personal localhost memory server, an assistant mode. None is a public product to "integrate with." This plan treats them purely as feature sources.
+
+---
+
+## Already harvested — Phone-side HUD renderer (HoloClaw)
+
+HoloClaw's `DisplayDSLView` (a native SwiftUI renderer that walks the same `MWDATDisplay.FlexBox/Text/Button/Image/Icon` tree the SDK sends to the lens) is **already ported** as [HUDPreviewView.swift](../../OpenGlasses/Sources/App/Views/HUDPreviewView.swift) on `display/hud-phase4` (Plan Y / Display Phase 4) — brand-styled (coral accent, capsule buttons) and driven by `GlassesDisplayService.previewFlexBox(for:)`. This was the single highest-value item across all four forks and it's done. ✅
+
+**Remaining follow-up (small):** add **snapshot tests** over `HUDPreviewView` for the canonical screens (task card, launcher menu) so the device-less preview is also a regression gate — this is the natural extension of "no Display hardware → tests are the gate." (~0.5 day.)
+
+---
+
+## Candidates
+
+| # | Feature | Source | Effort | Verdict |
+|---|---|---|---|---|
+| 1 | **Kokoro on-device TTS tier** | FortisRiders | ~3–4 days | ✅ Take — fills a real gap |
+| 2 | **Provider API keys → Keychain** | FortisRiders | ~0.5–1 day | ✅ Take — security; task chip filed |
+| 3 | **Shared `DeviceSession` (camera + display)** | benkraus | ~2–3 days | ✅ Take — closes a standing TODO |
+| 4 | **`needs` / follow-ups in BrainStore** | wert-yunsub | ~1 day | ◻︎ Optional — small native add |
+| 5 | **Alternative hands-free triggers** | Vamiko234 | ~2–4 days | ◻︎ Conditional — Accessibility tier; App-Store caveat |
+| 6 | **Multi-user profiles + PIN gate** | FortisRiders | ~4–6 days | ◻︎ Conditional — only if shared-device is a goal |
+| 7 | **Declarative HUD widget board** | HoloClaw | ~3–5 days | ⏸ Defer — Display Phase 5 concept |
+
+---
+
+### 1. Kokoro on-device TTS tier  *(headline)*
+
+**Today:** [TextToSpeechService.swift](../../OpenGlasses/Sources/Services/TextToSpeechService.swift) has exactly two engines — ElevenLabs (cloud, paid; `speakWithElevenLabs` ~L479) and AVSpeechSynthesizer (robotic fallback; `speakWithiOS` ~L557). There is **no on-device neural voice**.
+
+**What the fork adds:** `KokoraTTSEngine` — a self-contained wrapper around **sherpa-onnx** running the `kokoro-int8-en-v0_19` model. It loads `model.int8.onnx` / `voices.bin` / `tokens.txt` from the bundle, generates a WAV on background CPU threads (`num_threads: 4`), and plays via `AVAudioPlayer`. Gated behind `#if KOKORO_ENABLED`.
+
+**Why it fits us specifically:**
+- **Offline + free + good quality** — a third tier between ElevenLabs and AVSpeech: no network, no per-character cost, far better than `AVSpeechSynthesizer`.
+- **Runs backgrounded.** It's CPU/ONNX, not Metal/MLX — so unlike our on-device MLX models (which can't run in the background, see [project_local_model_background]), Kokoro *can* speak while backgrounded. This is the key differentiator and the reason it's worth the dependency.
+
+**Plan:**
+1. Add the **sherpa-onnx** dependency (vendored `.xcframework` / binary target) + the `SherpaOnnxBridge.h` bridging header. Register in `project.base.yml`, regenerate via `./Scripts/generate-xcodeproj.sh`, and refresh `ci_scripts/Package.resolved` (see [project_xcode_cloud_resolved]).
+2. Port `KokoraTTSEngine` as `KokoroTTSEngine` (load on a background task; expose `isReady`, `speak(_:onFinish:)`).
+3. Wire it into the fallback chain in `TextToSpeechService.speak(_:urgency:mirrorToHUD:)` (~L140): **ElevenLabs (if key + online) → Kokoro (if model present) → AVSpeech**. Add a Settings toggle + a TTS-engine preference.
+4. **Model delivery:** the int8 model is tens of MB. Prefer a **downloadable model** (fetch on first enable into Application Support) over bundling, to avoid bloating the app binary — make Kokoro a no-op until the model is present (mirrors the SDK's no-Display no-op discipline).
+5. Tests: sanitization still applies (we already sanitize before TTS); add a headless test that the engine-selection logic picks Kokoro when "model present + offline" and falls through correctly.
+
+**Risk:** binary-dependency size/signing, and license of the Kokoro weights — confirm redistribution terms before bundling/hosting.
+
+---
+
+### 2. Provider API keys → Keychain  *(security)*
+
+**Today:** [Config.swift](../../OpenGlasses/Sources/Utils/Config.swift) persists provider secrets in **UserDefaults plaintext** (e.g. `UserDefaults.standard.set(key, forKey: "anthropicAPIKey")` ~L374), which lands in unencrypted device backups. We already use the Keychain elsewhere ([ConversationEncryptionService.swift](../../OpenGlasses/Sources/Services/ConversationEncryptionService.swift)).
+
+**Plan:** add a small `KeychainService`, route every provider secret getter/setter through it, and run a one-time migration that copies existing UserDefaults values into the Keychain then deletes the plaintext copies. Keep Config's public API stable so call sites don't change. Migrate **secrets only** — not toggles/onboarding flags. Fits our secrets-hygiene history (the scrubbed-Meta-creds PR). *A background task chip has been filed for this (`task_a50c6d7a`).*
+
+---
+
+### 3. Shared `DeviceSession` — camera + display on one session
+
+**Today:** [GlassesDisplayService.swift](../../OpenGlasses/Sources/Services/GlassesDisplayService.swift) owns its own `DeviceSession` via `AutoDeviceSelector`, **separate** from `CameraService`. The SDK allows one session per device, so while the HUD session is held, the camera falls back to the iPhone-camera path. The file's own header flags unifying the two as "a tracked follow-up."
+
+**What the fork shows:** benkraus's `DisplayHUDManager` implements exactly this — `useSharedDeviceSession(_:)` + an `ownsDeviceSession` flag, so the display capability attaches to an externally-owned session (created by the camera path) instead of spinning up its own; it only creates+owns a session when none is shared.
+
+**Plan:** crib the ownership pattern (not the file — our service is more advanced: render queue, dedup, interactive screens). Introduce a session owner/coordinator so `CameraService` and `GlassesDisplayService` share one `DeviceSession` when both want the glasses, and the display gracefully owns-its-own when the camera isn't active. Validate by headless tests of the ownership state machine; on-glasses behaviour (camera + HUD simultaneously) is a device-only check to log as outstanding.
+
+---
+
+### 4. `needs` / follow-ups in BrainStore  *(optional, small)*
+
+The wert-yunsub fork's one genuinely-new memory concept is `save_need` — tracking what a person wants / is looking for / you owe them (a CRM follow-up). Our [BrainStore.swift](../../OpenGlasses/Sources/Services/Brain/BrainStore.swift) models entities, relationship edges, and encounters, but has no first-class "need/want/follow-up."
+
+**Plan:** add a `needs`/`wants` relation (or a light `Need` record) to BrainStore, surface it in the `dossier`/`person` output of [BrainTool.swift](../../OpenGlasses/Sources/Services/NativeTools/BrainTool.swift), and optionally let `ProactiveAlertService` nudge open needs before a meeting. Native-first (brain works without OpenClaw). Everything else in that fork — people/meeting/memory search — we already have (`SemanticMemoryStore` + `MemorySearchTool`, `MeetingAssistantService` + `MeetingSummaryTool`, `FaceRecognitionService`).
+
+---
+
+### 5. Alternative hands-free triggers  *(conditional — Accessibility tier)*
+
+**Today:** the only hands-free entry into the assistant is the **wake word** ([WakeWordService.swift](../../OpenGlasses/Sources/Services/WakeWordService.swift)) plus Siri App Intents / Shortcuts (Plan Z). There is **no non-voice, no-Siri trigger** — nothing for a user who can't or won't speak, or who's in a loud/silent setting.
+
+**What the fork adds:** several alternative ways to fire the assistant hands-free —
+- **Volume-button trigger** (`VolumeButtonTrigger.swift`, KVO on `AVAudioSession.outputVolume`) — a volume press fires "what am I looking at."
+- **Shake trigger** — a deliberate phone shake (added, then they removed it in favour of an exam-solver prompt — the code is still a reference).
+- **Cough / acoustic trigger** (`CoughTrigger.swift`, ~185 lines, `SoundAnalysis`/`SNClassifySoundRequest`) — fires on a detected cough.
+- **AirPod stem trigger** — a background AppIntent with Ray-Ban audio priority.
+
+**Fit:** a natural **Accessibility tier** (Plan A) feature — "alternative input methods" for users who can't use wake-word/voice. The acoustic-trigger pattern generalises (clap/snap/whistle), and the volume/shake triggers are tiny and self-contained.
+
+**Plan:** add an `AlternativeTriggerService` exposing opt-in triggers (volume, shake, acoustic), each routing to the same entry point as the wake word; gate behind a Settings section. Start with **shake** (lowest risk) and the **acoustic** pattern; treat volume-button as opt-in/off-by-default.
+
+**Caveats (why this is conditional, not a default-take):**
+- **App Store risk:** hijacking the **volume button** as an app trigger runs against Apple's HIG and has historically drawn rejections — ship it off-by-default, clearly user-enabled, and be ready to drop it.
+- **False positives:** cough/acoustic and low-threshold shake triggers misfire easily; need a confidence threshold + a debounce, and they shouldn't run while a card/critical flow is held.
+- Battery: continuous `SoundAnalysis` is a wakeful audio tap — coordinate with the wake-word pipeline and the Presence-Aware Throttle ([Plan W](W-presence-aware-agent-throttle.md)) rather than running a second always-on listener.
+
+**Negative knowledge (record, don't re-attempt):** the fork tried a **glasses double-tap / touchpad** trigger and reverted it — *"DAT SDK exposes no touchpad gesture events."* This corroborates [Plan X](X-interactive-hud-now-next-tasks.md): the glasses/Neural Band firmware owns gesture, focus and select; there is **no raw gesture/touchpad stream** to subscribe to. Triggers must therefore be phone-side (button/motion/audio) — not from the glasses hardware.
+
+---
+
+### 6. Multi-user profiles + PIN gate  *(conditional)*
+
+The fork's only genuinely-new *capability* (we have nothing equivalent — `ReadingProfile` is unrelated accessibility prefs): per-user, PIN-gated, profile-scoped storage (`ProfileManager`, `ProfileGateView`, `PINPadView`, `ProfileScopedStore`, `KeychainService`).
+
+**Fit:** meaningful only for **shared-device / kiosk** deployments — which our museum-docent and field-assist directions imply (one pair of glasses shared across staff, each with isolated brain/memory/conversations). **Take the PIN + `ProfileScopedStore` core; skip their email-OTP** (it needs a backend; overkill on-device). Treat as a product decision, not a default — sequence it only if shared-device use is committed. Any auto/agentic behaviour stays behind `agentModeEnabled`.
+
+---
+
+### 7. Declarative HUD widget board  *(defer — Display Phase 5)*
+
+HoloClaw's `WidgetSpec` + `WidgetBoardView` is an LLM-driven declarative board: a `render_widgets` tool emits a list of widgets (text/image/table/music) that the app renders. A natural **Display Phase 5** direction beyond our single-frame + Now/Next task card (Plan X) and launcher (Plan Y). But the fork code is hackathon-grade (hardcoded placeholder image URLs, Gemini-coupled, phone-card-only, not sent to the lens). **Take the concept + the JSON-decoding shape, not the code.** Defer until X/Y are fully shipped and there's a concrete multi-widget use case.
+
+---
+
+## Explicitly NOT bringing
+
+- **Grok** as a provider/voice (benkraus replaces Gemini; we're multi-provider and it overlaps OpenAI Realtime / Gemini Live — only if specifically wanted).
+- **Tailnet/Grok OAuth broker** (benkraus) — xAI-OAuth- and OpenClaw-gateway-specific; the generic idea ("tailnet key broker so secrets never live in the app") is a future design, not a port, and would sit behind `agentModeEnabled`.
+- **A "Jarvis Memory API" client** (wert-yunsub) — couples us to an undocumented personal localhost server; duplicates our native brain.
+- **Lock-screen widget / Live Activity / App Intents / PTT** (FortisRiders) — we're already ahead (`LiveActivityManager`, `GlassesActivityWidget`, full Intents suite).
+- **Multi-chat session management** (FortisRiders) — we have `ConversationStore` (+ encryption).
+- **Wake-word manager** (benkraus) — our `WakeWordService` is more mature.
+- **Gemini Live reliability tuning** (Vamiko234 — indefinite reconnect, frame-scaling for code-1007) — we already have automatic reconnection with **exponential backoff** ([GeminiLiveService.swift:35](../../OpenGlasses/Sources/Services/GeminiLive/GeminiLiveService.swift)) + a `FrameThrottler`; theirs is a cruder forever-retry.
+- **Exam-solver prompt / "solve this problem"** (Vamiko234) — off-strategy use case; skip.
+- **GitHub Actions iOS build** (Vamiko234) — we use Xcode Cloud (`ci_scripts/`); no second CI.
+- **Glasses double-tap / touchpad trigger** — not possible (no SDK gesture stream; see candidate 5).
+- **Bluetooth glasses-mic audio fix, pre-emptive Gemini Vision, DirectSession, reconnect** (chisince1991-debug) — all already handled here, more robustly (`.allowBluetoothHFP/A2DP` across WakeWord/GeminiLive/OpenAIRealtime/LiveTranslation; `LLMService.analyzeFrame`; Direct mode; backoff reconnect).
+- Rebrands, eye icons, and all **Android** changes.
+
+## Watch items (recorded, not actioned)
+
+- **TTS request cancellation** (from chisince1991-debug). [TextToSpeechService.swift:62](../../OpenGlasses/Sources/Services/TextToSpeechService.swift) and [:508](../../OpenGlasses/Sources/Services/TextToSpeechService.swift) use `URLSession.shared.data(for:)`, which **propagates `Task` cancellation** — if the enclosing speak `Task` is cancelled mid-fetch, the request throws `URLError(.cancelled)` and audio silently drops. Often that's *desired* (a newer utterance supersedes an older one), so this is **not a confirmed bug** — but if ElevenLabs TTS is ever observed dropping mid-request, the fix is an explicit `dataTask` + continuation (or shielding the fetch in an unstructured `Task`) so cancellation is deliberate, not incidental.
+
+---
+
+## Suggested sequence
+
+1. **HUDPreviewView snapshot tests** (~0.5 day) — finish the already-shipped renderer as a regression gate.
+2. **API keys → Keychain** (~0.5–1 day) — security; isolated; task already filed.
+3. **Kokoro on-device TTS tier** (~3–4 days) — the headline capability.
+4. **Shared `DeviceSession`** (~2–3 days) — closes the standing camera+display TODO.
+5. **`needs` in BrainStore** (~1 day) — small, optional, native-first.
+6. *(If Accessibility tier is in scope)* **Alternative triggers** (~2–4 days) — shake + acoustic first; volume opt-in.
+7. *(If shared-device committed)* **Profiles + PIN** (~4–6 days).
+8. *(Deferred)* **Declarative widget board** — Display Phase 5, after X/Y ship.
+
+## Device-less validation
+
+No Ray-Ban Display / Neural Band hardware is on hand, so — consistent with Plans X/Y — **headless tests + the on-phone `HUDPreviewView` are the gate.** Outstanding device-only checks to log, not block on: Kokoro audio-session interplay on glasses, simultaneous camera + HUD on one shared `DeviceSession`, and on-glass legibility of any new frames.


### PR DESCRIPTION
## Summary

Bundled per request. Three related changes — the **Keychain** commit was made by a parallel agent on this branch; I folded it in with my **live HUD mirror** work and the parallel agent's **harvest-plan docs**.

### 🔐 Harden secret storage — provider keys → Keychain *(commit `3dec626`, parallel agent)*
New `KeychainService`; `Config` reads/writes provider API keys through the Keychain instead of UserDefaults. Tests: `KeychainServiceTests` + `ConfigTests`.

### 🪞 Live in-app HUD mirror *(Display Phase 4 / Plan Y)*
`HUDRouter.currentScreen` is now `@Published`; **`HUDMirrorView`** observes it and renders the current task card / launcher menu via `HUDPreviewView` — so you can **watch the real HUD on the phone in real time**, with or without Display glasses (the router sets `currentScreen` regardless of whether the glasses render). View-only; drive with the band/voice. Surfaced under **Settings → Hardware & Privacy → "HUD Mirror (phone preview)"**. This makes the previously static previews live.

### 📋 Round 7 — community fork harvest plan *(docs)*
`community-fork-harvest.md` + a README section — the umbrella that motivated both the Keychain harvest and the earlier `HUDPreviewView`. Records what to lift (Keychain ✅, phone renderer ✅, Kokoro on-device TTS, shared camera+display `DeviceSession`, BrainStore "needs") and what to skip. *(These docs were uncommitted in the shared tree; bundled here — drop the commit if they belong to a separate effort.)*

## Verification
- **Debug: 41 tests pass** (Keychain + Config + HUD launcher/mirror), on a fresh sim.
- **Release: green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)