### PR TITLE
Shared DeviceSession: ownership coordinator core (tested)

### DIFF
--- a/OpenGlasses/Sources/Services/Device/DeviceSessionCoordinator.swift
+++ b/OpenGlasses/Sources/Services/Device/DeviceSessionCoordinator.swift
@@ -1,0 +1,87 @@
+import Foundation
+import MWDATCore
+
+/// The minimal surface the coordinator needs from a device session, so its lifecycle/ref-counting is
+/// testable without the SDK. `MWDATCore.DeviceSession` already has `stop()`, so it conforms with no
+/// new code; tests inject a fake.
+protocol DeviceSessionHandle: AnyObject {
+    func stop()
+}
+
+extension DeviceSession: DeviceSessionHandle {}
+
+/// Owns the single shared `DeviceSession` and lends it to the capabilities that want the glasses
+/// (Additional Capabilities #3). The first capability to `acquire` triggers creation; the last to
+/// `release` tears it down — so the camera and the in-lens display can run on **one** session instead
+/// of contending (the SDK allows only one per device). All the *decision* logic lives in the pure,
+/// fully-tested `DeviceSessionOwnership`; this is the thin `@MainActor` layer that holds the real
+/// session and is itself testable via an injected session factory.
+///
+/// Adoption is staged: this is the tested coordinator. Wiring `CameraService` and
+/// `GlassesDisplayService` to source their session here (and the on-glasses "camera + HUD at once"
+/// check) is the device-only follow-up — it can't be validated without Display hardware.
+@MainActor
+final class DeviceSessionCoordinator {
+
+    typealias Capability = DeviceSessionOwnership.Capability
+
+    /// The app-wide coordinator. Its factory creates a real auto-selected `DeviceSession` lazily on
+    /// first `acquire`, so constructing `shared` touches no SDK.
+    static let shared = DeviceSessionCoordinator(makeSession: {
+        try Wearables.shared.createSession(deviceSelector: AutoDeviceSelector(wearables: Wearables.shared))
+    })
+
+    private let makeSession: () throws -> DeviceSessionHandle
+    private var ownership = DeviceSessionOwnership()
+    private var handle: DeviceSessionHandle?
+
+    /// Observability for tests / diagnostics — how many sessions this coordinator has created and
+    /// torn down over its lifetime.
+    private(set) var createCount = 0
+    private(set) var teardownCount = 0
+
+    init(makeSession: @escaping () throws -> DeviceSessionHandle) {
+        self.makeSession = makeSession
+    }
+
+    // MARK: - State
+
+    var holders: Set<Capability> { ownership.holders }
+    var isShared: Bool { ownership.isShared }
+    var isHeld: Bool { ownership.isHeld }
+    var currentHandle: DeviceSessionHandle? { handle }
+
+    // MARK: - Lifecycle
+
+    /// Lend the shared session to `capability`, creating it on the first acquire. The caller then
+    /// adds its own capability to the returned session (`addStream` for the camera, `addDisplay` for
+    /// the HUD).
+    @discardableResult
+    func acquire(_ capability: Capability) throws -> DeviceSessionHandle {
+        let session: DeviceSessionHandle
+        if let handle {
+            session = handle
+        } else {
+            // Create before recording the holder, so a failed creation leaves state untouched.
+            session = try makeSession()
+            handle = session
+            createCount += 1
+        }
+        ownership.acquire(capability)
+        return session
+    }
+
+    /// Release `capability`'s hold; stops + drops the session once the last holder leaves.
+    func release(_ capability: Capability) {
+        guard ownership.release(capability) else { return }   // others still hold it
+        handle?.stop()
+        handle = nil
+        teardownCount += 1
+    }
+
+    /// Forget a session that died underneath us (the SDK reported it `.stopped`) **without** changing
+    /// who holds it, so the next `acquire` recreates a fresh one for the existing holders.
+    func invalidate() {
+        handle = nil
+    }
+}

--- a/OpenGlasses/Sources/Services/Device/DeviceSessionOwnership.swift
+++ b/OpenGlasses/Sources/Services/Device/DeviceSessionOwnership.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Pure reference-counting state machine for the single shared `DeviceSession` (Additional
+/// Capabilities #3). The DAT SDK allows **one session per device**, so the camera and the in-lens
+/// display can't each spin up their own without one falling back to the iPhone-camera path. This
+/// tracks which capabilities currently want the session and answers the two decisions a coordinator
+/// needs — *should I create it now?* (first holder) and *should I tear it down?* (last holder) —
+/// with no SDK types, so the logic is fully unit-testable.
+struct DeviceSessionOwnership: Equatable {
+
+    /// A consumer that can hold the shared session.
+    enum Capability: String, CaseIterable, Hashable {
+        case camera
+        case display
+    }
+
+    private(set) var holders: Set<Capability> = []
+
+    /// Record that `capability` now wants the session. Returns `true` when this is the **first**
+    /// holder — i.e. the caller must create the session. Idempotent: re-acquiring an existing holder
+    /// never reports "first" again.
+    @discardableResult
+    mutating func acquire(_ capability: Capability) -> Bool {
+        let wasEmpty = holders.isEmpty
+        let inserted = holders.insert(capability).inserted
+        return wasEmpty && inserted
+    }
+
+    /// Release `capability`'s hold. Returns `true` when **no holders remain** — i.e. the caller must
+    /// tear the session down. Releasing a capability that isn't holding is a no-op (returns `false`).
+    @discardableResult
+    mutating func release(_ capability: Capability) -> Bool {
+        guard holders.remove(capability) != nil else { return false }
+        return holders.isEmpty
+    }
+
+    /// Whether any capability currently holds the session.
+    var isHeld: Bool { !holders.isEmpty }
+
+    /// Whether more than one capability holds it — i.e. the session is genuinely *shared* (the win:
+    /// camera + display live on one session instead of contending).
+    var isShared: Bool { holders.count > 1 }
+
+    func holds(_ capability: Capability) -> Bool { holders.contains(capability) }
+}

--- a/OpenGlassesTests/DeviceSessionCoordinatorTests.swift
+++ b/OpenGlassesTests/DeviceSessionCoordinatorTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for the shared `DeviceSession` ownership core (Additional Capabilities #3): the pure
+/// `DeviceSessionOwnership` ref-count state machine and the `DeviceSessionCoordinator`'s
+/// create/teardown lifecycle (via an injected fake session, no SDK).
+@MainActor
+final class DeviceSessionCoordinatorTests: XCTestCase {
+
+    // MARK: - DeviceSessionOwnership (pure)
+
+    func testFirstAcquireReportsFirstHolder() {
+        var ownership = DeviceSessionOwnership()
+        XCTAssertTrue(ownership.acquire(.camera))    // first → create
+        XCTAssertFalse(ownership.acquire(.display))  // second → reuse
+        XCTAssertTrue(ownership.isShared)
+    }
+
+    func testAcquireIsIdempotentForSameCapability() {
+        var ownership = DeviceSessionOwnership()
+        XCTAssertTrue(ownership.acquire(.camera))
+        XCTAssertFalse(ownership.acquire(.camera))   // already holding → not "first" again
+        XCTAssertEqual(ownership.holders, [.camera])
+        XCTAssertFalse(ownership.isShared)
+    }
+
+    func testReleaseLastHolderReportsEmpty() {
+        var ownership = DeviceSessionOwnership()
+        ownership.acquire(.camera)
+        ownership.acquire(.display)
+        XCTAssertFalse(ownership.release(.camera))   // display still holds → keep
+        XCTAssertTrue(ownership.release(.display))    // last out → tear down
+        XCTAssertFalse(ownership.isHeld)
+    }
+
+    func testReleaseUnheldCapabilityIsNoOp() {
+        var ownership = DeviceSessionOwnership()
+        ownership.acquire(.camera)
+        XCTAssertFalse(ownership.release(.display))   // wasn't holding
+        XCTAssertTrue(ownership.holds(.camera))
+    }
+
+    // MARK: - DeviceSessionCoordinator (fake session)
+
+    private final class FakeSession: DeviceSessionHandle {
+        private(set) var stopCount = 0
+        func stop() { stopCount += 1 }
+    }
+
+    private func makeCoordinator() -> (DeviceSessionCoordinator, () -> [FakeSession]) {
+        final class Box { var created: [FakeSession] = [] }
+        let box = Box()
+        let coordinator = DeviceSessionCoordinator(makeSession: {
+            let session = FakeSession()
+            box.created.append(session)
+            return session
+        })
+        return (coordinator, { box.created })
+    }
+
+    func testFirstAcquireCreatesSession() throws {
+        let (coordinator, created) = makeCoordinator()
+        let handle = try coordinator.acquire(.display)
+        XCTAssertNotNil(handle)
+        XCTAssertEqual(coordinator.createCount, 1)
+        XCTAssertEqual(created().count, 1)
+        XCTAssertTrue(coordinator.isHeld)
+    }
+
+    func testSecondAcquireReusesTheSameSession() throws {
+        let (coordinator, created) = makeCoordinator()
+        let a = try coordinator.acquire(.camera)
+        let b = try coordinator.acquire(.display)
+        XCTAssertTrue(a === b)                         // one shared session
+        XCTAssertEqual(coordinator.createCount, 1)
+        XCTAssertEqual(created().count, 1)
+        XCTAssertTrue(coordinator.isShared)
+    }
+
+    func testReleaseLastHolderTearsDownAndStops() throws {
+        let (coordinator, created) = makeCoordinator()
+        try coordinator.acquire(.display)
+        coordinator.release(.display)
+        XCTAssertNil(coordinator.currentHandle)
+        XCTAssertEqual(coordinator.teardownCount, 1)
+        XCTAssertEqual(created().first?.stopCount, 1)  // session.stop() called
+    }
+
+    func testReleaseNonLastHolderKeepsSessionAlive() throws {
+        let (coordinator, created) = makeCoordinator()
+        try coordinator.acquire(.camera)
+        try coordinator.acquire(.display)
+        coordinator.release(.camera)                   // display still holds
+        XCTAssertNotNil(coordinator.currentHandle)
+        XCTAssertEqual(coordinator.teardownCount, 0)
+        XCTAssertEqual(created().first?.stopCount, 0)  // not stopped
+        XCTAssertEqual(coordinator.holders, [.display])
+    }
+
+    func testReacquireAfterTeardownCreatesFreshSession() throws {
+        let (coordinator, created) = makeCoordinator()
+        try coordinator.acquire(.display)
+        coordinator.release(.display)
+        try coordinator.acquire(.display)
+        XCTAssertEqual(coordinator.createCount, 2)
+        XCTAssertEqual(created().count, 2)
+    }
+
+    func testInvalidateDropsHandleButKeepsHolders() throws {
+        let (coordinator, created) = makeCoordinator()
+        try coordinator.acquire(.display)
+        coordinator.invalidate()                       // session died underneath us
+        XCTAssertNil(coordinator.currentHandle)
+        XCTAssertEqual(coordinator.holders, [.display]) // holder retained
+        try coordinator.acquire(.display)               // recreates for the existing holder
+        XCTAssertEqual(coordinator.createCount, 2)
+        XCTAssertEqual(created().last?.stopCount, 0)
+    }
+
+    func testAcquirePropagatesFactoryErrorAndLeavesStateClean() {
+        struct Boom: Error {}
+        let coordinator = DeviceSessionCoordinator(makeSession: { throw Boom() })
+        XCTAssertThrowsError(try coordinator.acquire(.camera))
+        XCTAssertFalse(coordinator.isHeld)              // holder not recorded on a failed create
+        XCTAssertEqual(coordinator.createCount, 0)
+        XCTAssertNil(coordinator.currentHandle)
+    }
+}

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -112,7 +112,7 @@ A set of self-contained capabilities that build on the shipped engines; each sco
 
 | Plan | Title | Effort | Reuses | Strategic fit |
 |---|---|---|---|---|
-| [Additional Capabilities](additional-capabilities.md) | Net-new features over the shipped engines | ~0.5–4 days each | TextToSpeechService, Config/Keychain, GlassesDisplayService + CameraService, BrainStore, WakeWordService | ✅ API keys → Keychain + BrainStore `needs`/follow-ups shipped. Remaining: Kokoro on-device TTS (offline + backgroundable), shared camera+display `DeviceSession`. Conditional: alternative hands-free triggers (accessibility), multi-user profiles + PIN. Deferred: declarative HUD widget board. |
+| [Additional Capabilities](additional-capabilities.md) | Net-new features over the shipped engines | ~0.5–4 days each | TextToSpeechService, Config/Keychain, GlassesDisplayService + CameraService, BrainStore, WakeWordService | ✅ API keys → Keychain + BrainStore `needs`/follow-ups shipped. 🚧 Shared camera+display `DeviceSession` — coordinator core tested (`DeviceSessionOwnership`/`DeviceSessionCoordinator`), live adoption deferred (device-only). Remaining: Kokoro on-device TTS (offline + backgroundable). Conditional: alternative hands-free triggers (accessibility), multi-user profiles + PIN. Deferred: declarative HUD widget board. |
 
 **Suggested sequence:** HUDPreviewView snapshot tests → ~~API keys → Keychain~~ ✅ → ~~BrainStore `needs`~~ ✅ → Kokoro TTS → shared `DeviceSession` → (if accessibility) alternative triggers → (if shared-device) profiles+PIN → (deferred) widget board.
 

--- a/docs/plans/additional-capabilities.md
+++ b/docs/plans/additional-capabilities.md
@@ -26,7 +26,7 @@ extension of "no Display hardware → tests are the gate." (~0.5 day.)
 |---|---|---|---|
 | 1 | **Kokoro on-device TTS tier** | ~3–4 days | ✅ Take — fills a real gap |
 | 2 | **Provider API keys → Keychain** | ~0.5–1 day | ✅ **Shipped** — secrets now Keychain-backed |
-| 3 | **Shared `DeviceSession` (camera + display)** | ~2–3 days | ✅ Take — closes a standing TODO |
+| 3 | **Shared `DeviceSession` (camera + display)** | ~2–3 days | 🚧 Core shipped — coordinator tested; live adoption deferred |
 | 4 | **`needs` / follow-ups in BrainStore** | ~1 day | ✅ **Shipped** (this PR) |
 | 5 | **Alternative hands-free triggers** | ~2–4 days | ◻︎ Conditional — Accessibility tier; App-Store caveat |
 | 6 | **Multi-user profiles + PIN gate** | ~4–6 days | ◻︎ Conditional — only if shared-device is a goal |
@@ -95,6 +95,24 @@ its own; it only creates+owns a session when none is shared.
 one `DeviceSession` when both want the glasses, and the display gracefully owns-its-own when the
 camera isn't active. Validate by headless tests of the ownership state machine; on-glasses behaviour
 (camera + HUD simultaneously) is a device-only check to log as outstanding.
+
+**Status: 🚧 core shipped.** The tested coordinator core is in:
+- [DeviceSessionOwnership.swift](../../OpenGlasses/Sources/Services/Device/DeviceSessionOwnership.swift)
+  — a pure reference-counting state machine over the `camera`/`display` capabilities: `acquire`
+  reports the **first** holder (create the session), `release` reports the **last** (tear it down),
+  idempotent, with `isShared`/`isHeld`/`holds`. No SDK types — fully unit-tested.
+- [DeviceSessionCoordinator.swift](../../OpenGlasses/Sources/Services/Device/DeviceSessionCoordinator.swift)
+  — `@MainActor` owner of the single real `DeviceSession`, driven by the ownership machine; creates on
+  first acquire, stops + drops on last release, `invalidate()` for a died-underneath session. A
+  `DeviceSessionHandle` protocol (which `MWDATCore.DeviceSession` satisfies with no new code) + an
+  injected session factory make its create/teardown ref-counting testable via a fake session.
+- 11 headless tests (`DeviceSessionCoordinatorTests`).
+
+**Deferred (device-only):** wiring `CameraService` and `GlassesDisplayService` to source their session
+from the coordinator (replacing their separate `Wearables.shared.createSession` calls with
+`acquire`/`release`), and the on-glasses "camera + HUD on one session at once" validation. Rewiring
+two hardware-coupled session owners can't be validated without Display hardware, so it's the staged
+follow-up — the coordinator is the tested foundation it adopts.
 
 ---
 


### PR DESCRIPTION
The DAT SDK allows **one `DeviceSession` per device**, so today `CameraService` and `GlassesDisplayService` each create their own — while the HUD session is held, the camera falls back to the iPhone-camera path. This lands the tested foundation for unifying them onto **one shared session** (a standing TODO flagged in `GlassesDisplayService`'s own header), per the deterministic-core-first rhythm. The live rewire is the device-only follow-up.

## What's in this PR
- **`DeviceSessionOwnership`** — a pure reference-counting state machine over the `camera`/`display` capabilities: `acquire` reports the **first** holder (caller creates the session), `release` reports the **last** (caller tears it down), idempotent, with `isShared`/`isHeld`/`holds`. No SDK types — fully unit-tested.
- **`DeviceSessionCoordinator`** — `@MainActor` owner of the single real `DeviceSession`, driven by the ownership machine: creates on first acquire (before recording the holder, so a failed create leaves state clean), stops + drops on last release, `invalidate()` for a session that died underneath us. A `DeviceSessionHandle` protocol (which `MWDATCore.DeviceSession` satisfies with no new code) + an injected session factory make its create/teardown ref-counting testable via a fake session.

## Tests
**+11 headless** (`DeviceSessionCoordinatorTests`) — the ownership transitions (first-creates / last-tears-down / idempotent / release-unheld no-op) and the coordinator's create / reuse / teardown / reacquire / invalidate / error-rollback lifecycle. Full suite **744 green** on Debug; **Release build green**.

## Deferred (device-only)
Wiring `CameraService` + `GlassesDisplayService` to source their session from the coordinator (replacing their separate `Wearables.shared.createSession` calls with `acquire`/`release`), and the on-glasses "camera + HUD on one session at once" validation. Rewiring two hardware-coupled session owners can't be validated without Display hardware, so it's the staged follow-up — this coordinator is the tested foundation it adopts.

Plan `Status:` + README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)