### PR TITLE
PR-1 hardening: ModelFetcher.modelsEndpoint refactor + Siri/local-server config tests

### DIFF
--- a/OpenGlasses/Sources/Services/ModelFetcher.swift
+++ b/OpenGlasses/Sources/Services/ModelFetcher.swift
@@ -32,20 +32,24 @@ enum ModelFetcher {
 
     // MARK: - OpenAI-compatible (/v1/models)
 
-    private static func fetchOpenAICompatible(apiKey: String, baseURL: String) async -> [RemoteModel] {
-        // Derive models endpoint from chat completions URL
-        // e.g. "https://api.openai.com/v1/chat/completions" → "https://api.openai.com/v1/models"
-        let modelsURL: String
+    /// Derive the `/models` listing endpoint from a chat-completions base URL.
+    /// Pure (no I/O) so it's unit-testable — the network call stays in the caller.
+    /// - `…/v1/chat/completions` → `…/v1/models`
+    /// - `…/v1`                  → `…/v1/models`
+    /// - bare host (any trailing slashes trimmed) → `…/models`
+    static func modelsEndpoint(from baseURL: String) -> String {
         if let range = baseURL.range(of: "/v1/", options: .backwards) {
-            modelsURL = String(baseURL[baseURL.startIndex..<range.upperBound]) + "models"
+            return String(baseURL[baseURL.startIndex..<range.upperBound]) + "models"
         } else if baseURL.hasSuffix("/v1") {
-            modelsURL = baseURL + "/models"
+            return baseURL + "/models"
         } else {
-            // Try appending /models to whatever base we have
             let trimmed = baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-            modelsURL = trimmed + "/models"
+            return trimmed + "/models"
         }
+    }
 
+    private static func fetchOpenAICompatible(apiKey: String, baseURL: String) async -> [RemoteModel] {
+        let modelsURL = modelsEndpoint(from: baseURL)
         guard let url = URL(string: modelsURL) else { return [] }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"

--- a/OpenGlassesTests/ModelFetcherTests.swift
+++ b/OpenGlassesTests/ModelFetcherTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Pure-logic coverage for the Custom / self-hosted-local-server plumbing:
+/// the models-endpoint URL derivation and the vision inference heuristic.
+/// Network I/O is deliberately untested — the string logic is the bug surface.
+final class ModelFetcherTests: XCTestCase {
+
+    // MARK: - modelsEndpoint(from:)
+
+    func testModelsEndpointFromChatCompletionsURL() {
+        // …/v1/chat/completions → …/v1/models (the OpenAI-style base URL the app stores)
+        XCTAssertEqual(
+            ModelFetcher.modelsEndpoint(from: "https://api.openai.com/v1/chat/completions"),
+            "https://api.openai.com/v1/models"
+        )
+    }
+
+    func testModelsEndpointFromV1Suffix() {
+        // …/v1 → …/v1/models (the typical Ollama / LM Studio base, e.g. http://host.local:11434/v1)
+        XCTAssertEqual(
+            ModelFetcher.modelsEndpoint(from: "http://my-mac.local:11434/v1"),
+            "http://my-mac.local:11434/v1/models"
+        )
+    }
+
+    func testModelsEndpointFromBareHost() {
+        // Bare host → /models
+        XCTAssertEqual(
+            ModelFetcher.modelsEndpoint(from: "http://my-mac.local:11434"),
+            "http://my-mac.local:11434/models"
+        )
+    }
+
+    func testModelsEndpointTrimsTrailingSlashOnBareHost() {
+        XCTAssertEqual(
+            ModelFetcher.modelsEndpoint(from: "http://my-mac.local:11434/"),
+            "http://my-mac.local:11434/models"
+        )
+    }
+
+    func testModelsEndpointPrefersLastV1Segment() {
+        // The `.backwards` search anchors on the final /v1/ occurrence.
+        XCTAssertEqual(
+            ModelFetcher.modelsEndpoint(from: "https://proxy.example.com/v1/openai/v1/chat/completions"),
+            "https://proxy.example.com/v1/openai/v1/models"
+        )
+    }
+
+    // MARK: - ModelConfig.inferredSupportsVision
+
+    private func inferredVision(_ provider: LLMProvider, _ model: String, baseURL: String = "") -> Bool {
+        ModelConfig.inferredSupportsVision(provider: provider, model: model, baseURL: baseURL)
+    }
+
+    func testInferredVisionCustomVisionModels() {
+        // A keyless local server commonly runs a vision model — these should default Vision on.
+        XCTAssertTrue(inferredVision(.custom, "llava"))
+        XCTAssertTrue(inferredVision(.custom, "pixtral-12b"))
+        XCTAssertTrue(inferredVision(.custom, "minicpm-v"))
+        XCTAssertTrue(inferredVision(.custom, "qwen2.5-vl-7b"))
+    }
+
+    func testInferredVisionCustomTextOnlyModel() {
+        // A bare text model on the Custom provider should default Vision off.
+        XCTAssertFalse(inferredVision(.custom, "llama3.1:8b"))
+        XCTAssertFalse(inferredVision(.custom, "mistral-7b"))
+    }
+
+    func testInferredVisionAlwaysOnProviders() {
+        XCTAssertTrue(inferredVision(.anthropic, "claude-anything"))
+        XCTAssertTrue(inferredVision(.gemini, "gemini-2.0-flash"))
+        XCTAssertTrue(inferredVision(.openai, "gpt-4o-mini"))
+    }
+
+    func testInferredVisionAlwaysOffProviders() {
+        XCTAssertFalse(inferredVision(.groq, "llama-3.1-70b"))
+        XCTAssertFalse(inferredVision(.local, "gemma-2b"))
+        XCTAssertFalse(inferredVision(.appleOnDevice, "apple"))
+    }
+
+    func testInferredVisionQwenHeuristic() {
+        XCTAssertTrue(inferredVision(.qwen, "qwen-vl-max"))
+        XCTAssertTrue(inferredVision(.qwen, "qwen-omni"))
+        XCTAssertFalse(inferredVision(.qwen, "qwen-turbo"))
+    }
+
+    func testInferredVisionOpenRouterHeuristic() {
+        XCTAssertTrue(inferredVision(.openrouter, "anthropic/claude-3.5-sonnet"))
+        XCTAssertTrue(inferredVision(.openrouter, "meta-llama/llava-13b"))
+        XCTAssertFalse(inferredVision(.openrouter, "mistralai/mistral-7b"))
+    }
+}

--- a/OpenGlassesTests/SiriIntentSupportTests.swift
+++ b/OpenGlassesTests/SiriIntentSupportTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Covers the pure config surface behind the Siri "Ask a Question" intent.
+/// (The intent's `perform()` itself drives `AppState`/Wearables, which a unit
+/// test must not touch — see the shared-services/Wearables testing note — so we
+/// pin the persisted flag it reads instead.)
+final class SiriIntentSupportTests: XCTestCase {
+
+    private let key = "siriAskOpensApp"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: key)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: key)
+        super.tearDown()
+    }
+
+    // MARK: - siriAskOpensApp
+
+    func testSiriAskOpensAppDefaultsToFalse() {
+        // Default false = hands-free background; Siri speaks the answer without
+        // forcing the app to the foreground.
+        XCTAssertFalse(Config.siriAskOpensApp)
+    }
+
+    func testSiriAskOpensAppSetAndGet() {
+        Config.setSiriAskOpensApp(true)
+        XCTAssertTrue(Config.siriAskOpensApp)
+
+        Config.setSiriAskOpensApp(false)
+        XCTAssertFalse(Config.siriAskOpensApp)
+    }
+}

--- a/docs/plans/siri-and-local-server.md
+++ b/docs/plans/siri-and-local-server.md
@@ -147,15 +147,19 @@ update the three intents' return types.
 Mirror `OpenGlassesTests/ConfigTests.swift` (UserDefaults setup/teardown).
 Refactor where needed so logic is pure and testable:
 
-- **`Config.siriAskOpensApp`** — default `false`; set/get round-trip.
-- **`ModelConfig.inferredSupportsVision`** — `custom` + `llava`/`pixtral`/
+- ✅ **`Config.siriAskOpensApp`** — default `false`; set/get round-trip.
+  (`SiriIntentSupportTests`)
+- ✅ **`ModelConfig.inferredSupportsVision`** — `custom` + `llava`/`pixtral`/
   `minicpm-v` → true; bare text model → false; existing provider cases.
-- **`ModelFetcher` models-endpoint derivation** — extract the URL-derivation in
-  `fetchOpenAICompatible` into a pure `static func modelsEndpoint(from:)` and
-  test `/v1/chat/completions` → `/v1/models`, `/v1` → `/v1/models`, bare host →
-  `/models`. (Network calls stay untested; the string logic is the bug surface.)
-- **Persona resolution helper (#1)** — name/phrase → persona match (pure).
-- **`LocalServerPreset` (#5)** — preset → base URL/model mapping.
+  (`ModelFetcherTests`)
+- ✅ **`ModelFetcher` models-endpoint derivation** — extracted the URL-derivation
+  in `fetchOpenAICompatible` into a pure `static func modelsEndpoint(from:)` and
+  tested `/v1/chat/completions` → `/v1/models`, `/v1` → `/v1/models`, bare host →
+  `/models` (+ trailing-slash and last-`/v1/`-wins edge cases). (`ModelFetcherTests`)
+- ⏳ **Persona resolution helper (#1)** — name/phrase → persona match (pure).
+  Deferred to PR-2 (lands with the persona intent it supports).
+- ⏳ **`LocalServerPreset` (#5)** — preset → base URL/model mapping.
+  Deferred to PR-3 (lands with the preset feature it supports).
 
 **Files:** new `OpenGlassesTests/SiriIntentSupportTests.swift`,
 `ModelFetcherTests.swift`; small pure-function refactors in `ModelFetcher.swift`.
@@ -164,8 +168,10 @@ Refactor where needed so logic is pure and testable:
 
 ## Suggested PR ordering (stacked)
 
-1. **PR-1 (hardening):** #7 tests + the pure-function refactors they require.
-   Lands first so the rest is de-risked.
+1. ✅ **PR-1 (hardening):** the #7 tests + refactor for surfaces that exist today
+   — `Config.siriAskOpensApp`, `ModelConfig.inferredSupportsVision`, and the
+   extracted `ModelFetcher.modelsEndpoint(from:)` (13 tests). The persona/preset
+   tests ride along with their features in PR-2/PR-3. Landed first to de-risk.
 2. **PR-2 (Siri):** #1 persona intent, #2 follow-up, #3 snippets.
 3. **PR-3 (local server):** #4 connection test, #5 presets, then #6 discovery
    (separately, behind an experimental flag — droppable).


### PR DESCRIPTION
## Summary

First of the stacked follow-ups to the merged Siri + keyless-local-server work ([#92](https://github.com/straff2002/OpenGlasses/pull/92)), per `docs/plans/siri-and-local-server.md` **item #7**. Deterministic, no-hardware, lands first to de-risk PR-2 (Siri persona/follow-up/snippets) and PR-3 (local-server connection-test/presets/discovery).

## Changes

- **Refactor (behaviour-preserving):** extract the models-endpoint URL derivation in `ModelFetcher.fetchOpenAICompatible` into a pure, unit-testable `static func modelsEndpoint(from:)`. Network I/O stays in the caller; the string logic was the untested bug surface.
- **`ModelFetcherTests` (11):**
  - `modelsEndpoint(from:)` — `/v1/chat/completions` → `/v1/models`, `/v1` → `/v1/models`, bare host → `/models`, plus trailing-slash and last-`/v1/`-wins edges.
  - `ModelConfig.inferredSupportsVision` — custom `llava`/`pixtral`/`minicpm-v`/`qwen-vl` → true, bare text model → false, always-on/off providers, qwen + openrouter heuristics.
- **`SiriIntentSupportTests` (2):** `Config.siriAskOpensApp` default-`false` + set/get round-trip (the persisted flag the Siri ask-intent reads).

Persona-resolution (#1) and `LocalServerPreset` (#5) test helpers are deferred to PR-2/PR-3, where those features land. Plan doc updated to mark this slice done.

## Verification

Release config (`-configuration Release ENABLE_TESTABILITY=YES`), iPhone 17 sim:
- 13 new tests pass.
- Full suite **979 tests** — only the pre-existing keychain-entitlement failures (an artifact of a headless `CODE_SIGNING_ALLOWED=NO` run; those classes can't reach the keychain without signing). **No regressions** from the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)