### PR TITLE
Teleprompter Phase 2 (PR B): Share Extension — share scripts into OpenGlasses

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -280,6 +280,12 @@ struct OpenGlassesApp: App {
             case .active:
                 print("📱 App became active")
                 appState.restoreFromBackground()
+                // Teleprompter (PR B): pull in any scripts shared via the iOS share sheet
+                // while we were away.
+                let imported = appState.teleprompterStore.importPendingShares()
+                if imported > 0 {
+                    appState.glassesDisplay.flash("Imported \(imported) teleprompter script\(imported == 1 ? "" : "s")")
+                }
                 // Refresh the Siri Shortcuts catalog — the user may have added shortcuts
                 // while away — so the agent's run_shortcut menu stays current (Plan Z).
                 Task { await ShortcutsCatalog.shared.refresh() }

--- a/OpenGlasses/Sources/Services/Teleprompter/TeleprompterScriptStore.swift
+++ b/OpenGlasses/Sources/Services/Teleprompter/TeleprompterScriptStore.swift
@@ -45,6 +45,7 @@ final class TeleprompterScriptStore: ObservableObject {
             ?? FileManager.default.temporaryDirectory
         fileURL = dir.appendingPathComponent("teleprompter_scripts.json")
         load()
+        importPendingShares()
     }
 
     // MARK: - Mutations
@@ -77,6 +78,20 @@ final class TeleprompterScriptStore: ObservableObject {
     func delete(at offsets: IndexSet) {
         scripts.remove(atOffsets: offsets)
         save()
+    }
+
+    /// Drain any scripts shared in via the Share Extension (PR B) and save them (newest
+    /// first). Called on init and on app foreground. Returns the number imported.
+    @discardableResult
+    func importPendingShares() -> Int {
+        let pending = SharedTeleprompterInbox.drain()
+        guard !pending.isEmpty else { return 0 }
+        for item in pending {
+            let title = item.title.isEmpty ? SavedScript.deriveTitle(from: item.text) : item.title
+            scripts.insert(SavedScript(title: title, text: item.text), at: 0)
+        }
+        save()
+        return pending.count
     }
 
     // MARK: - Lookup

--- a/OpenGlasses/Sources/Shared/SharedTeleprompterInbox.swift
+++ b/OpenGlasses/Sources/Shared/SharedTeleprompterInbox.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// App-group hand-off for teleprompter scripts shared into OpenGlasses from the iOS share
+/// sheet. The Share Extension runs in a separate process and can't touch the app's
+/// Documents, so it appends pending scripts to a JSON file in the shared app-group
+/// container; the main app drains them into `TeleprompterScriptStore` on launch/foreground.
+///
+/// Compiled into BOTH the app and the extension target. The pure, side-effect-free helpers
+/// plus the `testContainerURL` seam make it unit-testable without the real container.
+enum SharedTeleprompterInbox {
+    static let appGroupID = "group.com.openglasses.app"
+    private static let fileName = "teleprompter_inbox.json"
+
+    /// Test seam: when set, used instead of the app-group container.
+    static var testContainerURL: URL?
+
+    struct PendingScript: Codable, Equatable {
+        var title: String
+        var text: String
+        var receivedAt: Date
+
+        init(title: String, text: String, receivedAt: Date = Date()) {
+            self.title = title
+            self.text = text
+            self.receivedAt = receivedAt
+        }
+    }
+
+    private static var fileURL: URL? {
+        let container = testContainerURL
+            ?? FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID)
+        return container?.appendingPathComponent(fileName)
+    }
+
+    /// Append a shared script to the inbox (called from the Share Extension).
+    static func append(title: String, text: String) {
+        let clean = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !clean.isEmpty, let url = fileURL else { return }
+        var pending = load()
+        pending.append(PendingScript(title: title.trimmingCharacters(in: .whitespacesAndNewlines), text: clean))
+        guard let data = try? JSONEncoder().encode(pending) else { return }
+        try? data.write(to: url, options: .atomic)
+    }
+
+    /// Return and clear all pending scripts (called from the main app).
+    static func drain() -> [PendingScript] {
+        let pending = load()
+        guard !pending.isEmpty, let url = fileURL else { return [] }
+        try? FileManager.default.removeItem(at: url)
+        return pending
+    }
+
+    private static func load() -> [PendingScript] {
+        guard let url = fileURL, let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode([PendingScript].self, from: data) else { return [] }
+        return decoded
+    }
+}

--- a/OpenGlassesShareExtension/Info.plist
+++ b/OpenGlassesShareExtension/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>OpenGlasses Teleprompter</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsAttachmentsWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>ShareViewController</string>
+	</dict>
+</dict>
+</plist>

--- a/OpenGlassesShareExtension/OpenGlassesShareExtension.entitlements
+++ b/OpenGlassesShareExtension/OpenGlassesShareExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.openglasses.app</string>
+	</array>
+</dict>
+</plist>

--- a/OpenGlassesShareExtension/ShareViewController.swift
+++ b/OpenGlassesShareExtension/ShareViewController.swift
@@ -1,0 +1,96 @@
+import UIKit
+import Social
+import UniformTypeIdentifiers
+
+/// Share Extension: lets the user send text (e.g. from an Apple Note), a URL, or a text
+/// file straight into OpenGlasses as a teleprompter script. Uses the system compose UI
+/// (`SLComposeServiceViewController`), which pre-fills the editable box with shared text,
+/// and hands the (possibly-edited) result to the main app via `SharedTeleprompterInbox`.
+@objc(ShareViewController)
+final class ShareViewController: SLComposeServiceViewController {
+
+    override func presentationAnimationDidFinish() {
+        super.presentationAnimationDidFinish()
+        // For non-text items (URL / text file) the box starts empty — pull the text in so
+        // the user sees and can edit it before posting.
+        if (contentText ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            loadSharedText { [weak self] text in
+                guard let self, let text, !text.isEmpty else { return }
+                self.textView.text = text
+                self.validateContent()
+            }
+        }
+    }
+
+    override func isContentValid() -> Bool {
+        !(contentText ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    override func didSelectPost() {
+        let typed = (contentText ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !typed.isEmpty {
+            save(typed)
+            complete()
+        } else {
+            // Fallback if the box never populated (e.g. attachment loaded late).
+            loadSharedText { [weak self] text in
+                if let text, !text.isEmpty { self?.save(text) }
+                self?.complete()
+            }
+        }
+    }
+
+    override func configurationItems() -> [Any]! { [] }
+
+    // MARK: - Helpers
+
+    private func save(_ text: String) {
+        SharedTeleprompterInbox.append(title: Self.deriveTitle(from: text), text: text)
+    }
+
+    private func complete() {
+        extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
+    }
+
+    /// First non-empty line, trimmed and clipped — the same default the app uses.
+    private static func deriveTitle(from text: String) -> String {
+        let firstLine = text.split(whereSeparator: \.isNewline)
+            .first { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+            .map { $0.trimmingCharacters(in: .whitespaces) } ?? ""
+        let clipped = String(firstLine.prefix(40)).trimmingCharacters(in: .whitespaces)
+        return clipped.isEmpty ? "Shared script" : clipped
+    }
+
+    /// Pull text out of the first attachment that's plain text, a file, or a URL.
+    private func loadSharedText(completion: @escaping (String?) -> Void) {
+        let providers = (extensionContext?.inputItems as? [NSExtensionItem])?
+            .flatMap { $0.attachments ?? [] } ?? []
+        guard !providers.isEmpty else { completion(nil); return }
+
+        let textTypes = [UTType.plainText.identifier, UTType.text.identifier]
+        let provider = providers.first { p in textTypes.contains { p.hasItemConformingToTypeIdentifier($0) } }
+            ?? providers.first { $0.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) }
+            ?? providers.first { $0.hasItemConformingToTypeIdentifier(UTType.url.identifier) }
+        guard let provider else { completion(nil); return }
+
+        let typeID = textTypes.first { provider.hasItemConformingToTypeIdentifier($0) }
+            ?? (provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+                ? UTType.fileURL.identifier : UTType.url.identifier)
+
+        provider.loadItem(forTypeIdentifier: typeID, options: nil) { item, _ in
+            var result: String?
+            switch item {
+            case let string as String:
+                result = string
+            case let url as URL:
+                // A file URL → read its contents; a web URL → use the link text.
+                result = (try? String(contentsOf: url, encoding: .utf8)) ?? url.absoluteString
+            case let data as Data:
+                result = String(data: data, encoding: .utf8)
+            default:
+                result = nil
+            }
+            DispatchQueue.main.async { completion(result) }
+        }
+    }
+}

--- a/OpenGlassesTests/TeleprompterShareInboxTests.swift
+++ b/OpenGlassesTests/TeleprompterShareInboxTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Headless tests for the Share Extension hand-off (Teleprompter PR B): the app-group
+/// inbox round-trip and the store draining it into saved scripts. Uses the inbox's
+/// `testContainerURL` seam so no real app-group container is touched.
+@MainActor
+final class TeleprompterShareInboxTests: XCTestCase {
+
+    private var container: URL!
+
+    override func setUp() {
+        super.setUp()
+        container = FileManager.default.temporaryDirectory.appendingPathComponent("inbox-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: container, withIntermediateDirectories: true)
+        SharedTeleprompterInbox.testContainerURL = container
+    }
+
+    override func tearDown() {
+        SharedTeleprompterInbox.testContainerURL = nil
+        try? FileManager.default.removeItem(at: container)
+        super.tearDown()
+    }
+
+    func testInboxAppendAndDrainRoundTrips() {
+        SharedTeleprompterInbox.append(title: "Keynote", text: "the opening line")
+        SharedTeleprompterInbox.append(title: "", text: "second script")
+
+        let drained = SharedTeleprompterInbox.drain()
+        XCTAssertEqual(drained.map(\.title), ["Keynote", ""])
+        XCTAssertEqual(drained.map(\.text), ["the opening line", "second script"])
+
+        // Draining clears the inbox.
+        XCTAssertTrue(SharedTeleprompterInbox.drain().isEmpty)
+    }
+
+    func testInboxIgnoresEmptyText() {
+        SharedTeleprompterInbox.append(title: "x", text: "   \n  ")
+        XCTAssertTrue(SharedTeleprompterInbox.drain().isEmpty)
+    }
+
+    func testStoreImportsPendingSharesNewestFirst() {
+        // A store over a separate temp directory (its own JSON file, not the inbox).
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("tp-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = TeleprompterScriptStore(directory: dir)
+        XCTAssertTrue(store.scripts.isEmpty)
+
+        SharedTeleprompterInbox.append(title: "First", text: "one")
+        SharedTeleprompterInbox.append(title: "", text: "Derived title\nbody")
+
+        let count = store.importPendingShares()
+        XCTAssertEqual(count, 2)
+        XCTAssertEqual(store.scripts.map(\.title), ["Derived title", "First"])  // newest first; empty title derived
+        XCTAssertTrue(SharedTeleprompterInbox.drain().isEmpty)                   // inbox consumed
+    }
+}

--- a/project.base.yml
+++ b/project.base.yml
@@ -151,6 +151,7 @@ targets:
       - package: SherpaOnnx
         product: SherpaOnnxWrapper
       - target: GlassesActivityWidget
+      - target: OpenGlassesShareExtension
 
   GlassesActivityWidget:
     type: app-extension
@@ -180,12 +181,51 @@ targets:
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
 
+  # Share Extension (Teleprompter Phase 2 / PR B): accepts shared text, URLs, and text
+  # files from the iOS share sheet and hands them to the app via the app-group inbox
+  # (SharedTeleprompterInbox), which the main app drains into TeleprompterScriptStore.
+  OpenGlassesShareExtension:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: OpenGlassesShareExtension
+      # Shared with the main app — the app-group hand-off inbox.
+      - path: OpenGlasses/Sources/Shared/SharedTeleprompterInbox.swift
+    entitlements:
+      path: OpenGlassesShareExtension/OpenGlassesShareExtension.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.com.openglasses.app
+    info:
+      path: OpenGlassesShareExtension/Info.plist
+      properties:
+        CFBundleDisplayName: "OpenGlasses Teleprompter"
+        CFBundleShortVersionString: "$(MARKETING_VERSION)"
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)"
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.share-services
+          NSExtensionPrincipalClass: ShareViewController
+          NSExtensionAttributes:
+            NSExtensionActivationRule:
+              NSExtensionActivationSupportsText: true
+              NSExtensionActivationSupportsWebURLWithMaxCount: 1
+              NSExtensionActivationSupportsAttachmentsWithMaxCount: 1
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
+        MARKETING_VERSION: "2.2.0"
+        CURRENT_PROJECT_VERSION: "11"
+        SWIFT_VERSION: "5.9"
+        SKIP_INSTALL: "YES"
+        CODE_SIGN_STYLE: Automatic
+
 schemes:
   OpenGlasses:
     build:
       targets:
         OpenGlasses: all
         GlassesActivityWidget: all
+        OpenGlassesShareExtension: all
     run:
       config: Debug
       debugEnabled: true

--- a/project.local.yml.example
+++ b/project.local.yml.example
@@ -14,3 +14,11 @@ targets:
       base:
         CODE_SIGN_ENTITLEMENTS: Config/Entitlements/Personal/GlassesActivityWidget.entitlements
         DEVELOPMENT_TEAM: YOUR_APPLE_TEAM_ID
+
+  # Teleprompter Share Extension (PR B). Copy Config/Entitlements/Personal/GlassesActivityWidget.entitlements
+  # to OpenGlassesShareExtension.entitlements (same app group) for device builds.
+  OpenGlassesShareExtension:
+    settings:
+      base:
+        CODE_SIGN_ENTITLEMENTS: Config/Entitlements/Personal/OpenGlassesShareExtension.entitlements
+        DEVELOPMENT_TEAM: YOUR_APPLE_TEAM_ID


### PR DESCRIPTION
**PR B of 2** for Teleprompter Phase 2 — **stacked on [#96](https://github.com/straff2002/OpenGlasses/pull/96)** (base is `feat/teleprompter-phase2-audio-paced`; review/merge #96 first, then this retargets to `main`).

Adds a **Share Extension** so OpenGlasses appears in the iOS share sheet for **text, URLs, and text files** — share an Apple Note straight in as a teleprompter script (the no-friction complement to the App-Intent/Shortcuts path in PR A).

## What's here
- **`OpenGlassesShareExtension` target** (app-extension) — `SLComposeServiceViewController` share UI: pre-fills the editable box with the shared text (or loads a URL / text file), lets the user tweak it, and on Post hands it off.
- **`SharedTeleprompterInbox`** — app-group hand-off. The extension is a separate process and can't touch the app's Documents, so it writes a JSON inbox in `group.com.openglasses.app`. Compiled into both targets; has a `testContainerURL` seam for headless tests.
- **`TeleprompterScriptStore.importPendingShares()`** drains the inbox into saved scripts on store init and on app foreground (with a HUD confirmation flash).
- **XcodeGen wiring** — target + main-app embed + scheme entry + `NSExtension` activation rule (text / web URL / attachment). `project.local.yml.example` gains the extension's signing block.

## Tests
- App **+ extension** build clean for the simulator (**BUILD SUCCEEDED**; `.appex` embeds in `OpenGlasses.app/PlugIns`).
- **40 teleprompter tests pass, 0 failures** (20 core + 17 Phase 2 + **3 new** in `TeleprompterShareInboxTests`: inbox round-trip, empty-text guard, store drain → newest-first import).

## Device signing
`options.developmentTeam` covers the team; the committed base entitlements grant the app group. For personal device builds, add the `OpenGlassesShareExtension` block from `project.local.yml.example` to your `project.local.yml` (+ a personal entitlements file with the app group).

## Device-pending
The share-sheet flow itself (selecting OpenGlasses from a real note's share sheet) — verifiable only on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)