### PR TITLE
Plan N Phase 2: Custom URL adapter + multi-harness registry + settings

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -867,16 +867,11 @@ class AppState: ObservableObject, AppStateProtocol {
         // Wire the presence-aware throttle (Plan W) into the loops + signal sources.
         configurePresence()
 
-        // Remote Agent Harness (Plan N): dispatch to the OpenClaw gateway by default, narrate via TTS.
-        // Gated at the tool layer by Config.agentModeEnabled.
-        AgentSessionService.shared.configure(
-            harness: OpenClawAgentHarness(send: { [weak self] method, params in
-                guard let self else { throw AgentHarnessError.transport("App unavailable.") }
-                return try await self.openClawBridge.agentRequest(method: method, params: params)
-            }),
-            speak: { [weak self] line in
-                Task { @MainActor in await self?.speechService.speak(line) }
-            })
+        // Remote Agent Harness (Plan N): build the harness registry (OpenClaw + Custom URL) and
+        // narrate via TTS. Gated at the tool layer by Config.agentModeEnabled.
+        AgentSessionService.shared.configure(registry: makeAgentRegistry(), speak: { [weak self] line in
+            Task { @MainActor in await self?.speechService.speak(line) }
+        })
 
         // Configure Navigation Assist (Plan J) similarly.
         NavigationAssistService.shared.configure(camera: cameraService, llm: llmService, tts: speechService)
@@ -2065,6 +2060,25 @@ class AppState: ObservableObject, AppStateProtocol {
             Task { @MainActor in self?.presenceMonitor.update() }
         }
         presenceMonitor.update()
+    }
+
+    // MARK: - Remote Agent Harness (Plan N)
+
+    /// Build the agent harness registry from current config: the OpenClaw gateway adapter plus the
+    /// Custom URL adapter (configured from `Config.customAgentHarness`). Rebuilt on settings change.
+    private func makeAgentRegistry() -> AgentHarnessRegistry {
+        let openClaw = OpenClawAgentHarness(send: { [weak self] method, params in
+            guard let self else { throw AgentHarnessError.transport("App unavailable.") }
+            return try await self.openClawBridge.agentRequest(method: method, params: params)
+        })
+        let custom = CustomAgentHarness(config: Config.customAgentHarness ?? CustomHarnessConfig())
+        return AgentHarnessRegistry([openClaw, custom])
+    }
+
+    /// Re-read the Custom endpoint config into the session's registry — call after the user edits the
+    /// Remote Agents settings so a new/changed endpoint takes effect without relaunch.
+    func rebuildAgentHarnessRegistry() {
+        AgentSessionService.shared.setRegistry(makeAgentRegistry())
     }
 
     /// Note an explicit user interaction (wake word / transcription) for the presence

--- a/OpenGlasses/Sources/App/Views/AgentHarnessSettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/AgentHarnessSettingsView.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+
+/// Settings for the Remote Agent Harness (Plan N): pick the default backend and configure a Custom
+/// URL endpoint. Surfaced from Agentic Features, so it only appears when Agent Mode is on.
+struct AgentHarnessSettingsView: View {
+    @EnvironmentObject var appState: AppState
+
+    @State private var defaultKind: AgentHarnessKind = Config.defaultAgentHarness
+    @State private var config: CustomHarnessConfig = Config.customAgentHarness ?? CustomHarnessConfig()
+    @State private var saved = false
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Default backend", selection: $defaultKind) {
+                    Text(AgentHarnessKind.openclaw.displayName).tag(AgentHarnessKind.openclaw)
+                    Text(AgentHarnessKind.custom.displayName).tag(AgentHarnessKind.custom)
+                }
+                .onChange(of: defaultKind) { _, kind in
+                    Config.setDefaultAgentHarness(kind)
+                }
+            } header: {
+                Text("Default")
+            } footer: {
+                Text("Which backend the “code_agent” voice tool dispatches to. OpenClaw uses your existing gateway connection; Custom uses the endpoint below.")
+            }
+
+            Section {
+                TextField("Name (e.g. My Agent SDK)", text: $config.name)
+                urlField("Start URL (POST)", text: $config.startURL)
+                urlField("Status URL — use {id}", text: $config.statusURLTemplate)
+                urlField("Cancel URL — use {id} (optional)", text: $config.cancelURLTemplate)
+            } header: {
+                Text("Custom endpoint")
+            } footer: {
+                Text("Point OpenGlasses at any agent endpoint you already run. {id} is replaced with the run id, e.g. https://host/runs/{id}.")
+            }
+
+            Section("Authentication") {
+                TextField("Header name", text: $config.authHeader)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                SecureField("Header value (e.g. Bearer …)", text: $config.authValue)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+            }
+
+            Section {
+                fieldRow("Prompt field", text: $config.promptField)
+                fieldRow("Project field", text: $config.projectField)
+                fieldRow("Run-id path", text: $config.idPath)
+                fieldRow("Status path", text: $config.statusPath)
+            } header: {
+                Text("Field mapping")
+            } footer: {
+                Text("Body keys sent on start, and dot-paths read from the responses (e.g. data.run.id).")
+            }
+
+            Section {
+                Button {
+                    save()
+                } label: {
+                    Label(saved ? "Saved" : "Save endpoint", systemImage: saved ? "checkmark.circle.fill" : "square.and.arrow.down")
+                }
+                .disabled(!config.isConfigured)
+
+                if Config.customAgentHarness != nil {
+                    Button(role: .destructive) {
+                        Config.setCustomAgentHarness(nil)
+                        config = CustomHarnessConfig()
+                        appState.rebuildAgentHarnessRegistry()
+                        saved = false
+                    } label: {
+                        Label("Remove endpoint", systemImage: "trash")
+                    }
+                }
+            } footer: {
+                Text("Stored securely in the Keychain. The token never leaves your device except to the endpoint you set.")
+            }
+        }
+        .navigationTitle("Remote Agents")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func save() {
+        Config.setCustomAgentHarness(config)
+        appState.rebuildAgentHarnessRegistry()
+        saved = true
+    }
+
+    @ViewBuilder
+    private func urlField(_ title: String, text: Binding<String>) -> some View {
+        TextField(title, text: text)
+            .autocorrectionDisabled()
+            .textInputAutocapitalization(.never)
+            .keyboardType(.URL)
+    }
+
+    @ViewBuilder
+    private func fieldRow(_ title: String, text: Binding<String>) -> some View {
+        TextField(title, text: text)
+            .autocorrectionDisabled()
+            .textInputAutocapitalization(.never)
+    }
+}

--- a/OpenGlasses/Sources/App/Views/AgenticFeaturesView.swift
+++ b/OpenGlasses/Sources/App/Views/AgenticFeaturesView.swift
@@ -60,6 +60,17 @@ struct AgenticFeaturesView: View {
                     Text("Deterministic rules that confirm or block risky actions before they run — voice approval, quiet hours, and an away-from-home geofence.")
                 }
 
+                // Remote Agent Harness (Plan N) — voice-drive a remote coding agent.
+                Section {
+                    NavigationLink {
+                        AgentHarnessSettingsView()
+                    } label: {
+                        Label("Remote Agents", systemImage: "terminal")
+                    }
+                } footer: {
+                    Text("Voice-control a remote coding agent (“have the agent fix the failing test”). Dispatches to OpenClaw or a custom endpoint; progress and a summary are spoken.")
+                }
+
                 // Agent Model
                 Section {
                     // Picker: local downloaded + configured cloud models

--- a/OpenGlasses/Sources/Services/AgentHarness/Adapters/CustomAgentHarness.swift
+++ b/OpenGlasses/Sources/Services/AgentHarness/Adapters/CustomAgentHarness.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Generic HTTP agent harness (Plan N, Phase 2): drives any user-supplied endpoint described by a
+/// `CustomHarnessConfig` — POST to start, GET to poll status, optional POST to cancel — mapping the
+/// responses through `JSONPath`. Same opt-in spirit as a custom MCP server: supported, never
+/// required, and entirely phone-only (we connect to a URL the user already runs).
+///
+/// The request building + response parsing live in `CustomHarnessConfig`/`JSONPath` (pure, tested);
+/// this adapter is the thin async layer. `session` is injectable so tests exercise the HTTP shape
+/// through a `URLProtocol` stub.
+struct CustomAgentHarness: AgentHarness {
+    let kind: AgentHarnessKind = .custom
+    let config: CustomHarnessConfig
+    var session: URLSession = .shared
+
+    init(config: CustomHarnessConfig, session: URLSession = .shared) {
+        self.config = config
+        self.session = session
+    }
+
+    var displayName: String {
+        config.name.trimmingCharacters(in: .whitespaces).isEmpty ? kind.displayName : config.name
+    }
+    var isConfigured: Bool { config.isConfigured }
+
+    // MARK: - AgentHarness
+
+    func start(prompt: String, project: String?) async throws -> AgentRun {
+        guard let request = config.startRequest(prompt: prompt, project: project) else {
+            throw AgentHarnessError.notConfigured(.custom)
+        }
+        let json = try await sendJSON(request)
+        guard let id = JSONPath.string(at: config.idPath, in: json) else {
+            throw AgentHarnessError.transport("Response had no run id at '\(config.idPath)'.")
+        }
+        let status = AgentRunStatus.parse(JSONPath.string(at: config.statusPath, in: json)) ?? .running
+        return AgentRun(id: id, harness: .custom, prompt: prompt, project: project,
+                        status: status, startedAt: Date())
+    }
+
+    func status(_ run: AgentRun) async throws -> AgentRunStatus {
+        guard let request = config.statusRequest(runID: run.id) else { return .running }
+        let json = try await sendJSON(request)
+        return AgentRunStatus.parse(JSONPath.string(at: config.statusPath, in: json)) ?? .running
+    }
+
+    func cancel(_ run: AgentRun) async throws {
+        guard let request = config.cancelRequest(runID: run.id) else {
+            throw AgentHarnessError.unsupported("Cancel")
+        }
+        _ = try await sendJSON(request)
+    }
+
+    /// Status-poll event stream (no assumed push channel for an arbitrary endpoint). Emits
+    /// `.started`, then polls until terminal and emits `.completed`/`.error`.
+    func events(for run: AgentRun) -> AsyncStream<AgentEvent> {
+        AsyncStream { continuation in
+            let task = Task {
+                continuation.yield(.started(run))
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 4_000_000_000)
+                    guard !Task.isCancelled else { break }
+                    let status = (try? await self.status(run)) ?? .running
+                    if status.isTerminal {
+                        continuation.yield(status == .failed ? .error("The agent run failed.")
+                                                             : .completed(AgentRunResult()))
+                        break
+                    }
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    // MARK: - HTTP
+
+    private func sendJSON(_ request: URLRequest) async throws -> [String: Any] {
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw AgentHarnessError.transport("HTTP \(http.statusCode): \(String(body.prefix(160)))")
+        }
+        return (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+    }
+}

--- a/OpenGlasses/Sources/Services/AgentHarness/Adapters/CustomHarnessConfig.swift
+++ b/OpenGlasses/Sources/Services/AgentHarness/Adapters/CustomHarnessConfig.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// User-supplied configuration for the Custom URL agent harness (Plan N, Phase 2). Same spirit as a
+/// custom MCP server or tool: a power user points OpenGlasses at any agent endpoint they already run
+/// (a self-hosted Agent SDK bridge, an internal service…) by giving its URLs, auth, and a small JSON
+/// field mapping. Keychain-backed (it holds a token).
+struct CustomHarnessConfig: Codable, Equatable {
+    var name: String = "Custom"
+    /// POST endpoint that starts a run. Required.
+    var startURL: String = ""
+    /// Status endpoint; `{id}` is substituted with the run id (e.g. "https://host/runs/{id}").
+    var statusURLTemplate: String = ""
+    /// Optional cancel endpoint; `{id}` substituted. POST.
+    var cancelURLTemplate: String = ""
+
+    /// Auth header applied to every request (header name + value). Empty ⇒ no auth header.
+    var authHeader: String = "Authorization"
+    var authValue: String = ""
+
+    /// JSON body keys for the start request.
+    var promptField: String = "prompt"
+    var projectField: String = "project"
+
+    /// Dot-paths into the responses (e.g. "data.run.id"). See `JSONPath`.
+    var idPath: String = "id"
+    var statusPath: String = "status"
+
+    /// Minimum viable config: a parseable start URL.
+    var isConfigured: Bool {
+        let trimmed = startURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && URL(string: trimmed) != nil
+    }
+}
+
+extension CustomHarnessConfig {
+    /// Build the start request, or `nil` if `startURL` is invalid.
+    func startRequest(prompt: String, project: String?) -> URLRequest? {
+        guard let url = URL(string: startURL.trimmingCharacters(in: .whitespacesAndNewlines)) else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        applyAuth(&request)
+        var body: [String: Any] = [promptField: prompt]
+        if let project, !project.isEmpty { body[projectField] = project }
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        request.timeoutInterval = 30
+        return request
+    }
+
+    /// The status URL for `runID` from the template, or `nil` if no template is set.
+    func statusURL(runID: String) -> URL? {
+        let filled = statusURLTemplate.replacingOccurrences(of: "{id}", with: runID)
+        guard !filled.isEmpty else { return nil }
+        return URL(string: filled)
+    }
+
+    /// Build the status (GET) request for `runID`, or `nil` if no status template is set.
+    func statusRequest(runID: String) -> URLRequest? {
+        guard let url = statusURL(runID: runID) else { return nil }
+        var request = URLRequest(url: url)
+        applyAuth(&request)
+        request.timeoutInterval = 15
+        return request
+    }
+
+    /// Build the cancel (POST) request for `runID`, or `nil` if no cancel template is set.
+    func cancelRequest(runID: String) -> URLRequest? {
+        let filled = cancelURLTemplate.replacingOccurrences(of: "{id}", with: runID)
+        guard !filled.isEmpty, let url = URL(string: filled) else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        applyAuth(&request)
+        request.timeoutInterval = 15
+        return request
+    }
+
+    private func applyAuth(_ request: inout URLRequest) {
+        guard !authHeader.isEmpty, !authValue.isEmpty else { return }
+        request.setValue(authValue, forHTTPHeaderField: authHeader)
+    }
+}
+
+/// Minimal dot-path extraction over a decoded JSON object (Plan N, Phase 2). Lets a custom endpoint's
+/// response shape be mapped without code — "data.run.id" walks nested dictionaries. Pure + tested.
+enum JSONPath {
+    /// The value at `path` ("a.b.c") in `json`, or `nil` if any segment is missing or not a dict.
+    static func value(at path: String, in json: [String: Any]) -> Any? {
+        var current: Any = json
+        for segment in path.split(separator: ".") {
+            guard let dict = current as? [String: Any], let next = dict[String(segment)] else { return nil }
+            current = next
+        }
+        return current
+    }
+
+    /// The string value at `path`, coercing a number/bool to its text form when reasonable.
+    static func string(at path: String, in json: [String: Any]) -> String? {
+        switch value(at: path, in: json) {
+        case let s as String: return s
+        case let n as Int:    return String(n)
+        case let b as Bool:   return b ? "true" : "false"
+        default:              return nil
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/AgentHarness/Adapters/OpenClawAgentHarness.swift
+++ b/OpenGlasses/Sources/Services/AgentHarness/Adapters/OpenClawAgentHarness.swift
@@ -128,17 +128,10 @@ struct OpenClawAgentHarness: AgentHarness {
         return result
     }
 
-    /// Map a gateway status string to `AgentRunStatus` (tolerant of a few spellings).
+    /// Map a gateway status string to `AgentRunStatus`. Delegates to the shared `AgentRunStatus.parse`
+    /// (kept as a named entry point for the adapter's call sites/tests).
     static func parseStatus(_ raw: String?) -> AgentRunStatus? {
-        switch raw?.lowercased() {
-        case "queued", "pending":            return .queued
-        case "running", "in_progress":       return .running
-        case "awaiting_input", "waiting":    return .awaitingInput
-        case "completed", "done", "success": return .completed
-        case "failed", "error":              return .failed
-        case "cancelled", "canceled":        return .cancelled
-        default:                             return nil
-        }
+        AgentRunStatus.parse(raw)
     }
 
     /// Pull a run id out of a gateway response under any of the common keys.

--- a/OpenGlasses/Sources/Services/AgentHarness/AgentHarnessRegistry.swift
+++ b/OpenGlasses/Sources/Services/AgentHarness/AgentHarnessRegistry.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Holds the agent harnesses the app knows about and resolves which one is *active* (Plan N).
+/// Mirrors how the LLM layer lists configured providers: only configured harnesses are offered, and
+/// the user's chosen default wins when it's usable, else the first configured one is the fallback.
+@MainActor
+final class AgentHarnessRegistry {
+    private(set) var harnesses: [AgentHarness]
+
+    init(_ harnesses: [AgentHarness]) {
+        self.harnesses = harnesses
+    }
+
+    /// Harnesses with credentials/endpoint present.
+    var configured: [AgentHarness] { harnesses.filter { $0.isConfigured } }
+
+    func harness(for kind: AgentHarnessKind) -> AgentHarness? {
+        harnesses.first { $0.kind == kind }
+    }
+
+    /// The harness to dispatch to: the user's configured default, else the first configured one,
+    /// else `nil` (nothing set up). `defaultKind` is injected so the resolution is testable without
+    /// touching `Config`.
+    func active(defaultKind: AgentHarnessKind) -> AgentHarness? {
+        if let preferred = harness(for: defaultKind), preferred.isConfigured {
+            return preferred
+        }
+        return configured.first
+    }
+
+    /// Convenience resolving the default from `Config`.
+    var active: AgentHarness? { active(defaultKind: Config.defaultAgentHarness) }
+}

--- a/OpenGlasses/Sources/Services/AgentHarness/AgentModels.swift
+++ b/OpenGlasses/Sources/Services/AgentHarness/AgentModels.swift
@@ -36,6 +36,20 @@ enum AgentRunStatus: String, Codable, Equatable {
         case .queued, .running, .awaitingInput: return false
         }
     }
+
+    /// Map a gateway/endpoint status string to a case, tolerant of common spellings. Shared by every
+    /// adapter (OpenClaw, Custom, …) so status parsing lives in one place.
+    static func parse(_ raw: String?) -> AgentRunStatus? {
+        switch raw?.lowercased() {
+        case "queued", "pending":            return .queued
+        case "running", "in_progress":       return .running
+        case "awaiting_input", "waiting":    return .awaitingInput
+        case "completed", "done", "success": return .completed
+        case "failed", "error":              return .failed
+        case "cancelled", "canceled":        return .cancelled
+        default:                             return nil
+        }
+    }
 }
 
 /// One dispatched remote agent task.

--- a/OpenGlasses/Sources/Services/AgentHarness/AgentSessionService.swift
+++ b/OpenGlasses/Sources/Services/AgentHarness/AgentSessionService.swift
@@ -19,8 +19,12 @@ final class AgentSessionService: ObservableObject {
     /// Everything spoken this session, in order — for the debug panel and tests.
     @Published private(set) var spokenLog: [String] = []
 
-    /// The active harness. Set by `configure`/`setHarness`; tests inject a mock.
+    /// A directly-set harness (tests/back-compat). When a `registry` is present it takes precedence,
+    /// so a default-harness change in Settings applies without re-dispatching.
     private(set) var harness: AgentHarness?
+
+    /// The harness registry (Phase 2). When set, `dispatch` uses its `active` harness.
+    private(set) var registry: AgentHarnessRegistry?
 
     /// Injected speaker. AppState wires `TextToSpeechService`; tests capture the lines.
     var speak: (String) -> Void = { _ in }
@@ -36,13 +40,26 @@ final class AgentSessionService: ObservableObject {
         self.speak = speak
     }
 
+    /// Configure with a registry (Phase 2): the active harness is resolved per dispatch from the
+    /// user's default, so adding/removing a Custom endpoint or switching the default takes effect live.
+    func configure(registry: AgentHarnessRegistry, speak: @escaping (String) -> Void) {
+        self.registry = registry
+        self.speak = speak
+    }
+
     func setHarness(_ harness: AgentHarness) { self.harness = harness }
+
+    /// Swap the registry (e.g. after the user edits the Custom endpoint in Settings).
+    func setRegistry(_ registry: AgentHarnessRegistry) { self.registry = registry }
+
+    /// The harness a dispatch would use right now (registry default wins).
+    var activeHarness: AgentHarness? { registry?.active ?? harness }
 
     // MARK: - Dispatch
 
     @discardableResult
     func dispatch(prompt: String, project: String?) async -> Result<AgentRun, AgentHarnessError> {
-        guard let harness else { return .failure(.notConfigured(.openclaw)) }
+        guard let harness = activeHarness else { return .failure(.notConfigured(Config.defaultAgentHarness)) }
         guard harness.isConfigured else { return .failure(.notConfigured(harness.kind)) }
 
         do {
@@ -110,7 +127,7 @@ final class AgentSessionService: ObservableObject {
     // MARK: - Controls
 
     func cancel() async {
-        guard let harness, let run = activeRun else { return }
+        guard let harness = activeHarness, let run = activeRun else { return }
         try? await harness.cancel(run)
         activeRun?.status = .cancelled
         let summary = AgentSummarizer.summarize(result, status: .cancelled)
@@ -122,7 +139,7 @@ final class AgentSessionService: ObservableObject {
 
     /// Answer an `awaitingInput` confirmation. Declining cancels the run (safety default).
     func respondToConfirmation(approved: Bool) async {
-        guard let harness, let run = activeRun, run.status == .awaitingInput else { return }
+        guard let harness = activeHarness, let run = activeRun, run.status == .awaitingInput else { return }
         try? await harness.respondToInput(run, approved: approved)
         awaitingInputPrompt = nil
         if approved {

--- a/OpenGlasses/Sources/Services/NativeTools/AgentControlTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/AgentControlTool.swift
@@ -22,7 +22,7 @@ struct AgentControlTool: NativeTool {
             "properties": [
                 "action": [
                     "type": "string",
-                    "enum": ["start", "status", "cancel", "confirm", "deny"],
+                    "enum": ["start", "status", "cancel", "confirm", "deny", "switch_harness"],
                     "description": "What to do. Defaults to start.",
                 ],
                 "prompt": [
@@ -32,6 +32,11 @@ struct AgentControlTool: NativeTool {
                 "project": [
                     "type": "string",
                     "description": "Optional project/repo the agent should act on.",
+                ],
+                "harness": [
+                    "type": "string",
+                    "enum": ["openclaw", "custom"],
+                    "description": "For action=switch_harness: which configured backend to make the default.",
                 ],
             ],
             "required": [] as [String],
@@ -74,6 +79,17 @@ struct AgentControlTool: NativeTool {
         case "deny", "decline", "no":
             await session.respondToConfirmation(approved: false)
             return "Okay, I won't proceed."
+
+        case "switch_harness", "switch":
+            guard let raw = (args["harness"] as? String)?.lowercased(),
+                  let kind = AgentHarnessKind(rawValue: raw) else {
+                return "Which agent backend? Try OpenClaw or Custom."
+            }
+            guard session.registry?.harness(for: kind)?.isConfigured == true else {
+                return "\(kind.displayName) isn't configured. Set it up in Settings first."
+            }
+            Config.setDefaultAgentHarness(kind)
+            return "Switched the agent backend to \(kind.displayName)."
 
         default:
             return "Unknown agent action '\(action)'. Try start, status, cancel, confirm, or deny."

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -398,6 +398,7 @@ struct Config {
         modelsKey,        // "savedModelConfigs" — ModelConfig.apiKey
         "savedGateways",  // GatewayConfig.token
         "mcpServers",     // MCPServerConfig.headers (Authorization)
+        "customAgentHarness", // CustomHarnessConfig.authValue (Plan N)
     ]
 
     /// One-time migration of plaintext secrets from UserDefaults into the Keychain.
@@ -2351,6 +2352,38 @@ struct Config {
 
     static func setAgentModeEnabled(_ enabled: Bool) {
         UserDefaults.standard.set(enabled, forKey: "agentModeEnabled")
+    }
+
+    // MARK: - Remote Agent Harness (Plan N)
+
+    /// Which harness the Remote Agent Harness dispatches to by default. Defaults to `.openclaw`.
+    static var defaultAgentHarness: AgentHarnessKind {
+        AgentHarnessKind(rawValue: UserDefaults.standard.string(forKey: "defaultAgentHarness") ?? "")
+            ?? .openclaw
+    }
+
+    static func setDefaultAgentHarness(_ kind: AgentHarnessKind) {
+        UserDefaults.standard.set(kind.rawValue, forKey: "defaultAgentHarness")
+    }
+
+    /// The Custom URL agent endpoint (Phase 2). Keychain-backed — it embeds an auth token. `nil`
+    /// until the user configures one.
+    static var customAgentHarness: CustomHarnessConfig? {
+        guard let data = KeychainService.data(for: "customAgentHarness"),
+              let config = try? JSONDecoder().decode(CustomHarnessConfig.self, from: data) else {
+            return nil
+        }
+        return config
+    }
+
+    static func setCustomAgentHarness(_ config: CustomHarnessConfig?) {
+        guard let config else {
+            _ = KeychainService.delete("customAgentHarness")
+            return
+        }
+        if let data = try? JSONEncoder().encode(config) {
+            KeychainService.setData(data, for: "customAgentHarness")
+        }
     }
 
     // MARK: - Field Assist (B2B)

--- a/OpenGlassesTests/AgentCustomHarnessTests.swift
+++ b/OpenGlassesTests/AgentCustomHarnessTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for Plan N Phase 2: the Custom URL harness config/request building, `JSONPath`, the
+/// `CustomAgentHarness` HTTP shape (via the shared `URLProtocol` stub), the `AgentHarnessRegistry`
+/// active-resolution, and the registry-backed dispatch + `switch_harness` tool action.
+@MainActor
+final class AgentCustomHarnessTests: XCTestCase {
+
+    private func config(start: String = "https://agent.test/start") -> CustomHarnessConfig {
+        var c = CustomHarnessConfig()
+        c.startURL = start
+        c.statusURLTemplate = "https://agent.test/runs/{id}"
+        c.authHeader = "Authorization"
+        c.authValue = "Bearer tok"
+        return c
+    }
+
+    // MARK: - CustomHarnessConfig
+
+    func testIsConfiguredRequiresValidStartURL() {
+        XCTAssertFalse(CustomHarnessConfig().isConfigured)
+        XCTAssertTrue(config().isConfigured)
+    }
+
+    func testConfigCodableRoundTrip() throws {
+        let original = config()
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CustomHarnessConfig.self, from: data)
+        XCTAssertEqual(decoded, original)
+    }
+
+    func testStatusURLSubstitutesId() {
+        XCTAssertEqual(config().statusURL(runID: "abc")?.absoluteString, "https://agent.test/runs/abc")
+        var c = CustomHarnessConfig(); c.statusURLTemplate = ""
+        XCTAssertNil(c.statusURL(runID: "abc"))
+    }
+
+    func testStartRequestBadURLIsNil() {
+        var c = CustomHarnessConfig(); c.startURL = ""
+        XCTAssertNil(c.startRequest(prompt: "p", project: nil))
+    }
+
+    // MARK: - JSONPath
+
+    func testJSONPathNestedExtraction() {
+        let json: [String: Any] = ["data": ["run": ["id": "r1", "n": 3, "ok": true]]]
+        XCTAssertEqual(JSONPath.string(at: "data.run.id", in: json), "r1")
+        XCTAssertEqual(JSONPath.string(at: "data.run.n", in: json), "3")     // number coerced
+        XCTAssertEqual(JSONPath.string(at: "data.run.ok", in: json), "true") // bool coerced
+        XCTAssertNil(JSONPath.string(at: "data.run.missing", in: json))
+        XCTAssertNil(JSONPath.string(at: "data.run.id.too.deep", in: json))  // walks past a leaf
+    }
+
+    // MARK: - CustomAgentHarness over the URLProtocol stub
+
+    func testStartBuildsRequestAndParsesRun() async throws {
+        MockURLProtocol.reset()
+        MockURLProtocol.responseBody = Data(#"{"id":"run-9","status":"running"}"#.utf8)
+        let harness = CustomAgentHarness(config: config(), session: MockURLProtocol.session())
+
+        let run = try await harness.start(prompt: "add a toggle", project: "my-app")
+        XCTAssertEqual(run.id, "run-9")
+        XCTAssertEqual(run.status, .running)
+        XCTAssertEqual(run.harness, .custom)
+
+        let request = try XCTUnwrap(MockURLProtocol.lastRequest)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://agent.test/start")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer tok")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        let body = try JSONSerialization.jsonObject(with: try XCTUnwrap(MockURLProtocol.lastBody)) as? [String: Any]
+        XCTAssertEqual(body?["prompt"] as? String, "add a toggle")
+        XCTAssertEqual(body?["project"] as? String, "my-app")
+    }
+
+    func testStartUsesCustomFieldMapping() async throws {
+        MockURLProtocol.reset()
+        MockURLProtocol.responseBody = Data(#"{"data":{"runId":"R7"},"state":"queued"}"#.utf8)
+        var c = config()
+        c.idPath = "data.runId"
+        c.statusPath = "state"
+        c.promptField = "task"
+        let harness = CustomAgentHarness(config: c, session: MockURLProtocol.session())
+
+        let run = try await harness.start(prompt: "do it", project: nil)
+        XCTAssertEqual(run.id, "R7")
+        XCTAssertEqual(run.status, .queued)
+
+        let body = try JSONSerialization.jsonObject(with: try XCTUnwrap(MockURLProtocol.lastBody)) as? [String: Any]
+        XCTAssertEqual(body?["task"] as? String, "do it")
+        XCTAssertNil(body?["project"])   // omitted when nil
+    }
+
+    func testStartThrowsWhenNoRunId() async {
+        MockURLProtocol.reset()
+        MockURLProtocol.responseBody = Data(#"{"status":"running"}"#.utf8)
+        let harness = CustomAgentHarness(config: config(), session: MockURLProtocol.session())
+        do { _ = try await harness.start(prompt: "p", project: nil); XCTFail("expected throw") }
+        catch let e as AgentHarnessError {
+            guard case .transport(let msg) = e else { return XCTFail("wrong case") }
+            XCTAssertTrue(msg.contains("run id"))
+        } catch { XCTFail("wrong error: \(error)") }
+    }
+
+    func testStartThrowsOnHTTPError() async {
+        MockURLProtocol.reset()
+        MockURLProtocol.statusCode = 401
+        MockURLProtocol.responseBody = Data("unauthorized".utf8)
+        let harness = CustomAgentHarness(config: config(), session: MockURLProtocol.session())
+        do { _ = try await harness.start(prompt: "p", project: nil); XCTFail("expected throw") }
+        catch let e as AgentHarnessError {
+            guard case .transport(let msg) = e else { return XCTFail("wrong case") }
+            XCTAssertTrue(msg.contains("401"))
+        } catch { XCTFail("wrong error: \(error)") }
+    }
+
+    func testStatusPolls() async throws {
+        MockURLProtocol.reset()
+        MockURLProtocol.responseBody = Data(#"{"status":"completed"}"#.utf8)
+        let harness = CustomAgentHarness(config: config(), session: MockURLProtocol.session())
+        let run = AgentRun(id: "r", harness: .custom, prompt: "p", project: nil, status: .running, startedAt: Date())
+        let status = try await harness.status(run)
+        XCTAssertEqual(status, .completed)
+    }
+
+    // MARK: - AgentRunStatus.parse (shared)
+
+    func testStatusParseTolerantSpellings() {
+        XCTAssertEqual(AgentRunStatus.parse("in_progress"), .running)
+        XCTAssertEqual(AgentRunStatus.parse("SUCCESS"), .completed)
+        XCTAssertEqual(AgentRunStatus.parse("canceled"), .cancelled)
+        XCTAssertNil(AgentRunStatus.parse("weird"))
+    }
+
+    // MARK: - AgentHarnessRegistry resolution
+
+    func testRegistryPrefersConfiguredDefault() {
+        let registry = AgentHarnessRegistry([
+            StubHarness(kind: .openclaw, configured: true),
+            StubHarness(kind: .custom, configured: true),
+        ])
+        XCTAssertEqual(registry.active(defaultKind: .custom)?.kind, .custom)
+        XCTAssertEqual(registry.active(defaultKind: .openclaw)?.kind, .openclaw)
+    }
+
+    func testRegistryFallsBackWhenDefaultUnconfigured() {
+        let registry = AgentHarnessRegistry([
+            StubHarness(kind: .openclaw, configured: true),
+            StubHarness(kind: .custom, configured: false),
+        ])
+        // Default custom isn't configured → first configured (openclaw).
+        XCTAssertEqual(registry.active(defaultKind: .custom)?.kind, .openclaw)
+    }
+
+    func testRegistryNilWhenNoneConfigured() {
+        let registry = AgentHarnessRegistry([StubHarness(kind: .openclaw, configured: false)])
+        XCTAssertNil(registry.active(defaultKind: .openclaw))
+    }
+
+    // MARK: - Registry-backed dispatch + switch_harness tool
+
+    func testSessionDispatchUsesRegistryActive() async {
+        let service = AgentSessionService()
+        service.configure(registry: AgentHarnessRegistry([StubHarness(kind: .custom, configured: true)]),
+                          speak: { _ in })
+        let result = await service.dispatch(prompt: "p", project: nil)
+        guard case .success(let run) = result else { return XCTFail("expected success") }
+        XCTAssertEqual(run.harness, .custom)
+    }
+
+    func testSessionDispatchFailsWhenRegistryEmpty() async {
+        let service = AgentSessionService()
+        service.configure(registry: AgentHarnessRegistry([StubHarness(kind: .openclaw, configured: false)]),
+                          speak: { _ in })
+        guard case .failure = await service.dispatch(prompt: "p", project: nil) else {
+            return XCTFail("expected failure")
+        }
+    }
+
+    func testToolSwitchHarnessUnknownAndUnconfigured() async throws {
+        let prior = Config.agentModeEnabled
+        defer { Config.setAgentModeEnabled(prior) }
+        Config.setAgentModeEnabled(true)
+
+        let unknown = try await AgentControlTool().execute(args: ["action": "switch_harness", "harness": "nope"])
+        XCTAssertTrue(unknown.contains("Which agent backend"))
+
+        // With no configured custom registry on the shared session, switching to custom is refused.
+        AgentSessionService.shared.setRegistry(AgentHarnessRegistry([StubHarness(kind: .custom, configured: false)]))
+        let unconfigured = try await AgentControlTool().execute(args: ["action": "switch_harness", "harness": "custom"])
+        XCTAssertTrue(unconfigured.contains("isn't configured"))
+    }
+}
+
+/// Minimal harness for registry/dispatch tests.
+private struct StubHarness: AgentHarness {
+    let kind: AgentHarnessKind
+    let configured: Bool
+    var displayName: String { kind.displayName }
+    var isConfigured: Bool { configured }
+    func start(prompt: String, project: String?) async throws -> AgentRun {
+        AgentRun(id: "stub", harness: kind, prompt: prompt, project: project, status: .running, startedAt: Date())
+    }
+    func events(for run: AgentRun) -> AsyncStream<AgentEvent> { AsyncStream { $0.finish() } }
+    func status(_ run: AgentRun) async throws -> AgentRunStatus { run.status }
+    func cancel(_ run: AgentRun) async throws {}
+}

--- a/docs/plans/N-remote-agent-harness.md
+++ b/docs/plans/N-remote-agent-harness.md
@@ -14,7 +14,14 @@
 - **Tool + wiring** — `AgentControlTool` (`code_agent`: start/status/cancel/confirm/deny), **gated on `Config.agentModeEnabled`**, registered in `NativeToolRegistry` and described in both the `LLMService` and `GeminiLive` system prompts. `AgentSessionService.shared.configure(...)` wired at launch to the OpenClaw harness + TTS.
 - **Tests:** 31 headless (`AgentSummarizerTests` 17, `AgentSessionTests` 14) covering the summarizer permutations, result aggregation, the session state machine (dispatch/complete/error/awaitingInput/cancel/confirm), and the adapter normalization + tool gate. Full suite 705 green, Debug + Release.
 
-**Deferred (per the build order):** the gateway-side `agent.*` methods + the rich live event stream (Phase 1's live half — needs a running gateway that exposes them; the adapter is ready and `normalize` maps the schema); `AgentHarnessSettingsView` (default-harness picker + custom endpoint UI); the **Custom URL adapter** (Phase 2); the **Codex-cloud / Claude-remote adapters** (Phase 3, pending the Phase 0 trigger verification); and live token-streaming + the HUD confirm view (Phase 4).
+**Phase 2 shipped** (`feat/remote-agent-harness-phase2`) — the Custom URL adapter + multi-harness selection + settings UI:
+- **`CustomAgentHarness`** — a generic HTTP adapter for any endpoint the user already runs: POST to start, GET-poll status, optional POST cancel. Request building + response mapping are pure (`CustomHarnessConfig.startRequest/statusRequest/cancelRequest` + `JSONPath` dot-path extraction with number/bool coercion), tested through a `URLProtocol` stub; the adapter is the thin async layer (injectable `URLSession`).
+- **`AgentHarnessRegistry`** — lists the configured harnesses and resolves the *active* one: the user's configured default wins, else the first configured, else none. `AgentSessionService` now dispatches through `registry.active`, so a default switch or a new endpoint applies live. `code_agent` gains a **`switch_harness`** action.
+- **Config** — `Config.defaultAgentHarness` (UserDefaults) + Keychain-backed `Config.customAgentHarness` (registered in the sensitive-keys list; status parsing shared via `AgentRunStatus.parse`).
+- **`AgentHarnessSettingsView`** — default-backend picker + custom endpoint form (URLs, auth, field mapping), surfaced from Agentic Features (Agent-Mode-gated). `AppState.rebuildAgentHarnessRegistry()` re-reads it on save.
+- **Tests:** +17 headless (`AgentCustomHarnessTests`) — config round-trip, `JSONPath`, request building + `start`/`status` over the stub, registry resolution, registry-backed dispatch, and the `switch_harness` action. Full suite 722 green, Debug + Release.
+
+**Still deferred (per the build order):** the gateway-side `agent.*` methods + the rich live event stream (Phase 1's live half — needs a running gateway that exposes them; the adapter is ready and `normalize` maps the schema); the **Codex-cloud / Claude-remote adapters** (Phase 3, pending the Phase 0 trigger verification); and live token-streaming + the HUD confirm view (Phase 4).
 
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -68,7 +68,7 @@ A–F are built (A1–A3, B, C, D, E, and Field Assist Phases 1–3). These reus
 
 | Plan | Title | Effort | Reuses | Strategic fit |
 |---|---|---|---|---|
-| [N](N-remote-agent-harness.md) | Remote Agent Harness (phone-only, harness-agnostic) | ~3–4 days core + ~1–2/adapter | OpenClawBridge + OpenClawEventClient, `agentModeEnabled`, LLMProvider pattern, MeetingSummaryTool | Glasses as a hands-free remote for any coding/agent backend (OpenClaw / Codex / Claude / custom). 🚧 Phase 1 core shipped — `AgentModels`/`AgentHarness`/`AgentSummarizer`/`AgentSessionService` + `OpenClawAgentHarness` (normalization tested) + `code_agent` tool (Agent-Mode-gated) + system-prompt/launch wiring; 31 tests. Deferred: gateway `agent.*` + live event stream, settings UI, Custom/Codex/Claude adapters, HUD confirm. |
+| [N](N-remote-agent-harness.md) | Remote Agent Harness (phone-only, harness-agnostic) | ~3–4 days core + ~1–2/adapter | OpenClawBridge + OpenClawEventClient, `agentModeEnabled`, LLMProvider pattern, MeetingSummaryTool | Glasses as a hands-free remote for any coding/agent backend (OpenClaw / Codex / Claude / custom). 🚧 Phases 1–2 shipped — core (`AgentModels`/`AgentHarness`/`AgentSummarizer`/`AgentSessionService`) + `OpenClawAgentHarness` + `code_agent` tool (Agent-Mode-gated); **Phase 2**: `CustomAgentHarness` (URL + auth + JSONPath field mapping), `AgentHarnessRegistry` active-resolution + `switch_harness`, `AgentHarnessSettingsView`; 48 tests. Deferred: gateway `agent.*` live event stream, Codex/Claude adapters (Phase 3), HUD confirm (Phase 4). |
 
 ## Round 4 — on-device knowledge
 


### PR DESCRIPTION
**Stacked on [#66](https://github.com/straff2002/OpenGlasses/pull/66)** (Plan N Phase 1) — base is `feat/remote-agent-harness`; retarget to `main` once #66 merges. Adds the generic **Custom URL adapter**, multi-harness selection, and the settings UI, so a power user can point OpenGlasses at any agent endpoint they already run and switch which backend `code_agent` dispatches to.

## Custom URL adapter (pure core + thin async layer)
- **`CustomHarnessConfig`** — URLs (start / status / cancel, with `{id}` substitution), auth header+value, and a small JSON field mapping. Keychain-backed (it holds a token), `Codable`.
- Pure request building (`startRequest` / `statusRequest` / `cancelRequest`) + **`JSONPath`** dot-path extraction (with number/bool coercion) — fully unit-tested.
- **`CustomAgentHarness`** conforms to `AgentHarness` over an injectable `URLSession`: POST start, GET-poll status, optional POST cancel. The HTTP shape is tested through the shared `URLProtocol` stub.

## Multi-harness selection
- **`AgentHarnessRegistry`** resolves the *active* harness: the user's configured default wins, else the first configured, else none. `AgentSessionService` now dispatches through `registry.active`, so a default switch or a newly-saved endpoint applies live.
- `code_agent` gains a **`switch_harness`** action.
- `AgentRunStatus.parse` is now shared by every adapter (OpenClaw delegates to it).

## Config + settings
- `Config.defaultAgentHarness` (UserDefaults) + Keychain-backed `Config.customAgentHarness` (added to the sensitive-keys list).
- **`AgentHarnessSettingsView`** — default-backend picker + custom endpoint form (URLs, auth, field mapping), surfaced from **Agentic Features** (Agent-Mode-gated). `AppState.rebuildAgentHarnessRegistry()` re-reads it on save.

## Tests
**+17 headless** (`AgentCustomHarnessTests`) — config round-trip, `JSONPath` nesting/coercion, request building + `start`/`status` over the stub (incl. custom field mapping, missing-id and HTTP-error throws), registry resolution (default-wins / fallback / none), registry-backed dispatch, and the `switch_harness` action. Full suite **722 green** on Debug; **Release build green**.

## Still deferred (per the build order)
- The gateway-side `agent.*` methods + the rich **live event stream** (Phase 1's live half — the adapter is ready and `normalize` maps the schema).
- **Codex-cloud / Claude-remote adapters** (Phase 3, pending the Phase 0 trigger verification).
- Live token-streaming + the HUD confirm view (Phase 4).

Plan `Status:` + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)