### PR TITLE
WebRTC expert call: realtime-session audio precedence (Plan M3)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -945,9 +945,14 @@ class AppState: ObservableObject, AppStateProtocol {
         EscalationCoordinator.shared.bridge = ExpertStreamBridge(
             streamer: webRTCStreaming, framePublisher: cameraService.framePublisher)
 
-        // Plan M3: hand the audio session to a live expert call (pause TTS + wake word).
+        // Plan M3: hand the audio session to a live expert call (pause TTS + wake word), and
+        // refuse to start one while a realtime voice session (Gemini Live / OpenAI Realtime)
+        // already owns the mic — only one audio owner at a time.
         ExpertCallAudioCoordinator.shared.control = AppExpertCallAudioControl(
             wakeWord: wakeWordService, tts: speechService)
+        ExpertCallAudioCoordinator.shared.isRealtimeSessionActive = { [weak self] in
+            (self?.geminiLiveSession.isActive ?? false) || (self?.openAIRealtimeSession.isActive ?? false)
+        }
 
         // MCP Glasses server (Plan E, dev-only) — configure and start if both gates are on.
         MCPGlassesServer.shared.configure(camera: cameraService, tts: speechService)

--- a/OpenGlasses/Sources/Services/FieldAssist/ExpertCallAudioCoordinator.swift
+++ b/OpenGlasses/Sources/Services/FieldAssist/ExpertCallAudioCoordinator.swift
@@ -20,17 +20,36 @@ protocol ExpertCallAudioControlling {
 final class ExpertCallAudioCoordinator {
     static let shared = ExpertCallAudioCoordinator()
 
+    /// Result of attempting to begin a call.
+    enum StartResult: Equatable {
+        case started            // pipeline handed to the call
+        case alreadyActive      // a call was already running
+        case blockedByRealtime  // a Gemini/OpenAI realtime session owns the mic — refused
+    }
+
     private(set) var isCallActive = false
     /// Injected by AppState; nil in tests that supply their own.
     var control: ExpertCallAudioControlling?
+    /// Whether a realtime (Gemini Live / OpenAI Realtime) session currently owns the mic.
+    /// Injected by AppState (Plan M3 precedence); nil ⇒ no realtime contention assumed.
+    var isRealtimeSessionActive: (() -> Bool)?
 
     init() {}
 
-    /// Begin a call: pause the voice pipeline. Idempotent — a second call is a no-op.
-    func beginCall() {
-        guard !isCallActive else { return }
+    /// True if starting a call right now would collide with a realtime session that owns the mic.
+    var isBlockedByRealtime: Bool {
+        !isCallActive && (isRealtimeSessionActive?() ?? false)
+    }
+
+    /// Begin a call: pause the voice pipeline. Idempotent. Refuses (without touching the pipeline)
+    /// when a realtime session owns the mic — only one audio owner at a time (Plan M3).
+    @discardableResult
+    func beginCall() -> StartResult {
+        guard !isCallActive else { return .alreadyActive }
+        if isRealtimeSessionActive?() == true { return .blockedByRealtime }
         isCallActive = true
         control?.pauseVoicePipeline()
+        return .started
     }
 
     /// End a call: resume the voice pipeline. Idempotent — ending when inactive is a no-op.

--- a/OpenGlasses/Sources/Services/FieldAssist/WebRTCPeerTransport.swift
+++ b/OpenGlasses/Sources/Services/FieldAssist/WebRTCPeerTransport.swift
@@ -99,6 +99,11 @@ final class WebRTCPeerTransport: ExpertStreamTransport {
             throw ExpertStreamError.transportUnavailable(
                 "WebRTC needs a signaling server. Set the Expert Signaling URL in Field Assist settings, or use the MJPEG transport.")
         }
+        // Plan M3 precedence: a live expert call and a realtime voice session can't both own the mic.
+        guard !ExpertCallAudioCoordinator.shared.isBlockedByRealtime else {
+            throw ExpertStreamError.transportUnavailable(
+                "A live voice session (Gemini Live / OpenAI Realtime) is using the mic. End it before starting an expert call.")
+        }
         guard let signaling = ExpertSignalingClient(url: signalingURL) else {
             throw ExpertStreamError.transportUnavailable("Invalid signaling URL.")
         }

--- a/OpenGlassesTests/ExpertCallPrecedenceTests.swift
+++ b/OpenGlassesTests/ExpertCallPrecedenceTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Headless tests for the Plan M3 audio-session precedence guard: a live expert call and a
+/// realtime voice session can't both own the mic. The coordinator's logic is pure (the
+/// pipeline side-effects + the realtime check are injected), so it's fully unit-testable.
+@MainActor
+final class ExpertCallPrecedenceTests: XCTestCase {
+
+    @MainActor
+    private final class StubControl: ExpertCallAudioControlling {
+        var paused = 0
+        var resumed = 0
+        func pauseVoicePipeline() { paused += 1 }
+        func resumeVoicePipeline() { resumed += 1 }
+    }
+
+    private func makeCoordinator(realtimeActive: Bool) -> (ExpertCallAudioCoordinator, StubControl) {
+        let coordinator = ExpertCallAudioCoordinator()
+        let control = StubControl()
+        coordinator.control = control
+        coordinator.isRealtimeSessionActive = { realtimeActive }
+        return (coordinator, control)
+    }
+
+    func testStartsWhenNoRealtimeSession() {
+        let (coordinator, control) = makeCoordinator(realtimeActive: false)
+        XCTAssertFalse(coordinator.isBlockedByRealtime)
+        XCTAssertEqual(coordinator.beginCall(), .started)
+        XCTAssertTrue(coordinator.isCallActive)
+        XCTAssertEqual(control.paused, 1)
+    }
+
+    func testBlockedByActiveRealtimeSession() {
+        let (coordinator, control) = makeCoordinator(realtimeActive: true)
+        XCTAssertTrue(coordinator.isBlockedByRealtime)
+        XCTAssertEqual(coordinator.beginCall(), .blockedByRealtime)
+        XCTAssertFalse(coordinator.isCallActive)      // pipeline untouched
+        XCTAssertEqual(control.paused, 0)
+    }
+
+    func testSecondBeginIsAlreadyActive() {
+        let (coordinator, _) = makeCoordinator(realtimeActive: false)
+        XCTAssertEqual(coordinator.beginCall(), .started)
+        XCTAssertEqual(coordinator.beginCall(), .alreadyActive)
+    }
+
+    func testEndCallResumesAndIsIdempotent() {
+        let (coordinator, control) = makeCoordinator(realtimeActive: false)
+        _ = coordinator.beginCall()
+        coordinator.endCall()
+        XCTAssertFalse(coordinator.isCallActive)
+        XCTAssertEqual(control.resumed, 1)
+        coordinator.endCall()                          // no-op
+        XCTAssertEqual(control.resumed, 1)
+    }
+
+    func testNotBlockedWhileACallIsAlreadyActive() {
+        let coordinator = ExpertCallAudioCoordinator()
+        coordinator.control = StubControl()
+        coordinator.isRealtimeSessionActive = { false }
+        XCTAssertEqual(coordinator.beginCall(), .started)
+        // A realtime session starting mid-call doesn't "block" the call that already owns the mic.
+        coordinator.isRealtimeSessionActive = { true }
+        XCTAssertFalse(coordinator.isBlockedByRealtime)
+    }
+
+    func testNilProviderNeverBlocks() {
+        let coordinator = ExpertCallAudioCoordinator()
+        coordinator.control = StubControl()
+        XCTAssertFalse(coordinator.isBlockedByRealtime)
+        XCTAssertEqual(coordinator.beginCall(), .started)
+    }
+}

--- a/docs/plans/M-webrtc-infra-and-audio.md
+++ b/docs/plans/M-webrtc-infra-and-audio.md
@@ -65,9 +65,11 @@ transitions). Keep the transition logic in a small, testable coordinator rather 
 > state machine; the real side-effects (stop TTS + pause wake word on begin, resume on end) live
 > behind `ExpertCallAudioControlling` (`AppExpertCallAudioControl`). `WebRTCPeerTransport` calls
 > `beginCall()`/`endCall()` on start/stop, and AppState injects the adapter. Transition logic is
-> unit-tested. **Not yet done:** precedence vs. an active Gemini/OpenAI realtime session (which owns
-> the mic), explicit `RTCAudioSession` category/echo-cancellation config, and on-device echo/
-> session-wedge testing — all of which need real hardware.
+> unit-tested. **Precedence shipped:** `beginCall()` now returns a `StartResult` and refuses
+> (`.blockedByRealtime`, pipeline untouched) when a Gemini/OpenAI realtime session owns the mic —
+> `isRealtimeSessionActive` is injected by AppState and `WebRTCPeerTransport.start()` guards on it;
+> unit-tested. **Still device-pending:** explicit `RTCAudioSession` category/echo-cancellation config
+> and on-device echo/session-wedge testing — both need real hardware.
 
 ---
 


### PR DESCRIPTION
Plan L/M follow-up — the headless remainder of M3 audio coordination: a live expert call and a Gemini/OpenAI **realtime** voice session can't both own the mic.

## What's here
- **`ExpertCallAudioCoordinator.beginCall()`** now returns a `StartResult` (`.started` / `.alreadyActive` / `.blockedByRealtime`) and **refuses** — leaving the voice pipeline untouched — when a realtime session owns the mic. `isRealtimeSessionActive` is injected by `AppState` (`geminiLiveSession.isActive || openAIRealtimeSession.isActive`).
- **`WebRTCPeerTransport.start()`** guards on `isBlockedByRealtime` up-front and throws a clear `transportUnavailable` error ("end the live session first") instead of seizing the mic mid-setup.
- Pure logic (the pipeline side-effects and the realtime check are both injected) → fully unit-tested.

## Tests
- Build clean for the simulator.
- **6 new `ExpertCallPrecedenceTests`**: starts when clear, blocked by active realtime (pipeline untouched), already-active, end-call resume + idempotent, not-blocked once a call already owns the mic, nil-provider never blocks.

## Scope
This was the headless slice of L/M3. The rest of L's open work (deploy the signaling relay + expert web client, explicit `RTCAudioSession` echo-cancellation config, on-device echo/wedge testing) is device/infra-pending — plan doc updated to reflect that.

Follow-up batch: structured-vision ✅ (#106), **L (this)**, then siri, T, U. Single PR off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)