### PR TITLE
Offline queue: audit-export store-and-forward + photo disk-pressure cap (Plan T)

### DIFF
--- a/OpenGlasses/Sources/Services/FieldAssist/FieldSessionService.swift
+++ b/OpenGlasses/Sources/Services/FieldAssist/FieldSessionService.swift
@@ -297,7 +297,13 @@ final class FieldSessionService: ObservableObject {
             throw FieldSessionError.noActiveSession
         }
         let dir = sessionsRoot.appendingPathComponent(sessionId, isDirectory: true)
-        return try SessionExporter.export(sessionDir: dir, formats: formats)
+        let urls = try SessionExporter.export(sessionDir: dir, formats: formats)
+        // Plan T: store-and-forward the audit — enqueue an op so the export syncs to a backend
+        // when one exists (no-op locally beyond a queued tombstone until a networked sink lands).
+        offlineQueue?.enqueue(QueuedOp.make(
+            kind: .auditExport, sessionId: sessionId,
+            json: ["files": urls.map(\.path), "exportedAt": Date().timeIntervalSince1970]))
+        return urls
     }
 
     // MARK: - History

--- a/OpenGlasses/Sources/Services/Offline/OfflineQueue.swift
+++ b/OpenGlasses/Sources/Services/Offline/OfflineQueue.swift
@@ -83,6 +83,39 @@ final class OfflineQueue {
         exec("DELETE FROM ops WHERE state = 'done'")
     }
 
+    /// Delete a single op by id.
+    func delete(id: String) {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "DELETE FROM ops WHERE id = ?", -1, &stmt, nil) == SQLITE_OK else { return }
+        defer { sqlite3_finalize(stmt) }
+        bindText(stmt, 1, id)
+        _ = sqlite3_step(stmt)
+    }
+
+    /// Evict the oldest **delivered** (`done`) photo evidence from disk when it exceeds `maxBytes`,
+    /// then drop those tombstones. Pending/in-flight photos are never touched. Returns bytes freed.
+    @discardableResult
+    func prunePhotoEvidence(maxBytes: Int) -> Int {
+        let fm = FileManager.default
+        let candidates = all().filter { $0.kind == .photoUpload && $0.state == .done }
+            .compactMap { op -> (op: QueuedOp, url: URL, size: Int)? in
+                guard let path = op.payloadJSON["path"] as? String else { return nil }
+                let size = (try? fm.attributesOfItem(atPath: path)[.size]) as? Int ?? 0
+                return (op, URL(fileURLWithPath: path), size)
+            }
+        let entries = candidates.map { PhotoCachePolicy.Entry(id: $0.op.id, sizeBytes: $0.size, createdAt: $0.op.createdAt) }
+        let evict = Set(PhotoCachePolicy.evictions(entries, maxBytes: maxBytes))
+        guard !evict.isEmpty else { return 0 }
+
+        var freed = 0
+        for item in candidates where evict.contains(item.op.id) {
+            freed += item.size
+            try? fm.removeItem(at: item.url)
+            delete(id: item.op.id)
+        }
+        return freed
+    }
+
     /// Test helper: wipe everything.
     func deleteAll() {
         exec("DELETE FROM ops")

--- a/OpenGlasses/Sources/Services/Offline/PhotoCachePolicy.swift
+++ b/OpenGlasses/Sources/Services/Offline/PhotoCachePolicy.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Disk-pressure cap for synced photo evidence (Plan T). Photos captured offline are kept on disk
+/// until their upload op is `done`; once delivered they're just a cache, so under disk pressure we
+/// evict the **oldest delivered** ones first until back under budget. Pure → fully unit-tested; the
+/// queue supplies real file sizes and does the deletion.
+enum PhotoCachePolicy {
+    struct Entry: Equatable {
+        let id: String
+        let sizeBytes: Int
+        let createdAt: Date
+    }
+
+    /// Ids to evict so the total drops to ≤ `maxBytes`, oldest first. Empty when already under budget.
+    static func evictions(_ entries: [Entry], maxBytes: Int) -> [String] {
+        let total = entries.reduce(0) { $0 + $1.sizeBytes }
+        guard total > maxBytes else { return [] }
+
+        var overflow = total - maxBytes
+        var evict: [String] = []
+        for entry in entries.sorted(by: { $0.createdAt < $1.createdAt }) {   // oldest first
+            if overflow <= 0 { break }
+            evict.append(entry.id)
+            overflow -= entry.sizeBytes
+        }
+        return evict
+    }
+}

--- a/OpenGlassesTests/PhotoCachePolicyTests.swift
+++ b/OpenGlassesTests/PhotoCachePolicyTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Headless tests for the Plan T photo disk-pressure cap: the pure eviction policy and the
+/// queue prune that applies it to delivered photo evidence.
+final class PhotoCachePolicyTests: XCTestCase {
+
+    private func entry(_ id: String, _ size: Int, _ t: TimeInterval) -> PhotoCachePolicy.Entry {
+        PhotoCachePolicy.Entry(id: id, sizeBytes: size, createdAt: Date(timeIntervalSince1970: t))
+    }
+
+    func testNoEvictionWhenUnderBudget() {
+        let entries = [entry("a", 100, 1), entry("b", 100, 2)]
+        XCTAssertEqual(PhotoCachePolicy.evictions(entries, maxBytes: 500), [])
+        XCTAssertEqual(PhotoCachePolicy.evictions(entries, maxBytes: 200), [])   // exactly at budget
+    }
+
+    func testEvictsOldestFirstUntilUnderBudget() {
+        let entries = [entry("new", 100, 3), entry("old", 100, 1), entry("mid", 100, 2)]
+        // total 300, budget 150 → drop oldest two (old, mid).
+        XCTAssertEqual(PhotoCachePolicy.evictions(entries, maxBytes: 150), ["old", "mid"])
+    }
+
+    func testEvictsAllWhenBudgetZero() {
+        let entries = [entry("a", 50, 1), entry("b", 50, 2)]
+        XCTAssertEqual(Set(PhotoCachePolicy.evictions(entries, maxBytes: 0)), ["a", "b"])
+    }
+
+    // MARK: - Queue integration
+
+    @MainActor
+    func testPrunePhotoEvidenceDeletesOldestDeliveredFiles() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("tphoto-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let queue = OfflineQueue(path: dir.appendingPathComponent("q.sqlite"))
+
+        func photoOp(_ name: String, bytes: Int, at t: TimeInterval, state: OpState) throws -> URL {
+            let url = dir.appendingPathComponent(name)
+            try Data(count: bytes).write(to: url)
+            let payload = try JSONSerialization.data(withJSONObject: ["path": url.path])
+            queue.enqueue(QueuedOp(kind: .photoUpload, sessionId: "s", payload: payload,
+                                   createdAt: Date(timeIntervalSince1970: t), state: state))
+            return url
+        }
+
+        let old = try photoOp("old.jpg", bytes: 100, at: 1, state: .done)
+        let mid = try photoOp("mid.jpg", bytes: 100, at: 2, state: .done)
+        let new = try photoOp("new.jpg", bytes: 100, at: 3, state: .done)
+        let pendingPhoto = try photoOp("pending.jpg", bytes: 100, at: 0, state: .pending)
+
+        let freed = queue.prunePhotoEvidence(maxBytes: 150)   // keep ~newest 150 bytes of delivered
+
+        XCTAssertEqual(freed, 200)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: old.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: mid.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: new.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: pendingPhoto.path))   // pending never evicted
+        // The two evicted tombstones are gone; the delivered survivor + pending remain.
+        XCTAssertEqual(queue.all().filter { $0.kind == .photoUpload }.count, 2)
+    }
+}

--- a/docs/plans/T-offline-field-queue-and-sync.md
+++ b/docs/plans/T-offline-field-queue-and-sync.md
@@ -15,8 +15,11 @@ offline/reconnect HUD + TTS), fed by `FieldSessionService.attachPhoto` (durable-
 phone **`SyncStatusView`** (connection, queue depth, per-op state, conflicts) linked from Field Assist settings.
 13 tests (queue FIFO/restart/tombstone, reachability edge, engine flush/transient-cap/conflict/idempotent/
 rising-edge, resolver). Full suite 583 green; Debug + Release verified.
-**Deferred:** a real networked sink + `ConflictResolver` live use; routing `SessionLogger` entries / `auditExport`
-/ `llmGrounding` through the queue (add a `synced` column); disk-pressure photo cache cap.
+**Shipped since:** `auditExport` routing (`exportSession` enqueues an `.auditExport` op) and the
+**disk-pressure photo-cache cap** (`PhotoCachePolicy` pure eviction + `OfflineQueue.prunePhotoEvidence`,
+oldest delivered photos first; pending never touched).
+**Still deferred (device-pending):** a real networked sink + `ConflictResolver` live use; routing
+`SessionLogger` entries / `llmGrounding` through the queue.
 
 ---
 


### PR DESCRIPTION
Two headless follow-ups from the [offline-field-queue plan](docs/plans/T-offline-field-queue-and-sync.md) (the durable queue/sink core already shipped).

## What's here
- **Audit-export store-and-forward** — `FieldSessionService.exportSession` now enqueues an `.auditExport` op (the op kind already existed), so a session's audit syncs when a networked sink lands; until then it's a queued tombstone, never blocking the export.
- **Photo disk-pressure cap** — `PhotoCachePolicy` (pure: evict **oldest delivered** photos first to a byte budget) + `OfflineQueue.prunePhotoEvidence(maxBytes:)` which applies it to `.done` photo-upload evidence, deletes the files, and drops the tombstones. **Pending/in-flight photos are never touched.** Adds `OfflineQueue.delete(id:)`.

## Tests
- Build clean for the simulator.
- **4 new `PhotoCachePolicyTests`**: pure eviction (under-budget no-op, oldest-first to budget, evict-all at zero) + a queue-prune integration test (temp files: oldest delivered evicted, newest + pending kept, tombstones dropped, bytes-freed correct).

## Remaining (device-pending)
A real networked sink + `ConflictResolver` live use, and routing `SessionLogger`/`llmGrounding` through the queue — all need a backend/network. Plan status updated.

Batch: structured-vision ✅, L ✅, siri ✅ (all merged), **T (this)**; **U** is the last one. Single PR off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)