### PR TITLE
plans: First-Aid/Emergency Assist + Personal Health-Safety Advisor

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -10,6 +10,8 @@ All plans A–M are **built and merged to `main`** to the extent verifiable with
 |---|---|
 | A1/A2/A3 Accessibility | ✅ Shipped (OCR reading tool, urgency TTS, scene/social assistive modes + HUD toggle) |
 | B Personal Health Vault | ✅ Shipped (templates, tool, editor) |
+| [First-Aid / Emergency Assist](first-aid-assist.md) | 📋 Planned (not built) — hands-free bystander coach: CPR metronome (100–120 bpm, 30:2) + first-aid protocols + nearest-AED finder/routing; reuses ProcedureRunner/TTS/Navigation/ExpertBridge. Advisory, not a medical device. |
+| [Personal Health-Safety Advisor](health-safety-advisor.md) | 📋 Planned (not built) — active "is this safe for me?" over the Health Vault: drug-interaction/contraindication/dietary checks with a deterministic high-severity rubric backstopping the LLM. Medical Compliance IAP. |
 | C Live Coach | ✅ Shipped (per-domain loop, dedup) |
 | D Utilities | ✅ Shipped (OneEuroFilter, aircraft_overhead) |
 | E MCP Server | ✅ Shipped (dev-only HTTP server) |

--- a/docs/plans/first-aid-assist.md
+++ b/docs/plans/first-aid-assist.md
@@ -1,0 +1,126 @@
+# Plan — First-Aid / Emergency Assist
+
+**Status: 📋 Planned (not built).** Runs on the engines we already ship. Accessibility/Medical-tier,
+life-safety.
+
+**Strategic fit:** A hands-free **bystander first-aid coach** for the seconds that matter — paces CPR,
+walks a responder through a structured emergency protocol, and routes them to the nearest defibrillator,
+all eyes-up and hands-free. Sits in the **Accessibility / Medical Compliance** line and reuses the
+remote-expert, navigation, HUD, and TTS engines already built. The brain dies after ~4 min without
+oxygen; ambulances take ~8–20 min — this is the gap a hands-free coach fills.
+
+**This is decision support, NOT a medical device** — every flow starts by confirming emergency services
+were called and carries an "advisory only" disclaimer.
+
+**Effort:** ~1 week (≈75% reuse; the metronome + protocol catalog + AED finder are the new pieces).
+
+---
+
+## Concept
+
+Triggered by voice ("emergency" / "start CPR"), an alternative trigger, or a tool call, the glasses
+enter a **First-Aid Assist mode** that:
+
+- **Gate first:** "Have you called emergency services?" — the mode never starts a protocol before the
+  responder confirms (or is prompted to) call 911/112.
+- **CPR metronome** — an audible 100–120 bpm beat (TTS tone) paces compressions, with spoken coaching
+  ("push hard and fast, centre of the chest") and **30:2 cycle tracking** (prompt 2 rescue breaths after
+  30 compressions), spoken at high urgency.
+- **Structured protocols** — a step-by-step runner for the highest-value bystander scenarios: **CPR/AED**,
+  **choking** (back blows / Heimlich), **severe bleeding** (pressure / tourniquet), **recovery position**,
+  and the **MARCH** trauma sequence. Hands-free advance (voice/"next").
+- **AED finder + routing** — the nearest defibrillator via an OpenStreetMap **Overpass** query
+  (`emergency=defibrillator`), spoken + an on-lens direction arrow + turn-by-turn (reuse Navigation Assist).
+- **Optional remote responder** — escalate to a live POV + two-way audio session over the existing
+  `ExpertBridge` transport.
+- **HUD** — the current step, a compression-beat indicator, and the AED bearing on the lens.
+
+---
+
+## Files
+
+```
+Sources/Services/FirstAid/
+├── FirstAidProtocol.swift        // catalog: CPR/AED, choking, bleeding, recovery, MARCH — structured steps
+├── CPRMetronome.swift            // PURE bpm/beat/30:2-cycle/compression-count timing model (clock injected)
+├── AEDFinder.swift               // Overpass query build + parse + nearest (haversine) + route hand-off
+├── FirstAidAssistService.swift   // @MainActor: runs a protocol, drives the metronome + HUD + escalation
+└── NativeTools/FirstAidTool.swift // first_aid: start <protocol> | next | aed | escalate | stop
+Sources/App/Views/
+└── FirstAidView.swift            // step + beat indicator + AED bearing (phone); mirrored to HUD
+```
+
+Reuse (no new infrastructure):
+- **Protocol stepping** — [ProcedureRunner](../../OpenGlasses/Sources/Services/FieldAssist/ProcedureRunner.swift) shape (a first-aid protocol is a Procedure with terminal/branch steps).
+- **Audio** — [TextToSpeechService](../../OpenGlasses/Sources/Services/TextToSpeechService.swift): the metronome reuses the in-memory tone generator (`generateToneData`); coaching uses `SpeechUrgency.high`.
+- **Routing** — [NavigationAssistService](../../OpenGlasses/Sources/Services/Accessibility/NavigationAssistService.swift) + `LocationService` for the walk to the AED.
+- **HUD** — [GlassesDisplayService](../../OpenGlasses/Sources/Services/GlassesDisplayService.swift): step card + AED bearing.
+- **Escalation** — [ExpertBridge](../../OpenGlasses/Sources/Services/FieldAssist/ExpertBridge.swift) / `EscalationCoordinator` for a remote responder.
+- **Trigger** — wake word, or the new `AlternativeTriggerService` (a deliberate shake to start CPR pacing hands-free).
+
+---
+
+## Deterministic core (the testable part)
+
+```swift
+/// Pure CPR pacing model — no audio, no timers. Given an injected clock it answers:
+/// which beat are we on, is it time for a compression tone, and have we hit a 30:2 breath break.
+struct CPRMetronome {
+    var rate: Int = 110                 // bpm, clamped 100...120 (AHA guideline window)
+    var compressionsPerCycle = 30
+    var breathsPerCycle = 2
+    private(set) var compressionCount = 0
+    private(set) var cyclesCompleted = 0
+
+    var beatInterval: TimeInterval { 60.0 / Double(min(max(rate, 100), 120)) }
+    /// Advance to time `now`; returns the events to fire (a compression tone, or a "give 2 breaths" cue).
+    mutating func tick(at now: TimeInterval) -> [Event] { /* … */ [] }
+    enum Event: Equatable { case compression(count: Int), breathBreak(cycle: Int) }
+}
+```
+
+- **`CPRMetronome`** — bpm → beat interval (clamped 100–120); compression counting; the **30:2 cycle**
+  (after 30 compressions, emit a breath-break event); fully unit-testable with a synthetic clock.
+- **`FirstAidProtocol`** — the catalog as structured step sequences; stable step ids; the "called
+  emergency services?" gate is step 0 of every protocol.
+- **`AEDFinder`** — Overpass query-URL construction (`node[emergency=defibrillator](around:R,lat,lon)`),
+  fixture-JSON parse, **nearest by haversine**, empty-result handling — all pure; the live HTTP + on-lens
+  route is device/network-gated.
+
+---
+
+## Tests (headless)
+
+- **CPRMetronome**: 110 bpm → ~0.545 s interval; rate clamped to 100–120; 30 compressions → a `breathBreak`
+  then the count resets and `cyclesCompleted` increments; compression count monotonic.
+- **FirstAidProtocol**: catalog completeness (CPR/choking/bleeding/recovery/MARCH); every protocol's step 0
+  is the call-emergency-services gate; stable step ids.
+- **AEDFinder**: Overpass URL built for a given radius/coord; fixture → `[AED]`; nearest selected by
+  haversine; empty list handled.
+- **Disclaimer gating**: a protocol can't advance past step 0 until the emergency-services prompt is
+  acknowledged.
+
+---
+
+## Deferred / risk
+
+- **Liability is the dominant risk.** Advisory only, not a medical device, not a substitute for
+  professional care. Every entry confirms 911/112 was called; every screen + the spoken intro carry the
+  disclaimer; the assistant never claims it performed a real-world action.
+- **On-device validation:** metronome timing precision (audio scheduling), real Overpass latency, on-lens
+  route legibility — device-gated. The deterministic core (pacing model, protocol catalog, AED query/parse)
+  is the headless gate.
+- **Scope:** ship **CPR/AED + choking + severe bleeding** first (the highest-value bystander scenarios);
+  MARCH/trauma and the remote-responder escalation are staged follow-ups (escalation reuses ExpertBridge).
+- **No autonomy:** this is reactive guidance only — nothing here runs unprompted; not gated behind
+  `agentModeEnabled` because it takes no autonomous action.
+
+---
+
+## Why this matters
+
+It turns the glasses into a hands-free first-aid coach exactly when a bystander's hands are busy and
+panic is high — pacing compressions, talking them through choking or bleeding control, and pointing them
+at the nearest AED. It's a flagship **Accessibility/Medical** capability that reuses the remote-expert,
+navigation, HUD, and TTS machinery already shipped, with a small, well-tested new core (the pacing model
++ protocol catalog + AED finder). High emotional + real-world impact; small new surface.

--- a/docs/plans/health-safety-advisor.md
+++ b/docs/plans/health-safety-advisor.md
@@ -1,0 +1,118 @@
+# Plan — Personal Health-Safety Advisor
+
+**Status: 📋 Planned (not built).** Grounds in our existing **Health Vault** ("can I take ibuprofen?" →
+checks meds + PGx + contraindications). Extends the **Medical Compliance** IAP line.
+
+**Strategic fit:** Turns the **Health Vault** (Plan B) from passive storage into an *active* "is this safe
+for **me**?" advisor: a hands-free, vault-grounded check for **drug interactions, contraindications, and
+dietary conflicts** — "Can I take ibuprofen?", "Can I eat this?" (point at the label). Reuses the Health
+Vault, Medication Identifier (OCR), and `LLMService`; the only genuinely new piece is a **deterministic
+known-interaction rubric** that backstops the model.
+
+**This is advisory, NOT medical advice** — every answer cites the vault entries it used and ends with
+"confirm with your pharmacist or doctor." Gated behind the Medical Compliance entitlement.
+
+**Effort:** ~0.5–1 week (≈80% reuse; the grounding selector + the interaction rubric are the new pieces).
+
+---
+
+## Concept
+
+A `health_check` flow grounds LLM reasoning in the user's Health Vault (current meds, conditions,
+allergies, and an optional pharmacogenomic / PGx profile) to answer two question shapes:
+
+- **"Can I take X?"** — cross-reference the substance against current prescriptions, conditions (e.g.
+  kidney disease, ulcers, anticoagulation), allergies, and PGx → flag interactions / contraindications
+  with a **severity** and the specific reason ("you take warfarin; ibuprofen raises bleeding risk").
+- **"Can I eat this?"** — optionally OCR a food/label (reuse the Medication Identifier capture path),
+  check against conditions (gout/uric acid, diabetes, sodium) and meds (warfarin↔vitamin K,
+  MAOI↔tyramine).
+
+**Two-layer safety** (the architectural point):
+1. **Deterministic rubric first** — a curated table of well-established **high-severity** interactions /
+   contraindications is checked in code. A model hallucination can never downgrade a known-dangerous combo
+   to "safe": if the rubric fires, the warning is authoritative.
+2. **LLM for the long tail** — grounded in the selected vault entries, for everything the rubric doesn't
+   cover, clearly labelled advisory.
+
+---
+
+## Files
+
+```
+Sources/Services/HealthSafety/
+├── HealthSafetyQuery.swift      // the structured query (substance | food + optional captured label)
+├── VaultGrounding.swift         // PURE: select the vault entries relevant to a query (meds/conditions/allergies)
+├── InteractionRubric.swift      // PURE: curated deterministic high-severity interaction/contraindication table
+├── HealthSafetyAdvisor.swift    // @MainActor: rubric check + grounded LLM reason + cite + disclaim
+└── NativeTools/HealthSafetyTool.swift // health_check: can_i_take <substance> | can_i_eat <food|photo>
+```
+
+Reuse (no new infrastructure):
+- **Grounding data** — [HealthVaultTool](../../OpenGlasses/Sources/Services/NativeTools/HealthVaultTool.swift) / the Health Vault (Plan B): meds, conditions, allergies.
+- **Capture/OCR** — [MedicationIdentifierTool](../../OpenGlasses/Sources/Services/NativeTools/MedicationIdentifierTool.swift) + `OCRService` for a pill/label photo.
+- **Reasoning + voice** — [LLMService](../../OpenGlasses/Sources/Services/LLMService.swift) (grounded prompt with the selected vault entries) + `TextToSpeechService`.
+
+---
+
+## Deterministic core (the testable part)
+
+```swift
+/// PURE: pick the vault entries relevant to a query, to ground the prompt + drive the rubric.
+struct VaultGrounding {
+    func relevantEntries(for query: HealthSafetyQuery, in vault: HealthVault) -> GroundingContext
+}
+
+/// PURE: curated, well-established, high-severity interactions/contraindications. Authoritative when it
+/// fires — the model is never allowed to override a hit. Deliberately NOT exhaustive (the LLM covers the
+/// long tail); each rule cites a clinical basis.
+struct InteractionRubric {
+    enum Severity: Int, Comparable { case info, caution, high }
+    struct Hit { let reason: String; let severity: Severity; let basis: String }
+    func check(_ substance: Substance, against context: GroundingContext) -> [Hit]
+    // e.g. warfarin + NSAID → .high (bleeding); MAOI + tyramine-rich food → .high (hypertensive crisis);
+    //      ACE-inhibitor + potassium → .caution; known allergy match → .high.
+}
+```
+
+- **`VaultGrounding`** — pure selection of the meds/conditions/allergies relevant to a query (so the
+  prompt is grounded and small); testable: given a vault + query, returns exactly the right entries.
+- **`InteractionRubric`** — the deterministic high-severity table; testable: known-dangerous combos fire
+  with correct severity; safe combos don't; severity ordering holds.
+- The **LLM reasoning** + the **OCR/camera** are device/LLM-gated; the grounding + the rubric + the
+  disclaimer gating are the headless core.
+
+---
+
+## Tests (headless)
+
+- **VaultGrounding**: "can I take ibuprofen" with a warfarin vault → warfarin selected; unrelated meds
+  excluded; allergy entries always included.
+- **InteractionRubric**: warfarin+NSAID → `.high`; MAOI+tyramine → `.high`; ACE-inhibitor+potassium →
+  `.caution`; allergy match → `.high`; an unrelated pairing → no hit; `Severity` ordering.
+- **Authority**: when the rubric returns a `.high` hit, the advisor surfaces it as a definite warning
+  regardless of any LLM text (the model can't downgrade it).
+- **Disclaimer gating**: every response carries "advisory only — confirm with your pharmacist/doctor" and
+  never asserts a definitive clinical decision.
+
+---
+
+## Deferred / risk
+
+- **Liability / scope.** Advisory only; not medical advice; not a substitute for a pharmacist or doctor.
+  The deterministic rubric is **curated high-severity only** (clearly stated; the LLM long-tail is labelled
+  non-authoritative). Strong, unavoidable disclaimer on every answer.
+- **PGx is optional/advanced** — most users won't have a pharmacogenomic profile; the feature degrades
+  gracefully to meds + conditions + allergies.
+- **Entitlement** — gated behind the Medical Compliance IAP (see [medical pricing]).
+- **Device/LLM-gated:** the OCR-a-label path and the LLM long-tail accuracy are validated on device; the
+  grounding selector + rubric are the headless gate.
+
+---
+
+## Why this matters
+
+It makes the Health Vault *do something* at the moment of decision — a hands-free, personalised "is this
+safe for me?" that backstops the model with a deterministic rule set for the genuinely dangerous combos.
+A natural, sellable extension of the Medical Compliance line that reuses the vault, OCR, and LLM machinery
+already shipped, with a small, well-tested new core and an honest, deterministic safety floor.


### PR DESCRIPTION
Two medical/accessibility plan candidates, scoped to OpenGlasses' shipped engines. **Docs only — no code.** Both are explicitly **advisory, not medical devices.**

## First-Aid / Emergency Assist
A hands-free bystander coach for the seconds that matter:
- **`CPRMetronome`** (pure, clock-injected) — 100–120 bpm pacing, **30:2 cycle** tracking, compression count.
- **`FirstAidProtocol`** catalog — CPR/AED, choking, severe bleeding, recovery position, MARCH — on the `ProcedureRunner` shape; **step 0 of every protocol is "called emergency services?"**.
- **`AEDFinder`** — nearest defibrillator via OSM Overpass (`emergency=defibrillator`) + route hand-off to Navigation Assist.
- Reuses `TextToSpeechService` tone gen (the metronome) + `SpeechUrgency.high`, `NavigationAssistService`, `GlassesDisplayService` HUD, `ExpertBridge` escalation.
- Deterministic core (pacing model + catalog + AED query/parse) is headlessly testable; audio timing / Overpass / on-lens routing are device-gated.

## Personal Health-Safety Advisor
Turns the **Health Vault** active — "Can I take ibuprofen?", "Can I eat this?":
- **Two-layer safety:** a **deterministic curated `InteractionRubric`** (warfarin+NSAID, MAOI+tyramine, ACE-inhibitor+potassium, allergy match, …) that the LLM **can never downgrade**, plus grounded LLM reasoning for the long tail.
- **`VaultGrounding`** (pure) selects the relevant meds/conditions/allergies to ground the prompt.
- Reuses the Health Vault, Medication Identifier OCR, `LLMService`. Gated behind the Medical Compliance IAP.
- Core (grounding + rubric + disclaimer gating) is headlessly testable; OCR + LLM long-tail are device/LLM-gated.

Both carry mandatory "advisory only — confirm with a professional / call emergency services" framing and take no autonomous action. README status rows added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)