### PR TITLE
Memory & Recall Phase 1: pure core (FTS index, query builder, analyzers, insights)

### DIFF
--- a/OpenGlasses/Sources/Services/Memory/ConversationIndex.swift
+++ b/OpenGlasses/Sources/Services/Memory/ConversationIndex.swift
@@ -1,0 +1,161 @@
+import Foundation
+import SQLite3
+
+/// On-device full-text index over conversation turns (SQLite **FTS5**) — the substrate for
+/// cross-session recall. Same `SQLite3` approach as `RAG/DocumentStore`; the DB path is
+/// injectable so tests run against a temp file. Timestamps are stored ISO-8601 (fixed-width,
+/// lexically sortable) so date-window filtering works with plain string comparisons.
+///
+/// Pure data layer — no model, no UI, no `Wearables` — so it's fully headless-testable.
+final class ConversationIndex {
+    private var db: OpaquePointer?
+    private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+    /// `text` is the only indexed column → FTS5 column index 3 for `snippet()`.
+    private static let textColumnIndex: Int32 = 3
+
+    init(dbURL: URL) {
+        if sqlite3_open(dbURL.path, &db) != SQLITE_OK {
+            NSLog("[ConversationIndex] Failed to open database at %@", dbURL.path)
+        }
+        exec("PRAGMA journal_mode=WAL")
+        exec("PRAGMA synchronous=NORMAL")
+        createTable()
+    }
+
+    /// Default location alongside the other on-device stores.
+    convenience init() {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        self.init(dbURL: docs.appendingPathComponent("conversation_index.sqlite"))
+    }
+
+    deinit { sqlite3_close(db) }
+
+    private func createTable() {
+        exec("""
+        CREATE VIRTUAL TABLE IF NOT EXISTS turns USING fts5(
+            turn_id UNINDEXED, thread_id UNINDEXED, role UNINDEXED, text, ts UNINDEXED
+        )
+        """)
+    }
+
+    // MARK: - Writes
+
+    /// Index a turn, replacing any existing row with the same `id` (idempotent re-index).
+    func index(_ turn: IndexedTurn) {
+        delete(id: turn.id)
+        let sql = "INSERT INTO turns (turn_id, thread_id, role, text, ts) VALUES (?, ?, ?, ?, ?)"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_text(stmt, 1, turn.id, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, turn.threadID, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 3, turn.role, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 4, turn.text, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 5, RecallTimestamp.string(from: turn.timestamp), -1, SQLITE_TRANSIENT)
+        _ = sqlite3_step(stmt)
+    }
+
+    /// Bulk index (first-run backfill), wrapped in one transaction.
+    func indexAll(_ turns: [IndexedTurn]) {
+        exec("BEGIN TRANSACTION")
+        for turn in turns { index(turn) }
+        exec("COMMIT")
+    }
+
+    func delete(id: String) {
+        let sql = "DELETE FROM turns WHERE turn_id = ?"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_text(stmt, 1, id, -1, SQLITE_TRANSIENT)
+        _ = sqlite3_step(stmt)
+    }
+
+    func clear() { exec("DELETE FROM turns") }
+
+    func count() -> Int {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "SELECT count(*) FROM turns", -1, &stmt, nil) == SQLITE_OK else { return 0 }
+        defer { sqlite3_finalize(stmt) }
+        return sqlite3_step(stmt) == SQLITE_ROW ? Int(sqlite3_column_int(stmt, 0)) : 0
+    }
+
+    // MARK: - Search
+
+    /// Search the index. With a text match, rows are ranked by FTS5 bm25 (best first) and
+    /// carry a highlighted snippet; without one (date-only / empty query) the most recent
+    /// turns in the window are returned.
+    func search(_ query: ParsedQuery, limit: Int = 12) -> [RecallHit] {
+        guard limit > 0 else { return [] }
+        var hits: [RecallHit] = []
+
+        let dateClause = [
+            query.since != nil ? "ts >= ?" : nil,
+            query.until != nil ? "ts < ?" : nil,
+        ].compactMap { $0 }
+
+        let sql: String
+        if query.match != nil {
+            let clauses = (["turns MATCH ?"] + dateClause).joined(separator: " AND ")
+            sql = """
+            SELECT turn_id, thread_id, role, text, ts,
+                   snippet(turns, \(Self.textColumnIndex), '[', ']', '…', 12), bm25(turns)
+            FROM turns WHERE \(clauses)
+            ORDER BY bm25(turns) LIMIT ?
+            """
+        } else {
+            let whereSQL = dateClause.isEmpty ? "" : "WHERE \(dateClause.joined(separator: " AND "))"
+            sql = """
+            SELECT turn_id, thread_id, role, text, ts, '', 0.0
+            FROM turns \(whereSQL) ORDER BY ts DESC LIMIT ?
+            """
+        }
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [] }
+        defer { sqlite3_finalize(stmt) }
+
+        var bindIndex: Int32 = 1
+        if let match = query.match {
+            sqlite3_bind_text(stmt, bindIndex, match, -1, SQLITE_TRANSIENT); bindIndex += 1
+        }
+        if let since = query.since {
+            sqlite3_bind_text(stmt, bindIndex, RecallTimestamp.string(from: since), -1, SQLITE_TRANSIENT); bindIndex += 1
+        }
+        if let until = query.until {
+            sqlite3_bind_text(stmt, bindIndex, RecallTimestamp.string(from: until), -1, SQLITE_TRANSIENT); bindIndex += 1
+        }
+        sqlite3_bind_int(stmt, bindIndex, Int32(limit))
+
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let id = String(cString: sqlite3_column_text(stmt, 0))
+            let threadID = String(cString: sqlite3_column_text(stmt, 1))
+            let role = String(cString: sqlite3_column_text(stmt, 2))
+            let text = String(cString: sqlite3_column_text(stmt, 3))
+            let tsString = String(cString: sqlite3_column_text(stmt, 4))
+            let snippetRaw = sqlite3_column_text(stmt, 5).map { String(cString: $0) } ?? ""
+            let rank = sqlite3_column_double(stmt, 6)
+            let snippet = snippetRaw.isEmpty ? String(text.prefix(140)) : snippetRaw
+            hits.append(RecallHit(
+                id: id, threadID: threadID, role: role, text: text,
+                timestamp: RecallTimestamp.date(from: tsString) ?? Date(timeIntervalSinceReferenceDate: 0),
+                snippet: snippet, rank: rank
+            ))
+        }
+        return hits
+    }
+
+    /// Convenience: parse a natural phrase then search.
+    func search(phrase: String, now: Date = Date(), limit: Int = 12) -> [RecallHit] {
+        search(FTSQueryBuilder.build(phrase, now: now), limit: limit)
+    }
+
+    // MARK: - SQLite helper
+
+    @discardableResult
+    private func exec(_ sql: String) -> Bool {
+        sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK
+    }
+}

--- a/OpenGlasses/Sources/Services/Memory/InsightsAggregator.swift
+++ b/OpenGlasses/Sources/Services/Memory/InsightsAggregator.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// One usage event for the insights recap.
+struct InsightEvent: Equatable {
+    let timestamp: Date
+    let role: String          // "user" / "assistant"
+    let toolNames: [String]
+    let text: String
+}
+
+/// A privacy-friendly, on-device recap of how the assistant is actually used over a window.
+struct InsightsReport: Equatable {
+    struct Count: Equatable { let name: String; let count: Int }
+    let windowStart: Date
+    let windowEnd: Date
+    let totalTurns: Int
+    let userTurns: Int
+    let topTools: [Count]
+    let topTopics: [Count]
+    let summary: String
+}
+
+/// Aggregates usage events into an `InsightsReport`. Pure (no network, no storage) — computed
+/// entirely on-device from data already in the app. Fully unit-tested.
+enum InsightsAggregator {
+    /// Extra noise words on top of the recall stopwords, for topic extraction.
+    private static let extraStop: Set<String> = [
+        "please", "thanks", "thank", "ok", "okay", "hey", "yeah", "want", "need",
+        "get", "got", "make", "show", "give", "tell", "let", "going", "just", "like",
+    ]
+
+    static func aggregate(_ events: [InsightEvent], since: Date, now: Date,
+                          topN: Int = 5) -> InsightsReport {
+        let inWindow = events.filter { $0.timestamp >= since && $0.timestamp <= now }
+        let userEvents = inWindow.filter { $0.role == "user" }
+
+        // Tool frequency across the window.
+        var toolCounts: [String: Int] = [:]
+        for event in inWindow {
+            for tool in event.toolNames { toolCounts[tool, default: 0] += 1 }
+        }
+        let topTools = rank(toolCounts, topN: topN)
+
+        // Topic frequency from user text (content words only).
+        let stop = FTSQueryBuilder.stopwords.union(extraStop)
+        var topicCounts: [String: Int] = [:]
+        for event in userEvents {
+            let tokens = event.text.lowercased()
+                .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                .filter { $0.count >= 3 && !stop.contains($0) }
+            for token in Set(tokens) { topicCounts[token, default: 0] += 1 }   // once per turn
+        }
+        let topTopics = rank(topicCounts, topN: topN)
+
+        return InsightsReport(
+            windowStart: since, windowEnd: now,
+            totalTurns: inWindow.count, userTurns: userEvents.count,
+            topTools: topTools, topTopics: topTopics,
+            summary: summarize(turns: inWindow.count, tools: topTools, topics: topTopics)
+        )
+    }
+
+    private static func rank(_ counts: [String: Int], topN: Int) -> [InsightsReport.Count] {
+        counts.sorted { ($0.value, $1.key) > ($1.value, $0.key) }   // count desc, name asc tiebreak
+            .prefix(topN)
+            .map { InsightsReport.Count(name: $0.key, count: $0.value) }
+    }
+
+    private static func summarize(turns: Int, tools: [InsightsReport.Count],
+                                  topics: [InsightsReport.Count]) -> String {
+        guard turns > 0 else { return "No activity in this window." }
+        var parts = ["\(turns) turn\(turns == 1 ? "" : "s")"]
+        if let top = tools.first { parts.append("most-used tool: \(top.name) (\(top.count)×)") }
+        if !topics.isEmpty {
+            parts.append("topics: " + topics.prefix(3).map(\.name).joined(separator: ", "))
+        }
+        return parts.joined(separator: " · ")
+    }
+}

--- a/OpenGlasses/Sources/Services/Memory/MemoryNudgeAnalyzer.swift
+++ b/OpenGlasses/Sources/Services/Memory/MemoryNudgeAnalyzer.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A completed user↔assistant exchange, as fed to the self-improving analyzers. Plain value
+/// type so the heuristics are pure and headless-testable.
+struct CompletedTurn: Equatable {
+    let userText: String
+    let assistantText: String
+    let toolNames: [String]
+
+    init(userText: String, assistantText: String = "", toolNames: [String] = []) {
+        self.userText = userText
+        self.assistantText = assistantText
+        self.toolNames = toolNames
+    }
+}
+
+/// A proposed memory the user can one-tap confirm. Never acts on its own — it's a suggestion
+/// surfaced through `ProactiveAlertService` (Phase 3).
+struct MemoryNudge: Equatable {
+    enum Kind: Equatable { case fact }
+    let kind: Kind
+    let prompt: String
+    let payload: String
+}
+
+/// Detects a durable personal fact worth offering to remember. Conservative by design —
+/// explicit "remember that…" cues and first-person durable statements only, never questions —
+/// so it rarely false-fires. Pure → fully unit-tested.
+enum MemoryNudgeAnalyzer {
+    /// Explicit "save this" cues; the payload is whatever follows the cue.
+    static let explicitCues = [
+        "remember that ", "remember to ", "remember ", "note that ",
+        "don't forget that ", "dont forget that ", "keep in mind that ", "for future reference ",
+    ]
+
+    /// First-person durable-statement openers (statement must *start* with one, for precision).
+    static let durableOpeners = [
+        "my ", "i live ", "i work ", "i prefer ", "i'm allergic", "im allergic",
+        "i am allergic", "i drive ", "i'm from ", "im from ", "i was born ", "call me ",
+    ]
+
+    static func nudge(for turn: CompletedTurn) -> MemoryNudge? {
+        let raw = turn.userText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard raw.count >= 8 else { return nil }
+        let lower = raw.lowercased()
+
+        // Never nudge on a question.
+        if lower.hasSuffix("?") { return nil }
+        let questionStarts = ["what ", "when ", "where ", "who ", "why ", "how ", "which ",
+                              "is ", "are ", "do ", "does ", "can ", "could ", "would ", "should "]
+        if questionStarts.contains(where: { lower.hasPrefix($0) }) { return nil }
+
+        // Explicit cue → payload is the clause after the cue.
+        for cue in explicitCues {
+            if let range = raw.range(of: cue, options: .caseInsensitive) {
+                let payload = String(raw[range.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+                guard payload.count >= 3 else { continue }
+                return MemoryNudge(kind: .fact, prompt: "Want me to remember that?", payload: payload)
+            }
+        }
+
+        // First-person durable statement → remember the whole line.
+        if durableOpeners.contains(where: { lower.hasPrefix($0) }) {
+            return MemoryNudge(kind: .fact, prompt: "Want me to remember that?", payload: raw)
+        }
+        return nil
+    }
+}

--- a/OpenGlasses/Sources/Services/Memory/RecallModels.swift
+++ b/OpenGlasses/Sources/Services/Memory/RecallModels.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// One conversation turn as fed to the recall index. A plain value type (decoupled from
+/// `ConversationStore`'s model) so the index + query builder are pure and headless-testable;
+/// Phase 2 maps `ConversationMessage` → `IndexedTurn`.
+struct IndexedTurn: Equatable {
+    let id: String          // stable per message (ConversationMessage.id)
+    let threadID: String
+    let role: String        // "user" / "assistant" / "system"
+    let text: String
+    let timestamp: Date
+}
+
+/// A search hit from the conversation index: the matched turn plus an FTS snippet and rank.
+struct RecallHit: Equatable {
+    let id: String
+    let threadID: String
+    let role: String
+    let text: String
+    let timestamp: Date
+    /// FTS5 `snippet()` excerpt with the match highlighted (falls back to a text prefix).
+    let snippet: String
+    /// FTS5 bm25 score — lower is a better match. 0 for non-MATCH (date-only) queries.
+    let rank: Double
+}
+
+/// A natural-language recall phrase parsed into an FTS5 query + optional date window.
+/// `match == nil` means "no text filter" (e.g. "what did we talk about yesterday") — the
+/// index then returns the most recent turns in the date window.
+struct ParsedQuery: Equatable {
+    let match: String?
+    let since: Date?
+    let until: Date?
+
+    var isEmpty: Bool { match == nil && since == nil && until == nil }
+}
+
+/// Turns a spoken recall phrase into a safe FTS5 MATCH + a date window. Pure and
+/// deterministic given an injected `now`, so date phrases ("yesterday", "last week") are
+/// fully unit-tested without a clock.
+enum FTSQueryBuilder {
+    /// Common words that carry no search signal (question words, articles, pronouns, aux verbs).
+    /// `last`/`this` are handled by date detection *before* this set is applied.
+    static let stopwords: Set<String> = [
+        "what", "when", "where", "who", "whom", "why", "how", "which",
+        "did", "do", "does", "was", "were", "is", "are", "am", "be", "been",
+        "the", "a", "an", "of", "to", "in", "on", "at", "for", "about", "with",
+        "we", "i", "you", "he", "she", "it", "they", "me", "my", "our", "your",
+        "that", "this", "these", "those", "and", "or", "but", "so", "then",
+        "say", "said", "talk", "talked", "tell", "told", "discuss", "discussed",
+    ]
+
+    static func build(_ phrase: String, now: Date, calendar: Calendar = .current) -> ParsedQuery {
+        let lower = phrase.lowercased()
+        let (since, until, dateWords) = dateWindow(in: lower, now: now, calendar: calendar)
+
+        let tokens = lower
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { $0.count >= 2 && !stopwords.contains($0) && !dateWords.contains($0) }
+
+        let match = tokens.isEmpty
+            ? nil
+            : tokens.map { "\"\($0)\"" }.joined(separator: " OR ")
+        return ParsedQuery(match: match, since: since, until: until)
+    }
+
+    /// Detect a relative-date phrase and return its [since, until) window plus the words to
+    /// drop from the token stream.
+    private static func dateWindow(in phrase: String, now: Date,
+                                   calendar: Calendar) -> (Date?, Date?, Set<String>) {
+        let startOfToday = calendar.startOfDay(for: now)
+        func day(_ offset: Int) -> Date { calendar.date(byAdding: .day, value: offset, to: startOfToday)! }
+
+        if phrase.contains("today") {
+            return (startOfToday, day(1), ["today"])
+        }
+        if phrase.contains("yesterday") {
+            return (day(-1), startOfToday, ["yesterday"])
+        }
+        if phrase.contains("last week") {
+            let startOfWeek = calendar.dateInterval(of: .weekOfYear, for: now)!.start
+            return (calendar.date(byAdding: .day, value: -7, to: startOfWeek)!, startOfWeek,
+                    ["last", "week"])
+        }
+        if phrase.contains("this week") {
+            let week = calendar.dateInterval(of: .weekOfYear, for: now)!
+            return (week.start, week.end, ["this", "week"])
+        }
+        if phrase.contains("last month") {
+            let startOfMonth = calendar.dateInterval(of: .month, for: now)!.start
+            return (calendar.date(byAdding: .month, value: -1, to: startOfMonth)!, startOfMonth,
+                    ["last", "month"])
+        }
+        if phrase.contains("this month") {
+            let month = calendar.dateInterval(of: .month, for: now)!
+            return (month.start, month.end, ["this", "month"])
+        }
+        return (nil, nil, [])
+    }
+}
+
+/// Shared ISO-8601 timestamp format for the index — fixed-width and lexically sortable, so
+/// FTS5 (whose columns are text) can range-filter chronologically with plain string compares.
+enum RecallTimestamp {
+    static let formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]   // yyyy-MM-dd'T'HH:mm:ssZ — sorts chronologically
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f
+    }()
+
+    static func string(from date: Date) -> String { formatter.string(from: date) }
+    static func date(from string: String) -> Date? { formatter.date(from: string) }
+}

--- a/OpenGlasses/Sources/Services/Memory/SkillPatternDetector.swift
+++ b/OpenGlasses/Sources/Services/Memory/SkillPatternDetector.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// A proposed `voice_skill` distilled from a repeated multi-step request.
+struct SkillSuggestion: Equatable {
+    let toolSignature: [String]   // the ordered tools the repeated request runs
+    let count: Int                // how many times it's been seen
+    let triggerHint: String       // a suggested trigger phrase (the user's latest wording)
+}
+
+/// Watches completed turns for a **repeated multi-tool sequence** and, once it crosses a
+/// threshold, suggests saving it as a skill — the "autonomous skill creation" idea, but as a
+/// suggestion the user confirms (never auto-saved). Holds a small rolling frequency map;
+/// deterministic given the sequence of `record(...)` calls, so it's unit-testable.
+final class SkillPatternDetector {
+    private let threshold: Int
+    private var counts: [String: Int] = [:]
+    private var latestHint: [String: String] = [:]
+    private var suggested: Set<String> = []
+
+    init(threshold: Int = 3) {
+        self.threshold = max(2, threshold)
+    }
+
+    /// Record a completed turn. Returns a suggestion the first time a multi-tool sequence
+    /// reaches the threshold (once per distinct sequence).
+    func record(toolNames: [String], triggerHint: String) -> SkillSuggestion? {
+        guard toolNames.count >= 2 else { return nil }          // only multi-step requests
+        let key = toolNames.joined(separator: ">")
+        counts[key, default: 0] += 1
+        latestHint[key] = triggerHint
+
+        guard counts[key]! >= threshold, !suggested.contains(key) else { return nil }
+        suggested.insert(key)
+        return SkillSuggestion(toolSignature: toolNames, count: counts[key]!,
+                               triggerHint: triggerHint)
+    }
+
+    func reset() {
+        counts.removeAll()
+        latestHint.removeAll()
+        suggested.removeAll()
+    }
+}

--- a/OpenGlassesTests/MemoryRecallCoreTests.swift
+++ b/OpenGlassesTests/MemoryRecallCoreTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Headless tests for the Memory/Recall pure core (Phase 1): FTS query builder, the FTS5
+/// conversation index, and the self-improving analyzers + insights aggregator. No model,
+/// no UI, no hardware.
+final class MemoryRecallCoreTests: XCTestCase {
+
+    // MARK: - FTSQueryBuilder
+
+    func testBuildExtractsContentWordsAndDropsStopwords() {
+        let q = FTSQueryBuilder.build("what did we decide about the museum app", now: Date())
+        XCTAssertNil(q.since)
+        // Only content words survive, each quoted, OR-joined.
+        XCTAssertEqual(q.match, "\"decide\" OR \"museum\" OR \"app\"")
+    }
+
+    func testBuildAllStopwordsYieldsNilMatch() {
+        let q = FTSQueryBuilder.build("what did we talk about", now: Date())
+        XCTAssertNil(q.match)
+        XCTAssertNil(q.since)
+        XCTAssertTrue(q.isEmpty)
+    }
+
+    func testBuildDetectsYesterdayWindowAndStripsDateWords() {
+        let cal = Calendar.current
+        let now = Date()
+        let q = FTSQueryBuilder.build("what did we discuss yesterday", now: now, calendar: cal)
+        let startToday = cal.startOfDay(for: now)
+        XCTAssertEqual(q.since, cal.date(byAdding: .day, value: -1, to: startToday))
+        XCTAssertEqual(q.until, startToday)
+        XCTAssertNil(q.match)   // "discuss" is a stopword; "yesterday" is a date word
+    }
+
+    func testBuildDetectsLastWeekWithContent() {
+        let q = FTSQueryBuilder.build("the budget last week", now: Date())
+        XCTAssertNotNil(q.since)
+        XCTAssertNotNil(q.until)
+        XCTAssertEqual(q.match, "\"budget\"")   // "last"/"week" consumed by date detection
+    }
+
+    // MARK: - ConversationIndex
+
+    private func makeIndex() -> ConversationIndex {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("idx-\(UUID().uuidString).sqlite")
+        return ConversationIndex(dbURL: url)
+    }
+
+    private func turn(_ id: String, _ text: String, role: String = "user",
+                      thread: String = "t1", at date: Date = Date()) -> IndexedTurn {
+        IndexedTurn(id: id, threadID: thread, role: role, text: text, timestamp: date)
+    }
+
+    func testIndexAndFullTextSearch() {
+        let idx = makeIndex()
+        idx.index(turn("a", "We decided to ship the museum docent feature next sprint"))
+        idx.index(turn("b", "The weather tomorrow looks rainy"))
+        XCTAssertEqual(idx.count(), 2)
+
+        let hits = idx.search(phrase: "museum feature")
+        XCTAssertEqual(hits.first?.id, "a")
+        XCTAssertFalse(hits.contains { $0.id == "b" })
+        XCTAssertFalse(hits.first?.snippet.isEmpty ?? true)
+    }
+
+    func testReindexIsIdempotent() {
+        let idx = makeIndex()
+        idx.index(turn("a", "original text about coffee"))
+        idx.index(turn("a", "updated text about espresso"))   // same id
+        XCTAssertEqual(idx.count(), 1)
+        XCTAssertTrue(idx.search(phrase: "espresso").contains { $0.id == "a" })
+        XCTAssertTrue(idx.search(phrase: "coffee").isEmpty)
+    }
+
+    func testDateWindowFiltersResults() {
+        let idx = makeIndex()
+        let now = Date()
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: now)
+        let twoDaysAgo = cal.date(byAdding: .day, value: -2, to: now)!
+        idx.index(turn("today", "standup notes", at: now))
+        idx.index(turn("old", "older standup notes", at: twoDaysAgo))
+
+        // Date-only query (no MATCH) for "today" → only today's turn.
+        let q = ParsedQuery(match: nil, since: today, until: cal.date(byAdding: .day, value: 1, to: today))
+        let hits = idx.search(q)
+        XCTAssertEqual(hits.map(\.id), ["today"])
+    }
+
+    func testEmptyQueryReturnsRecentFirst() {
+        let idx = makeIndex()
+        let now = Date()
+        idx.index(turn("older", "first", at: now.addingTimeInterval(-100)))
+        idx.index(turn("newer", "second", at: now))
+        let hits = idx.search(ParsedQuery(match: nil, since: nil, until: nil), limit: 10)
+        XCTAssertEqual(hits.first?.id, "newer")   // ORDER BY ts DESC
+    }
+
+    // MARK: - MemoryNudgeAnalyzer
+
+    func testNudgeExplicitCueExtractsPayload() {
+        let n = MemoryNudgeAnalyzer.nudge(for: CompletedTurn(userText: "Remember that the wifi password is hunter2"))
+        XCTAssertEqual(n?.kind, .fact)
+        XCTAssertEqual(n?.payload, "the wifi password is hunter2")
+    }
+
+    func testNudgeDurableStatement() {
+        XCTAssertEqual(MemoryNudgeAnalyzer.nudge(for: CompletedTurn(userText: "My daughter's name is Mia"))?.payload,
+                       "My daughter's name is Mia")
+    }
+
+    func testNudgeSkipsQuestionsAndSmalltalk() {
+        XCTAssertNil(MemoryNudgeAnalyzer.nudge(for: CompletedTurn(userText: "What's the weather today?")))
+        XCTAssertNil(MemoryNudgeAnalyzer.nudge(for: CompletedTurn(userText: "thanks!")))
+        XCTAssertNil(MemoryNudgeAnalyzer.nudge(for: CompletedTurn(userText: "how do I get home")))
+    }
+
+    // MARK: - SkillPatternDetector
+
+    func testSkillSuggestedAfterThreshold() {
+        let d = SkillPatternDetector(threshold: 3)
+        let tools = ["get_weather", "get_news"]
+        XCTAssertNil(d.record(toolNames: tools, triggerHint: "morning brief"))
+        XCTAssertNil(d.record(toolNames: tools, triggerHint: "morning brief"))
+        let s = d.record(toolNames: tools, triggerHint: "morning brief")
+        XCTAssertEqual(s?.toolSignature, tools)
+        XCTAssertEqual(s?.count, 3)
+        // Doesn't re-suggest the same sequence.
+        XCTAssertNil(d.record(toolNames: tools, triggerHint: "morning brief"))
+    }
+
+    func testSkillIgnoresSingleToolTurns() {
+        let d = SkillPatternDetector(threshold: 2)
+        XCTAssertNil(d.record(toolNames: ["set_timer"], triggerHint: "timer"))
+        XCTAssertNil(d.record(toolNames: ["set_timer"], triggerHint: "timer"))
+    }
+
+    // MARK: - InsightsAggregator
+
+    func testInsightsCountsToolsAndTopics() {
+        let now = Date()
+        let since = now.addingTimeInterval(-3600)
+        let events = [
+            InsightEvent(timestamp: now.addingTimeInterval(-100), role: "user", toolNames: [], text: "remind me about the museum proposal"),
+            InsightEvent(timestamp: now.addingTimeInterval(-90), role: "assistant", toolNames: ["reminder"], text: ""),
+            InsightEvent(timestamp: now.addingTimeInterval(-50), role: "user", toolNames: [], text: "what's on my museum calendar"),
+            InsightEvent(timestamp: now.addingTimeInterval(-40), role: "assistant", toolNames: ["calendar", "reminder"], text: ""),
+        ]
+        let r = InsightsAggregator.aggregate(events, since: since, now: now)
+        XCTAssertEqual(r.totalTurns, 4)
+        XCTAssertEqual(r.userTurns, 2)
+        XCTAssertEqual(r.topTools.first?.name, "reminder")   // appears twice
+        XCTAssertEqual(r.topTools.first?.count, 2)
+        XCTAssertEqual(r.topTopics.first?.name, "museum")    // in both user turns
+        XCTAssertTrue(r.summary.contains("4 turns"))
+    }
+
+    func testInsightsWindowExcludesOldAndEmpty() {
+        let now = Date()
+        let since = now.addingTimeInterval(-3600)
+        let old = InsightEvent(timestamp: now.addingTimeInterval(-99999), role: "user", toolNames: ["x"], text: "old")
+        let r = InsightsAggregator.aggregate([old], since: since, now: now)
+        XCTAssertEqual(r.totalTurns, 0)
+        XCTAssertTrue(r.summary.contains("No activity"))
+    }
+}


### PR DESCRIPTION
First PR for the [memory-recall plan](docs/plans/memory-recall.md) — the deterministic, headless core, same posture as teleprompter Phase 1 (#95): **no model, no UI, no app wiring yet** (that's Phases 2–4).

## What's here (`Sources/Services/Memory/`)
- **`ConversationIndex`** — SQLite **FTS5** over conversation turns (same `SQLite3` approach as `RAG/DocumentStore`; injectable DB path). ISO-8601 timestamps so date windows filter via lexical string compares. Idempotent re-index, **bm25**-ranked search with highlighted snippets, and a date-only/empty-query path that returns recent turns. No new SPM dep (system SQLite).
- **`FTSQueryBuilder`** — natural phrase → safe quoted FTS5 `MATCH` + a relative-date window (today / yesterday / this·last week / this·last month); drops stopwords; empty content ⇒ nil match ⇒ recent-in-window.
- **`MemoryNudgeAnalyzer`** — conservative durable-fact detector (explicit "remember…" cues + first-person openers; never fires on questions/small-talk). Suggestion only — never acts.
- **`SkillPatternDetector`** — suggests saving a repeated multi-tool sequence as a `voice_skill` once it crosses a threshold (once per sequence).
- **`InsightsAggregator`** — on-device usage recap (top tools/topics over a window).

## Tests
- Build clean for the simulator (**BUILD SUCCEEDED**).
- **15 `MemoryRecallCoreTests` pass, 0 failures**: query building + date detection, FTS index search/ranking/snippets, idempotent re-index, date-window + empty-query paths, nudge cue/durable/question handling, skill threshold logic, insights counts/window/summary.

## Next (separate PRs, per the plan)
- **Phase 2 — Recall:** `RecallService` (search + on-device summarize + citations) wired into `ConversationStore` + a `brain` `recall` action + voice.
- **Phase 3 — Self-improving loop:** route nudges/skill-suggestions through `ProactiveAlertService` (opt-in, presence-aware) → `BrainStore.ingest` / `voice_skill`.
- **Phase 4 — Insights:** `InsightsView` + spoken recap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
