### PR TITLE
Structured Vision Assessment — schema-validated vision + vision_assess + read-the-instrument

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -888,6 +888,10 @@ class AppState: ObservableObject, AppStateProtocol {
         // First-Aid / Emergency Assist (Additional Capabilities) — spoken protocol coach + CPR metronome.
         FirstAidAssistService.shared.configure(tts: speechService, glassesDisplay: glassesDisplay, location: locationService)
 
+        // Configure Structured Vision (vision_assess / read-the-instrument) similarly.
+        StructuredVisionService.shared.configure(camera: cameraService, llm: llmService, tts: speechService)
+        StructuredVisionService.shared.glassesDisplay = glassesDisplay
+
         // Field Assist Phase 5 (Plan K2): expert stream bridge for escalations. Transport
         // (MJPEG / WebRTC) is selected in Settings; MJPEG is the working default.
         EscalationCoordinator.shared.bridge = ExpertStreamBridge(

--- a/OpenGlasses/Sources/App/RootView.swift
+++ b/OpenGlasses/Sources/App/RootView.swift
@@ -8,6 +8,10 @@ struct RootView: View {
         ZStack {
             MainView()
 
+            // Structured-vision result card (vision_assess), presented over the main UI.
+            AssessmentCardOverlay()
+                .zIndex(0.5)
+
             if showLaunchScreen {
                 LaunchScreen()
                     .transition(.opacity)

--- a/OpenGlasses/Sources/App/Views/AssessmentCardView.swift
+++ b/OpenGlasses/Sources/App/Views/AssessmentCardView.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+/// Renders any `AssessmentCard` (structured-vision plan, Phase 3) — tier chip, summary, instrument
+/// readings, findings, recommended action, and "still needed". Generic over the schema: it knows
+/// nothing about any vertical. AI attribution uses the coral accent.
+struct AssessmentCardView: View {
+    let card: AssessmentCard
+    var onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+
+            if !card.summary.isEmpty {
+                Text(card.summary).font(.subheadline).foregroundStyle(.primary)
+            }
+
+            if !card.readings.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(card.readings) { reading in readingRow(reading) }
+                }
+            }
+
+            if !card.findings.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(card.findings) { finding in findingRow(finding) }
+                }
+            }
+
+            if let action = card.recommendedAction, !action.isEmpty {
+                Label(action, systemImage: "arrow.right.circle.fill")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(tierColor)
+            }
+
+            if !card.stillNeeded.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(card.stillNeeded, id: \.self) { need in
+                        Label(need, systemImage: "circle.dashed")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            footer
+        }
+        .padding(16)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(tierColor.opacity(0.35), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.18), radius: 14, y: 6)
+    }
+
+    // MARK: - Pieces
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: card.tier.systemImage).foregroundStyle(tierColor)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(card.title).font(.headline)
+                Text("AI vision · \(card.tier.displayLabel)")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(AppAccent.aiCoral)
+            }
+            Spacer()
+            Button(action: onDismiss) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title3).foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss")
+        }
+    }
+
+    private func readingRow(_ reading: InstrumentReading) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(reading.quantity.capitalized).font(.subheadline)
+            Spacer()
+            VStack(alignment: .trailing, spacing: 0) {
+                Text("\(Self.fmt(reading.value)) \(reading.unit)")
+                    .font(.subheadline.weight(.semibold)).monospacedDigit()
+                if let c = reading.canonical, let cu = reading.canonicalUnit, cu != reading.unit {
+                    Text("\(Self.fmt(c)) \(cu)")
+                        .font(.caption2).foregroundStyle(.secondary).monospacedDigit()
+                }
+            }
+        }
+    }
+
+    private func findingRow(_ finding: AssessmentFinding) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Circle().fill(color(for: finding.severity)).frame(width: 7, height: 7).padding(.top, 5)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(finding.label).font(.subheadline)
+                if let detail = finding.detail, !detail.isEmpty {
+                    Text(detail).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Text("Confidence \(Int((card.confidence * 100).rounded()))%")
+                .font(.caption2).foregroundStyle(.secondary)
+            Spacer()
+            if let disclaimer = card.disclaimer, !disclaimer.isEmpty {
+                Text(disclaimer).font(.caption2).foregroundStyle(.secondary)
+                    .multilineTextAlignment(.trailing)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var tierColor: Color { color(for: card.tier) }
+
+    private func color(for tier: AssessmentTier) -> Color {
+        switch tier {
+        case .ok: return .green
+        case .caution: return .orange
+        case .critical: return .red
+        }
+    }
+
+    private static func fmt(_ value: Double) -> String { String(format: "%g", value) }
+}
+
+/// Overlay that presents the latest `AssessmentCard` over the main UI. Hosted by `RootView`.
+struct AssessmentCardOverlay: View {
+    @ObservedObject private var vision = StructuredVisionService.shared
+
+    var body: some View {
+        if let card = vision.latest {
+            VStack {
+                Spacer()
+                AssessmentCardView(card: card) { vision.dismiss() }
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 24)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+            .animation(.spring(response: 0.4, dampingFraction: 0.85), value: vision.latest)
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift
+++ b/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift
@@ -502,6 +502,7 @@ class GeminiLiveSessionManager: ObservableObject {
             - first_aid: Hands-free first-aid coaching — speaks steps and paces CPR. Actions: start (cpr/choking/bleeding/recovery/march), next, back, aed (nearest defibrillator), stop. Advisory only; always reminds to call emergency services.
             - identify_color: Name the dominant color of what the user sees (on-device). Use for "what color is this?".
             - identify_money: Identify a banknote's currency and denomination from the camera, for low-vision support. Use for "how much is this note?".
+            - vision_assess: Structured visual assessment with a typed result card (kind selects the type). Use kind 'instrument_reading' to read a number off a gauge, thermometer, refractometer, scale, or meter. Optional note adds context.
             - photo_log: Capture a glasses-camera photo, attach it to the session audit log with a caption, and return it for analysis. Use to document gauge readings and evidence.
             - escalate_to_expert: Escalate the active session to a human expert when you can't safely resolve it or the technician asks for a person. Actions: request (reason), status, resolve, cancel. Live video is Phase 5 — for now it's logged and the expert pool is notified.
             """

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -280,6 +280,7 @@ class LLMService: ObservableObject {
             - medical_export: Export clinical transcripts to medical platforms or share manually. Actions: export_fhir (upload to FHIR server), export_file (create file), share (open share sheet), status (check config). Params: format (text/pdf/fhir_json/hl7), transcript (optional, uses latest recording). Use when the user says 'export the transcript', 'send to the EMR', 'share the notes', or 'upload to the health record'.
             - qr_context: Scan a QR code and load its content as context (museum exhibits, venue info, procedures). Use at museums, venues, or workplaces. Can also load context from a URL directly.
             - smart_capture: Capture a business card, receipt, or event flyer and extract structured details (mode: contact/receipt/event). Then chain to contacts/calendar/notes_vault to act. Use for "save this card", "log this receipt", "add this event from the flyer".
+            - vision_assess: Run a structured visual assessment of what the glasses camera sees and show a typed result card (kind selects the assessment). Use kind 'instrument_reading' to read a number off a gauge, thermometer, refractometer, scale, or meter ("what does this gauge read?", "read the thermometer"). Optional note adds context.
             - golf_mode: Golf caddy assistant — track shots with GPS, get club recommendations, log scores, view round summary, and get course strategy. Actions: start_round, track_shot, club_recommendation, log_score, round_summary, strategy.
             - live_translate: Start/stop continuous live translation. Listens to spoken foreign language and translates in real-time. Actions: start, stop, status, set_language.
             - field_session: Start, pause, resume, end, or query a Field Assist session for grounded, domain-specific technical support (refrigeration, IT, electrical, automotive). Sessions load a domain knowledge vault and emit an audit log. Use 'start' when the technician begins work, 'end' when they finish, 'export' to generate a work-order PDF + audit JSON. Actions: start, pause, resume, end, status, list, escalate, export. Params: vault (e.g. 'refrigeration'), asset_id, mode ('ai_only' default), outcome, reason, format ('pdf'/'json'/'both').
@@ -936,6 +937,108 @@ class LLMService: ObservableObject {
             }
         } catch {
             NSLog("[LLM] analyzeFrame request failed: %@", error.localizedDescription)
+            return nil
+        }
+    }
+
+    /// Stateless one-shot STRUCTURED vision analysis (structured-vision plan, Phase 2): like
+    /// `analyzeFrame`, but forces the active provider to return a JSON object matching `jsonSchema` —
+    /// Anthropic forced `tool_choice`, OpenAI-compatible forced function, Gemini JSON response. The
+    /// pure `StructuredVisionParser` extracts the object and also falls back to tolerant parsing of any
+    /// returned text, so a model that answers with prose JSON still yields a result. Does NOT mutate
+    /// conversation history. Returns the JSON object, or nil on failure / unsupported provider
+    /// (local, appleOnDevice). The caller decodes/validates against its schema.
+    func analyzeFrameStructured(systemPrompt: String, userText: String, imageData: Data,
+                                jsonSchema: [String: Any], toolName: String = "assessment",
+                                maxTokens: Int = 1024) async -> [String: Any]? {
+        guard let modelConfig = Config.activeModel else { return nil }
+        let base64 = imageData.base64EncodedString()
+        let provider = modelConfig.llmProvider
+        let toolDescription = "Return the structured assessment for the image."
+
+        do {
+            switch provider {
+            case .anthropic:
+                var request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
+                request.httpMethod = "POST"
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.setValue(modelConfig.apiKey, forHTTPHeaderField: "x-api-key")
+                request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+                request.timeoutInterval = 30
+                let body: [String: Any] = [
+                    "model": modelConfig.model,
+                    "max_tokens": maxTokens,
+                    "system": systemPrompt,
+                    "tools": [["name": toolName, "description": toolDescription, "input_schema": jsonSchema]],
+                    "tool_choice": ["type": "tool", "name": toolName],
+                    "messages": [["role": "user", "content": [
+                        ["type": "image", "source": ["type": "base64", "media_type": "image/jpeg", "data": base64]],
+                        ["type": "text", "text": userText]
+                    ]]]
+                ]
+                request.httpBody = try JSONSerialization.data(withJSONObject: body)
+                let (data, response) = try await URLSession.shared.data(for: request)
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+                return StructuredVisionParser.anthropic(data, toolName: toolName)
+
+            case .openai, .groq, .zai, .qwen, .minimax, .openrouter, .custom:
+                var baseURL = modelConfig.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !baseURL.hasSuffix("/chat/completions") {
+                    baseURL += baseURL.hasSuffix("/") ? "chat/completions" : "/chat/completions"
+                }
+                guard let url = URL(string: baseURL) else { return nil }
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.setValue("Bearer \(modelConfig.apiKey)", forHTTPHeaderField: "Authorization")
+                request.timeoutInterval = 30
+                let body: [String: Any] = [
+                    "model": modelConfig.model,
+                    "max_tokens": maxTokens,
+                    "messages": [
+                        ["role": "system", "content": systemPrompt],
+                        ["role": "user", "content": [
+                            ["type": "text", "text": userText],
+                            ["type": "image_url", "image_url": ["url": "data:image/jpeg;base64,\(base64)"]]
+                        ]]
+                    ],
+                    "tools": [["type": "function", "function": [
+                        "name": toolName, "description": toolDescription, "parameters": jsonSchema]]],
+                    "tool_choice": ["type": "function", "function": ["name": toolName]]
+                ]
+                request.httpBody = try JSONSerialization.data(withJSONObject: body)
+                let (data, response) = try await URLSession.shared.data(for: request)
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+                return StructuredVisionParser.openAI(data)
+
+            case .gemini:
+                guard let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/models/\(modelConfig.model):generateContent?key=\(modelConfig.apiKey)") else { return nil }
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.timeoutInterval = 30
+                // `responseMimeType` enforces a JSON object; the exact shape is conveyed by the schema's
+                // system prompt. (Translating a generic JSON Schema to Gemini `responseSchema` is a
+                // future refinement — the parser already handles a `functionCall` channel if added.)
+                let body: [String: Any] = [
+                    "system_instruction": ["parts": [["text": systemPrompt]]],
+                    "contents": [["role": "user", "parts": [
+                        ["text": userText],
+                        ["inlineData": ["mimeType": "image/jpeg", "data": base64]]
+                    ]]],
+                    "generationConfig": ["maxOutputTokens": maxTokens, "responseMimeType": "application/json"]
+                ]
+                request.httpBody = try JSONSerialization.data(withJSONObject: body)
+                let (data, response) = try await URLSession.shared.data(for: request)
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+                return StructuredVisionParser.gemini(data)
+
+            case .local, .appleOnDevice:
+                // On-device structured vision isn't supported here; the caller may fall back.
+                return nil
+            }
+        } catch {
+            NSLog("[LLM] analyzeFrameStructured request failed: %@", error.localizedDescription)
             return nil
         }
     }

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
@@ -101,6 +101,7 @@ final class NativeToolRegistry {
             register(CapturePhotoTool(cameraService: camera))
             register(QRContextTool(cameraService: camera))
             register(SmartCaptureTool(cameraService: camera))
+            register(VisionAssessTool())   // structured vision (read the instrument, etc.) via StructuredVisionService.shared
             if let recorder = videoRecorder {
                 register(VideoRecordingTool(cameraService: camera, videoRecorder: recorder,
                                             medicalExportService: medicalExportService))

--- a/OpenGlasses/Sources/Services/NativeTools/VisionAssessTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/VisionAssessTool.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// `vision_assess` — run a structured visual assessment of what the glasses camera sees and surface a
+/// typed result card (structured-vision plan, Phase 3). Schema-parameterized via `kind`; the built-in
+/// `instrument_reading` reads numbers off gauges/thermometers/scales/meters. Delegates to
+/// `StructuredVisionService.shared`, which publishes the card and mirrors a summary to the HUD; this
+/// tool returns a concise text summary for the LLM to speak.
+@MainActor
+final class VisionAssessTool: NativeTool {
+    let name = "vision_assess"
+
+    var description: String {
+        let available = AssessmentSchemaRegistry.shared.kinds
+        let list = available.isEmpty ? "instrument_reading" : available.joined(separator: ", ")
+        return """
+        Run a structured visual assessment of what the glasses camera sees and show a result card. \
+        `kind` selects the assessment type (available: \(list)). Use 'instrument_reading' to read a \
+        number off a gauge, thermometer, refractometer, scale, or meter. Optional `note` adds context.
+        """
+    }
+
+    let parametersSchema: [String: Any] = [
+        "type": "object",
+        "properties": [
+            "kind": ["type": "string", "description": "Assessment type, e.g. instrument_reading"],
+            "note": ["type": "string", "description": "Optional extra context for the assessment"]
+        ],
+        "required": ["kind"]
+    ]
+
+    func execute(args: [String: Any]) async throws -> String {
+        let kind = (args["kind"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let available = AssessmentSchemaRegistry.shared.kinds
+        let availableList = available.isEmpty ? "instrument_reading" : available.joined(separator: ", ")
+
+        guard !kind.isEmpty else {
+            return "Specify what to assess via `kind`. Available: \(availableList)."
+        }
+        guard AssessmentSchemaRegistry.shared.contains(kind) else {
+            return "Unknown assessment kind '\(kind)'. Available: \(availableList)."
+        }
+
+        let rawNote = (args["note"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let note = (rawNote?.isEmpty == false) ? rawNote : nil
+
+        do {
+            let card = try await StructuredVisionService.shared.assessCurrentFrame(kind: kind, note: note)
+            return Self.summarize(card)
+        } catch StructuredVisionError.noFrame {
+            return "I couldn't get a camera frame. Make sure the glasses camera is streaming and the subject is in view."
+        } catch StructuredVisionError.analysisFailed {
+            return "The visual assessment didn't return a usable result. Try again with a clearer, steadier view."
+        } catch {
+            return "Vision assessment failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// A concise, speakable summary of the card for the LLM to relay.
+    static func summarize(_ card: AssessmentCard) -> String {
+        var lines: [String] = [card.summary]
+        for r in card.readings {
+            var line = "\(r.quantity): \(fmt(r.value)) \(r.unit)"
+            if let c = r.canonical, let cu = r.canonicalUnit, cu != r.unit {
+                line += " (\(fmt(c)) \(cu))"
+            }
+            lines.append(line)
+        }
+        for f in card.findings {
+            lines.append("\(f.severity.displayLabel): \(f.label)")
+        }
+        if let action = card.recommendedAction, !action.isEmpty {
+            lines.append("Recommended: \(action)")
+        }
+        if !card.stillNeeded.isEmpty {
+            lines.append("Still needed: " + card.stillNeeded.joined(separator: "; "))
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func fmt(_ value: Double) -> String {
+        String(format: "%g", value)
+    }
+}

--- a/OpenGlasses/Sources/Services/StructuredVision/AssessmentCard.swift
+++ b/OpenGlasses/Sources/Services/StructuredVision/AssessmentCard.swift
@@ -1,0 +1,209 @@
+import Foundation
+
+// Structured Vision Assessment — normalized result model (see docs/plans/structured-vision-assessment.md).
+//
+// A *schema* (one per vertical) maps its own private payload onto this normalized `AssessmentCard`.
+// Everything downstream — the card view, the HUD, the audit log — consumes `AssessmentCard` and knows
+// nothing about any vertical's payload type. These types are PURE and headless (no UIKit, no network,
+// no MainActor) so the whole core is unit-testable without a device.
+
+/// A normalized 3-level status every vertical maps onto. Semantic status colours (green/amber/red)
+/// are applied by the view layer — distinct from the coral AI-attribution accent used on the chrome.
+enum AssessmentTier: String, Codable, CaseIterable, Comparable {
+    case ok
+    case caution
+    case critical
+
+    /// Escalation order — `backstop` may only raise a tier, never lower it.
+    var rank: Int {
+        switch self {
+        case .ok: return 0
+        case .caution: return 1
+        case .critical: return 2
+        }
+    }
+
+    static func < (lhs: AssessmentTier, rhs: AssessmentTier) -> Bool { lhs.rank < rhs.rank }
+
+    /// The higher (more severe) of two tiers.
+    static func escalated(_ a: AssessmentTier, _ b: AssessmentTier) -> AssessmentTier { a.rank >= b.rank ? a : b }
+
+    var displayLabel: String {
+        switch self {
+        case .ok: return "OK"
+        case .caution: return "Caution"
+        case .critical: return "Critical"
+        }
+    }
+
+    /// SF Symbol hint for the view layer (kept here as pure presentation metadata, like `HUDIcon`).
+    var systemImage: String {
+        switch self {
+        case .ok: return "checkmark.circle.fill"
+        case .caution: return "exclamationmark.triangle.fill"
+        case .critical: return "exclamationmark.octagon.fill"
+        }
+    }
+}
+
+/// One observed issue in the scene.
+struct AssessmentFinding: Codable, Identifiable, Equatable {
+    let id: UUID
+    let label: String          // "Suspected arterial bleeding"
+    let detail: String?        // short note
+    let severity: AssessmentTier
+    let confidence: Double      // 0.0–1.0
+    let region: [Double]?       // optional normalized [x, y, w, h] for an overlay
+
+    init(id: UUID = UUID(), label: String, detail: String? = nil,
+         severity: AssessmentTier = .caution, confidence: Double = 1.0, region: [Double]? = nil) {
+        self.id = id
+        self.label = label
+        self.detail = detail
+        self.severity = severity
+        self.confidence = confidence
+        self.region = region
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, label, detail, severity, confidence, region
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        label = try c.decode(String.self, forKey: .label)
+        detail = try c.decodeIfPresent(String.self, forKey: .detail)
+        severity = try c.decodeIfPresent(AssessmentTier.self, forKey: .severity) ?? .caution
+        confidence = try c.decodeIfPresent(Double.self, forKey: .confidence) ?? 1.0
+        region = try c.decodeIfPresent([Double].self, forKey: .region)
+    }
+}
+
+/// A numeric value read off a physical instrument in-frame — the "read the instrument" capability.
+/// `unit` is the unit *as displayed on the device*; `canonical`/`canonicalUnit` are filled
+/// deterministically by `UnitNormalizer` so range checks, HUD, and audit records are unit-stable.
+struct InstrumentReading: Codable, Identifiable, Equatable {
+    let id: UUID
+    let quantity: String        // "temperature", "pressure", "brix", "weight", "voltage", "flow", "spo2"…
+    let instrument: String?     // "probe thermometer", "manifold gauge", "refractometer", "scale", "multimeter"
+    let value: Double
+    let unit: String            // AS DISPLAYED: "°F", "psig", "°Bx", "lb", "V"
+    let canonical: Double?
+    let canonicalUnit: String?
+    let confidence: Double       // 0.0–1.0 — low confidence drives a re-capture, never a silent guess
+    let region: [Double]?        // normalized [x, y, w, h] of the display, for an overlay highlight
+
+    init(id: UUID = UUID(), quantity: String, instrument: String? = nil,
+         value: Double, unit: String, canonical: Double? = nil, canonicalUnit: String? = nil,
+         confidence: Double = 1.0, region: [Double]? = nil) {
+        self.id = id
+        self.quantity = quantity
+        self.instrument = instrument
+        self.value = value
+        self.unit = unit
+        self.canonical = canonical
+        self.canonicalUnit = canonicalUnit
+        self.confidence = confidence
+        self.region = region
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, quantity, instrument, value, unit, canonical
+        case canonicalUnit = "canonical_unit"
+        case confidence, region
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        quantity = try c.decode(String.self, forKey: .quantity)
+        instrument = try c.decodeIfPresent(String.self, forKey: .instrument)
+        value = try c.decode(Double.self, forKey: .value)
+        unit = try c.decode(String.self, forKey: .unit)
+        canonical = try c.decodeIfPresent(Double.self, forKey: .canonical)
+        canonicalUnit = try c.decodeIfPresent(String.self, forKey: .canonicalUnit)
+        confidence = try c.decodeIfPresent(Double.self, forKey: .confidence) ?? 1.0
+        region = try c.decodeIfPresent([Double].self, forKey: .region)
+    }
+
+    /// Returns a copy with `canonical`/`canonicalUnit` filled from `UnitNormalizer`. If the unit is
+    /// unrecognised the reading is returned unchanged (the displayed value is still preserved).
+    func normalized() -> InstrumentReading {
+        guard let c = UnitNormalizer.canonical(value: value, unit: unit) else { return self }
+        return InstrumentReading(id: id, quantity: quantity, instrument: instrument, value: value, unit: unit,
+                                 canonical: c.value, canonicalUnit: c.unit, confidence: confidence, region: region)
+    }
+}
+
+/// What the generic renderer, HUD, and audit log consume. Schemas produce this.
+struct AssessmentCard: Codable, Equatable {
+    let kind: String                    // schema id, e.g. "instrument_reading"
+    let title: String
+    let subtitle: String?
+    let tier: AssessmentTier
+    let summary: String                 // 1–2 sentence plain-English
+    let findings: [AssessmentFinding]
+    let recommendedAction: String?
+    let stillNeeded: [String]           // "what to check / capture next"
+    let readings: [InstrumentReading]   // "read the instrument" — first-class
+    let confidence: Double
+    let disclaimer: String?             // e.g. advisory / not a medical device
+
+    init(kind: String, title: String, subtitle: String? = nil, tier: AssessmentTier,
+         summary: String, findings: [AssessmentFinding] = [], recommendedAction: String? = nil,
+         stillNeeded: [String] = [], readings: [InstrumentReading] = [],
+         confidence: Double = 1.0, disclaimer: String? = nil) {
+        self.kind = kind
+        self.title = title
+        self.subtitle = subtitle
+        self.tier = tier
+        self.summary = summary
+        self.findings = findings
+        self.recommendedAction = recommendedAction
+        self.stillNeeded = stillNeeded
+        self.readings = readings
+        self.confidence = confidence
+        self.disclaimer = disclaimer
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case kind, title, subtitle, tier, summary, findings
+        case recommendedAction = "recommended_action"
+        case stillNeeded = "still_needed"
+        case readings, confidence, disclaimer
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        kind = try c.decode(String.self, forKey: .kind)
+        title = try c.decode(String.self, forKey: .title)
+        subtitle = try c.decodeIfPresent(String.self, forKey: .subtitle)
+        tier = try c.decodeIfPresent(AssessmentTier.self, forKey: .tier) ?? .caution
+        summary = try c.decodeIfPresent(String.self, forKey: .summary) ?? ""
+        findings = try c.decodeIfPresent([AssessmentFinding].self, forKey: .findings) ?? []
+        recommendedAction = try c.decodeIfPresent(String.self, forKey: .recommendedAction)
+        stillNeeded = try c.decodeIfPresent([String].self, forKey: .stillNeeded) ?? []
+        readings = try c.decodeIfPresent([InstrumentReading].self, forKey: .readings) ?? []
+        confidence = try c.decodeIfPresent(Double.self, forKey: .confidence) ?? 1.0
+        disclaimer = try c.decodeIfPresent(String.self, forKey: .disclaimer)
+    }
+
+    /// Returns a copy with every reading run through `UnitNormalizer`.
+    func normalizingReadings() -> AssessmentCard {
+        AssessmentCard(kind: kind, title: title, subtitle: subtitle, tier: tier, summary: summary,
+                       findings: findings, recommendedAction: recommendedAction, stillNeeded: stillNeeded,
+                       readings: readings.map { $0.normalized() }, confidence: confidence, disclaimer: disclaimer)
+    }
+
+    /// Returns a copy with the tier escalated to at least `tier` and, optionally, an overriding action.
+    /// Used by `AssessmentSchema.backstop` — it may only raise severity, never lower it.
+    func escalating(to floor: AssessmentTier, action: String? = nil,
+                    appending need: String? = nil) -> AssessmentCard {
+        AssessmentCard(kind: kind, title: title, subtitle: subtitle,
+                       tier: AssessmentTier.escalated(tier, floor), summary: summary, findings: findings,
+                       recommendedAction: action ?? recommendedAction,
+                       stillNeeded: need.map { stillNeeded + [$0] } ?? stillNeeded,
+                       readings: readings, confidence: confidence, disclaimer: disclaimer)
+    }
+}

--- a/OpenGlasses/Sources/Services/StructuredVision/AssessmentJSON.swift
+++ b/OpenGlasses/Sources/Services/StructuredVision/AssessmentJSON.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Tolerant JSON helpers for structured vision (see docs/plans/structured-vision-assessment.md).
+///
+/// The forced tool-use / responseSchema paths (Phase 2) return a clean JSON object, but the
+/// local / on-device fallback only gets free text. `object(fromText:)` recovers a JSON object from
+/// a bare object, a ```json fenced block, a ``` fenced block, or a first-`{`…last-`}` slice.
+/// Pure and headless.
+enum AssessmentJSON {
+
+    /// Best-effort extraction of a JSON object from arbitrary model text. Returns `nil` if no
+    /// candidate parses to a dictionary.
+    static func object(fromText text: String) -> [String: Any]? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        for candidate in candidates(in: trimmed) {
+            if let dict = parse(candidate) { return dict }
+        }
+        return nil
+    }
+
+    /// Decode a `Decodable` from a `[String: Any]` JSON object (the shape schemas receive in
+    /// `makeCard`). Round-trips through `JSONSerialization` so snake_case `CodingKeys` apply.
+    static func decode<T: Decodable>(_ type: T.Type, from json: [String: Any]) throws -> T {
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    // MARK: - Internals
+
+    private static func candidates(in trimmed: String) -> [String] {
+        var out: [String] = []
+        if trimmed.hasPrefix("{") { out.append(trimmed) }
+        if let fenced = slice(in: trimmed, after: "```json") { out.append(fenced) }
+        if let fenced = slice(in: trimmed, after: "```") { out.append(fenced) }
+        if let first = trimmed.firstIndex(of: "{"), let last = trimmed.lastIndex(of: "}"), first < last {
+            out.append(String(trimmed[first...last]))
+        }
+        return out
+    }
+
+    /// The text between the first occurrence of `marker` and the next ``` fence after it.
+    private static func slice(in text: String, after marker: String) -> String? {
+        guard let start = text.range(of: marker) else { return nil }
+        guard let end = text.range(of: "```", range: start.upperBound..<text.endIndex) else { return nil }
+        return String(text[start.upperBound..<end.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func parse(_ s: String) -> [String: Any]? {
+        guard let data = s.data(using: .utf8),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        return obj
+    }
+}

--- a/OpenGlasses/Sources/Services/StructuredVision/AssessmentSchema.swift
+++ b/OpenGlasses/Sources/Services/StructuredVision/AssessmentSchema.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// The full contract for one structured-vision vertical (see docs/plans/structured-vision-assessment.md):
+/// a JSON Schema (the forced tool `input_schema` / Gemini `responseSchema`), a system prompt, and an
+/// adapter that maps the decoded payload onto a normalized `AssessmentCard`. Adding a vertical never
+/// touches the renderer, the networking, or the tool — only a schema is registered.
+///
+/// Schemas are PURE (no MainActor, no network): `makeCard` is given an already-decoded JSON object.
+protocol AssessmentSchema {
+    /// Stable id used by the `vision_assess` tool's `kind` parameter.
+    var kind: String { get }
+    /// Human title for the card header.
+    var title: String { get }
+    /// The JSON Schema handed to the provider as a forced tool `input_schema` / `responseSchema`.
+    var jsonSchema: [String: Any] { get }
+    /// The system prompt for the assessment call. Implementations should include
+    /// `AssessmentPrompt.instrumentFragment` so every vertical reads instruments for free.
+    var systemPrompt: String { get }
+    /// Findings/readings below this confidence are surfaced as a re-capture, not landed silently.
+    var confidenceFloor: Double { get }
+
+    /// Map the decoded model JSON onto a normalized card.
+    func makeCard(from json: [String: Any], context: String?) throws -> AssessmentCard
+
+    /// Deterministic guardrail run AFTER the model. May only ESCALATE tier / force an action —
+    /// never downgrade. Default is identity.
+    func backstop(_ card: AssessmentCard) -> AssessmentCard
+}
+
+extension AssessmentSchema {
+    var confidenceFloor: Double { 0.4 }
+    func backstop(_ card: AssessmentCard) -> AssessmentCard { card }
+
+    /// Convenience: normalize readings, then push any reading below `confidenceFloor` into
+    /// `stillNeeded` as a re-capture prompt. Schemas call this from `makeCard` before returning.
+    func applyingReadingPolicy(to card: AssessmentCard) -> AssessmentCard {
+        let normalized = card.normalizingReadings()
+        let lowConfidence = normalized.readings.filter { $0.confidence < confidenceFloor }
+        guard !lowConfidence.isEmpty else { return normalized }
+        let recaptures = lowConfidence.map { "Re-capture the \($0.quantity) display (low confidence)." }
+        return AssessmentCard(
+            kind: normalized.kind, title: normalized.title, subtitle: normalized.subtitle,
+            tier: normalized.tier, summary: normalized.summary, findings: normalized.findings,
+            recommendedAction: normalized.recommendedAction,
+            stillNeeded: normalized.stillNeeded + recaptures, readings: normalized.readings,
+            confidence: normalized.confidence, disclaimer: normalized.disclaimer)
+    }
+}
+
+/// Reusable system-prompt fragments shared across schemas.
+enum AssessmentPrompt {
+    /// The standing "read the instrument" instruction every schema should include, so instrument
+    /// reading is picked up for free even by verticals not primarily about measurement.
+    static let instrumentFragment = """
+    Read any visible instrument, gauge, label, meter, thermometer, refractometer, or scale and report \
+    each as a reading with its numeric value, the unit exactly as displayed, and a confidence 0.0–1.0. \
+    Never guess an off-screen, blurry, or illegible value — lower the confidence instead of inventing a number.
+    """
+}
+
+/// Errors a schema may throw while mapping model output.
+enum AssessmentSchemaError: Error, LocalizedError {
+    case unknownKind(String)
+    case malformedPayload(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownKind(let k): return "No assessment schema registered for kind '\(k)'."
+        case .malformedPayload(let m): return "Assessment payload could not be mapped: \(m)"
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/StructuredVision/AssessmentSchemaRegistry.swift
+++ b/OpenGlasses/Sources/Services/StructuredVision/AssessmentSchemaRegistry.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Central registry of structured-vision schemas keyed by `kind`
+/// (see docs/plans/structured-vision-assessment.md). Verticals register a schema at startup; the
+/// `vision_assess` tool and `StructuredVisionService` look one up by the `kind` parameter.
+///
+/// Registration happens once during app setup (single-threaded), after which the registry is read-only
+/// on the main actor — so a plain dictionary is sufficient. Tests construct fresh instances.
+final class AssessmentSchemaRegistry {
+    static let shared = AssessmentSchemaRegistry()
+
+    private var schemas: [String: AssessmentSchema] = [:]
+
+    init() {}
+
+    /// Register (or replace) a schema. Last registration for a `kind` wins.
+    func register(_ schema: AssessmentSchema) {
+        schemas[schema.kind] = schema
+    }
+
+    /// Look up a schema by `kind`, or `nil` if none is registered.
+    func schema(for kind: String) -> AssessmentSchema? {
+        schemas[kind]
+    }
+
+    /// All registered kinds, sorted — for tool descriptions and diagnostics.
+    var kinds: [String] {
+        schemas.keys.sorted()
+    }
+
+    /// Whether any schema is registered for `kind`.
+    func contains(_ kind: String) -> Bool {
+        schemas[kind] != nil
+    }
+}

--- a/OpenGlasses/Sources/Services/StructuredVision/Schemas/InstrumentReadingSchema.swift
+++ b/OpenGlasses/Sources/Services/StructuredVision/Schemas/InstrumentReadingSchema.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// The built-in, domain-free "read the instrument" schema (structured-vision plan, Phase 3): point the
+/// glasses at a physical display — thermometer, pressure/manifold gauge, refractometer, scale,
+/// multimeter, any meter — and get the number(s) back as typed `InstrumentReading`s, unit-normalized.
+/// No vertical required; usable on its own via `vision_assess kind:"instrument_reading"`.
+struct InstrumentReadingSchema: AssessmentSchema {
+    let kind = "instrument_reading"
+    let title = "Instrument Reading"
+    var confidenceFloor: Double { 0.5 }
+
+    var jsonSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [
+                "readings": [
+                    "type": "array",
+                    "items": [
+                        "type": "object",
+                        "properties": [
+                            "quantity": ["type": "string", "description": "e.g. temperature, pressure, brix, weight, voltage"],
+                            "instrument": ["type": "string", "description": "the device, if identifiable"],
+                            "value": ["type": "number"],
+                            "unit": ["type": "string", "description": "the unit EXACTLY as displayed, e.g. °F, psig, °Bx, lb, V"],
+                            "confidence": ["type": "number", "description": "0.0–1.0"],
+                            "region": ["type": "array", "items": ["type": "number"], "description": "normalized [x,y,w,h] of the display"]
+                        ],
+                        "required": ["quantity", "value", "unit", "confidence"]
+                    ]
+                ],
+                "summary": ["type": "string"],
+                "confidence": ["type": "number"]
+            ],
+            "required": ["readings", "summary"]
+        ]
+    }
+
+    var systemPrompt: String {
+        """
+        You are an instrument-reading assistant for smart glasses. The user points the camera at a \
+        physical display — a thermometer, pressure or manifold gauge, refractometer, scale, multimeter, \
+        or any meter — and wants the value(s) read back.
+
+        \(AssessmentPrompt.instrumentFragment)
+
+        Return ONLY the structured assessment: a `readings` array (each with quantity, the instrument if \
+        identifiable, value, the unit exactly as displayed, and confidence 0.0–1.0, plus a normalized \
+        [x,y,w,h] region for the display when you can), a one-sentence `summary`, and an overall \
+        `confidence`. If no instrument or display is visible, return an empty `readings` array and say so \
+        in the summary.
+        """
+    }
+
+    func makeCard(from json: [String: Any], context: String?) throws -> AssessmentCard {
+        let items = json["readings"] as? [[String: Any]] ?? []
+        let readings = items.compactMap { try? AssessmentJSON.decode(InstrumentReading.self, from: $0) }
+
+        let rawSummary = (json["summary"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let summary = !rawSummary.isEmpty ? rawSummary
+            : (readings.isEmpty ? "No instrument display detected — point the camera at the gauge."
+                                : "Read \(readings.count) value\(readings.count == 1 ? "" : "s").")
+
+        let confidence = (json["confidence"] as? Double)
+            ?? (readings.isEmpty ? 0 : readings.map(\.confidence).reduce(0, +) / Double(readings.count))
+
+        let base = AssessmentCard(
+            kind: kind, title: title,
+            tier: readings.isEmpty ? .caution : .ok,
+            summary: summary,
+            stillNeeded: readings.isEmpty ? ["Point the camera squarely at the instrument display."] : [],
+            readings: readings, confidence: confidence)
+
+        // Normalize units and convert any low-confidence reading into a re-capture prompt.
+        return applyingReadingPolicy(to: base)
+    }
+}

--- a/OpenGlasses/Sources/Services/StructuredVision/StructuredVisionParser.swift
+++ b/OpenGlasses/Sources/Services/StructuredVision/StructuredVisionParser.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Pure, per-provider extraction of the structured-vision JSON object from a raw HTTP response body
+/// (see docs/plans/structured-vision-assessment.md, Phase 2). No network — unit-tested with recorded
+/// response bodies. Each parser prefers the provider's structured channel (forced tool call /
+/// function call) and falls back to tolerant parsing of any returned text, so a model that answers
+/// with prose JSON instead of a tool call still yields a result.
+enum StructuredVisionParser {
+
+    /// Anthropic Messages API: a forced `tool_use` block's `input`, else any `text` block parsed
+    /// tolerantly. `toolName` empty matches any tool.
+    static func anthropic(_ data: Data, toolName: String = "") -> [String: Any]? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]] else { return nil }
+        for block in content where block["type"] as? String == "tool_use" {
+            if toolName.isEmpty || block["name"] as? String == toolName,
+               let input = block["input"] as? [String: Any] {
+                return input
+            }
+        }
+        for block in content {
+            if let text = block["text"] as? String, let obj = AssessmentJSON.object(fromText: text) {
+                return obj
+            }
+        }
+        return nil
+    }
+
+    /// OpenAI-compatible chat completions: `choices[0].message.tool_calls[0].function.arguments`
+    /// (a JSON string), else `message.content` parsed tolerantly.
+    static func openAI(_ data: Data) -> [String: Any]? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let message = choices.first?["message"] as? [String: Any] else { return nil }
+        if let toolCalls = message["tool_calls"] as? [[String: Any]],
+           let function = toolCalls.first?["function"] as? [String: Any],
+           let args = function["arguments"] as? String,
+           let obj = AssessmentJSON.object(fromText: args) {
+            return obj
+        }
+        if let text = message["content"] as? String { return AssessmentJSON.object(fromText: text) }
+        return nil
+    }
+
+    /// Gemini generateContent: a `functionCall.args` part, else the first text part (which is a JSON
+    /// object when `responseMimeType` is `application/json`) parsed tolerantly.
+    static func gemini(_ data: Data) -> [String: Any]? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let candidates = json["candidates"] as? [[String: Any]],
+              let content = candidates.first?["content"] as? [String: Any],
+              let parts = content["parts"] as? [[String: Any]] else { return nil }
+        for part in parts {
+            if let call = part["functionCall"] as? [String: Any],
+               let args = call["args"] as? [String: Any] {
+                return args
+            }
+        }
+        for part in parts {
+            if let text = part["text"] as? String, let obj = AssessmentJSON.object(fromText: text) {
+                return obj
+            }
+        }
+        return nil
+    }
+}

--- a/OpenGlasses/Sources/Services/StructuredVision/StructuredVisionService.swift
+++ b/OpenGlasses/Sources/Services/StructuredVision/StructuredVisionService.swift
@@ -1,0 +1,111 @@
+import Foundation
+import UIKit
+import Combine
+
+/// Errors surfaced by `StructuredVisionService`.
+enum StructuredVisionError: Error, LocalizedError {
+    case unknownKind(String)
+    case noFrame
+    case analysisFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .unknownKind(let k): return "No assessment schema registered for '\(k)'."
+        case .noFrame: return "No camera frame available."
+        case .analysisFailed: return "The structured vision call returned no usable result."
+        }
+    }
+}
+
+/// Runs a structured-vision assessment end to end (structured-vision plan, Phase 3): grabs a camera
+/// frame, calls the active provider's forced structured-output path, decodes against the chosen
+/// schema, applies the deterministic backstop, and publishes the resulting `AssessmentCard` for the
+/// card view + HUD. Configured by `AppState`, exactly like `NavigationAssistService` / `LiveCoachService`.
+///
+/// The LLM call is a settable `analyze` seam so the core (`assess(kind:imageData:note:)`) is unit-testable
+/// without a network or a device. The `registry` is likewise injectable for tests.
+@MainActor
+final class StructuredVisionService: ObservableObject {
+    static let shared = StructuredVisionService()
+
+    @Published private(set) var latest: AssessmentCard?
+    @Published private(set) var isAnalyzing = false
+
+    /// Schema lookup — defaults to the shared registry; tests may swap in a fresh one.
+    var registry: AssessmentSchemaRegistry = .shared
+
+    /// The structured-vision call seam: (systemPrompt, userText, jpeg, jsonSchema, toolName) → JSON object.
+    /// Set by `configure(...)` to call `LLMService.analyzeFrameStructured`; tests inject a fake.
+    var analyze: ((String, String, Data, [String: Any], String) async -> [String: Any]?)?
+
+    private weak var camera: CameraService?
+    weak var glassesDisplay: GlassesDisplayService?
+
+    init() {}
+
+    /// Wire the live dependencies (called once at app launch).
+    func configure(camera: CameraService, llm: LLMService, tts: TextToSpeechService) {
+        self.camera = camera
+        self.analyze = { [weak llm] systemPrompt, userText, imageData, jsonSchema, toolName in
+            await llm?.analyzeFrameStructured(systemPrompt: systemPrompt, userText: userText,
+                                              imageData: imageData, jsonSchema: jsonSchema, toolName: toolName)
+        }
+        registerBuiltinSchemas()
+    }
+
+    /// Register the built-in, domain-free schemas. Idempotent.
+    func registerBuiltinSchemas() {
+        if !registry.contains("instrument_reading") { registry.register(InstrumentReadingSchema()) }
+    }
+
+    /// Dismiss the currently presented card.
+    func dismiss() { latest = nil }
+
+    // MARK: - Core (testable)
+
+    /// Assess a specific JPEG against `kind`. Decodes, backstops, publishes, and mirrors to the HUD.
+    func assess(kind: String, imageData: Data, note: String?) async throws -> AssessmentCard {
+        guard let schema = registry.schema(for: kind) else { throw StructuredVisionError.unknownKind(kind) }
+        guard let analyze else { throw StructuredVisionError.analysisFailed }
+        isAnalyzing = true
+        defer { isAnalyzing = false }
+
+        let userText = note.map { "Assess the scene. Context: \($0)" } ?? "Assess the scene."
+        guard let json = await analyze(schema.systemPrompt, userText, imageData, schema.jsonSchema, "assessment") else {
+            throw StructuredVisionError.analysisFailed
+        }
+        var card = try schema.makeCard(from: json, context: note)
+        card = schema.backstop(card)
+        latest = card
+        mirrorToHUD(card)
+        return card
+    }
+
+    // MARK: - Convenience (uses the live camera)
+
+    /// Grab the current camera frame and assess it.
+    func assessCurrentFrame(kind: String, note: String?) async throws -> AssessmentCard {
+        guard let camera else { throw StructuredVisionError.noFrame }
+        let data: Data
+        if let frame = camera.latestFrame, let jpeg = frame.jpegData(compressionQuality: 0.7) {
+            data = jpeg
+        } else if let captured = try? await camera.capturePhoto() {
+            data = captured
+        } else {
+            throw StructuredVisionError.noFrame
+        }
+        return try await assess(kind: kind, imageData: data, note: note)
+    }
+
+    // MARK: - HUD
+
+    private func mirrorToHUD(_ card: AssessmentCard) {
+        let icon: GlassesDisplayService.HUDIcon
+        switch card.tier {
+        case .ok: icon = .success
+        case .caution: icon = .warning
+        case .critical: icon = .hazard
+        }
+        glassesDisplay?.showNavigation("\(card.title): \(card.summary)", icon: icon)
+    }
+}

--- a/OpenGlasses/Sources/Services/StructuredVision/UnitNormalizer.swift
+++ b/OpenGlasses/Sources/Services/StructuredVision/UnitNormalizer.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Deterministic unit normalization for the "read the instrument" capability
+/// (see docs/plans/structured-vision-assessment.md). Pure and headless — no model involvement —
+/// so range checks, HUD, and audit records are unit-stable regardless of what the gauge displays.
+///
+/// Canonical units per dimension: temperature → °C, pressure → kPa, mass → kg, brix → °Bx,
+/// voltage → V. Unrecognised units return `nil` (the caller keeps the displayed value).
+enum UnitNormalizer {
+
+    /// Converts `value` (in `unit`) to its canonical unit. Returns `nil` for unknown units.
+    static func canonical(value: Double, unit: String) -> (value: Double, unit: String)? {
+        guard let def = def(for: unit) else { return nil }
+        return (def.toCanonical(value), canonicalUnit(for: def.dimension))
+    }
+
+    /// Converts `value` from one unit to another within the same dimension. Returns `nil` if either
+    /// unit is unknown or they belong to different dimensions.
+    static func convert(_ value: Double, from: String, to: String) -> Double? {
+        guard let src = def(for: from), let dst = def(for: to), src.dimension == dst.dimension else { return nil }
+        return dst.fromCanonical(src.toCanonical(value))
+    }
+
+    /// The canonical display unit for a dimension.
+    static func canonicalUnit(for dimension: Dimension) -> String {
+        switch dimension {
+        case .temperature: return "°C"
+        case .pressure: return "kPa"
+        case .mass: return "kg"
+        case .brix: return "°Bx"
+        case .voltage: return "V"
+        }
+    }
+
+    enum Dimension { case temperature, pressure, mass, brix, voltage }
+
+    // MARK: - Unit table
+
+    private struct UnitDef {
+        let dimension: Dimension
+        let toCanonical: (Double) -> Double
+        let fromCanonical: (Double) -> Double
+    }
+
+    private static func def(for unit: String) -> UnitDef? { table[token(unit)] }
+
+    /// Normalize a free-form unit string to a lookup token: lowercase, trim, drop the degree sign
+    /// and a trailing period, then fold common synonyms.
+    private static func token(_ unit: String) -> String {
+        var t = unit.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        t = t.replacingOccurrences(of: "°", with: "")
+        if t.hasSuffix(".") { t.removeLast() }
+        switch t {
+        case "f", "fahrenheit", "degf", "deg f": return "degf"
+        case "c", "celsius", "centigrade", "degc", "deg c": return "degc"
+        case "psi", "psig", "psia", "pounds per square inch": return "psi"
+        case "kpa", "kilopascal", "kilopascals": return "kpa"
+        case "bar", "bars": return "bar"
+        case "inhg", "in hg", "inches of mercury", "inhg.": return "inhg"
+        case "lb", "lbs", "pound", "pounds": return "lb"
+        case "kg", "kilogram", "kilograms", "kgs": return "kg"
+        case "g", "gram", "grams": return "g"
+        case "oz", "ounce", "ounces": return "oz"
+        case "bx", "brix", "°bx": return "bx"
+        case "v", "volt", "volts": return "v"
+        default: return t
+        }
+    }
+
+    private static let table: [String: UnitDef] = [
+        // Temperature (canonical °C) — affine.
+        "degf": UnitDef(dimension: .temperature, toCanonical: { ($0 - 32) * 5 / 9 }, fromCanonical: { $0 * 9 / 5 + 32 }),
+        "degc": UnitDef(dimension: .temperature, toCanonical: { $0 }, fromCanonical: { $0 }),
+        // Pressure (canonical kPa). psig is treated as a magnitude in psi for canonicalisation.
+        "psi":  UnitDef(dimension: .pressure, toCanonical: { $0 * 6.894757 }, fromCanonical: { $0 / 6.894757 }),
+        "kpa":  UnitDef(dimension: .pressure, toCanonical: { $0 }, fromCanonical: { $0 }),
+        "bar":  UnitDef(dimension: .pressure, toCanonical: { $0 * 100 }, fromCanonical: { $0 / 100 }),
+        "inhg": UnitDef(dimension: .pressure, toCanonical: { $0 * 3.386389 }, fromCanonical: { $0 / 3.386389 }),
+        // Mass (canonical kg).
+        "lb":   UnitDef(dimension: .mass, toCanonical: { $0 * 0.45359237 }, fromCanonical: { $0 / 0.45359237 }),
+        "kg":   UnitDef(dimension: .mass, toCanonical: { $0 }, fromCanonical: { $0 }),
+        "g":    UnitDef(dimension: .mass, toCanonical: { $0 / 1000 }, fromCanonical: { $0 * 1000 }),
+        "oz":   UnitDef(dimension: .mass, toCanonical: { $0 * 0.0283495231 }, fromCanonical: { $0 / 0.0283495231 }),
+        // Dimensionless-ish (identity, canonical = itself).
+        "bx":   UnitDef(dimension: .brix, toCanonical: { $0 }, fromCanonical: { $0 }),
+        "v":    UnitDef(dimension: .voltage, toCanonical: { $0 }, fromCanonical: { $0 }),
+    ]
+}

--- a/OpenGlassesTests/AssessmentJSONTests.swift
+++ b/OpenGlassesTests/AssessmentJSONTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for `AssessmentJSON` — tolerant object extraction from model text (the local/fallback path)
+/// plus the snake_case decode helper used by schema adapters. Pure/headless.
+final class AssessmentJSONTests: XCTestCase {
+
+    func testBareObject() {
+        let dict = AssessmentJSON.object(fromText: #"{"tier":"ok","confidence":0.9}"#)
+        XCTAssertEqual(dict?["tier"] as? String, "ok")
+        XCTAssertEqual(dict?["confidence"] as? Double, 0.9)
+    }
+
+    func testJSONFencedBlock() {
+        let text = """
+        Here is the assessment:
+        ```json
+        {"tier":"critical","summary":"not breathing"}
+        ```
+        Hope that helps.
+        """
+        let dict = AssessmentJSON.object(fromText: text)
+        XCTAssertEqual(dict?["tier"] as? String, "critical")
+        XCTAssertEqual(dict?["summary"] as? String, "not breathing")
+    }
+
+    func testPlainFencedBlock() {
+        let text = "```\n{\"value\": 42}\n```"
+        XCTAssertEqual(AssessmentJSON.object(fromText: text)?["value"] as? Int, 42)
+    }
+
+    func testProseWrappedFirstToLastBrace() {
+        let text = "The model says { \"tier\": \"caution\" } and nothing else."
+        XCTAssertEqual(AssessmentJSON.object(fromText: text)?["tier"] as? String, "caution")
+    }
+
+    func testMalformedReturnsNil() {
+        XCTAssertNil(AssessmentJSON.object(fromText: "no json here at all"))
+        XCTAssertNil(AssessmentJSON.object(fromText: "{ not valid json"))
+    }
+
+    func testDecodeHelperHonoursSnakeCaseCodingKeys() throws {
+        let json: [String: Any] = [
+            "quantity": "temperature", "value": 38.0, "unit": "°F",
+            "canonical": 3.33, "canonical_unit": "°C", "confidence": 0.8
+        ]
+        let reading = try AssessmentJSON.decode(InstrumentReading.self, from: json)
+        XCTAssertEqual(reading.quantity, "temperature")
+        XCTAssertEqual(reading.value, 38.0, accuracy: 0.0001)
+        XCTAssertEqual(reading.unit, "°F")
+        XCTAssertEqual(reading.canonicalUnit, "°C")
+        XCTAssertEqual(reading.confidence, 0.8, accuracy: 0.0001)
+    }
+}

--- a/OpenGlassesTests/InstrumentReadingSchemaTests.swift
+++ b/OpenGlassesTests/InstrumentReadingSchemaTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for the built-in `InstrumentReadingSchema` ("read the instrument") adapter (structured-vision
+/// Phase 3): mapping model JSON → typed, unit-normalized `InstrumentReading`s, the empty-readings case,
+/// and the low-confidence → re-capture policy. Headless.
+@MainActor
+final class InstrumentReadingSchemaTests: XCTestCase {
+
+    private let schema = InstrumentReadingSchema()
+
+    func testMapsAndNormalizesReadings() throws {
+        let json: [String: Any] = [
+            "readings": [
+                ["quantity": "temperature", "value": 212.0, "unit": "°F", "confidence": 0.9],
+                ["quantity": "pressure", "value": 100.0, "unit": "psi", "confidence": 0.8]
+            ],
+            "summary": "Two gauges read.",
+            "confidence": 0.85
+        ]
+        let card = try schema.makeCard(from: json, context: nil)
+        XCTAssertEqual(card.kind, "instrument_reading")
+        XCTAssertEqual(card.tier, .ok)
+        XCTAssertEqual(card.readings.count, 2)
+        let temp = card.readings.first { $0.quantity == "temperature" }
+        XCTAssertEqual(temp?.canonical ?? -1, 100, accuracy: 0.001)   // 212°F → 100°C
+        XCTAssertEqual(temp?.canonicalUnit, "°C")
+        let psi = card.readings.first { $0.quantity == "pressure" }
+        XCTAssertEqual(psi?.canonicalUnit, "kPa")
+        XCTAssertTrue(card.stillNeeded.isEmpty)
+    }
+
+    func testEmptyReadingsAsksToReposition() throws {
+        let card = try schema.makeCard(from: ["readings": [], "summary": ""], context: nil)
+        XCTAssertEqual(card.tier, .caution)
+        XCTAssertTrue(card.readings.isEmpty)
+        XCTAssertTrue(card.stillNeeded.contains { $0.localizedCaseInsensitiveContains("point the camera") })
+    }
+
+    func testLowConfidenceTriggersRecapture() throws {
+        let json: [String: Any] = [
+            "readings": [["quantity": "brix", "value": 12.0, "unit": "°Bx", "confidence": 0.2]],
+            "summary": "Refractometer, blurry."
+        ]
+        let card = try schema.makeCard(from: json, context: nil)
+        XCTAssertTrue(card.stillNeeded.contains { $0.localizedCaseInsensitiveContains("brix") })
+    }
+}

--- a/OpenGlassesTests/StructuredVisionCoreTests.swift
+++ b/OpenGlassesTests/StructuredVisionCoreTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for the structured-vision pure core (Phase 1): `AssessmentCard` codable round-trip + decode
+/// from snake_case model JSON, `AssessmentTier` ordering/escalation, reading normalization, the
+/// `AssessmentSchemaRegistry`, and the `AssessmentSchema` reading/backstop policy via a fake schema.
+/// Headless — no network, no MainActor.
+final class StructuredVisionCoreTests: XCTestCase {
+
+    // MARK: - AssessmentTier
+
+    func testTierIsOrdered() {
+        XCTAssertTrue(AssessmentTier.ok < .caution)
+        XCTAssertTrue(AssessmentTier.caution < .critical)
+        XCTAssertEqual(AssessmentTier.escalated(.ok, .critical), .critical)
+        XCTAssertEqual(AssessmentTier.escalated(.caution, .ok), .caution)
+    }
+
+    // MARK: - Card round-trip + decode
+
+    func testCardEncodeDecodeRoundTrip() throws {
+        let card = AssessmentCard(
+            kind: "instrument_reading", title: "Reading", tier: .caution,
+            summary: "One gauge read.",
+            findings: [AssessmentFinding(label: "Frost on coil", severity: .caution, confidence: 0.7)],
+            recommendedAction: "monitor", stillNeeded: ["cut fruit"],
+            readings: [InstrumentReading(quantity: "pressure", value: 100, unit: "psi")],
+            confidence: 0.8, disclaimer: "Advisory only.")
+        let data = try JSONEncoder().encode(card)
+        let decoded = try JSONDecoder().decode(AssessmentCard.self, from: data)
+        XCTAssertEqual(decoded, card)
+    }
+
+    func testCardDecodesFromSnakeCaseModelJSON() throws {
+        let json: [String: Any] = [
+            "kind": "first_aid_triage", "title": "Triage", "tier": "critical",
+            "summary": "Casualty unresponsive.", "recommended_action": "call_emergency",
+            "still_needed": ["check breathing"], "confidence": 0.6,
+            "readings": [["quantity": "spo2", "value": 88.0, "unit": "%", "confidence": 0.5]]
+        ]
+        let card = try AssessmentJSON.decode(AssessmentCard.self, from: json)
+        XCTAssertEqual(card.tier, .critical)
+        XCTAssertEqual(card.recommendedAction, "call_emergency")
+        XCTAssertEqual(card.stillNeeded, ["check breathing"])
+        XCTAssertEqual(card.readings.first?.quantity, "spo2")
+    }
+
+    func testCardDefaultsTolerateMissingFields() throws {
+        let card = try AssessmentJSON.decode(AssessmentCard.self, from: ["kind": "x", "title": "X"])
+        XCTAssertEqual(card.tier, .caution)        // default
+        XCTAssertTrue(card.findings.isEmpty)
+        XCTAssertTrue(card.readings.isEmpty)
+        XCTAssertEqual(card.confidence, 1.0, accuracy: 0.0001)
+    }
+
+    // MARK: - Escalation only raises
+
+    func testEscalatingOnlyRaisesTier() {
+        let card = AssessmentCard(kind: "k", title: "T", tier: .ok, summary: "")
+        let raised = card.escalating(to: .critical, action: "call 111", appending: "check airway")
+        XCTAssertEqual(raised.tier, .critical)
+        XCTAssertEqual(raised.recommendedAction, "call 111")
+        XCTAssertEqual(raised.stillNeeded, ["check airway"])
+        // Escalating "down" is a no-op on tier; an existing action is preserved when none is supplied.
+        let high = AssessmentCard(kind: "k", title: "T", tier: .critical, summary: "", recommendedAction: "x")
+        let lowered = high.escalating(to: .ok)
+        XCTAssertEqual(lowered.tier, .critical)
+        XCTAssertEqual(lowered.recommendedAction, "x")
+    }
+
+    // MARK: - Reading normalization
+
+    func testReadingNormalizationFillsCanonical() {
+        let r = InstrumentReading(quantity: "temperature", value: 212, unit: "°F").normalized()
+        XCTAssertEqual(r.canonical!, 100, accuracy: 0.0001)
+        XCTAssertEqual(r.canonicalUnit, "°C")
+    }
+
+    func testReadingNormalizationLeavesUnknownUnitsAlone() {
+        let r = InstrumentReading(quantity: "x", value: 5, unit: "furlongs").normalized()
+        XCTAssertNil(r.canonical)
+        XCTAssertEqual(r.value, 5, accuracy: 0.0001)
+    }
+
+    // MARK: - Registry
+
+    func testRegistryRegisterLookup() {
+        let reg = AssessmentSchemaRegistry()
+        XCTAssertNil(reg.schema(for: "fake"))
+        XCTAssertFalse(reg.contains("fake"))
+        reg.register(FakeSchema())
+        XCTAssertNotNil(reg.schema(for: "fake"))
+        XCTAssertTrue(reg.contains("fake"))
+        XCTAssertEqual(reg.kinds, ["fake"])
+    }
+
+    // MARK: - Schema reading policy + backstop
+
+    func testReadingPolicyPushesLowConfidenceToStillNeeded() throws {
+        let schema = FakeSchema()
+        let json: [String: Any] = [
+            "tier": "caution",
+            "readings": [
+                ["quantity": "pressure", "value": 100.0, "unit": "psi", "confidence": 0.9],
+                ["quantity": "temperature", "value": 38.0, "unit": "°F", "confidence": 0.2]
+            ]
+        ]
+        let card = try schema.makeCard(from: json, context: nil)
+        // Low-confidence temperature reading → a re-capture entry; high-confidence pressure → none.
+        XCTAssertTrue(card.stillNeeded.contains { $0.contains("temperature") })
+        XCTAssertFalse(card.stillNeeded.contains { $0.contains("pressure") })
+        // Readings were normalized in passing.
+        XCTAssertEqual(card.readings.first(where: { $0.quantity == "pressure" })?.canonicalUnit, "kPa")
+    }
+
+    func testBackstopEscalates() {
+        let schema = FakeSchema()
+        let ok = AssessmentCard(kind: "fake", title: "T", tier: .ok, summary: "danger word")
+        XCTAssertEqual(schema.backstop(ok).tier, .critical)
+        let calm = AssessmentCard(kind: "fake", title: "T", tier: .ok, summary: "all good")
+        XCTAssertEqual(schema.backstop(calm).tier, .ok)
+    }
+}
+
+// MARK: - Fixture
+
+/// Minimal schema exercising the protocol surface: decodes free-form readings, applies the reading
+/// policy, and escalates to critical when the summary contains the word "danger".
+private struct FakeSchema: AssessmentSchema {
+    let kind = "fake"
+    let title = "Fake"
+    var jsonSchema: [String: Any] { ["type": "object"] }
+    var systemPrompt: String { AssessmentPrompt.instrumentFragment }
+
+    func makeCard(from json: [String: Any], context: String?) throws -> AssessmentCard {
+        let readings = (json["readings"] as? [[String: Any]])?.compactMap {
+            try? AssessmentJSON.decode(InstrumentReading.self, from: $0)
+        } ?? []
+        let tier = AssessmentTier(rawValue: json["tier"] as? String ?? "caution") ?? .caution
+        let card = AssessmentCard(kind: kind, title: title, tier: tier,
+                                  summary: json["summary"] as? String ?? "", readings: readings)
+        return applyingReadingPolicy(to: card)
+    }
+
+    func backstop(_ card: AssessmentCard) -> AssessmentCard {
+        card.summary.localizedCaseInsensitiveContains("danger") ? card.escalating(to: .critical) : card
+    }
+}

--- a/OpenGlassesTests/StructuredVisionParserTests.swift
+++ b/OpenGlassesTests/StructuredVisionParserTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for `StructuredVisionParser` (structured-vision Phase 2) — pure extraction of the assessment
+/// JSON object from recorded provider response bodies, including the text fallback when the model
+/// answers with prose JSON instead of a forced tool/function call. Headless — no network.
+final class StructuredVisionParserTests: XCTestCase {
+
+    private func data(_ s: String) -> Data { Data(s.utf8) }
+
+    // MARK: - Anthropic
+
+    func testAnthropicForcedToolUse() {
+        let body = """
+        {"content":[
+          {"type":"tool_use","name":"assessment","input":{"tier":"critical","confidence":0.9}}
+        ]}
+        """
+        let obj = StructuredVisionParser.anthropic(data(body), toolName: "assessment")
+        XCTAssertEqual(obj?["tier"] as? String, "critical")
+        XCTAssertEqual(obj?["confidence"] as? Double, 0.9)
+    }
+
+    func testAnthropicFallsBackToTextBlock() {
+        let body = #"{"content":[{"type":"text","text":"```json\n{\"tier\":\"ok\"}\n```"}]}"#
+        XCTAssertEqual(StructuredVisionParser.anthropic(data(body), toolName: "assessment")?["tier"] as? String, "ok")
+    }
+
+    func testAnthropicWrongToolNameNoTextReturnsNil() {
+        let body = #"{"content":[{"type":"tool_use","name":"other","input":{"tier":"ok"}}]}"#
+        XCTAssertNil(StructuredVisionParser.anthropic(data(body), toolName: "assessment"))
+    }
+
+    func testAnthropicEmptyToolNameMatchesAny() {
+        let body = #"{"content":[{"type":"tool_use","name":"whatever","input":{"tier":"caution"}}]}"#
+        XCTAssertEqual(StructuredVisionParser.anthropic(data(body))?["tier"] as? String, "caution")
+    }
+
+    // MARK: - OpenAI-compatible
+
+    func testOpenAIFunctionArguments() {
+        let body = """
+        {"choices":[{"message":{"role":"assistant","tool_calls":[
+          {"type":"function","function":{"name":"assessment","arguments":"{\\"tier\\":\\"caution\\",\\"summary\\":\\"x\\"}"}}
+        ]}}]}
+        """
+        let obj = StructuredVisionParser.openAI(data(body))
+        XCTAssertEqual(obj?["tier"] as? String, "caution")
+        XCTAssertEqual(obj?["summary"] as? String, "x")
+    }
+
+    func testOpenAIFallsBackToContent() {
+        let body = #"{"choices":[{"message":{"role":"assistant","content":"{\"tier\":\"ok\"}"}}]}"#
+        XCTAssertEqual(StructuredVisionParser.openAI(data(body))?["tier"] as? String, "ok")
+    }
+
+    func testOpenAIMalformedReturnsNil() {
+        XCTAssertNil(StructuredVisionParser.openAI(data(#"{"choices":[]}"#)))
+    }
+
+    // MARK: - Gemini
+
+    func testGeminiJSONTextPart() {
+        let body = #"{"candidates":[{"content":{"parts":[{"text":"{\"tier\":\"critical\"}"}]}}]}"#
+        XCTAssertEqual(StructuredVisionParser.gemini(data(body))?["tier"] as? String, "critical")
+    }
+
+    func testGeminiFunctionCallArgs() {
+        let body = #"{"candidates":[{"content":{"parts":[{"functionCall":{"name":"assessment","args":{"tier":"ok"}}}]}}]}"#
+        XCTAssertEqual(StructuredVisionParser.gemini(data(body))?["tier"] as? String, "ok")
+    }
+
+    func testGeminiMalformedReturnsNil() {
+        XCTAssertNil(StructuredVisionParser.gemini(data(#"{"candidates":[]}"#)))
+    }
+}

--- a/OpenGlassesTests/StructuredVisionServiceTests.swift
+++ b/OpenGlassesTests/StructuredVisionServiceTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for `StructuredVisionService` core (structured-vision Phase 3) via the injectable `analyze`
+/// seam and a fresh registry — no network, no camera. Covers the happy path (decode + publish),
+/// unknown kind, and an empty analysis result.
+@MainActor
+final class StructuredVisionServiceTests: XCTestCase {
+
+    private func makeService(analyze: @escaping (String, String, Data, [String: Any], String) async -> [String: Any]?) -> StructuredVisionService {
+        let svc = StructuredVisionService()
+        let registry = AssessmentSchemaRegistry()
+        registry.register(InstrumentReadingSchema())
+        svc.registry = registry
+        svc.analyze = analyze
+        return svc
+    }
+
+    func testAssessHappyPathDecodesAndPublishes() async throws {
+        let svc = makeService { _, _, _, _, _ in
+            ["readings": [["quantity": "temperature", "value": 212.0, "unit": "°F", "confidence": 0.9]],
+             "summary": "Reads 212°F.", "confidence": 0.9]
+        }
+        let card = try await svc.assess(kind: "instrument_reading", imageData: Data(), note: nil)
+        XCTAssertEqual(card.readings.first?.canonicalUnit, "°C")
+        XCTAssertEqual(card.readings.first?.canonical ?? -1, 100, accuracy: 0.001)
+        XCTAssertEqual(svc.latest, card)            // published for the card view
+        XCTAssertFalse(svc.isAnalyzing)             // reset after completion
+    }
+
+    func testUnknownKindThrows() async {
+        let svc = makeService { _, _, _, _, _ in [:] }
+        do {
+            _ = try await svc.assess(kind: "nope", imageData: Data(), note: nil)
+            XCTFail("expected unknownKind")
+        } catch StructuredVisionError.unknownKind(let k) {
+            XCTAssertEqual(k, "nope")
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testNilAnalysisThrows() async {
+        let svc = makeService { _, _, _, _, _ in nil }
+        do {
+            _ = try await svc.assess(kind: "instrument_reading", imageData: Data(), note: nil)
+            XCTFail("expected analysisFailed")
+        } catch StructuredVisionError.analysisFailed {
+            // expected
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testContextNoteIsPassedToAnalyze() async throws {
+        var seenUserText = ""
+        let svc = makeService { _, userText, _, _, _ in
+            seenUserText = userText
+            return ["readings": [], "summary": "none"]
+        }
+        _ = try await svc.assess(kind: "instrument_reading", imageData: Data(), note: "suction line")
+        XCTAssertTrue(seenUserText.contains("suction line"))
+    }
+}

--- a/OpenGlassesTests/UnitNormalizerTests.swift
+++ b/OpenGlassesTests/UnitNormalizerTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for `UnitNormalizer` — the deterministic unit conversion behind the "read the instrument"
+/// capability (structured-vision plan). Pure/headless: no model, no network.
+final class UnitNormalizerTests: XCTestCase {
+
+    private let acc = 0.0001
+
+    // MARK: - Temperature (canonical °C)
+
+    func testFahrenheitToCanonicalCelsius() {
+        XCTAssertEqual(UnitNormalizer.canonical(value: 32, unit: "°F")!.value, 0, accuracy: acc)
+        XCTAssertEqual(UnitNormalizer.canonical(value: 212, unit: "F")!.value, 100, accuracy: acc)
+        XCTAssertEqual(UnitNormalizer.canonical(value: 98.6, unit: "fahrenheit")!.value, 37, accuracy: 0.01)
+        XCTAssertEqual(UnitNormalizer.canonical(value: 32, unit: "°F")!.unit, "°C")
+    }
+
+    func testCelsiusIsIdentity() {
+        let c = UnitNormalizer.canonical(value: 4, unit: "°C")!
+        XCTAssertEqual(c.value, 4, accuracy: acc)
+        XCTAssertEqual(c.unit, "°C")
+    }
+
+    func testConvertCelsiusToFahrenheit() {
+        XCTAssertEqual(UnitNormalizer.convert(100, from: "C", to: "F")!, 212, accuracy: acc)
+        XCTAssertEqual(UnitNormalizer.convert(37, from: "celsius", to: "fahrenheit")!, 98.6, accuracy: 0.01)
+    }
+
+    // MARK: - Pressure (canonical kPa)
+
+    func testPressureToCanonicalKPa() {
+        XCTAssertEqual(UnitNormalizer.canonical(value: 100, unit: "psi")!.value, 689.4757, accuracy: 0.001)
+        XCTAssertEqual(UnitNormalizer.canonical(value: 1, unit: "bar")!.value, 100, accuracy: acc)
+        XCTAssertEqual(UnitNormalizer.canonical(value: 1, unit: "inHg")!.value, 3.386389, accuracy: 0.0001)
+        XCTAssertEqual(UnitNormalizer.canonical(value: 50, unit: "kPa")!.unit, "kPa")
+    }
+
+    func testPsigTreatedAsPsiMagnitude() {
+        XCTAssertEqual(UnitNormalizer.canonical(value: 100, unit: " psig ")!.value,
+                       UnitNormalizer.canonical(value: 100, unit: "psi")!.value, accuracy: acc)
+    }
+
+    // MARK: - Mass (canonical kg)
+
+    func testMassToCanonicalKg() {
+        XCTAssertEqual(UnitNormalizer.canonical(value: 1, unit: "lb")!.value, 0.45359237, accuracy: acc)
+        XCTAssertEqual(UnitNormalizer.canonical(value: 1000, unit: "g")!.value, 1, accuracy: acc)
+        XCTAssertEqual(UnitNormalizer.canonical(value: 16, unit: "oz")!.value, 0.45359237, accuracy: 0.001)
+        XCTAssertEqual(UnitNormalizer.convert(2.2046226, from: "lbs", to: "kg")!, 1, accuracy: 0.0001)
+    }
+
+    // MARK: - Identity dimensions
+
+    func testBrixAndVoltageAreIdentity() {
+        XCTAssertEqual(UnitNormalizer.canonical(value: 12.5, unit: "°Bx")!.value, 12.5, accuracy: acc)
+        XCTAssertEqual(UnitNormalizer.canonical(value: 12.5, unit: "brix")!.unit, "°Bx")
+        XCTAssertEqual(UnitNormalizer.canonical(value: 240, unit: "V")!.value, 240, accuracy: acc)
+    }
+
+    // MARK: - Failure modes
+
+    func testUnknownUnitReturnsNil() {
+        XCTAssertNil(UnitNormalizer.canonical(value: 1, unit: "furlongs"))
+        XCTAssertNil(UnitNormalizer.canonical(value: 1, unit: "%"))
+    }
+
+    func testConvertAcrossDimensionsReturnsNil() {
+        XCTAssertNil(UnitNormalizer.convert(1, from: "psi", to: "kg"))
+        XCTAssertNil(UnitNormalizer.convert(1, from: "°F", to: "bar"))
+    }
+}

--- a/OpenGlassesTests/VisionAssessToolTests.swift
+++ b/OpenGlassesTests/VisionAssessToolTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for `VisionAssessTool` routing (structured-vision Phase 3): missing/unknown `kind` guidance
+/// (no camera needed) and the speakable `summarize` output. The camera happy path is integration-only.
+@MainActor
+final class VisionAssessToolTests: XCTestCase {
+
+    private let tool = VisionAssessTool()
+
+    override func setUp() {
+        super.setUp()
+        // Ensure at least the built-in kind is discoverable via the shared registry.
+        AssessmentSchemaRegistry.shared.register(InstrumentReadingSchema())
+    }
+
+    func testMissingKindReturnsGuidance() async throws {
+        let result = try await tool.execute(args: [:])
+        XCTAssertTrue(result.localizedCaseInsensitiveContains("specify"))
+        XCTAssertTrue(result.contains("instrument_reading"))
+    }
+
+    func testUnknownKindIsRejected() async throws {
+        let result = try await tool.execute(args: ["kind": "bogus"])
+        XCTAssertTrue(result.contains("Unknown assessment kind 'bogus'"))
+        XCTAssertTrue(result.contains("instrument_reading"))
+    }
+
+    func testToolMetadata() {
+        XCTAssertEqual(tool.name, "vision_assess")
+        XCTAssertTrue(tool.description.contains("instrument_reading"))
+        let props = tool.parametersSchema["properties"] as? [String: Any]
+        XCTAssertNotNil(props?["kind"])
+        XCTAssertEqual(tool.parametersSchema["required"] as? [String], ["kind"])
+    }
+
+    func testSummarizeIncludesReadingsAndAction() {
+        let card = AssessmentCard(
+            kind: "instrument_reading", title: "Instrument Reading", tier: .ok,
+            summary: "Read 1 value.",
+            recommendedAction: "log it",
+            stillNeeded: ["wipe the lens"],
+            readings: [InstrumentReading(quantity: "pressure", value: 100, unit: "psi",
+                                         canonical: 689.4757, canonicalUnit: "kPa")])
+        let s = VisionAssessTool.summarize(card)
+        XCTAssertTrue(s.contains("Read 1 value."))
+        XCTAssertTrue(s.contains("pressure: 100 psi"))
+        XCTAssertTrue(s.contains("kPa"))
+        XCTAssertTrue(s.contains("Recommended: log it"))
+        XCTAssertTrue(s.contains("Still needed: wipe the lens"))
+    }
+}

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -17,6 +17,7 @@ All plans A–M are **built and merged to `main`** to the extent verifiable with
 | E MCP Server | ✅ Shipped (dev-only HTTP server) |
 | F Field Assist | ✅ Phases 1–3 shipped (vault, procedures, domain calc, audit/PDF export, escalation) |
 | [Safety Assessment (HECA)](safety-assessment.md) | 📋 Planned (not built) — camera-assisted High-Energy Control Assessment (EEI/CSRA SIF); a Field Assist vertical reusing `analyzeFrame` + audit/PDF. Plan refined with a structured schema, energy-source catalog, 3-part direct-control test, and image-seeded advisor. |
+| [Structured Vision Assessment](structured-vision-assessment.md) | 🚧 Core shipped on `feat/structured-vision` (Phases 1–3) — reusable **schema-validated** sibling of `analyzeFrame`: frame → typed `AssessmentCard` via forced tool-use → `vision_assess` tool + card + HUD. First-class **"read the instrument"** (`InstrumentReading` + `UnitNormalizer`); built-in `instrument_reading` consumer. 46 tests, Debug+Release green. Deferred to follow-ups: first-aid triage consumer (now unblocked — #82 merged), Gemini `responseSchema`, CaptureFlow `voice_number` auto-fill. Substrate that HECA builds on. |
 | G IT/Network pack | ✅ Shipped (vault, 5 procedures, subnet calc) |
 | H Custom vault import | ✅ Shipped (validator, importer, manager UI) |
 | I Medication Identifier | ✅ Shipped (OCR × Health Vault) |

--- a/docs/plans/structured-vision-assessment.md
+++ b/docs/plans/structured-vision-assessment.md
@@ -1,0 +1,267 @@
+# Plan — Structured Vision Assessment (schema-validated `analyzeFrame`)
+
+**Status: 🚧 Core shipped on `feat/structured-vision` (Phases 1–3).** Drafted + built 2026-06-19.
+Shipped: the pure core (`AssessmentCard`/`AssessmentTier`/`AssessmentFinding`/`InstrumentReading`,
+`UnitNormalizer`, `AssessmentSchema`/registry, tolerant `AssessmentJSON`); `LLMService.analyzeFrameStructured`
++ per-provider `StructuredVisionParser` (forced tool-use / function / JSON, text fallback);
+`StructuredVisionService` + `vision_assess` tool + `AssessmentCardView`/HUD; and the built-in
+**`instrument_reading`** ("read the instrument") consumer. **46 tests, Debug + Release green.**
+**Deferred to follow-up PRs:** first-aid triage consumer (now unblocked — #82 merged), Gemini
+`responseSchema` translation, CaptureFlow `voice_number` auto-fill.
+
+**Strategic fit:** Today every camera-reasoning feature funnels through
+[`LLMService.analyzeFrame`](../../OpenGlasses/Sources/Services/LLMService.swift) (line 848), which returns
+**free text**. Each consumer then either narrates that text (Assistive Modes, Live Coach, Navigation Assist)
+or — for anything that needs to *branch* on the result — would have to re-invent "prompt for JSON, scrape it
+out of a markdown fence, decode it, hope it validates." The planned [Safety Assessment / HECA](safety-assessment.md)
+vertical already proposes exactly that, bespoke, inside its own service.
+
+This plan adds the **missing substrate**: a reusable, **schema-validated** structured-vision call. One frame
+(or a few) → a **typed, validated assessment** → a normalized result card + HUD surface + optional audit/export.
+Each vertical becomes *data + an adapter*, not a new prompt-and-parse pipeline. It uses **forced tool-use /
+response-schema** per provider so the model returns validated JSON natively, instead of regex-scraping free text.
+
+**First consumer:** **First-aid casualty triage** — directly on the in-flight `feat/first-aid-assist`
+line, extending [`FirstAidAssistService`](../../OpenGlasses/Sources/Services/FirstAid/FirstAidAssistService.swift)
+rather than duplicating it.
+
+**Downstream consumers (separate PRs, not this one):** HECA (its plan collapses to "define a schema + adapter"),
+and CaptureFlow `.photo` steps that auto-grade instead of just filing a path.
+
+**Effort:** ~1 week. The deterministic core (Phase 1) and the per-provider parsers (Phase 2) are pure and fully
+unit-testable with **no live API**; only the tool wiring + card view (Phase 3) touch the app shell.
+
+---
+
+## Concept
+
+```
+            ┌─────────────────────── reusable primitive (this plan) ───────────────────────┐
+ camera ───▶│ StructuredVisionService.assess(kind:image:context:)                           │
+            │   → AssessmentSchemaRegistry[kind]  (jsonSchema + systemPrompt + card adapter) │
+            │   → LLMService.analyzeFrameStructured(schema, image)   ← forced tool-use       │
+            │        Anthropic: tools + tool_choice:{type:tool}                              │
+            │        OpenAI-compat: tools + tool_choice:{type:function}                      │
+            │        Gemini: responseMimeType:application/json + responseSchema              │
+            │        local/appleOnDevice: free-text + tolerant JSON extraction (fallback)    │
+            │   → decode → schema.makeCard(...) → deterministic backstop → AssessmentCard    │
+            └──────────────────────────────────────────────────────────────────────────────┘
+                         │                         │                        │
+                  AssessmentCardView        GlassesDisplayService     SessionLogger / SessionExporter
+                  (phone card)              (.hazard HUD card)        (audit + PDF, when in a Field session)
+```
+
+A **schema** is the whole contract for one vertical: a JSON Schema, a system prompt, and an adapter that maps
+its decoded payload onto a **normalized `AssessmentCard`** (tier · findings · recommended action · still-needed ·
+measurements · confidence · disclaimer). The generic card view and HUD path render *any* `AssessmentCard`, so
+adding a vertical never touches the renderer, the networking, or the tool.
+
+---
+
+## Files
+
+```
+OpenGlasses/Sources/Services/StructuredVision/
+├── AssessmentCard.swift            // normalized view-model: AssessmentTier, AssessmentFinding, InstrumentReading, AssessmentCard
+├── AssessmentSchema.swift          // protocol AssessmentSchema (kind, jsonSchema, systemPrompt, makeCard, backstop)
+├── AssessmentSchemaRegistry.swift  // register/lookup schemas by `kind`
+├── UnitNormalizer.swift            // PURE: canonical units + conversions (°F↔°C, psi↔kPa, lb↔kg, …) for instrument readings
+├── StructuredVisionService.swift   // @MainActor ObservableObject: assess(kind:image:context:) → AssessmentCard
+├── StructuredVisionParser.swift    // PURE per-provider response → [String:Any] JSON object (no network)
+└── Schemas/
+    ├── FirstAidTriageSchema.swift     // first consumer: casualty triage schema + adapter + deterministic backstop
+    └── InstrumentReadingSchema.swift  // built-in "read the instrument" schema: gauges/thermometers/scales/refractometers/meters
+
+OpenGlasses/Sources/Services/NativeTools/
+└── VisionAssessTool.swift          // `vision_assess` { kind, note? } — generic, schema-parameterized
+
+OpenGlasses/Sources/App/Views/
+└── AssessmentCardView.swift        // renders any AssessmentCard (tier chip, findings, action, still-needed)
+```
+
+**Touched (small, additive):**
+- [`LLMService.swift`](../../OpenGlasses/Sources/Services/LLMService.swift) — add `analyzeFrameStructured(...)`
+  mirroring `analyzeFrame`'s provider switch (line 848); reuse the per-provider tool-declaration formatting in
+  [`ToolCallModels.ToolDeclarations`](../../OpenGlasses/Sources/Models/ToolCallModels.swift) to declare the single
+  forced tool. Add the `vision_assess` line to the tool catalog (~line 209–291).
+- [`GeminiLiveSessionManager.swift`](../../OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift)
+  — add the `vision_assess` description to `buildSystemInstruction()` (~line 393–502).
+- [`NativeToolRegistry.swift`](../../OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift) — register
+  `VisionAssessTool`; respect `Config.hipaaMode` like other camera/PII tools (line 226–227).
+- [`FirstAidTool.swift`](../../OpenGlasses/Sources/Services/NativeTools/FirstAidTool.swift) — add a `triage`
+  action that delegates to `vision_assess kind:"first_aid_triage"` so the existing first-aid intent covers it.
+
+**Reuse (no new infrastructure):**
+- **Vision transport** — extends the existing multi-provider `analyzeFrame`.
+- **Camera frame** — `CameraService` periodic capture (glasses POV) + iPhone-camera fallback (same source the
+  assistive loops already use).
+- **HUD** — [`GlassesDisplayService`](../../OpenGlasses/Sources/Services/GlassesDisplayService.swift):
+  `showNotification(...)` / `showNavigation(_:icon:)` with the existing `.hazard` / `.warning` / `.info` icons.
+- **Audit + PDF** — when invoked inside a Field session,
+  [`FieldSessionService`](../../OpenGlasses/Sources/Services/FieldAssist/FieldSessionService.swift) + `SessionLogger`
+  + [`SessionExporter`](../../OpenGlasses/Sources/Services/FieldAssist/SessionExporter.swift). Optional, not required.
+- **Result surfacing pattern** — `@Published latest` on the service observed by a SwiftUI view, exactly as
+  `NavigationAssistService.lastAdvice` / `LiveCoachService.lastAdvice` do today.
+
+---
+
+## Model (sketch)
+
+```swift
+/// Normalized 3-level status every vertical maps onto. Semantic status colours
+/// (green/amber/red) — distinct from the coral AI-attribution accent used on the card chrome.
+enum AssessmentTier: String, Codable { case ok, caution, critical }
+
+struct AssessmentFinding: Codable, Identifiable {
+    let id: UUID
+    let label: String          // "Suspected arterial bleeding"
+    let detail: String?        // short note
+    let severity: AssessmentTier
+    let confidence: Double      // 0.0–1.0
+    let region: [Double]?       // optional normalized [x,y,w,h] for an overlay
+}
+
+/// A numeric value read off a physical instrument in-frame — the "read the instrument" capability.
+struct InstrumentReading: Codable, Identifiable {
+    let id: UUID
+    let quantity: String        // "temperature", "pressure", "brix", "weight", "voltage", "flow", "spo2"…
+    let instrument: String?     // "probe thermometer", "manifold gauge", "refractometer", "scale", "multimeter"
+    let value: Double
+    let unit: String            // AS DISPLAYED on the device: "°F", "psig", "°Bx", "lb", "V"
+    let canonical: Double?       // value normalized to the canonical unit for `quantity` (filled by UnitNormalizer)
+    let canonicalUnit: String?
+    let confidence: Double       // 0.0–1.0 — low confidence drives a re-capture prompt, never a silent guess
+    let region: [Double]?        // normalized [x,y,w,h] of the display, for an overlay highlight
+}
+
+/// What the generic renderer + HUD + audit consume. Schemas produce this; nothing
+/// downstream knows about any vertical's private payload type.
+struct AssessmentCard: Codable {
+    let kind: String                    // schema id, e.g. "first_aid_triage"
+    let title: String
+    let subtitle: String?
+    let tier: AssessmentTier
+    let summary: String                 // 1–2 sentence plain-English
+    let findings: [AssessmentFinding]
+    let recommendedAction: String?
+    let stillNeeded: [String]           // "what to check / capture next"
+    let readings: [InstrumentReading]   // "read the instrument" — first-class, see below
+    let confidence: Double
+    let disclaimer: String?             // e.g. advisory / not a medical device
+}
+
+@MainActor
+protocol AssessmentSchema {
+    var kind: String { get }
+    var jsonSchema: [String: Any] { get }   // the tool input_schema / responseSchema
+    var systemPrompt: String { get }
+    func makeCard(from json: [String: Any], context: String?) throws -> AssessmentCard
+    /// Deterministic guardrail run AFTER the model — can only ESCALATE tier / force an action.
+    func backstop(_ card: AssessmentCard) -> AssessmentCard
+}
+
+@MainActor
+final class StructuredVisionService: ObservableObject {
+    @Published private(set) var latest: AssessmentCard?
+    @Published private(set) var isAnalyzing = false
+    func assess(kind: String, image: Data, context: String?) async throws -> AssessmentCard
+}
+```
+
+**First consumer — `FirstAidTriageSchema`.** Payload: responsiveness, breathing (yes/no/unsure), severe external
+bleeding, suspected conditions, per-condition severity, recommended action (`call_emergency` / `start_cpr` /
+`recovery_position` / `control_bleeding` / `monitor`), ordered steps, `still_to_check`, confidence.
+**Deterministic backstop** (consistent with the `SafetySupervisor` / health-advisor "rubric backstops the LLM"
+house pattern): if `breathing == no` OR `responsiveness == unresponsive` OR `severe_bleeding == true`, force
+`tier = .critical` and surface "Call emergency services now" regardless of what the model returned. Every card
+carries the existing first-aid **advisory disclaimer**.
+
+---
+
+## Read the instrument (first-class)
+
+"Read the instrument" — glasses pull a **number** off a physical display hands-free: a probe/dial thermometer,
+manifold/pressure gauge, refractometer (°Bx), scale, multimeter, flow meter, even a BP cuff or pulse-ox. It's the
+highest-leverage reuse of the primitive, so it's built into the model rather than bolted on as a loose dictionary.
+
+- **Typed readings on every card.** `AssessmentCard.readings: [InstrumentReading]` carries quantity · instrument ·
+  value · **unit exactly as displayed** · confidence · optional region box. The base system-prompt fragment shared
+  by *every* schema includes a standing instruction: *"read any visible instrument, gauge, label, or meter and
+  report value + unit + confidence; never guess an off-screen or illegible value — lower the confidence instead."*
+- **Deterministic unit normalization.** `UnitNormalizer` (pure, Phase 1) fills `canonical`/`canonicalUnit` —
+  °F↔°C, psi/psig↔kPa↔bar↔inHg, lb↔kg, etc. — so range checks, HUD, and audit records are unit-stable regardless
+  of what the gauge shows. No model involvement; fully unit-tested.
+- **Confidence → re-capture, never a silent guess.** A reading below the schema's confidence floor doesn't quietly
+  land; the adapter pushes "re-capture the &lt;quantity&gt; display" into `stillNeeded` and (inside a flow) re-prompts —
+  the same posture as the [`CaptureFlowRunner`](../../OpenGlasses/Sources/Services/CaptureFlow/CaptureFlowRunner.swift)
+  bad-answer re-prompt.
+- **Built-in `instrument_reading` schema.** A generic, domain-free schema (second consumer, Phase 3): point at a
+  display, get the number(s) and nothing else. Usable on its own via `vision_assess kind:"instrument_reading"`, or
+  by Field Assist / Live Coach — no vertical required.
+- **CaptureFlow killer combo (downstream PR).** A `voice_number` step in
+  [`CaptureFlow`](../../OpenGlasses/Sources/Services/CaptureFlow/CaptureFlow.swift) already carries a `unit` and a
+  `[min,max]` range (`Completion.range`). An instrument reading can **fill that step instead of dictation** — read →
+  normalize to the step's unit → range-validate → store, with voice as the fallback. This makes hands-free
+  instrument capture an opt-in property of *existing* flows; wiring is a follow-on PR, but the model and normalizer
+  here are built to support it now.
+
+---
+
+## Phases (single PR, deterministic core first)
+
+Per the project's plan-delivery rhythm: ship the deterministic, testable core before the risky live-API
+integration; full suite + **Release** build green before the PR.
+
+- **Phase 1 — Pure core (no network).** `AssessmentCard`, `AssessmentTier`, `AssessmentFinding`,
+  `InstrumentReading`, `UnitNormalizer`, `AssessmentSchema`, `AssessmentSchemaRegistry`, and a tolerant
+  JSON-object decoder (handles bare object, ```json fences, and first-`{`…last-`}` slices — the local/fallback
+  path). Fully unit-tested against golden payloads. No app-shell changes.
+- **Phase 2 — `analyzeFrameStructured` + parsers.** Add the provider switch to `LLMService` (Anthropic forced
+  `tool_choice`, OpenAI-compatible forced function, Gemini `responseSchema`, local/appleOnDevice → free-text +
+  Phase-1 tolerant decode). Factor each provider's **response → `[String:Any]`** extraction into the pure
+  `StructuredVisionParser` so it's unit-tested with recorded response bodies (no live calls).
+- **Phase 3 — Tools + first consumers + UI.** `StructuredVisionService`, `VisionAssessTool` (`vision_assess`),
+  registry registration + system-prompt entries (both LLM + Gemini Live), `AssessmentCardView` (renders findings
+  *and* readings), HUD surfacing. Two consumers: `FirstAidTriageSchema` + its backstop + the `first_aid triage`
+  action, and the built-in `InstrumentReadingSchema` ("read the instrument"). Tests for tool routing, the first-aid
+  adapter, the backstop escalation table, and the instrument-reading adapter.
+
+**Sequencing note:** this plan branches from `main`, so the **domain-free `InstrumentReadingSchema`** ("read the
+instrument") is the first end-to-end consumer shipped here — it depends on nothing outside the primitive. The
+**first-aid triage** consumer depends on `FirstAidAssistService`, which lands with PR #82 (`feat/first-aid-assist`);
+it follows as a small Phase 3 addition once #82 merges. Phases 1–2 + `instrument_reading` are independent of #82.
+
+---
+
+## Tests (headless, device-independent)
+
+- Tolerant decoder: bare JSON, fenced JSON, prose-wrapped JSON, malformed → typed error.
+- Per-provider parser: golden Anthropic `tool_use`, OpenAI `tool_calls.arguments`, Gemini JSON-text bodies →
+  identical `[String:Any]`.
+- Registry: register/lookup/unknown-kind.
+- `FirstAidTriageSchema.makeCard`: representative payload → expected `AssessmentCard`.
+- **Backstop table:** not-breathing / unresponsive / severe-bleeding each force `.critical` + emergency action,
+  including when the model under-rates them.
+- **Read the instrument:** `UnitNormalizer` round-trips and canonicalization (°F↔°C, psig↔kPa↔bar, lb↔kg);
+  `InstrumentReadingSchema` golden payloads (thermometer / manifold gauge / refractometer / scale) → typed
+  `InstrumentReading`s with displayed + canonical units; a below-floor confidence pushes a re-capture into
+  `stillNeeded` rather than landing the value.
+- `VisionAssessTool`: unknown kind → graceful message; HIPAA-mode gating; happy path via a mock LLM seam.
+
+---
+
+## Decisions / risks
+
+- **Gating.** First-aid shipped as **advisory** and ungated (bystander aid). Triage-from-camera is more
+  interpretive. Default: keep it advisory with the spoken disclaimer and the deterministic backstop; do **not**
+  put it behind the Medical Compliance IAP (that gate is for the personal Health Vault). Revisit if it ever moves
+  toward diagnosis. *(Flag for confirmation before Phase 3.)*
+- **Forced-tool support across "OpenAI-compatible" providers.** groq/zai/qwen/etc. vary in function-calling
+  fidelity. Mitigation: the local/fallback tolerant-decode path doubles as the universal fallback — if a forced
+  tool call comes back empty, retry once as prompt-instructed JSON before failing.
+- **Latency / cost.** One extra vision round-trip per assessment; `vision_assess` is user/agent-invoked, not a
+  background loop, so no new always-on cost. On-device (MLX) vision is out of scope — guarded by the existing
+  local-model background restriction.
+- **Don't duplicate HECA.** This plan deliberately ships the *substrate*; the HECA plan should be retrofitted to
+  define a `SafetyAssessmentSchema` + adapter on top of it rather than its own service. Noted there as a
+  follow-up, not done here.


### PR DESCRIPTION
## Summary

A reusable **structured-vision primitive** (plan: `docs/plans/structured-vision-assessment.md`): a camera frame → a **typed, validated `AssessmentCard`**. Each vertical is just a *schema + adapter* — it never touches the networking, the renderer, or the tool. This is the substrate the planned **HECA / Safety Assessment** vertical builds on, and it adds first-class **"read the instrument"** support.

Ships the substrate + one domain-free consumer (`instrument_reading`). The first-aid triage consumer is intentionally left for a follow-up PR.

## What's included

- **Phase 1 — pure core:** `AssessmentCard` / `AssessmentTier` / `AssessmentFinding` / `InstrumentReading`, `UnitNormalizer` (°F↔°C, psi/bar/inHg↔kPa, lb/oz/g↔kg, brix, V), `AssessmentSchema` + registry, tolerant `AssessmentJSON` (fence/brace extraction + snake_case decode).
- **Phase 2 — provider layer:** `LLMService.analyzeFrameStructured` — Anthropic forced `tool_choice`, OpenAI-compatible forced function, Gemini JSON response, local fallback — plus a pure `StructuredVisionParser` per provider with a tolerant **text fallback** (a model that replies with prose JSON still yields a result).
- **Phase 3 — integration + UI:** `StructuredVisionService` (configured in `AppState`), the `vision_assess` tool (registered + described in both the LLM and Gemini Live system prompts), `AssessmentCardView` (coral AI accent) + HUD mirror, and the built-in **`instrument_reading`** consumer.

## Read the instrument

`AssessmentCard.readings: [InstrumentReading]` is first-class: typed value + unit-as-displayed + confidence, with `UnitNormalizer` filling canonical units deterministically. A reading below the schema's confidence floor becomes a **re-capture prompt**, never a silent guess. Usable on its own via `vision_assess kind:"instrument_reading"` — point at a gauge/thermometer/refractometer/scale/meter and get the number.

## Tests

**46 new tests** across 7 headless classes (units, tolerant JSON, card codable/escalation, provider parsers, schema adapter, service core via an injected analyze-seam, tool routing). Green on **Debug and Release**. Verified coexisting with the first-aid suite (69 tests total green) after rebasing onto current `main`.

## Deferred (follow-up PRs)

- First-aid casualty-triage consumer (now unblocked — #82 merged): a small schema + adapter + deterministic backstop.
- Gemini `responseSchema` translation (currently JSON-mode + prompt).
- CaptureFlow `voice_number` auto-fill from an instrument reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)