### PR TITLE
Memory & Recall Phase 3: self-improving loop (nudges + skill suggestions)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -930,6 +930,12 @@ class AppState: ObservableObject, AppStateProtocol {
                 ?? RecallService.fallbackSummary(hits)
         }
 
+        // Memory & Recall Phase 3 — the self-improving loop: nudge (or, in Agent Mode, silently
+        // save) durable facts + repeated multi-step requests. Presence-aware; off by default.
+        MemoryLoopService.shared.configure(presence: presenceMonitor) { [weak self] message in
+            Task { @MainActor in await self?.speechService.speak(message) }
+        }
+
         // Field Assist Phase 5 (Plan K2): expert stream bridge for escalations. Transport
         // (MJPEG / WebRTC) is selected in Settings; MJPEG is the working default.
         EscalationCoordinator.shared.bridge = ExpertStreamBridge(
@@ -2741,6 +2747,11 @@ class AppState: ObservableObject, AppStateProtocol {
             if Config.conversationPersistenceEnabled {
                 conversationStore.appendMessage(role: "assistant", content: response)
             }
+
+            // Memory loop (Phase 3): spot a durable fact or a repeated multi-step request and
+            // offer to remember it (or silently save it in Agent Mode).
+            MemoryLoopService.shared.observeTurn(userText: query, assistantText: response,
+                                                 toolNames: nativeToolRouter.takeTurnToolNames())
 
             // Speak the response (user can still say "stop")
             if speakResponse {

--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
     // Intelligence settings
     @State private var intentClassifierEnabled = Config.intentClassifierEnabled
     @State private var userMemoryEnabled = Config.userMemoryEnabled
+    @State private var memoryNudgesEnabled = Config.memoryNudgesEnabled
     @State private var conversationPersistenceEnabled = Config.conversationPersistenceEnabled
     @State private var autoModelRoutingEnabled = Config.autoModelRoutingEnabled
 
@@ -219,6 +220,11 @@ struct SettingsView: View {
                     title: "Conversation History",
                     isOn: $conversationPersistenceEnabled,
                     info: "Saves conversation transcripts so you can review them later in the History tab. Also provides context for follow-up questions within a session. When off, conversations are ephemeral and discarded after each session."
+                )
+                InfoToggle(
+                    title: "Memory Suggestions",
+                    isOn: $memoryNudgesEnabled,
+                    info: "After you state a durable fact (\"my daughter's name is Mia\") or repeat a multi-step request, the assistant offers a spoken nudge to remember it or save it as a skill — you confirm by voice. With Agentic Features on, these are saved automatically instead of nudged. Off by default."
                 )
 
                 NavigationLink {
@@ -666,6 +672,7 @@ struct SettingsView: View {
 
         Config.setIntentClassifierEnabled(intentClassifierEnabled)
         Config.setUserMemoryEnabled(userMemoryEnabled)
+        Config.setMemoryNudgesEnabled(memoryNudgesEnabled)
         Config.setConversationPersistenceEnabled(conversationPersistenceEnabled)
 
         Config.setBroadcastPlatform(broadcastPlatform)

--- a/OpenGlasses/Sources/Services/Memory/MemoryLoopService.swift
+++ b/OpenGlasses/Sources/Services/Memory/MemoryLoopService.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Combine
+
+/// What the memory loop decided to do for a completed turn. Returned by `decide` so the
+/// decision logic is unit-testable without touching `BrainStore` / `VoiceSkillStore` / TTS.
+enum MemoryAction: Equatable {
+    case nudgeFact(String)                          // speak an offer to remember a stated fact
+    case saveFact(String)                           // silently ingest the fact (Agent Mode)
+    case nudgeSkill(String)                         // speak an offer to save a repeated request
+    case saveSkill(trigger: String, instruction: String)   // silently save the skill (Agent Mode)
+}
+
+/// The self-improving loop (Memory & Recall Phase 3): after each completed turn it spots a
+/// durable fact (`MemoryNudgeAnalyzer`) or a repeated multi-step request (`SkillPatternDetector`)
+/// and either **offers** to save it (spoken nudge, opt-in) or **silently saves** it when Agent
+/// Mode is on. Presence-aware and rate-limited so nudges never nag.
+///
+/// `decide(...)` is pure of `Config`/singletons/TTS (flags are parameters) → fully unit-tested;
+/// `observeTurn` reads `Config`, calls `decide`, and performs the side effects.
+@MainActor
+final class MemoryLoopService: ObservableObject {
+    static let shared = MemoryLoopService()
+
+    private let skillDetector: SkillPatternDetector
+    /// Spoken nudges are suppressed unless this many turns have passed since the last one.
+    private let nudgeCooldownTurns: Int
+    private var turnsSinceNudge: Int
+
+    weak var presence: PresenceMonitor?
+    /// Speak a nudge through TTS. Wired by `AppState`.
+    var speak: ((String) -> Void)?
+
+    init(skillDetector: SkillPatternDetector = SkillPatternDetector(), nudgeCooldownTurns: Int = 4) {
+        self.skillDetector = skillDetector
+        self.nudgeCooldownTurns = nudgeCooldownTurns
+        self.turnsSinceNudge = nudgeCooldownTurns   // allow the first nudge immediately
+    }
+
+    func configure(presence: PresenceMonitor?, speak: @escaping (String) -> Void) {
+        self.presence = presence
+        self.speak = speak
+    }
+
+    /// Live entry point — call at turn completion.
+    func observeTurn(userText: String, assistantText: String = "", toolNames: [String] = []) {
+        let nudges = Config.memoryNudgesEnabled
+        let agent = Config.agentModeEnabled
+        guard nudges || agent else { return }
+        let turn = CompletedTurn(userText: userText, assistantText: assistantText, toolNames: toolNames)
+        let actions = decide(turn: turn, nudgesEnabled: nudges, agentMode: agent, present: isPresent)
+        perform(actions)
+    }
+
+    /// Decide what to do for a turn. Deterministic given the flags + internal detector/cooldown
+    /// state — the unit-tested core.
+    func decide(turn: CompletedTurn, nudgesEnabled: Bool, agentMode: Bool, present: Bool) -> [MemoryAction] {
+        turnsSinceNudge += 1
+        var actions: [MemoryAction] = []
+
+        if let nudge = MemoryNudgeAnalyzer.nudge(for: turn) {
+            if agentMode {
+                actions.append(.saveFact(nudge.payload))
+            } else if nudgesEnabled, present, canNudge() {
+                actions.append(.nudgeFact("I can remember that — just say \u{201C}remember it.\u{201D}"))
+                markNudged()
+            }
+        }
+
+        // Always feed the detector so repeat-counts accrue, even when nudges are suppressed.
+        if let suggestion = skillDetector.record(toolNames: turn.toolNames, triggerHint: turn.userText) {
+            let trigger = Self.triggerPhrase(from: suggestion.triggerHint)
+            let instruction = "Repeat what we did before: \(suggestion.toolSignature.joined(separator: ", "))."
+            if agentMode {
+                actions.append(.saveSkill(trigger: trigger, instruction: instruction))
+            } else if nudgesEnabled, present, canNudge() {
+                actions.append(.nudgeSkill("You've done that a few times — say \u{201C}save that as a skill\u{201D} and I'll learn it."))
+                markNudged()
+            }
+        }
+        return actions
+    }
+
+    // MARK: - Side effects
+
+    private func perform(_ actions: [MemoryAction]) {
+        for action in actions {
+            switch action {
+            case .saveFact(let payload):
+                BrainStore.shared.ingest(text: payload, sourceRef: "memory-loop", sourceKind: "fact")
+            case .saveSkill(let trigger, let instruction):
+                VoiceSkillStore.shared.save(VoiceSkill(id: UUID().uuidString, trigger: trigger,
+                                                       instruction: instruction, createdAt: Date()))
+            case .nudgeFact(let message), .nudgeSkill(let message):
+                speak?(message)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var isPresent: Bool {
+        guard let presence else { return true }
+        return presence.mode >= .present   // active or present, not idle/away
+    }
+
+    private func canNudge() -> Bool { turnsSinceNudge >= nudgeCooldownTurns }
+    private func markNudged() { turnsSinceNudge = 0 }
+
+    /// A short, lower-cased trigger phrase from the user's wording (first few words).
+    static func triggerPhrase(from hint: String) -> String {
+        let words = hint.lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(whereSeparator: { $0 == " " || $0 == "\n" })
+            .prefix(6)
+        return words.joined(separator: " ")
+    }
+}

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
@@ -29,6 +29,18 @@ final class NativeToolRouter {
     /// Tool execution timeout in seconds (prevents hung tools from blocking forever).
     var toolTimeoutSeconds: TimeInterval = 30
 
+    /// Names of tools routed since the last `takeTurnToolNames()` — lets the memory loop
+    /// (Memory & Recall Phase 3) see which tools a turn used, to spot repeated multi-step
+    /// requests worth saving as a skill.
+    private(set) var turnToolNames: [String] = []
+
+    /// Return and clear the tools routed this turn.
+    func takeTurnToolNames() -> [String] {
+        let names = turnToolNames
+        turnToolNames = []
+        return names
+    }
+
     init(registry: NativeToolRegistry, openClawBridge: OpenClawBridge? = nil) {
         self.registry = registry
         self.openClawBridge = openClawBridge
@@ -36,6 +48,8 @@ final class NativeToolRouter {
 
     /// Handle a tool call by name. Routing order: native → MCP → OpenClaw → error.
     func handleToolCall(name: String, args: [String: Any]) async -> ToolResult {
+        turnToolNames.append(name)   // Phase 3: track tools used this turn for skill detection
+
         // 0. Deterministic safety supervisor (Plan S): the single pre-execution safety gate when
         // agent mode is on. It subsumes the high-impact confirmation backstop — its
         // `needsVoiceApproval` rule reproduces it — and adds deterministic block/confirm rules

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -2283,6 +2283,19 @@ struct Config {
         UserDefaults.standard.set(enabled, forKey: "glassesDisplayEnabled")
     }
 
+    // MARK: - Memory loop (self-improving)
+
+    /// When on, the assistant offers a spoken nudge after you state a durable fact or repeat a
+    /// multi-step request ("say 'remember it'" / "save that as a skill"). Off by default. When
+    /// Agent Mode is also on, those are auto-saved silently instead of nudged.
+    static var memoryNudgesEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "memoryNudgesEnabled")
+    }
+
+    static func setMemoryNudgesEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: "memoryNudgesEnabled")
+    }
+
     // MARK: - Teleprompter
 
     /// Default pacing mode for new teleprompter sessions.

--- a/OpenGlassesTests/MemoryLoopTests.swift
+++ b/OpenGlassesTests/MemoryLoopTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Headless tests for the Memory & Recall Phase 3 self-improving loop. `decide(...)` takes the
+/// flags as parameters (no Config / no singletons / no TTS), so the nudge-vs-auto-save vs
+/// presence vs cooldown logic is fully deterministic and unit-tested.
+@MainActor
+final class MemoryLoopTests: XCTestCase {
+
+    private func service() -> MemoryLoopService {
+        MemoryLoopService(skillDetector: SkillPatternDetector(threshold: 3), nudgeCooldownTurns: 4)
+    }
+
+    private let fact = CompletedTurn(userText: "My daughter's name is Mia")
+    private let neutral = CompletedTurn(userText: "thanks, that's all")
+
+    // MARK: - Facts
+
+    func testFactAutoSavedInAgentMode() {
+        let actions = service().decide(turn: fact, nudgesEnabled: false, agentMode: true, present: false)
+        XCTAssertEqual(actions, [.saveFact("My daughter's name is Mia")])
+    }
+
+    func testFactNudgedWhenEnabledAndPresent() {
+        let actions = service().decide(turn: fact, nudgesEnabled: true, agentMode: false, present: true)
+        guard case .nudgeFact = actions.first else { return XCTFail("expected a fact nudge") }
+    }
+
+    func testFactNotNudgedWhenAway() {
+        let actions = service().decide(turn: fact, nudgesEnabled: true, agentMode: false, present: false)
+        XCTAssertTrue(actions.isEmpty)
+    }
+
+    func testNothingWhenAllOff() {
+        XCTAssertTrue(service().decide(turn: fact, nudgesEnabled: false, agentMode: false, present: true).isEmpty)
+    }
+
+    func testNeutralTurnProducesNothing() {
+        XCTAssertTrue(service().decide(turn: neutral, nudgesEnabled: true, agentMode: true, present: true).isEmpty)
+    }
+
+    // MARK: - Cooldown
+
+    func testNudgeCooldownSuppressesConsecutive() {
+        let s = service()
+        let first = s.decide(turn: fact, nudgesEnabled: true, agentMode: false, present: true)
+        guard case .nudgeFact = first.first else { return XCTFail("first should nudge") }
+        // Immediately again — within the 4-turn cooldown → suppressed.
+        XCTAssertTrue(s.decide(turn: fact, nudgesEnabled: true, agentMode: false, present: true).isEmpty)
+    }
+
+    // MARK: - Skills
+
+    func testSkillNudgedAfterThreshold() {
+        let s = service()
+        let tools = ["get_weather", "get_news"]
+        let t = CompletedTurn(userText: "give me my morning brief", toolNames: tools)
+        XCTAssertTrue(s.decide(turn: t, nudgesEnabled: true, agentMode: false, present: true).isEmpty)
+        XCTAssertTrue(s.decide(turn: t, nudgesEnabled: true, agentMode: false, present: true).isEmpty)
+        let third = s.decide(turn: t, nudgesEnabled: true, agentMode: false, present: true)
+        guard case .nudgeSkill = third.first else { return XCTFail("expected a skill nudge on the 3rd repeat") }
+    }
+
+    func testSkillAutoSavedInAgentMode() {
+        let s = service()
+        let tools = ["calendar", "reminder"]
+        let t = CompletedTurn(userText: "set up my day", toolNames: tools)
+        _ = s.decide(turn: t, nudgesEnabled: false, agentMode: true, present: false)
+        _ = s.decide(turn: t, nudgesEnabled: false, agentMode: true, present: false)
+        let third = s.decide(turn: t, nudgesEnabled: false, agentMode: true, present: false)
+        guard case let .saveSkill(trigger, instruction) = third.first else {
+            return XCTFail("expected a skill save on the 3rd repeat")
+        }
+        XCTAssertEqual(trigger, "set up my day")
+        XCTAssertTrue(instruction.contains("calendar"))
+    }
+
+    func testSingleToolNeverSuggestsSkill() {
+        let s = service()
+        let t = CompletedTurn(userText: "set a timer", toolNames: ["set_timer"])
+        for _ in 0..<5 {
+            XCTAssertTrue(s.decide(turn: t, nudgesEnabled: true, agentMode: true, present: true).isEmpty)
+        }
+    }
+
+    func testTriggerPhraseClipsToSixWords() {
+        XCTAssertEqual(MemoryLoopService.triggerPhrase(from: "Give Me My Morning Brief Please Now Quickly"),
+                       "give me my morning brief please")
+    }
+}


### PR DESCRIPTION
Phase 3 of the [memory-recall plan](docs/plans/memory-recall.md) — the self-improving loop. **Stacked on [#101](https://github.com/straff2002/OpenGlasses/pull/101)** (base is `feat/memory-recall-service`; merge #101 first, then this retargets to `main`).

Per your call: **both** behaviors (spoken opt-in nudge normally + silent auto-save in Agent Mode), and skill suggestions **included** with new tool-call tracking.

## What's here
- **`MemoryLoopService`** — observes each completed turn and decides: a durable fact (`MemoryNudgeAnalyzer`) or a repeated multi-step request (`SkillPatternDetector`) → either a **spoken nudge** ("say 'remember it'" / "save that as a skill") or, in **Agent Mode**, a **silent save** (`BrainStore.ingest` / `voice_skill`). **Presence-aware** (only nudges when active/present, via `PresenceMonitor`) and **cooldown rate-limited** so it never nags.
- **`NativeToolRouter`** now tracks tools routed per turn (`takeTurnToolNames()`) — the single chokepoint, so the loop can spot repeated multi-tool sequences.
- Wired at the Direct-mode turn-completion in `AppState`; speaks via TTS. `Config.memoryNudgesEnabled` (**off by default**) + a Settings toggle ("Memory Suggestions"); auto-save gated behind `agentModeEnabled`.

## Design notes
- `decide(turn:, nudgesEnabled:, agentMode:, present:)` takes flags as **parameters** (no Config/singletons/TTS) → the whole nudge-vs-save / presence / cooldown / threshold logic is deterministic and unit-tested.
- Suggestions only — nothing is saved without either your spoken confirmation or Agent Mode being explicitly on (per your `agentModeEnabled` gating rule).

## Tests
- Build clean for the simulator (**BUILD SUCCEEDED**).
- **31 memory tests pass** (15 core + 6 service + **10 new** `MemoryLoopTests`: fact auto-save vs nudge, away-suppression, all-off, cooldown, skill threshold nudge/save, single-tool ignored, trigger-phrase).

## Merge order
Merge **#101 first**; GitHub then retargets this to `main`. Don't merge both simultaneously (avoids the stacked-merge race we hit with #97).

## Next
- **Phase 4 — insights:** `InsightsView` + spoken recap (the `InsightsAggregator` core is already merged in #100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)