### PR TITLE
PR-2 (Siri): persona-targeted intent + conversational follow-up + result snippet

### DIFF
--- a/OpenGlasses/Sources/App/Intents/AskOpenGlassesIntent.swift
+++ b/OpenGlasses/Sources/App/Intents/AskOpenGlassesIntent.swift
@@ -68,18 +68,21 @@ struct TakePhotoIntent: AppIntent {
 /// Register shortcuts so they appear in the Shortcuts app and Action Button picker.
 struct OpenGlassesShortcuts: AppShortcutsProvider {
     static var appShortcuts: [AppShortcut] {
-        // NOTE: App Shortcut phrases may only interpolate parameters whose type is
-        // an AppEntity or AppEnum — Siri needs a finite, resolvable set to predict
-        // against. A free-form String like `$question` is rejected by the AppIntents
+        // App Shortcut phrases may only interpolate parameters whose type is an
+        // AppEntity or AppEnum — Siri needs a finite, resolvable set to predict
+        // against. A free-form String (the question) is rejected by the AppIntents
         // metadata processor with a *halting* error that wipes ALL exported intent
-        // metadata, so the spoken question can't ride inside the phrase. Instead the
-        // phrase invokes the intent and Siri resolves the question two-step via the
-        // parameter's `requestValueDialog`.
+        // metadata, so it's resolved two-step via `requestValueDialog`. The persona,
+        // however, IS an AppEntity, so it can ride inside the phrase ("Ask Claude on
+        // OpenGlasses…"). Persona is optional — the generic phrase falls back to the
+        // active/first persona, so this one intent covers both the generic and the
+        // persona-targeted ask (and keeps us at iOS's 10-shortcut cap).
         AppShortcut(
-            intent: AskQuestionIntent(),
+            intent: AskPersonaIntent(),
             phrases: [
                 "Ask \(.applicationName) a question",
-                "Question for \(.applicationName)"
+                "Ask \(\.$persona) on \(.applicationName)",
+                "Ask \(\.$persona) \(.applicationName)"
             ],
             shortTitle: "Ask a Question",
             systemImageName: "bubble.left.and.bubble.right.fill"

--- a/OpenGlasses/Sources/App/Intents/AskPersonaIntent.swift
+++ b/OpenGlasses/Sources/App/Intents/AskPersonaIntent.swift
@@ -1,0 +1,109 @@
+import AppIntents
+
+/// Persona-targeted conversational Siri intent:
+/// *"Hey Siri, ask Claude on OpenGlasses what's on my calendar."*
+///
+/// Carries the persona as an `AppEntity` parameter (allowed inside an AppShortcut
+/// phrase, so the persona name can ride in one breath) and the question as a
+/// two-step `requestValueDialog` parameter. Runs the query under the chosen
+/// persona's model + prompt preset, has Siri speak the answer, then restores the
+/// previously-active model so a one-off Siri ask never permanently switches the
+/// user's setup.
+///
+/// The persona is **optional**: omit it ("Ask OpenGlasses a question") and it
+/// falls back to the active persona, else the first enabled one — so this single
+/// intent serves both the generic and the persona-targeted ask.
+struct AskPersonaIntent: AppIntent {
+    static var title: LocalizedStringResource = "Ask a Persona"
+    static var description = IntentDescription(
+        "Ask a specific OpenGlasses persona by voice and hear the answer"
+    )
+
+    static var openAppWhenRun: Bool { Config.siriAskOpensApp }
+    static var isDiscoverable: Bool { true }
+
+    @Parameter(title: "Persona")
+    var persona: PersonaEntity?
+
+    @Parameter(
+        title: "Question",
+        description: "What you want to ask",
+        requestValueDialog: "What would you like to ask?"
+    )
+    var question: String
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog & ShowsSnippetView {
+        // Step 1 — await the connection signal (shared with AskQuestionIntent).
+        let appState = try await IntentSupport.awaitConnectedAppState()
+
+        // Don't ride a stale `lastResponse` if a voice turn is already in flight.
+        guard !appState.isProcessing else {
+            throw IntentError.busy
+        }
+
+        // Step 2 — the question is resolved two-step by Siri before we get here.
+        let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw IntentError.emptyQuestion
+        }
+
+        let resolved = resolvePersona(appState: appState)
+
+        // Conversational follow-up: continue a recent Siri thread, else start fresh.
+        if Config.conversationPersistenceEnabled {
+            appState.conversationStore.continueRecentOrStartThread(
+                mode: appState.currentMode.rawValue,
+                within: Self.followUpWindow
+            )
+        }
+
+        // Run under the persona (model + preset), restoring the prior setup after.
+        if let resolved {
+            await appState.askUnderPersona(resolved, question: trimmed)
+        } else {
+            await appState.sendTextMessage(trimmed, speakResponse: false)
+        }
+
+        let answer = appState.lastResponse.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !answer.isEmpty else {
+            throw IntentError.noResponse
+        }
+
+        let snippet = AnswerSnippetView(personaName: resolved?.name, answer: answer)
+        return .result(value: answer, dialog: IntentDialog(stringLiteral: answer), view: snippet)
+    }
+
+    /// Consecutive Siri asks within this window continue the same conversation thread.
+    private static let followUpWindow: TimeInterval = 5 * 60
+
+    /// Resolve which persona to run under: the explicitly named one (if still
+    /// enabled), else the currently-active persona, else the first enabled persona.
+    @MainActor
+    private func resolvePersona(appState: AppState) -> Persona? {
+        if let persona, let match = Config.enabledPersonas.first(where: { $0.id == persona.id }) {
+            return match
+        }
+        if let active = appState.activePersona {
+            return active
+        }
+        return Config.enabledPersonas.first
+    }
+
+    enum IntentError: Error, CustomLocalizedStringResourceConvertible {
+        case busy
+        case emptyQuestion
+        case noResponse
+
+        var localizedStringResource: LocalizedStringResource {
+            switch self {
+            case .busy:
+                return "OpenGlasses is still working on something. Try again in a moment."
+            case .emptyQuestion:
+                return "I didn't catch a question."
+            case .noResponse:
+                return "Sorry, I couldn't get an answer."
+            }
+        }
+    }
+}

--- a/OpenGlasses/Sources/App/Intents/AskQuestionIntent.swift
+++ b/OpenGlasses/Sources/App/Intents/AskQuestionIntent.swift
@@ -37,10 +37,6 @@ struct AskQuestionIntent: AppIntent {
     static var openAppWhenRun: Bool { Config.siriAskOpensApp }
     static var isDiscoverable: Bool { true }
 
-    /// How long to wait for the app to signal it's up before giving up (step 1).
-    private static let connectionTimeout: Duration = .seconds(4)
-    private static let connectionPollInterval: Duration = .milliseconds(100)
-
     @Parameter(
         title: "Question",
         description: "What you want to ask OpenGlasses",
@@ -49,11 +45,11 @@ struct AskQuestionIntent: AppIntent {
     var question: String
 
     @MainActor
-    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
-        // Step 1 — await the connection signal. The app may not be wired up the
-        // instant Siri calls us (background invocation, or a fresh launch when
-        // `siriAskOpensApp` is on), so wait briefly instead of failing immediately.
-        let appState = try await awaitConnectedAppState()
+    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog & ShowsSnippetView {
+        // Step 1 — await the connection signal (shared with the persona intent).
+        // The app may not be wired up the instant Siri calls us (background
+        // invocation, or a fresh launch when `siriAskOpensApp` is on).
+        let appState = try await IntentSupport.awaitConnectedAppState()
 
         // Don't ride on a stale `lastResponse`: if a wake-word/voice turn is already
         // in flight, `sendTextMessage` would no-op and we'd speak the previous answer.
@@ -77,35 +73,17 @@ struct AskQuestionIntent: AppIntent {
             throw IntentError.noResponse
         }
 
-        return .result(value: answer, dialog: IntentDialog(stringLiteral: answer))
-    }
-
-    /// Wait up to `connectionTimeout` for the app to signal it's running and wired
-    /// up, polling on the main actor. Returns as soon as `AppStateProvider.shared`
-    /// is available; throws `appNotRunning` only if the signal never arrives (the
-    /// app was killed and not relaunched). A no-op when the app is already resident.
-    @MainActor
-    private func awaitConnectedAppState() async throws -> AppState {
-        if let appState = AppStateProvider.shared { return appState }
-
-        let deadline = ContinuousClock.now + Self.connectionTimeout
-        while ContinuousClock.now < deadline {
-            try await Task.sleep(for: Self.connectionPollInterval)
-            if let appState = AppStateProvider.shared { return appState }
-        }
-        throw IntentError.appNotRunning
+        let snippet = AnswerSnippetView(personaName: appState.activePersona?.name, answer: answer)
+        return .result(value: answer, dialog: IntentDialog(stringLiteral: answer), view: snippet)
     }
 
     enum IntentError: Error, CustomLocalizedStringResourceConvertible {
-        case appNotRunning
         case busy
         case emptyQuestion
         case noResponse
 
         var localizedStringResource: LocalizedStringResource {
             switch self {
-            case .appNotRunning:
-                return "OpenGlasses is not running. Open the app first."
             case .busy:
                 return "OpenGlasses is still working on something. Try again in a moment."
             case .emptyQuestion:

--- a/OpenGlasses/Sources/App/Intents/IntentSnippets.swift
+++ b/OpenGlasses/Sources/App/Intents/IntentSnippets.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Compact result card shown in the Siri / Shortcuts UI alongside the spoken
+/// answer (the dialog stays for the eyes-free case; the snippet is additive).
+struct AnswerSnippetView: View {
+    let personaName: String?
+    let answer: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let personaName, !personaName.isEmpty {
+                Label(personaName, systemImage: "person.wave.2.fill")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            Text(answer)
+                .font(.body)
+                .foregroundStyle(.primary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+    }
+}

--- a/OpenGlasses/Sources/App/Intents/IntentSupport.swift
+++ b/OpenGlasses/Sources/App/Intents/IntentSupport.swift
@@ -1,0 +1,34 @@
+import AppIntents
+
+/// Shared helpers for the Siri App Intents.
+enum IntentSupport {
+    /// Await the app "connection signal" — poll for `AppStateProvider.shared`.
+    ///
+    /// Siri can invoke a background intent before the app scene is fully resident
+    /// (more so under iOS 27's background-driven conversational Siri), so we wait
+    /// briefly rather than failing the instant `.shared` is nil. Returns as soon as
+    /// the app is up; throws `appNotRunning` only if the signal never arrives.
+    @MainActor
+    static func awaitConnectedAppState(
+        timeout: Duration = .seconds(4),
+        pollInterval: Duration = .milliseconds(100)
+    ) async throws -> AppState {
+        if let appState = AppStateProvider.shared { return appState }
+
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            try await Task.sleep(for: pollInterval)
+            if let appState = AppStateProvider.shared { return appState }
+        }
+        throw IntentConnectionError.appNotRunning
+    }
+}
+
+/// Error thrown when a Siri intent can't reach a running app.
+enum IntentConnectionError: Error, CustomLocalizedStringResourceConvertible {
+    case appNotRunning
+
+    var localizedStringResource: LocalizedStringResource {
+        "OpenGlasses is not running. Open the app first."
+    }
+}

--- a/OpenGlasses/Sources/App/Intents/PersonaEntity.swift
+++ b/OpenGlasses/Sources/App/Intents/PersonaEntity.swift
@@ -1,0 +1,54 @@
+import AppIntents
+
+/// An enabled persona, exposed to Siri/Shortcuts as a selectable parameter.
+///
+/// Crucially, an `AppEntity` parameter (unlike a free-form `String`) IS allowed
+/// inside an `AppShortcut` phrase — so "Ask Claude on OpenGlasses…" works in one
+/// breath, with Siri resolving "Claude" against the user's real persona list.
+struct PersonaEntity: AppEntity, Identifiable {
+    static var typeDisplayRepresentation: TypeDisplayRepresentation = "Persona"
+    static var defaultQuery = PersonaQuery()
+
+    let id: String
+    let name: String
+
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+
+    init(_ persona: Persona) {
+        self.id = persona.id
+        self.name = persona.name
+    }
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(name)")
+    }
+}
+
+/// Enumerates the user's enabled personas for the Siri/Shortcuts parameter UI.
+/// `EntityStringQuery` (not just `EntityQuery`) so Siri can resolve a *spoken*
+/// persona name — "ask Claude" → the Claude persona — rather than always falling
+/// back to a disambiguation list.
+struct PersonaQuery: EntityStringQuery {
+    func entities(for identifiers: [PersonaEntity.ID]) async throws -> [PersonaEntity] {
+        Config.enabledPersonas
+            .filter { identifiers.contains($0.id) }
+            .map(PersonaEntity.init)
+    }
+
+    func suggestedEntities() async throws -> [PersonaEntity] {
+        Config.enabledPersonas.map(PersonaEntity.init)
+    }
+
+    /// Match a spoken/typed persona name (case-insensitive substring) so Siri can
+    /// resolve "ask Claude" to the Claude persona.
+    func entities(matching string: String) async throws -> [PersonaEntity] {
+        let target = string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !target.isEmpty else { return [] }
+        return Config.enabledPersonas
+            .filter { $0.name.lowercased().contains(target) }
+            .map(PersonaEntity.init)
+    }
+}

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2714,6 +2714,27 @@ class AppState: ObservableObject, AppStateProtocol {
         speechService.stopThinkingSound()
     }
 
+    /// Run a one-shot query under a specific persona, then restore the prior
+    /// active model/preset/persona. Used by the Siri persona intent so a persona
+    /// ask doesn't permanently switch the user's active setup. `sendMessage`
+    /// reads `Config.activeModel` per call, so switching here routes this turn to
+    /// the persona's model (mirrors the wake-word persona-routing path).
+    func askUnderPersona(_ persona: Persona, question: String) async {
+        let prevModelId = Config.activeModelId
+        let prevPresetId = Config.activePresetId
+        let prevPersona = activePersona
+
+        activePersona = persona
+        Config.setActiveModelId(persona.modelId)
+        Config.setActivePresetId(persona.presetId)
+
+        await sendTextMessage(question, speakResponse: false)
+
+        Config.setActiveModelId(prevModelId)
+        Config.setActivePresetId(prevPresetId)
+        activePersona = prevPersona
+    }
+
     /// Start wake word listener in "stop detection" mode during TTS playback.
     /// With .playAndRecord audio session (Bluetooth HFP), mic works during TTS.
     private func startStopListener() {

--- a/OpenGlasses/Sources/Services/ConversationStore.swift
+++ b/OpenGlasses/Sources/Services/ConversationStore.swift
@@ -145,6 +145,26 @@ class ConversationStore: ObservableObject {
         NSLog("[ConversationStore] Ended thread")
     }
 
+    // MARK: - Recency (one-shot entry points like Siri)
+
+    /// True when `last` is within `window` seconds of `now`. Pure — unit-testable
+    /// (nonisolated so it's callable off the main actor, e.g. from tests).
+    nonisolated static func isWithinRecencyWindow(_ last: Date, now: Date, window: TimeInterval) -> Bool {
+        now.timeIntervalSince(last) <= window
+    }
+
+    /// For one-shot entry points (e.g. the Siri ask intents): keep the active
+    /// thread if its last turn was recent, otherwise start a fresh one so that
+    /// unrelated asks minutes apart don't pile into a single thread.
+    func continueRecentOrStartThread(mode: String, within window: TimeInterval, now: Date = Date()) {
+        if let id = activeThreadId,
+           let thread = threads.first(where: { $0.id == id }),
+           Self.isWithinRecencyWindow(thread.updatedAt, now: now, window: window) {
+            return  // reuse the recent active thread (conversational follow-up)
+        }
+        startThread(mode: mode)
+    }
+
     /// Resume an existing thread (e.g. after app relaunch).
     func resumeThread(_ threadId: String) -> ConversationThread? {
         guard let thread = threads.first(where: { $0.id == threadId }) else { return nil }

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -1579,6 +1579,14 @@ struct Config {
         }
     }
 
+    /// Resolve an enabled persona by its display name (case-insensitive), for the
+    /// Siri persona intent's fuzzy parameter matching. Pure — unit-testable.
+    static func persona(named name: String) -> Persona? {
+        let target = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !target.isEmpty else { return nil }
+        return enabledPersonas.first { $0.name.lowercased() == target }
+    }
+
     /// All wake phrases across all enabled personas (for speech recognition boosting).
     static var allActiveWakePhrases: [String] {
         enabledPersonas.flatMap(\.allPhrases)

--- a/OpenGlassesTests/PersonaIntentTests.swift
+++ b/OpenGlassesTests/PersonaIntentTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Pure-logic coverage for the Siri persona intent (#1) and the conversational
+/// follow-up recency window (#2). The intent's `perform()` drives AppState /
+/// Wearables, which a unit test must not touch — so we pin the deterministic
+/// pieces: entity mapping, name resolution, and the recency predicate.
+final class PersonaIntentTests: XCTestCase {
+
+    private func makePersona(
+        id: String, name: String, enabled: Bool = true
+    ) -> Persona {
+        Persona(
+            id: id,
+            name: name,
+            wakePhrase: "hey \(name.lowercased())",
+            alternativeWakePhrases: [],
+            modelId: "model-\(id)",
+            presetId: "preset-\(id)",
+            enabled: enabled
+        )
+    }
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: "savedPersonas")
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "savedPersonas")
+        super.tearDown()
+    }
+
+    // MARK: - PersonaEntity mapping
+
+    func testPersonaEntityMapsIdAndName() {
+        let persona = makePersona(id: "abc123", name: "Claude")
+        let entity = PersonaEntity(persona)
+        XCTAssertEqual(entity.id, "abc123")
+        XCTAssertEqual(entity.name, "Claude")
+    }
+
+    // MARK: - Config.persona(named:)
+
+    func testPersonaNamedMatchesCaseInsensitively() {
+        Config.setSavedPersonas([
+            makePersona(id: "1", name: "Claude"),
+            makePersona(id: "2", name: "Jarvis"),
+        ])
+        XCTAssertEqual(Config.persona(named: "claude")?.id, "1")
+        XCTAssertEqual(Config.persona(named: "CLAUDE")?.id, "1")
+        XCTAssertEqual(Config.persona(named: "  jarvis ")?.id, "2")
+    }
+
+    func testPersonaNamedReturnsNilForUnknownOrEmpty() {
+        Config.setSavedPersonas([makePersona(id: "1", name: "Claude")])
+        XCTAssertNil(Config.persona(named: "Cortana"))
+        XCTAssertNil(Config.persona(named: ""))
+        XCTAssertNil(Config.persona(named: "   "))
+    }
+
+    func testPersonaNamedIgnoresDisabledPersonas() {
+        Config.setSavedPersonas([
+            makePersona(id: "1", name: "Claude", enabled: false),
+            makePersona(id: "2", name: "Jarvis", enabled: true),
+        ])
+        XCTAssertNil(Config.persona(named: "Claude"))
+        XCTAssertEqual(Config.persona(named: "Jarvis")?.id, "2")
+    }
+
+    // MARK: - ConversationStore recency window
+
+    func testRecencyWindowWithinReturnsTrue() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let last = now.addingTimeInterval(-60)  // 1 min ago
+        XCTAssertTrue(ConversationStore.isWithinRecencyWindow(last, now: now, window: 300))
+    }
+
+    func testRecencyWindowOutsideReturnsFalse() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let last = now.addingTimeInterval(-600)  // 10 min ago
+        XCTAssertFalse(ConversationStore.isWithinRecencyWindow(last, now: now, window: 300))
+    }
+
+    func testRecencyWindowBoundaryIsInclusive() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let last = now.addingTimeInterval(-300)  // exactly at the window edge
+        XCTAssertTrue(ConversationStore.isWithinRecencyWindow(last, now: now, window: 300))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ OpenGlasses ships App Intents + Siri Shortcuts, so you can drive it straight fro
 
 | Say | What Happens |
 |-----|-------------|
-| "Hey Siri, ask OpenGlasses a question" | Siri asks **"What would you like to ask?"**, you speak the question, it's routed through your model/persona pipeline, and **Siri reads the answer back** |
+| "Hey Siri, ask **Claude** on OpenGlasses what's on my calendar" | Runs the question under that **persona's** model + prompt, **Siri reads the answer back**, then restores your active model |
+| "Hey Siri, ask OpenGlasses a question" | Siri asks **"What would you like to ask?"**, you speak the question, it's answered under your active persona |
 | "Hey Siri, OpenGlasses take a photo" | Captures via the glasses and describes the scene |
 | "Hey Siri, OpenGlasses describe surroundings" | Accessibility scene description |
 
-The first time, iOS surfaces these in the **Shortcuts** app and the Siri phrase picker (you can rename the phrase to anything you like). The "ask a question" flow is **two-step**: the trigger phrase invokes the intent, then Siri prompts for the question and awaits your spoken reply — iOS only lets App Shortcut phrases embed a fixed set of choices, not free-form text, so the question is asked second rather than crammed into the trigger. The intent runs in the background and speaks the result — no need to bring the app forward. If Siri ever says OpenGlasses isn't running, enable **Settings → Voice → Open App for Siri Questions** to have it launch the app first.
+The first time, iOS surfaces these in the **Shortcuts** app and the Siri phrase picker (you can rename the phrase to anything you like). A **persona name** can ride in the phrase ("ask Claude…") because it's a fixed, resolvable choice; the **question** can't (iOS only lets App Shortcut phrases embed fixed choices, not free-form text), so it's asked **two-step** — Siri prompts and awaits your spoken reply. Consecutive asks within a few minutes continue the **same conversation thread**, and Siri shows the answer in a result card. The intent runs in the background and speaks the result — no need to bring the app forward. If Siri ever says OpenGlasses isn't running, enable **Settings → Voice → Open App for Siri Questions** to have it launch the app first.
 
 ### On-Device Local LLM
 

--- a/docs/plans/siri-and-local-server.md
+++ b/docs/plans/siri-and-local-server.md
@@ -29,15 +29,15 @@ medium; #6 (mDNS discovery) is the only piece with real platform risk.
 
 ## Scope (items 1–7)
 
-| # | Item | Thread | Effort | Risk |
-|---|------|--------|--------|------|
-| 1 | Persona-targeted Siri intent | Siri | S | low |
-| 2 | Conversational follow-up | Siri | M | low |
-| 3 | Result snippet UI | Siri | S–M | low |
-| 4 | Connection-test button | Local server | S | low |
-| 5 | Local-server presets | Local server | S | low |
-| 6 | LAN auto-detect (mDNS) | Local server | M–L | **medium** (platform) |
-| 7 | Unit tests | Hardening | S | low |
+| # | Item | Thread | Effort | Risk | Status |
+|---|------|--------|--------|------|--------|
+| 1 | Persona-targeted Siri intent | Siri | S | low | ✅ PR-2 |
+| 2 | Conversational follow-up | Siri | M | low | ✅ PR-2 |
+| 3 | Result snippet UI | Siri | S–M | low | ✅ PR-2 |
+| 4 | Connection-test button | Local server | S | low | PR-3 |
+| 5 | Local-server presets | Local server | S | low | PR-3 |
+| 6 | LAN auto-detect (mDNS) | Local server | M–L | **medium** (platform) | PR-3 |
+| 7 | Unit tests | Hardening | S | low | ✅ PR-1 (#93) |
 
 ---
 
@@ -172,7 +172,13 @@ Refactor where needed so logic is pure and testable:
    — `Config.siriAskOpensApp`, `ModelConfig.inferredSupportsVision`, and the
    extracted `ModelFetcher.modelsEndpoint(from:)` (13 tests). The persona/preset
    tests ride along with their features in PR-2/PR-3. Landed first to de-risk.
-2. **PR-2 (Siri):** #1 persona intent, #2 follow-up, #3 snippets.
+2. ✅ **PR-2 (Siri):** #1 `AskPersonaIntent` + `PersonaEntity`/`PersonaQuery`
+   (`EntityStringQuery`; optional persona param so the generic ask still works;
+   replaces the generic shortcut to stay under the 10-phrase cap); #2 thread-recency
+   follow-up (`ConversationStore.continueRecentOrStartThread`); #3 `AnswerSnippetView`
+   result card. `AppState.askUnderPersona` runs the turn under the persona's model
+   then restores. Pure logic unit-tested; live Siri/persona routing is a hardware
+   path, not device-verified.
 3. **PR-3 (local server):** #4 connection test, #5 presets, then #6 discovery
    (separately, behind an experimental flag — droppable).
 


### PR DESCRIPTION
## Summary

Second stacked follow-up to the Siri + keyless-local-server work, per `docs/plans/siri-and-local-server.md` **items #1–#3**. Builds on PR-1 ([#93](https://github.com/straff2002/OpenGlasses/pull/93)).

## #1 — Persona-targeted Siri intent
- **`PersonaEntity`** (`AppEntity`) + **`PersonaQuery`** (`EntityStringQuery`) expose the user's enabled personas to Siri/Shortcuts. An `AppEntity` parameter **is** allowed inside an AppShortcut phrase (a free-form `String` is not — that was the PR #92 halting-error lesson), so **"Ask Claude on OpenGlasses…"** resolves the persona in one breath; the question is still resolved two-step via `requestValueDialog`.
- **`AskPersonaIntent`** — optional `persona` param (falls back to the active persona, else the first enabled one), two-step `question`. It **replaces** the generic `AskQuestionIntent` shortcut so a single intent covers both the generic and persona-targeted ask — keeping us at iOS's hard **10-phrase cap**.
- **`AppState.askUnderPersona`** runs the turn under the persona's model + prompt preset (`sendMessage` reads `Config.activeModel` per call, mirroring the wake-word routing path), then **restores** the prior model/preset/persona so a one-off Siri ask never permanently switches your setup.
- **`IntentSupport.awaitConnectedAppState`** factored out of `AskQuestionIntent`, now shared by both ask intents.

## #2 — Conversational follow-up
- **`ConversationStore.continueRecentOrStartThread(within:)`** + pure **`isWithinRecencyWindow`**: consecutive Siri asks within **5 minutes** continue the same conversation thread; outside the window, start fresh. (`LLMService` already keeps in-session history, so the model sees prior turns.)

## #3 — Result snippet
- **`AnswerSnippetView`** shown via `.result(value:dialog:view:)` on both ask intents, surfacing the persona name when present. The spoken `dialog` stays for the eyes-free case.

## Tests
`PersonaIntentTests` (7): `PersonaEntity` mapping, `Config.persona(named:)` (case-insensitive, enabled-only), recency-window predicate (within / outside / inclusive boundary).

## Verification
Release config (`ENABLE_TESTABILITY=YES`), iPhone 17 sim:
- App target + **AppIntents metadata export compile clean** — the `AppEntity`-in-phrase and the snippet return types both pass the `appintentsmetadataprocessor` (the exact stage that caught PR #92's bug).
- 7 new tests green.
- ⚠️ Live Siri invocation + persona model-switch routing is a **hardware path** and is **not** device-verified here (no glasses/device in this environment).

## Plan status
Marks #1–#3 ✅ in the plan. Remaining: **PR-3 (local server)** — #4 connection-test, #5 presets, #6 mDNS discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)