### PR TITLE
Structured Vision: first-aid casualty triage consumer

### DIFF
--- a/OpenGlasses/Sources/Services/StructuredVision/Schemas/FirstAidTriageSchema.swift
+++ b/OpenGlasses/Sources/Services/StructuredVision/Schemas/FirstAidTriageSchema.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// First-aid casualty triage on the structured-vision substrate (structured-vision plan, Phase 3
+/// consumer — unblocked once first-aid coaching shipped). Point the glasses at a casualty and get a
+/// typed triage: responsiveness, breathing, severe bleeding, and visible injuries → a tiered
+/// `AssessmentCard`. The life-safety call (tier + recommended action) is computed **deterministically**
+/// from the reported vitals, not left to the model — the same guardrail posture as HECA.
+///
+/// Advisory only — not a medical diagnosis; always escalates to emergency services. Pairs with the
+/// `first_aid` coaching tool (triage tells you *what's wrong*; first_aid walks the *response*).
+struct FirstAidTriageSchema: AssessmentSchema {
+    let kind = "first_aid_triage"
+    let title = "First-Aid Triage"
+
+    static let disclaimer = "Advisory only — not a medical diagnosis. Call emergency services."
+
+    var jsonSchema: [String: Any] {
+        [
+            "type": "object",
+            "properties": [
+                "responsive": ["type": "boolean", "description": "Does the casualty appear responsive / conscious?"],
+                "breathing": ["type": "string", "enum": ["normal", "abnormal", "absent", "unknown"],
+                              "description": "Breathing status, as best visible (chest movement, gasping=abnormal)."],
+                "severe_bleeding": ["type": "boolean", "description": "Is there visible severe/arterial bleeding?"],
+                "findings": [
+                    "type": "array",
+                    "items": [
+                        "type": "object",
+                        "properties": [
+                            "label": ["type": "string", "description": "e.g. 'open fracture, left forearm'"],
+                            "detail": ["type": "string"],
+                            "severity": ["type": "string", "enum": AssessmentTier.allCases.map(\.rawValue)],
+                            "region": ["type": "array", "items": ["type": "number"], "description": "normalized [x,y,w,h]"]
+                        ],
+                        "required": ["label", "severity"]
+                    ]
+                ],
+                "summary": ["type": "string"],
+                "confidence": ["type": "number"]
+            ],
+            "required": ["responsive", "breathing", "severe_bleeding", "summary"]
+        ]
+    }
+
+    var systemPrompt: String {
+        """
+        You are a first-aid triage assistant for smart glasses. The user points the camera at a casualty \
+        and needs a fast, factual triage — NOT a diagnosis. Report only what you can actually see.
+
+        Assess three life-safety vitals: is the person `responsive`; is `breathing` normal / abnormal \
+        (gasping, irregular) / absent / unknown; and is there `severe_bleeding` (heavy or spurting). Then \
+        list visible injuries as `findings`, each with a short label, a `severity` of ok / caution / \
+        critical, and a normalized [x,y,w,h] `region` when you can localise it.
+
+        \(AssessmentPrompt.instrumentFragment)
+
+        Do not invent vitals you cannot observe — use "unknown" for breathing and omit uncertain findings. \
+        Return ONLY the structured assessment (responsive, breathing, severe_bleeding, findings, a \
+        one-sentence summary, and overall confidence). The system decides the urgency and the recommended \
+        action from these vitals; you just report them accurately.
+        """
+    }
+
+    func makeCard(from json: [String: Any], context: String?) throws -> AssessmentCard {
+        let responsive = json["responsive"] as? Bool
+        let breathing = (json["breathing"] as? String)?.lowercased()
+        let severeBleeding = (json["severe_bleeding"] as? Bool) ?? false
+        let notBreathing = breathing == "absent"
+        let abnormalBreathing = breathing == "abnormal"
+        let unresponsive = responsive == false
+
+        let modelFindings = (json["findings"] as? [[String: Any]] ?? [])
+            .compactMap { try? AssessmentJSON.decode(AssessmentFinding.self, from: $0) }
+
+        // Deterministic life-safety findings from the reported vitals.
+        var findings: [AssessmentFinding] = []
+        if notBreathing { findings.append(AssessmentFinding(label: "Not breathing", severity: .critical)) }
+        if severeBleeding { findings.append(AssessmentFinding(label: "Severe bleeding", severity: .critical)) }
+        if unresponsive && !notBreathing {
+            findings.append(AssessmentFinding(label: "Unresponsive (breathing present)", severity: .critical))
+        }
+        if abnormalBreathing { findings.append(AssessmentFinding(label: "Abnormal breathing", severity: .caution)) }
+        findings += modelFindings
+
+        // Recommended action by strict priority: airway/breathing → bleeding → responsiveness.
+        let action: String?
+        if notBreathing {
+            action = "Not breathing — start CPR now and call emergency services."
+        } else if severeBleeding {
+            action = "Severe bleeding — apply firm direct pressure and call emergency services."
+        } else if unresponsive {
+            action = "Unresponsive but breathing — place in the recovery position and call emergency services."
+        } else if abnormalBreathing {
+            action = "Monitor breathing closely and be ready to start CPR. Call emergency services."
+        } else if !findings.isEmpty {
+            action = "Call emergency services and keep monitoring the casualty."
+        } else {
+            action = nil
+        }
+
+        let tier = findings.reduce(AssessmentTier.ok) { AssessmentTier.escalated($0, $1.severity) }
+
+        let rawSummary = (json["summary"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let summary = !rawSummary.isEmpty ? rawSummary
+            : (findings.isEmpty ? "No casualty in view — point the camera at the person."
+                                : "Triage: \(findings.count) finding\(findings.count == 1 ? "" : "s").")
+
+        let readings = (json["readings"] as? [[String: Any]] ?? [])
+            .compactMap { try? AssessmentJSON.decode(InstrumentReading.self, from: $0) }
+
+        return AssessmentCard(
+            kind: kind, title: title, tier: tier, summary: summary,
+            findings: findings, recommendedAction: action,
+            readings: readings,
+            confidence: (json["confidence"] as? Double) ?? 1.0,
+            disclaimer: Self.disclaimer
+        ).normalizingReadings()
+    }
+}

--- a/OpenGlasses/Sources/Services/StructuredVision/StructuredVisionService.swift
+++ b/OpenGlasses/Sources/Services/StructuredVision/StructuredVisionService.swift
@@ -56,6 +56,7 @@ final class StructuredVisionService: ObservableObject {
     /// Register the built-in, domain-free schemas. Idempotent.
     func registerBuiltinSchemas() {
         if !registry.contains("instrument_reading") { registry.register(InstrumentReadingSchema()) }
+        if !registry.contains("first_aid_triage") { registry.register(FirstAidTriageSchema()) }
     }
 
     /// Dismiss the currently presented card.

--- a/OpenGlassesTests/FirstAidTriageSchemaTests.swift
+++ b/OpenGlassesTests/FirstAidTriageSchemaTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Headless tests for `FirstAidTriageSchema` — the life-safety tier + recommended action are
+/// computed deterministically from the reported vitals (not the model), so they're fully
+/// unit-tested. Mirrors the HECA consumer's guardrail posture.
+final class FirstAidTriageSchemaTests: XCTestCase {
+
+    private let schema = FirstAidTriageSchema()
+
+    private func card(responsive: Bool? = true, breathing: String = "normal",
+                      bleeding: Bool = false, findings: [[String: Any]] = [],
+                      summary: String = "casualty in view") throws -> AssessmentCard {
+        var json: [String: Any] = ["breathing": breathing, "severe_bleeding": bleeding,
+                                   "findings": findings, "summary": summary]
+        if let responsive { json["responsive"] = responsive }
+        return try schema.makeCard(from: json, context: nil)
+    }
+
+    func testNotBreathingIsCriticalCPR() throws {
+        let c = try card(breathing: "absent")
+        XCTAssertEqual(c.tier, .critical)
+        XCTAssertTrue(c.recommendedAction?.contains("CPR") ?? false)
+        XCTAssertTrue(c.findings.contains { $0.label == "Not breathing" })
+    }
+
+    func testSevereBleedingIsCriticalPressure() throws {
+        let c = try card(breathing: "normal", bleeding: true)
+        XCTAssertEqual(c.tier, .critical)
+        XCTAssertTrue(c.recommendedAction?.lowercased().contains("pressure") ?? false)
+    }
+
+    func testUnresponsiveBreathingIsCriticalRecovery() throws {
+        let c = try card(responsive: false, breathing: "normal")
+        XCTAssertEqual(c.tier, .critical)
+        XCTAssertTrue(c.recommendedAction?.lowercased().contains("recovery") ?? false)
+    }
+
+    func testAbnormalBreathingIsCaution() throws {
+        let c = try card(breathing: "abnormal")
+        XCTAssertEqual(c.tier, .caution)
+        XCTAssertTrue(c.findings.contains { $0.label == "Abnormal breathing" })
+    }
+
+    func testAllNormalNoFindingsIsOK() throws {
+        let c = try card()
+        XCTAssertEqual(c.tier, .ok)
+        XCTAssertNil(c.recommendedAction)
+        XCTAssertTrue(c.findings.isEmpty)
+    }
+
+    func testModelFindingRaisesTier() throws {
+        let c = try card(findings: [["label": "Open fracture, left forearm", "severity": "caution"]])
+        XCTAssertEqual(c.tier, .caution)
+        XCTAssertEqual(c.recommendedAction, "Call emergency services and keep monitoring the casualty.")
+    }
+
+    func testAirwayPriorityWhenBleedingAndNotBreathing() throws {
+        let c = try card(breathing: "absent", bleeding: true)
+        XCTAssertEqual(c.tier, .critical)
+        XCTAssertTrue(c.recommendedAction?.contains("CPR") ?? false)   // breathing beats bleeding
+        // Both life-safety findings are still surfaced.
+        XCTAssertTrue(c.findings.contains { $0.label == "Not breathing" })
+        XCTAssertTrue(c.findings.contains { $0.label == "Severe bleeding" })
+    }
+
+    func testCarriesDisclaimer() throws {
+        XCTAssertEqual(try card().disclaimer, FirstAidTriageSchema.disclaimer)
+    }
+
+    func testRegisteredInRegistry() {
+        let registry = AssessmentSchemaRegistry()
+        registry.register(FirstAidTriageSchema())
+        XCTAssertTrue(registry.contains("first_aid_triage"))
+        XCTAssertNotNil(registry.schema(for: "first_aid_triage"))
+    }
+}

--- a/docs/plans/structured-vision-assessment.md
+++ b/docs/plans/structured-vision-assessment.md
@@ -6,8 +6,9 @@ Shipped: the pure core (`AssessmentCard`/`AssessmentTier`/`AssessmentFinding`/`I
 + per-provider `StructuredVisionParser` (forced tool-use / function / JSON, text fallback);
 `StructuredVisionService` + `vision_assess` tool + `AssessmentCardView`/HUD; and the built-in
 **`instrument_reading`** ("read the instrument") consumer. **46 tests, Debug + Release green.**
-**Deferred to follow-up PRs:** first-aid triage consumer (now unblocked — #82 merged), Gemini
-`responseSchema` translation, CaptureFlow `voice_number` auto-fill.
+**Deferred to follow-up PRs:** ~~first-aid triage consumer~~ ✅ shipped (`FirstAidTriageSchema` —
+deterministic life-safety tier/action from reported vitals); Gemini `responseSchema` translation,
+CaptureFlow `voice_number` auto-fill still pending.
 
 **Strategic fit:** Today every camera-reasoning feature funnels through
 [`LLMService.analyzeFrame`](../../OpenGlasses/Sources/Services/LLMService.swift) (line 848), which returns


### PR DESCRIPTION
First of the plan follow-ups you asked for — the **structured-vision** plan's deferred (now-unblocked) Phase-3 consumer. Point the glasses at a casualty → a typed triage card.

## What's here
- **`FirstAidTriageSchema`** on the structured-vision substrate: reports `responsive` / `breathing` / `severe_bleeding` + visible injury `findings`, mapped to a tiered `AssessmentCard`.
- **Deterministic life-safety call** — the tier and recommended action are computed from the reported vitals (not the model's free choice), the same guardrail posture as the HECA consumer. Strict priority: **not breathing → start CPR** › **severe bleeding → direct pressure** › **unresponsive-but-breathing → recovery position** › **abnormal breathing → caution**. Always advisory, always escalates to emergency services.
- Registered in `StructuredVisionService.registerBuiltinSchemas`; the `vision_assess` tool auto-lists the new `kind` from the registry (no tool change).
- Pairs with the existing `first_aid` coaching tool: triage tells you *what's wrong*, `first_aid` walks the *response*.

## Tests
- Build clean for the simulator.
- **9 new `FirstAidTriageSchemaTests`** (each life-safety branch, airway-priority when bleeding+not-breathing, model-finding tier escalation, OK case, disclaimer, registry) + structured-vision core/tool suites green (no regression).

## Plan status
This was the headline structured-vision follow-up. The two smaller remaining items — Gemini `responseSchema` translation and CaptureFlow `voice_number` auto-fill — are noted in the plan and can follow.

Part of the N/T/U/V/W/structured-vision/L/siri follow-up batch. Single PR off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)