### PR TITLE
Siri/local-server: connection test + local-server presets

### DIFF
--- a/OpenGlasses/Sources/App/Views/ModelFormView.swift
+++ b/OpenGlasses/Sources/App/Views/ModelFormView.swift
@@ -19,6 +19,11 @@ struct ModelFormView: View {
     /// When true, changing provider also resets the model ID to the new provider's default.
     var resetModelOnProviderChange: Bool = true
 
+    // Connection-test state (siri-and-local-server plan)
+    @State private var isTestingConnection = false
+    @State private var connectionStatus: String?
+    @State private var connectionOK = false
+
     var body: some View {
         Section {
             TextField("e.g. Claude Sonnet, GPT-4o", text: $name)
@@ -109,10 +114,22 @@ struct ModelFormView: View {
                 }
 
                 if selectedProvider.showBaseURL {
+                    Menu {
+                        ForEach(LocalServerPreset.allCases) { preset in
+                            Button(preset.displayName) {
+                                baseURL = preset.baseURL
+                                resetModelList()
+                                connectionStatus = nil
+                            }
+                        }
+                    } label: {
+                        Label("Local server preset", systemImage: "server.rack")
+                    }
+
                     TextField("Base URL", text: $baseURL)
                         .autocorrectionDisabled()
                         .textInputAutocapitalization(.never)
-                        .onChange(of: baseURL) { _, _ in resetModelList() }
+                        .onChange(of: baseURL) { _, _ in resetModelList(); connectionStatus = nil }
                 }
 
                 Button {
@@ -143,6 +160,29 @@ struct ModelFormView: View {
                     Label(error, systemImage: "xmark.circle")
                         .font(.footnote)
                         .foregroundStyle(.red)
+                }
+
+                if selectedProvider.showBaseURL {
+                    Button {
+                        Task { await testConnection() }
+                    } label: {
+                        HStack {
+                            if isTestingConnection {
+                                ProgressView().scaleEffect(0.8)
+                                Text("Testing…")
+                            } else {
+                                Image(systemName: "bolt.horizontal.circle")
+                                Text("Test Connection")
+                            }
+                        }
+                    }
+                    .disabled(baseURL.isEmpty || isTestingConnection)
+
+                    if let connectionStatus {
+                        Label(connectionStatus, systemImage: connectionOK ? "checkmark.circle.fill" : "xmark.circle")
+                            .font(.footnote)
+                            .foregroundStyle(connectionOK ? .green : .red)
+                    }
                 }
             } header: {
                 Text("API Key")
@@ -183,6 +223,24 @@ struct ModelFormView: View {
         availableModels = []
         keyValidated = false
         fetchError = nil
+    }
+
+    private func testConnection() async {
+        isTestingConnection = true
+        connectionStatus = nil
+        defer { isTestingConnection = false }
+        let result = await ModelFetcher.testConnection(provider: selectedProvider, apiKey: apiKey, baseURL: baseURL)
+        connectionOK = result.isSuccess
+        switch result {
+        case .ok(let latencyMs, let count):
+            connectionStatus = "Reachable — \(latencyMs) ms, \(count) model\(count == 1 ? "" : "s")"
+        case .httpError(let code):
+            connectionStatus = "Server returned HTTP \(code)"
+        case .insecure:
+            connectionStatus = "Blocked by App Transport Security — use https, or allow this host in Info.plist"
+        case .unreachable(let why):
+            connectionStatus = "Unreachable — \(why)"
+        }
     }
 
     private func fetchModels() async {

--- a/OpenGlasses/Sources/Models/LocalServerPreset.swift
+++ b/OpenGlasses/Sources/Models/LocalServerPreset.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Quick-fill presets for common self-hosted, OpenAI-compatible LLM servers (siri-and-local-server
+/// plan). Picking one prefills the base URL (+ a model hint) so the user doesn't hand-type the
+/// host/port. Pure data — fully unit-testable.
+enum LocalServerPreset: String, CaseIterable, Identifiable {
+    case ollama
+    case lmStudio
+    case vllm
+    case localAI
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .ollama: return "Ollama"
+        case .lmStudio: return "LM Studio"
+        case .vllm: return "vLLM"
+        case .localAI: return "LocalAI"
+        }
+    }
+
+    /// Default OpenAI-compatible base URL (chat-completions root) for the server's usual port.
+    var baseURL: String {
+        switch self {
+        case .ollama: return "http://localhost:11434/v1"
+        case .lmStudio: return "http://localhost:1234/v1"
+        case .vllm: return "http://localhost:8000/v1"
+        case .localAI: return "http://localhost:8080/v1"
+        }
+    }
+
+    /// What to type in the model field once connected.
+    var modelHint: String {
+        switch self {
+        case .ollama: return "a pulled model, e.g. llama3.2 or qwen2.5"
+        case .lmStudio: return "the model currently loaded in LM Studio"
+        case .vllm: return "the model passed to --model"
+        case .localAI: return "the model name from your LocalAI config"
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/ModelFetcher.swift
+++ b/OpenGlasses/Sources/Services/ModelFetcher.swift
@@ -8,6 +8,53 @@ enum ModelFetcher {
         let name: String    // display-friendly label
     }
 
+    /// Outcome of a lightweight "can I reach this endpoint?" probe (siri-and-local-server plan).
+    enum ConnectionTestResult: Equatable {
+        case ok(latencyMs: Int, modelCount: Int)
+        case httpError(Int)
+        case unreachable(String)
+        case insecure          // http:// blocked by App Transport Security
+
+        var isSuccess: Bool { if case .ok = self { return true }; return false }
+    }
+
+    /// Pure status → result mapping (no I/O) so it's unit-testable.
+    static func classify(statusCode: Int, modelCount: Int, latencyMs: Int) -> ConnectionTestResult {
+        (200...299).contains(statusCode) ? .ok(latencyMs: latencyMs, modelCount: modelCount)
+                                         : .httpError(statusCode)
+    }
+
+    /// Probe the provider's `/models` endpoint: reachable? how fast? how many models? The result
+    /// classification is the pure `classify(...)`; only the GET + error mapping live here.
+    static func testConnection(provider: LLMProvider, apiKey: String, baseURL: String) async -> ConnectionTestResult {
+        guard let url = URL(string: modelsEndpoint(from: baseURL)) else { return .unreachable("Invalid URL") }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        if !apiKey.isEmpty { request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization") }
+        request.timeoutInterval = 15
+
+        let start = Date()
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let latencyMs = Int(Date().timeIntervalSince(start) * 1000)
+            guard let http = response as? HTTPURLResponse else { return .unreachable("No HTTP response") }
+            return classify(statusCode: http.statusCode, modelCount: modelCount(in: data), latencyMs: latencyMs)
+        } catch let error as URLError {
+            if error.code == .appTransportSecurityRequiresSecureConnection { return .insecure }
+            return .unreachable(error.localizedDescription)
+        } catch {
+            return .unreachable(error.localizedDescription)
+        }
+    }
+
+    /// Count models in a `/models` (OpenAI `data[]`) or `/api/tags` (Ollama `models[]`) response.
+    private static func modelCount(in data: Data) -> Int {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return 0 }
+        if let models = json["data"] as? [[String: Any]] { return models.count }
+        if let models = json["models"] as? [[String: Any]] { return models.count }
+        return 0
+    }
+
     /// Fetch models for a provider. Returns an empty array on failure.
     static func fetchModels(provider: LLMProvider, apiKey: String, baseURL: String) async -> [RemoteModel] {
         // Local OpenAI-compatible servers (Ollama, llama.cpp, LM Studio, vLLM…) usually

--- a/OpenGlassesTests/SiriLocalServerTests.swift
+++ b/OpenGlassesTests/SiriLocalServerTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Headless tests for the siri-and-local-server follow-ups: the pure connection-result
+/// classifier and the local-server presets. The network probe itself is a thin shell; its
+/// result mapping (`classify`) is pure and tested here.
+final class SiriLocalServerTests: XCTestCase {
+
+    // MARK: - ConnectionTestResult.classify
+
+    func testClassifyOK() {
+        XCTAssertEqual(ModelFetcher.classify(statusCode: 200, modelCount: 5, latencyMs: 42),
+                       .ok(latencyMs: 42, modelCount: 5))
+        XCTAssertTrue(ModelFetcher.classify(statusCode: 204, modelCount: 0, latencyMs: 10).isSuccess)
+    }
+
+    func testClassifyReachableButNoModelsStillOK() {
+        let r = ModelFetcher.classify(statusCode: 200, modelCount: 0, latencyMs: 7)
+        XCTAssertEqual(r, .ok(latencyMs: 7, modelCount: 0))   // server up, just nothing loaded
+    }
+
+    func testClassifyHTTPErrors() {
+        XCTAssertEqual(ModelFetcher.classify(statusCode: 401, modelCount: 0, latencyMs: 5), .httpError(401))
+        XCTAssertEqual(ModelFetcher.classify(statusCode: 404, modelCount: 0, latencyMs: 5), .httpError(404))
+        XCTAssertEqual(ModelFetcher.classify(statusCode: 503, modelCount: 0, latencyMs: 5), .httpError(503))
+        XCTAssertFalse(ModelFetcher.classify(statusCode: 500, modelCount: 0, latencyMs: 5).isSuccess)
+    }
+
+    // MARK: - LocalServerPreset
+
+    func testPresetsCoverTheCommonServers() {
+        XCTAssertEqual(Set(LocalServerPreset.allCases.map(\.displayName)),
+                       ["Ollama", "LM Studio", "vLLM", "LocalAI"])
+    }
+
+    func testPresetBaseURLsAreLocalAndDistinct() {
+        let urls = LocalServerPreset.allCases.map(\.baseURL)
+        XCTAssertEqual(Set(urls).count, urls.count)                       // all distinct
+        XCTAssertTrue(urls.allSatisfy { $0.hasPrefix("http://localhost:") && $0.hasSuffix("/v1") })
+        XCTAssertEqual(LocalServerPreset.ollama.baseURL, "http://localhost:11434/v1")
+    }
+
+    func testPresetModelHintsPresent() {
+        XCTAssertTrue(LocalServerPreset.allCases.allSatisfy { !$0.modelHint.isEmpty })
+    }
+
+    func testPresetEndpointDerivationRoundTrips() {
+        // A preset base URL → the /models listing endpoint the probe hits.
+        XCTAssertEqual(ModelFetcher.modelsEndpoint(from: LocalServerPreset.ollama.baseURL),
+                       "http://localhost:11434/v1/models")
+    }
+}

--- a/docs/plans/siri-and-local-server.md
+++ b/docs/plans/siri-and-local-server.md
@@ -1,6 +1,13 @@
 # Plan — Siri Conversational Intents + Self-Hosted Local Server Polish
 
-**Status: 📋 Planned.** Builds on the Siri App-Intents layer and the keyless
+**Status: 🚧 Mostly shipped.** Thread A (Siri persona intent + conversational follow-up +
+snippet) shipped in PRs #93/#94. Thread B/C: **connection-test (#4) + local-server presets
+(#5) shipped** — `ModelFetcher.testConnection` (pure `classify`) + a "Test Connection" button,
+and `LocalServerPreset` (Ollama / LM Studio / vLLM / LocalAI) with a base-URL prefill picker in
+`ModelFormView`. **Remaining: #6 LAN auto-detect (mDNS)** — device-pending (NWBrowser + Bonjour;
+many local servers don't advertise, real-LAN testing needed).
+
+Builds on the Siri App-Intents layer and the keyless
 Custom (OpenAI-compatible) provider already on
 `claude/siri-meta-glasses-integration-g0q7xf`:
 


### PR DESCRIPTION
The buildable Thread B/C follow-ups from the [siri-and-local-server plan](docs/plans/siri-and-local-server.md). (Thread A — persona Siri intent + conversational follow-up + snippet — already shipped in #93/#94.)

## What's here
- **`ModelFetcher.testConnection(provider:apiKey:baseURL:)`** — probes the provider's `/models` endpoint and reports **latency + model count**. The result mapping is a **pure `classify(statusCode:modelCount:latencyMs:)`** (→ `.ok` / `.httpError`); only the GET + ATS/unreachable mapping is the shell.
- **`LocalServerPreset`** — Ollama / LM Studio / vLLM / LocalAI, with default base URL + a model hint (pure data).
- **`ModelFormView`** — a "Local server preset" picker that prefills the base URL, and a **"Test Connection"** button showing latency/model-count, HTTP error, ATS-blocked, or unreachable.

## Tests
- Build clean for the simulator.
- **7 new `SiriLocalServerTests`**: `classify` (OK incl. zero-models, HTTP 401/404/503), preset coverage/distinct-local-URLs/hints, and preset→`/models` endpoint derivation.

## Remaining
Only **#6 LAN auto-detect (mDNS)** is left, and it's device-pending (NWBrowser + Bonjour; many local servers don't advertise; needs real-LAN testing). Plan status updated to 🚧 mostly-shipped.

Batch progress: structured-vision ✅ (#106), L (#107), **siri (this)**; T and U next. Single PR off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)