### PR TITLE
docs(plans): scrub external-repo references from plan docs

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -14,7 +14,7 @@ All plans A–M are **built and merged to `main`** to the extent verifiable with
 | D Utilities | ✅ Shipped (OneEuroFilter, aircraft_overhead) |
 | E MCP Server | ✅ Shipped (dev-only HTTP server) |
 | F Field Assist | ✅ Phases 1–3 shipped (vault, procedures, domain calc, audit/PDF export, escalation) |
-| [Safety Assessment (HECA)](safety-assessment.md) | 📋 Planned (not built) — camera-assisted High-Energy Control Assessment (EEI/CSRA SIF); a Field Assist vertical reusing `analyzeFrame` + audit/PDF. Plan refined with HECA v2 (structured schema, energy-source catalog, 3-part direct-control test, image-seeded advisor). |
+| [Safety Assessment (HECA)](safety-assessment.md) | 📋 Planned (not built) — camera-assisted High-Energy Control Assessment (EEI/CSRA SIF); a Field Assist vertical reusing `analyzeFrame` + audit/PDF. Plan refined with a structured schema, energy-source catalog, 3-part direct-control test, and image-seeded advisor. |
 | G IT/Network pack | ✅ Shipped (vault, 5 procedures, subnet calc) |
 | H Custom vault import | ✅ Shipped (validator, importer, manager UI) |
 | I Medication Identifier | ✅ Shipped (OCR × Health Vault) |

--- a/docs/plans/additional-capabilities.md
+++ b/docs/plans/additional-capabilities.md
@@ -295,8 +295,7 @@ and gives no emotion / audio-event signal.
 ship** (vendored for Kokoro TTS, #1). The binary's `c-api.h` already exports the full ASR surface
 (`SherpaOnnxCreateOfflineRecognizer`, `SherpaOnnxOfflineSenseVoiceModelConfig`,
 `SherpaOnnxDecodeOfflineStream`, …) — so this is **zero new dependency**, just a model bundle + the
-same engine pattern as Kokoro, an `OfflineRecognizer` instead of an `OfflineTts`. (Idea sourced from
-[VisionClaw #61](https://github.com/Intent-Lab/VisionClaw/issues/61).)
+same engine pattern as Kokoro, an `OfflineRecognizer` instead of an `OfflineTts`.
 
 **Why it fits us specifically:**
 - **Zero marginal binary cost.** sherpa-onnx + onnxruntime are already vendored ([Vendor/SherpaOnnx](../../Vendor/SherpaOnnx)); ASR reuses the exact wrapper, bridging, and `KOKORO_ENABLED`-style gating.
@@ -350,9 +349,7 @@ step, checks the camera frame against the step's expected objects / postconditio
 **auto-advances** when a **confidence threshold** is met **and sustained over a stability/evidence
 window** (N stable observations across an active-duration), with **critical-step gating** (critical
 steps never auto-advance — they surface an explicit confirm). Turns Field Assist procedures genuinely
-hands-free. (Pattern sourced from the `GeminiLiveSpotter` in
-[a VisionClaw fork](https://github.com/Intent-Lab/VisionClaw/compare/main...Lcunha25:VisionClaw:main) —
-adapted to run **native-first** through our own `analyzeFrame`, not their Cloud-Run relay.)
+hands-free, run **native-first** through our own `analyzeFrame` (no external relay).
 
 **Why it fits us specifically:**
 - Reuses [LLMService.analyzeFrame](../../OpenGlasses/Sources/Services/LLMService.swift) (vision),
@@ -389,8 +386,8 @@ adapted to run **native-first** through our own `analyzeFrame`, not their Cloud-
   only run mid-procedure.
 - **Safety:** a false auto-advance on a critical step is dangerous → critical steps **never** auto-advance
   (hard gate). Evidence-required steps must capture the frame as proof before advancing.
-- **No new backend:** unlike the source fork (Gemini spotter via a Cloud-Run `WorkerAdminAPI`), this runs
-  through native `analyzeFrame` — native-first, no relay (see [project_brain_store]).
+- **No new backend:** the spotter runs through native `analyzeFrame` — native-first, no external relay
+  or hosted service (see [project_brain_store]).
 
 **Scope the deterministic core (the PR after #8):** the `Procedure.Step` schema extension + the
 `SpotterPolicy` pure state machine + the `ProcedureSpotter` loop wiring (gated, throttled, with a fake

--- a/docs/plans/safety-assessment.md
+++ b/docs/plans/safety-assessment.md
@@ -1,6 +1,6 @@
 # Plan — Safety Assessment (High-Energy Control Assessment)
 
-**Status: 📋 Planned (not built).** Plan refined with HECA v2 refinements (2026-06-18); no code yet —
+**Status: 📋 Planned (not built).** Plan refined 2026-06-18 (structured-output + catalog); no code yet —
 none of the named files exist. Sequenced as a Field Assist vertical after the in-flight #8 (ASR) / #9
 (SOP spotter) cores.
 
@@ -66,7 +66,7 @@ enum ControlStatus: String, Codable { case direct, indirect, none }
 
 /// The 13 categorical high-energy hazards (EEI Appendix 3). **Snake_case raw ids** (LLM-friendly —
 /// they are the exact category ids in the prompt + response schema), each mapped to its energy-wheel
-/// source and an SF Symbol for the overlay/HUD. Catalog reconciled with HECA v2.
+/// source and an SF Symbol for the overlay/HUD.
 enum HighEnergyHazard: String, Codable, CaseIterable, Identifiable {
     case suspendedLoad = "suspended_load"
     case fallFromElevation = "fall_from_elevation"
@@ -128,7 +128,7 @@ struct SafetyReport: Codable, Identifiable {
 
 The 13-hazard catalog and the direct-vs-indirect rubric are injected into the system prompt so the model returns all 13 with the exact category ids; parsing validates completeness.
 
-**Structured output (adopted from HECA v2).** Rather than free-form JSON, drive the assessment with a
+**Structured output.** Rather than free-form JSON, drive the assessment with a
 **provider structured-output schema**: an object `{ summary, assessments: [...] }` where each assessment
 is `{ category (enum, the 13 ids), is_present (bool), has_direct_control (bool), direct_control (str),
 has_indirect_control (bool), indirect_control (str), comments (str), evidence: [{ note, box_2d:[ymin,
@@ -201,10 +201,10 @@ optional: PDF export (SessionExporter) · spoken advisor follow-up
 
 ---
 
-## Adopted from HECA v2 (VisionClaw fork)
+## Refinements (structured output + catalog)
 
-This plan predates VisionClaw's HECA **v2**; the concrete refinements folded in (the concept is ours,
-native-first on `analyzeFrame` — no Gemini-REST/backend coupling):
+Concrete refinements in this revision of the plan — native-first on `analyzeFrame`, no external REST /
+backend coupling:
 
 1. **Structured-output response schema** (enum-constrained `category`, explicit `is_present` /
    `has_direct_control` / `has_indirect_control` booleans, evidence `box_2d`, all `required`) instead of
@@ -221,9 +221,8 @@ native-first on `analyzeFrame` — no Gemini-REST/backend coupling):
 6. *(optional)* a few **bundled sample job-site frames** (scaffold, hot work, confined space/manhole,
    man-lift, formwork, shotcrete) for a demo/try-it path and as parser test fixtures.
 
-Not adopted: their Gemini-REST `generateContent` transport, the `WorkerAdminAPI`/backend, and the UIKit
-result view — we run through `analyzeFrame` (multi-provider, offline-degrading) and our own SwiftUI +
-audit/PDF stack.
+Transport stays native: the assessment runs through `analyzeFrame` (multi-provider, offline-degrading)
+with our own SwiftUI + audit/PDF stack — no external REST endpoint or backend service.
 
 ## Dependencies / prereqs
 


### PR DESCRIPTION
Removes competitor-repo attributions from the plan docs, keeping the substantive design content and the public EEI/CSRA methodology grounding.

Touches the Safety Assessment plan, the Additional Capabilities ASR + SOP-spotter sections, and the related README rows.