### PR TITLE
Memory & Recall Phase 2: cross-session recall (RecallService + brain action)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -541,6 +541,8 @@ class AppState: ObservableObject, AppStateProtocol {
 
     // Tier 1 services
     let conversationStore = ConversationStore()
+    /// On-device FTS index over conversation turns for cross-session recall (Memory & Recall Phase 2).
+    let conversationIndex = ConversationIndex()
     let userMemory = SemanticMemoryStore()
     let documentStore = DocumentStore()
     let intentClassifier = IntentClassifier()
@@ -916,6 +918,17 @@ class AppState: ObservableObject, AppStateProtocol {
         // Configure Study Mode — generates decks from documents via the text→JSON LLM call;
         // camera enables the hands-free scan → OCR source.
         StudyService.shared.configure(llm: llmService, documentStore: documentStore, tts: speechService, camera: cameraService)
+
+        // Memory & Recall Phase 2 — index conversation turns; recall summarizes via the user's
+        // active provider (on-device when that's their choice). Backfill existing history once.
+        conversationStore.recallIndex = conversationIndex
+        if conversationIndex.count() == 0 { conversationStore.backfillIndex() }
+        RecallService.shared.configure(index: conversationIndex) { [weak self] question, hits in
+            guard let self else { return RecallService.fallbackSummary(hits) }
+            let prompt = RecallService.summarizationPrompt(question: question, hits: hits)
+            return (try? await self.llmService.completeStateless(prompt.user, system: prompt.system))
+                ?? RecallService.fallbackSummary(hits)
+        }
 
         // Field Assist Phase 5 (Plan K2): expert stream bridge for escalations. Transport
         // (MJPEG / WebRTC) is selected in Settings; MJPEG is the working default.

--- a/OpenGlasses/Sources/Services/ConversationStore.swift
+++ b/OpenGlasses/Sources/Services/ConversationStore.swift
@@ -62,6 +62,10 @@ class ConversationStore: ObservableObject {
     private let storageURL: URL
     private let encryption = ConversationEncryptionService.shared
 
+    /// On-device full-text index for cross-session recall (Memory & Recall Phase 2). Set by
+    /// `AppState`; nil keeps everything working with no indexing.
+    weak var recallIndex: ConversationIndex?
+
     /// Key for persisting the active thread ID across restarts.
     private static let activeThreadKey = "conversationStore_activeThreadId"
 
@@ -123,6 +127,34 @@ class ConversationStore: ObservableObject {
         threads[idx].messages.append(msg)
         threads[idx].updatedAt = Date()
         save()
+        indexMessage(msg, threadID: threads[idx].id)
+    }
+
+    // MARK: - Recall index (Memory & Recall Phase 2)
+
+    /// Index a single message (user/assistant turns only — system turns aren't recalled).
+    private func indexMessage(_ msg: ConversationMessage, threadID: String) {
+        guard let recallIndex, msg.role == "user" || msg.role == "assistant" else { return }
+        let trimmed = msg.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        recallIndex.index(IndexedTurn(id: msg.id, threadID: threadID, role: msg.role,
+                                      text: msg.content, timestamp: msg.timestamp))
+    }
+
+    /// One-time backfill of existing conversation history into the recall index (idempotent —
+    /// re-indexing the same message id is a no-op replace). Called by `AppState` when the index
+    /// is empty.
+    func backfillIndex() {
+        guard let recallIndex else { return }
+        let turns = threads.flatMap { thread in
+            thread.messages
+                .filter { ($0.role == "user" || $0.role == "assistant")
+                    && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+                .map { IndexedTurn(id: $0.id, threadID: thread.id, role: $0.role,
+                                   text: $0.content, timestamp: $0.timestamp) }
+        }
+        recallIndex.indexAll(turns)
+        NSLog("[ConversationStore] Backfilled %d turns into the recall index", turns.count)
     }
 
     /// End the active thread and auto-generate a title and summary.

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -257,7 +257,7 @@ class LLMService: ObservableObject {
             - object_memory: Remember where physical objects are. Save ('remember my keys are on the counter'), find ('where are my keys?'), list, forget.
             - contextual_note: Save notes with automatic location and time context. Search notes by keyword or location.
             - social_context: Remember facts about people. Add facts ('remember John works at Stripe'), recall ('what do I know about John?'), list people.
-            - brain: Unified search across ALL on-device memory (facts, documents, people, notes, meetings, knowledge graph + encounter log). action 'query' for any "what do I know about…" when unsure where it lives; 'person' for a dossier before/after meeting someone ("brief me on Alice"); 'link' to record relationships ('Alice works at Acme'); 'encounters' for recent sightings ("when did I last see Bob?"); 'save_need' for a follow-up ("Bob wants the deck"), 'needs' to list open follow-ups, 'resolve_need' to close one. Cites sources and says what's missing — answer only from its findings.
+            - brain: Unified search across ALL on-device memory (facts, documents, people, notes, meetings, knowledge graph + encounter log). action 'query' for any "what do I know about…" when unsure where it lives; 'recall' to search PAST CONVERSATIONS — what you actually said in earlier sessions — and get a cited answer ("what did we decide about X?", "what did I say about Y last week?"); 'person' for a dossier before/after meeting someone ("brief me on Alice"); 'link' to record relationships ('Alice works at Acme'); 'encounters' for recent sightings ("when did I last see Bob?"); 'save_need' for a follow-up ("Bob wants the deck"), 'needs' to list open follow-ups, 'resolve_need' to close one. Cites sources and says what's missing — answer only from its findings.
             - home_assistant: Control Home Assistant smart home — toggle devices, check states, list entities, run automations, or use 'converse' action to send natural language commands directly to HA (e.g. action=converse, text="turn on the kitchen lights"). ALWAYS try this tool when asked about smart home control. Use entity IDs from the device list below when available; the tool also fuzzy-matches and falls back to HA's voice assistant.
             - vehicle_status: Get the user's vehicle / EV charge %, range, charging state, and plug status. Reads live from Home Assistant — use for "what's my car's charge?", "is the car charging?", "how much range do I have?".
             - scan_code: Scan QR codes or barcodes from the camera. Returns decoded content (URLs, text, product codes). Works offline.
@@ -542,7 +542,9 @@ class LLMService: ObservableObject {
     /// A stateless, tools-off completion for the planner: it sees only the system prompt + the
     /// request, never the live conversation history (planning must use trusted context only, and
     /// must not pollute the chat). History is snapshotted and restored even on error.
-    private func completeStateless(_ text: String, system: String) async throws -> String {
+    /// Stateless, tool-free completion against the user's active provider (honors on-device
+    /// models). Used by lightweight features like recall summarization.
+    func completeStateless(_ text: String, system: String) async throws -> String {
         guard let config = Config.activeModel else {
             throw LLMError.missingAPIKey("No model configured")
         }

--- a/OpenGlasses/Sources/Services/Memory/RecallService.swift
+++ b/OpenGlasses/Sources/Services/Memory/RecallService.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Combine
+
+/// A recall result: a synthesized answer plus the conversation turns it was drawn from.
+struct RecallAnswer: Equatable {
+    let summary: String
+    let citations: [RecallHit]
+    var isEmpty: Bool { citations.isEmpty }
+}
+
+/// Cross-session recall (Phase 2): searches the `ConversationIndex` and summarizes the top
+/// turns into a cited answer. The summarizer is an injectable seam (wired in `AppState` to the
+/// user's active provider via `LLMService.completeStateless` — which honors on-device models),
+/// so the search→answer flow is unit-testable without a model. Shared singleton like
+/// `BrainStore` / `StudyService`.
+@MainActor
+final class RecallService: ObservableObject {
+    static let shared = RecallService()
+
+    private var index: ConversationIndex?
+    /// (question, hits) → answer text. Injected by `configure`; nil → a plain bulleted fallback.
+    var summarize: ((String, [RecallHit]) async -> String)?
+
+    var isConfigured: Bool { index != nil }
+
+    init() {}
+
+    func configure(index: ConversationIndex,
+                   summarize: @escaping (String, [RecallHit]) async -> String) {
+        self.index = index
+        self.summarize = summarize
+    }
+
+    /// Raw search (no summarization).
+    func search(_ phrase: String, now: Date = Date(), limit: Int = 12) -> [RecallHit] {
+        index?.search(phrase: phrase, now: now, limit: limit) ?? []
+    }
+
+    /// Search + summarize into a cited answer.
+    func recall(_ question: String, now: Date = Date()) async -> RecallAnswer {
+        let hits = search(question, now: now, limit: 8)
+        guard !hits.isEmpty else {
+            return RecallAnswer(
+                summary: "I couldn't find anything about that in our past conversations.",
+                citations: []
+            )
+        }
+        let summary = await summarize?(question, hits) ?? Self.fallbackSummary(hits)
+        return RecallAnswer(summary: summary, citations: hits)
+    }
+
+    /// Bulleted snippets — used when no summarizer is wired (or it fails).
+    static func fallbackSummary(_ hits: [RecallHit]) -> String {
+        hits.prefix(5).map { "• \($0.snippet)" }.joined(separator: "\n")
+    }
+
+    /// The prompt the configured summarizer runs: answer strictly from the cited excerpts.
+    static func summarizationPrompt(question: String, hits: [RecallHit]) -> (system: String, user: String) {
+        let excerpts = hits.enumerated().map { i, hit in
+            "[\(i + 1)] (\(hit.role), \(RecallTimestamp.string(from: hit.timestamp))) \(hit.text)"
+        }.joined(separator: "\n")
+        let system = """
+        You answer the user's question using ONLY the excerpts from their past conversations \
+        below. Be concise and conversational. Cite excerpts inline like [1]. If the excerpts \
+        don't actually answer the question, say you couldn't find it.
+        """
+        let user = "Question: \(question)\n\nPast conversation excerpts:\n\(excerpts)"
+        return (system, user)
+    }
+}

--- a/OpenGlasses/Sources/Services/NativeTools/BrainTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/BrainTool.swift
@@ -14,16 +14,18 @@ struct BrainTool: NativeTool {
     a relationship ('Alice works at Acme'). 'encounters' lists recent face-recognition sightings. \
     'forget' erases an entity. 'status' reports brain size. 'save_need' records a follow-up — what \
     a person wants, is looking for, or you owe them ('Bob wants a copy of the deck') — and 'needs' \
-    lists open follow-ups (per person, or all); 'resolve_need' marks one done.
+    lists open follow-ups (per person, or all); 'resolve_need' marks one done. 'recall' searches \
+    your PAST CONVERSATIONS (what you actually said in earlier sessions) and returns a cited \
+    answer — use for "what did we decide about X?", "what did I say about Y last week?".
     """
 
     var parametersSchema: [String: Any] {
         [
             "type": "object",
             "properties": [
-                "action": ["type": "string", "description": "query, person, link, encounters, save_need, needs, resolve_need, forget, or status",
-                           "enum": ["query", "person", "link", "encounters", "save_need", "needs", "resolve_need", "forget", "status"]],
-                "question": ["type": "string", "description": "On 'query': what to look up."],
+                "action": ["type": "string", "description": "query, recall, person, link, encounters, save_need, needs, resolve_need, forget, or status",
+                           "enum": ["query", "recall", "person", "link", "encounters", "save_need", "needs", "resolve_need", "forget", "status"]],
+                "question": ["type": "string", "description": "On 'query': what to look up across memory. On 'recall': what to find in past conversations (may include 'yesterday'/'last week')."],
                 "person": ["type": "string", "description": "On 'person'/'encounters'/'save_need'/'needs'/'resolve_need'/'forget': the person or entity name."],
                 "source": ["type": "string", "description": "On 'link': subject entity (e.g. 'Alice')."],
                 "relation": ["type": "string", "description": "On 'link': works_at, lives_in, founded, leads, married_to, studied_at, invested_in, attended, or knows."],
@@ -50,6 +52,14 @@ struct BrainTool: NativeTool {
                 return "What should I look up in the brain?"
             }
             return unifiedQuery(question, brain: brain)
+
+        case "recall", "remember", "history":
+            guard let question = (args["question"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !question.isEmpty else {
+                return "What should I recall from past conversations?"
+            }
+            let answer = await RecallService.shared.recall(question)
+            return answer.summary
 
         case "person", "dossier", "who":
             guard let person = (args["person"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -135,7 +145,7 @@ struct BrainTool: NativeTool {
                    "Semantic memory \(memoryCount); \(docCount) documents; \(SocialContextStore.shared.allPeople().count) people with notes."
 
         default:
-            return "Unknown action. Use: query, person, link, encounters, save_need, needs, resolve_need, forget, or status."
+            return "Unknown action. Use: query, recall, person, link, encounters, save_need, needs, resolve_need, forget, or status."
         }
     }
 

--- a/OpenGlassesTests/MemoryRecallServiceTests.swift
+++ b/OpenGlassesTests/MemoryRecallServiceTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Headless tests for Memory & Recall Phase 2 — `RecallService` (search + summarize + cite).
+/// The summarizer is injected (the real one calls the user's LLM), and the index is a temp
+/// FTS DB, so the search→answer flow runs with no model and no hardware.
+@MainActor
+final class MemoryRecallServiceTests: XCTestCase {
+
+    private func populatedIndex() -> ConversationIndex {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("recall-\(UUID().uuidString).sqlite")
+        let idx = ConversationIndex(dbURL: url)
+        idx.index(IndexedTurn(id: "1", threadID: "t1", role: "user",
+                              text: "Let's go with the coral accent for the AI elements", timestamp: Date()))
+        idx.index(IndexedTurn(id: "2", threadID: "t1", role: "assistant",
+                              text: "Got it — coral it is, never cyan", timestamp: Date()))
+        idx.index(IndexedTurn(id: "3", threadID: "t2", role: "user",
+                              text: "Remind me to water the plants", timestamp: Date()))
+        return idx
+    }
+
+    func testRecallReturnsCitedAnswer() async {
+        let service = RecallService()
+        service.configure(index: populatedIndex()) { question, hits in
+            "Answered '\(question)' from \(hits.count) excerpts"
+        }
+        let answer = await service.recall("what accent color did we choose")
+        XCTAssertFalse(answer.isEmpty)
+        XCTAssertTrue(answer.citations.contains { $0.id == "1" })
+        XCTAssertFalse(answer.citations.contains { $0.id == "3" })   // unrelated turn excluded
+        XCTAssertTrue(answer.summary.hasPrefix("Answered"))
+    }
+
+    func testRecallEmptyWhenNoMatch() async {
+        let service = RecallService()
+        service.configure(index: populatedIndex()) { _, _ in "should not be called" }
+        let answer = await service.recall("quarterly tax filing deadline")
+        XCTAssertTrue(answer.isEmpty)
+        XCTAssertTrue(answer.summary.lowercased().contains("couldn't find"))
+    }
+
+    func testSearchDelegatesToIndex() {
+        let service = RecallService()
+        service.configure(index: populatedIndex()) { _, _ in "" }
+        XCTAssertTrue(service.search("plants").contains { $0.id == "3" })
+    }
+
+    func testUnconfiguredServiceIsSafe() async {
+        let service = RecallService()
+        XCTAssertFalse(service.isConfigured)
+        XCTAssertTrue(service.search("anything").isEmpty)
+        let answer = await service.recall("anything")
+        XCTAssertTrue(answer.isEmpty)
+    }
+
+    func testSummarizationPromptCitesExcerpts() {
+        let hits = [
+            RecallHit(id: "1", threadID: "t", role: "user", text: "ship Friday",
+                      timestamp: Date(timeIntervalSinceReferenceDate: 0), snippet: "ship Friday", rank: -1),
+        ]
+        let p = RecallService.summarizationPrompt(question: "when do we ship?", hits: hits)
+        XCTAssertTrue(p.user.contains("when do we ship?"))
+        XCTAssertTrue(p.user.contains("[1]"))
+        XCTAssertTrue(p.user.contains("ship Friday"))
+        XCTAssertTrue(p.system.lowercased().contains("only"))   // answer strictly from excerpts
+    }
+
+    func testFallbackSummaryBulletsHits() {
+        let hits = (1...3).map {
+            RecallHit(id: "\($0)", threadID: "t", role: "user", text: "line \($0)",
+                      timestamp: Date(), snippet: "line \($0)", rank: 0)
+        }
+        let summary = RecallService.fallbackSummary(hits)
+        XCTAssertTrue(summary.contains("• line 1"))
+        XCTAssertEqual(summary.components(separatedBy: "\n").count, 3)
+    }
+}

--- a/docs/plans/memory-recall.md
+++ b/docs/plans/memory-recall.md
@@ -5,10 +5,10 @@ heuristics, skill-pattern detector, insights aggregator) is fully headless-testa
 on-device summarization call is model-dependent — same posture as the rest of the brain work.
 Native-first (the brain works without OpenClaw — see `[[project_brain_store]]`).
 
-Three features cribbed *as capabilities* (not code — it's a Python project) from the
-self-improving loop in Nous's Hermes Agent, all reinforcing OpenGlasses' on-device brain
-rather than the gateway. They share one substrate (`ConversationStore` + `BrainStore` + a new
-conversation index), so they're phased as one effort:
+Three features built around a self-improving "closed learning loop," all reinforcing
+OpenGlasses' on-device brain rather than the gateway. They share one substrate
+(`ConversationStore` + `BrainStore` + a new conversation index), so they're phased as one
+effort:
 
 1. **Cross-session recall** — search and summarize your own past conversations.
 2. **Self-improving memory loop** — proactive "remember this?" nudges + autonomous skill
@@ -133,6 +133,6 @@ past conversation into something you can ask about hands-free; the self-improvin
 the brain *grows* without the user having to curate it by hand; insights make that growth
 legible. All three deepen the on-device brain (native-first, private) rather than leaning on
 the gateway — and the hard parts (FTS query building, nudge/skill heuristics, aggregation) are
-pure, fully-testable functions over data structures already in the app. Reference: the
-Hermes Agent "closed learning loop" (agent-curated memory, autonomous skill creation,
-cross-session recall) proves the shape; the code here is written fresh in Swift.
+pure, fully-testable functions over data structures already in the app. The closed-learning-loop
+shape (agent-curated memory, autonomous skill creation, cross-session recall) is well-proven;
+the code here is written fresh in Swift.


### PR DESCRIPTION
Phase 2 of the [memory-recall plan](docs/plans/memory-recall.md) — wires the Phase-1 FTS core ([#100](https://github.com/straff2002/OpenGlasses/pull/100)) into a working **cross-session recall** feature.

## What's here
- **`RecallService`** (shared) — searches the `ConversationIndex` and summarizes the top turns into a **cited answer**. The summarizer is an injectable seam wired to `LLMService.completeStateless`, which routes to the user's **active provider** (so it's on-device when that's their choice); falls back to a bulleted snippet list if it fails. No model needed in tests.
- **`ConversationStore`** — indexes each user/assistant turn into the recall index on append, plus a one-time **idempotent backfill** of existing history (when the index is empty).
- **`brain` tool** — new **`recall`** action: *"what did we decide about X?"*, *"what did I say about Y last week?"* → a cited answer drawn from past conversations (the FTS query builder parses relative dates like "last week"). Reachable by voice through normal tool-calling.
- `LLMService.completeStateless` made internal for the recall summarizer; `brain` description updated in the tool + the Direct-mode prompt.
- `AppState` wires the shared `ConversationIndex` into the store + `RecallService`.

## Privacy
Recall search/index are fully on-device. Summarization uses the **user's already-configured provider** (the same one their conversations already go through), so it introduces no new egress — and stays on-device when their active model is local.

## Tests
- Build clean for the simulator (**BUILD SUCCEEDED**).
- **21 memory tests pass, 0 failures** (15 `MemoryRecallCoreTests` + 6 new `MemoryRecallServiceTests`: cited-answer flow, empty-match fallback, search delegation, unconfigured safety, prompt construction, fallback formatting).

## Next (separate PRs)
- **Phase 3 — self-improving loop:** route `MemoryNudgeAnalyzer` / `SkillPatternDetector` through `ProactiveAlertService` (opt-in, presence-aware) → `BrainStore.ingest` / `voice_skill`.
- **Phase 4 — insights:** `InsightsView` + spoken recap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)