### PR TITLE
Audio-session resilience: safe formats, typed errors, activation fallback

### DIFF
--- a/OpenGlasses/Sources/Services/Audio/AudioFormatFactory.swift
+++ b/OpenGlasses/Sources/Services/Audio/AudioFormatFactory.swift
@@ -1,0 +1,36 @@
+import AVFoundation
+
+/// Constructs `AVAudioFormat` values without force-unwrapping.
+///
+/// `AVAudioFormat`'s initializer is failable: it returns `nil` for parameter combinations the
+/// OS can't represent. In practice this bites on unexpected native input formats from some
+/// Bluetooth / iOS LE-Audio mic routes — exactly the routes these glasses use — where a
+/// force-unwrap (`AVAudioFormat(...)!`) becomes a hard crash mid-call. This helper turns that
+/// failure into a typed `AudioSessionError.invalidFormat(context:)` the caller can handle.
+enum AudioFormatFactory {
+    /// A PCM `AVAudioFormat`, or throw `AudioSessionError.invalidFormat(context:)`.
+    ///
+    /// - Parameter context: names the role (e.g. "playback", "capture resampling") for the
+    ///   thrown error and any logging — purely diagnostic.
+    static func pcm(
+        _ commonFormat: AVAudioCommonFormat,
+        sampleRate: Double,
+        channels: AVAudioChannelCount,
+        interleaved: Bool,
+        context: String
+    ) throws -> AVAudioFormat {
+        // Guard the obviously-degenerate inputs up front: AVAudioFormat asserts (rather than
+        // returning nil) on a zero channel count, so we must not reach its initializer with one.
+        guard sampleRate > 0, channels > 0,
+              let format = AVAudioFormat(
+                commonFormat: commonFormat,
+                sampleRate: sampleRate,
+                channels: channels,
+                interleaved: interleaved
+              )
+        else {
+            throw AudioSessionError.invalidFormat(context: context)
+        }
+        return format
+    }
+}

--- a/OpenGlasses/Sources/Services/Audio/AudioSessionActivator.swift
+++ b/OpenGlasses/Sources/Services/Audio/AudioSessionActivator.swift
@@ -1,0 +1,46 @@
+import AVFoundation
+import Foundation
+
+/// Activates an `AVAudioSession` with graceful degradation.
+///
+/// The realtime managers prefer a specific category/mode/options for echo cancellation and
+/// routing (`.voiceChat`/`.videoChat`, Bluetooth + speaker). If the OS won't grant that
+/// combination on the current route, a bare `try session.setActive(true)` throws and kills the
+/// whole session — and the live conversation with it. This activator instead retries once with
+/// a conservative `.default` configuration before giving up, and surfaces a typed
+/// `AudioSessionError.activationFailed` only if even the fallback fails.
+enum AudioSessionActivator {
+    /// Configure and activate `session`, falling back to `.default` + `[.defaultToSpeaker]` if
+    /// the preferred configuration can't be activated.
+    ///
+    /// - Parameter configure: run after `setCategory` and before `setActive` on each attempt —
+    ///   use it for non-fatal hints like `setPreferredSampleRate` (call them with `try?` inside;
+    ///   a rejected hint must not abort activation).
+    static func activate(
+        _ session: AVAudioSession,
+        category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions,
+        configure: (AVAudioSession) -> Void = { _ in }
+    ) throws {
+        // Clear any stale active route first so a pending route change doesn't block activation.
+        try? session.setActive(false, options: .notifyOthersOnDeactivation)
+
+        do {
+            try session.setCategory(category, mode: mode, options: options)
+            configure(session)
+            try session.setActive(true)
+        } catch {
+            NSLog("[Audio] Preferred session config failed (mode %@): %@ — retrying with .default",
+                  mode.rawValue, error.localizedDescription)
+            do {
+                try session.setCategory(category, mode: .default, options: [.defaultToSpeaker])
+                configure(session)
+                try session.setActive(true)
+                NSLog("[Audio] Activated with fallback (.default)")
+            } catch {
+                throw AudioSessionError.activationFailed(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/Audio/AudioSessionError.swift
+++ b/OpenGlasses/Sources/Services/Audio/AudioSessionError.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Typed errors for the realtime audio managers (Gemini Live, OpenAI Realtime).
+///
+/// These exist so that a `nil` audio format or a failed session activation surfaces as a
+/// clear, user-meaningful error the caller can present or log — instead of trapping on a
+/// force-unwrap or throwing an opaque low-level `AVAudioSession` error mid-conversation.
+/// Mirrors the `WakeWordError` pattern already used by `WakeWordService`.
+enum AudioSessionError: LocalizedError, Equatable {
+    /// Microphone permission is in the `.denied` state — the session can't capture.
+    case microphonePermissionDenied
+    /// `AVAudioFormat` could not be constructed for the given role (e.g. "playback",
+    /// "capture resampling"). `context` names the role for logging/diagnostics.
+    case invalidFormat(context: String)
+    /// The audio session could not be activated even after the conservative fallback.
+    case activationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .microphonePermissionDenied:
+            return "Microphone access is required. Enable microphone permission for OpenGlasses in Settings."
+        case .invalidFormat(let context):
+            return "Could not create the \(context) audio format."
+        case .activationFailed(let detail):
+            return "Could not start the audio session: \(detail)"
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveAudioManager.swift
+++ b/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveAudioManager.swift
@@ -11,35 +11,29 @@ class GeminiLiveAudioManager {
     private let playerNode = AVAudioPlayerNode()
     private var isCapturing = false
 
-    private let outputFormat: AVAudioFormat
-
     // Accumulate resampled PCM into ~100ms chunks before sending
     private let sendQueue = DispatchQueue(label: "audio.accumulator")
     private var accumulatedData = Data()
     private let minSendBytes = 3200  // 100ms at 16kHz mono Int16 = 1600 frames × 2 bytes
 
-    init() {
-        self.outputFormat = AVAudioFormat(
-            commonFormat: .pcmFormatInt16,
-            sampleRate: Config.geminiLiveOutputSampleRate,
-            channels: Config.geminiLiveAudioChannels,
-            interleaved: true
-        )!
-    }
-
     /// Configure the audio session for Gemini Live.
     /// - Parameter useIPhoneMode: `true` for `.voiceChat` (iPhone mic), `false` for `.videoChat` (glasses mic).
     func setupAudioSession(useIPhoneMode: Bool = false) throws {
         let session = AVAudioSession.sharedInstance()
+        guard AVAudioApplication.shared.recordPermission != .denied else {
+            throw AudioSessionError.microphonePermissionDenied
+        }
         let mode: AVAudioSession.Mode = useIPhoneMode ? .voiceChat : .videoChat
-        try session.setCategory(
-            .playAndRecord,
+        try AudioSessionActivator.activate(
+            session,
+            category: .playAndRecord,
             mode: mode,
             options: [.defaultToSpeaker, .allowBluetoothHFP, .allowBluetoothA2DP]
-        )
-        try session.setPreferredSampleRate(Config.geminiLiveInputSampleRate)
-        try session.setPreferredIOBufferDuration(0.064)
-        try session.setActive(true)
+        ) { session in
+            // Preferred rate/buffer are hints — a rejected hint must not abort activation.
+            try? session.setPreferredSampleRate(Config.geminiLiveInputSampleRate)
+            try? session.setPreferredIOBufferDuration(0.064)
+        }
         NSLog("[Audio] Session mode: %@", useIPhoneMode ? "voiceChat (iPhone)" : "videoChat (glasses)")
     }
 
@@ -49,12 +43,13 @@ class GeminiLiveAudioManager {
 
         // Attach player node for playback
         audioEngine.attach(playerNode)
-        let playerFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
+        let playerFormat = try AudioFormatFactory.pcm(
+            .pcmFormatFloat32,
             sampleRate: Config.geminiLiveOutputSampleRate,
             channels: Config.geminiLiveAudioChannels,
-            interleaved: false
-        )!
+            interleaved: false,
+            context: "playback"
+        )
         audioEngine.connect(playerNode, to: audioEngine.mainMixerNode, format: playerFormat)
 
         let inputNode = audioEngine.inputNode
@@ -72,15 +67,20 @@ class GeminiLiveAudioManager {
 
         sendQueue.async { self.accumulatedData = Data() }
 
+        // Build the resample target format once and reuse it for every tap buffer
+        // (it's constant), rather than reconstructing — and force-unwrapping — it per buffer.
         var converter: AVAudioConverter?
+        var resampleFormat: AVAudioFormat?
         if needsResample {
-            let resampleFormat = AVAudioFormat(
-                commonFormat: .pcmFormatFloat32,
+            let format = try AudioFormatFactory.pcm(
+                .pcmFormatFloat32,
                 sampleRate: Config.geminiLiveInputSampleRate,
                 channels: Config.geminiLiveAudioChannels,
-                interleaved: false
-            )!
-            converter = AVAudioConverter(from: inputNativeFormat, to: resampleFormat)
+                interleaved: false,
+                context: "capture resampling"
+            )
+            resampleFormat = format
+            converter = AVAudioConverter(from: inputNativeFormat, to: format)
         }
 
         var tapCount = 0
@@ -90,13 +90,7 @@ class GeminiLiveAudioManager {
             tapCount += 1
             let pcmData: Data
 
-            if let converter {
-                let resampleFormat = AVAudioFormat(
-                    commonFormat: .pcmFormatFloat32,
-                    sampleRate: Config.geminiLiveInputSampleRate,
-                    channels: Config.geminiLiveAudioChannels,
-                    interleaved: false
-                )!
+            if let converter, let resampleFormat {
                 guard let resampled = self.convertBuffer(buffer, using: converter, targetFormat: resampleFormat) else {
                     if tapCount <= 3 { NSLog("[Audio] Resample failed for tap #%d", tapCount) }
                     return
@@ -129,12 +123,16 @@ class GeminiLiveAudioManager {
     func playAudio(data: Data) {
         guard isCapturing, !data.isEmpty else { return }
 
-        let playerFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
+        guard let playerFormat = try? AudioFormatFactory.pcm(
+            .pcmFormatFloat32,
             sampleRate: Config.geminiLiveOutputSampleRate,
             channels: Config.geminiLiveAudioChannels,
-            interleaved: false
-        )!
+            interleaved: false,
+            context: "playback"
+        ) else {
+            NSLog("[Audio] Invalid playback format — dropping %d bytes", data.count)
+            return
+        }
 
         let frameCount = UInt32(data.count) / (Config.geminiLiveAudioBitsPerSample / 8 * Config.geminiLiveAudioChannels)
         guard frameCount > 0 else { return }

--- a/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeAudioManager.swift
+++ b/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeAudioManager.swift
@@ -43,15 +43,20 @@ class OpenAIRealtimeAudioManager {
     /// Configure the audio session for OpenAI Realtime.
     func setupAudioSession(useIPhoneMode: Bool = false) throws {
         let session = AVAudioSession.sharedInstance()
+        guard AVAudioApplication.shared.recordPermission != .denied else {
+            throw AudioSessionError.microphonePermissionDenied
+        }
         let mode: AVAudioSession.Mode = useIPhoneMode ? .voiceChat : .videoChat
-        try session.setCategory(
-            .playAndRecord,
+        try AudioSessionActivator.activate(
+            session,
+            category: .playAndRecord,
             mode: mode,
             options: [.defaultToSpeaker, .allowBluetoothHFP, .allowBluetoothA2DP]
-        )
-        try session.setPreferredSampleRate(Self.sampleRate)
-        try session.setPreferredIOBufferDuration(0.064)
-        try session.setActive(true)
+        ) { session in
+            // Preferred rate/buffer are hints — a rejected hint must not abort activation.
+            try? session.setPreferredSampleRate(Self.sampleRate)
+            try? session.setPreferredIOBufferDuration(0.064)
+        }
         NSLog("[OpenAI Audio] Session mode: %@", useIPhoneMode ? "voiceChat" : "videoChat")
     }
 
@@ -60,12 +65,13 @@ class OpenAIRealtimeAudioManager {
         guard !isCapturing else { return }
 
         audioEngine.attach(playerNode)
-        let playerFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
+        let playerFormat = try AudioFormatFactory.pcm(
+            .pcmFormatFloat32,
             sampleRate: Self.sampleRate,
             channels: Self.channels,
-            interleaved: false
-        )!
+            interleaved: false,
+            context: "playback"
+        )
         audioEngine.connect(playerNode, to: audioEngine.mainMixerNode, format: playerFormat)
 
         let inputNode = audioEngine.inputNode
@@ -80,15 +86,20 @@ class OpenAIRealtimeAudioManager {
 
         sendQueue.async { self.accumulatedData = Data() }
 
+        // Build the resample target format once and reuse it for every tap buffer (it's
+        // constant), rather than reconstructing — and force-unwrapping — it per buffer.
         var converter: AVAudioConverter?
+        var targetFormat: AVAudioFormat?
         if needsResample {
-            let targetFormat = AVAudioFormat(
-                commonFormat: .pcmFormatFloat32,
+            let format = try AudioFormatFactory.pcm(
+                .pcmFormatFloat32,
                 sampleRate: Self.sampleRate,
                 channels: Self.channels,
-                interleaved: false
-            )!
-            converter = AVAudioConverter(from: inputNativeFormat, to: targetFormat)
+                interleaved: false,
+                context: "capture resampling"
+            )
+            targetFormat = format
+            converter = AVAudioConverter(from: inputNativeFormat, to: format)
         }
 
         inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputNativeFormat) { [weak self] buffer, _ in
@@ -97,13 +108,7 @@ class OpenAIRealtimeAudioManager {
             let pcmData: Data
             let amplitudeBuffer: AVAudioPCMBuffer
 
-            if let converter {
-                let targetFormat = AVAudioFormat(
-                    commonFormat: .pcmFormatFloat32,
-                    sampleRate: Self.sampleRate,
-                    channels: Self.channels,
-                    interleaved: false
-                )!
+            if let converter, let targetFormat {
                 guard let resampled = self.convertBuffer(buffer, using: converter, targetFormat: targetFormat) else {
                     return
                 }
@@ -148,12 +153,16 @@ class OpenAIRealtimeAudioManager {
     func playAudio(data: Data) {
         guard isCapturing, !data.isEmpty else { return }
 
-        let playerFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
+        guard let playerFormat = try? AudioFormatFactory.pcm(
+            .pcmFormatFloat32,
             sampleRate: Self.sampleRate,
             channels: Self.channels,
-            interleaved: false
-        )!
+            interleaved: false,
+            context: "playback"
+        ) else {
+            NSLog("[OpenAI Audio] Invalid playback format — dropping %d bytes", data.count)
+            return
+        }
 
         let frameCount = UInt32(data.count) / (Self.bitsPerSample / 8 * Self.channels)
         guard frameCount > 0 else { return }

--- a/OpenGlassesTests/AudioFormatFactoryTests.swift
+++ b/OpenGlassesTests/AudioFormatFactoryTests.swift
@@ -1,0 +1,83 @@
+import AVFoundation
+import XCTest
+@testable import OpenGlasses
+
+/// Tests the pure, throwing `AVAudioFormat` constructor that replaces the force-unwrapped
+/// `AVAudioFormat(...)!` calls in the realtime audio managers. Valid params yield a matching
+/// format; degenerate params throw a typed `AudioSessionError.invalidFormat(context:)` instead
+/// of trapping (the crash these glasses hit on unexpected Bluetooth/LE-Audio input formats).
+final class AudioFormatFactoryTests: XCTestCase {
+
+    func testValidInt16InterleavedFormat() throws {
+        let format = try AudioFormatFactory.pcm(
+            .pcmFormatInt16,
+            sampleRate: 24000,
+            channels: 1,
+            interleaved: true,
+            context: "playback"
+        )
+        XCTAssertEqual(format.sampleRate, 24000)
+        XCTAssertEqual(format.channelCount, 1)
+        XCTAssertEqual(format.commonFormat, .pcmFormatInt16)
+        XCTAssertTrue(format.isInterleaved)
+    }
+
+    func testValidFloat32NonInterleavedFormat() throws {
+        let format = try AudioFormatFactory.pcm(
+            .pcmFormatFloat32,
+            sampleRate: 16000,
+            channels: 1,
+            interleaved: false,
+            context: "capture resampling"
+        )
+        XCTAssertEqual(format.sampleRate, 16000)
+        XCTAssertEqual(format.channelCount, 1)
+        XCTAssertEqual(format.commonFormat, .pcmFormatFloat32)
+        XCTAssertFalse(format.isInterleaved)
+    }
+
+    func testZeroSampleRateThrowsInvalidFormatWithContext() {
+        XCTAssertThrowsError(
+            try AudioFormatFactory.pcm(
+                .pcmFormatFloat32,
+                sampleRate: 0,
+                channels: 1,
+                interleaved: false,
+                context: "playback"
+            )
+        ) { error in
+            XCTAssertEqual(error as? AudioSessionError, .invalidFormat(context: "playback"))
+        }
+    }
+
+    func testZeroChannelsThrowsInvalidFormatWithContext() {
+        XCTAssertThrowsError(
+            try AudioFormatFactory.pcm(
+                .pcmFormatFloat32,
+                sampleRate: 16000,
+                channels: 0,
+                interleaved: false,
+                context: "capture resampling"
+            )
+        ) { error in
+            XCTAssertEqual(error as? AudioSessionError, .invalidFormat(context: "capture resampling"))
+        }
+    }
+
+    func testContextIsPreservedInThrownError() {
+        XCTAssertThrowsError(
+            try AudioFormatFactory.pcm(
+                .pcmFormatInt16,
+                sampleRate: -1,
+                channels: 2,
+                interleaved: true,
+                context: "diagnostic-marker"
+            )
+        ) { error in
+            guard case .invalidFormat(let context)? = error as? AudioSessionError else {
+                return XCTFail("Expected AudioSessionError.invalidFormat, got \(error)")
+            }
+            XCTAssertEqual(context, "diagnostic-marker")
+        }
+    }
+}

--- a/OpenGlassesTests/AudioSessionErrorTests.swift
+++ b/OpenGlassesTests/AudioSessionErrorTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Each `AudioSessionError` case must carry a non-empty, user-meaningful message so a failed
+/// audio path can be surfaced or logged clearly instead of as an opaque low-level error.
+final class AudioSessionErrorTests: XCTestCase {
+
+    func testEveryCaseHasNonEmptyDescription() {
+        let cases: [AudioSessionError] = [
+            .microphonePermissionDenied,
+            .invalidFormat(context: "playback"),
+            .activationFailed("route unavailable")
+        ]
+        for error in cases {
+            let description = error.errorDescription ?? ""
+            XCTAssertFalse(description.isEmpty, "\(error) has an empty description")
+        }
+    }
+
+    func testPermissionMessageMentionsMicrophone() {
+        let description = AudioSessionError.microphonePermissionDenied.errorDescription ?? ""
+        XCTAssertTrue(description.localizedCaseInsensitiveContains("microphone"))
+    }
+
+    func testInvalidFormatMessageNamesContext() {
+        let description = AudioSessionError.invalidFormat(context: "capture resampling").errorDescription ?? ""
+        XCTAssertTrue(description.contains("capture resampling"))
+    }
+
+    func testActivationFailedMessageIncludesDetail() {
+        let description = AudioSessionError.activationFailed("route unavailable").errorDescription ?? ""
+        XCTAssertTrue(description.contains("route unavailable"))
+    }
+
+    func testEquatableConformance() {
+        XCTAssertEqual(AudioSessionError.invalidFormat(context: "playback"),
+                       .invalidFormat(context: "playback"))
+        XCTAssertNotEqual(AudioSessionError.invalidFormat(context: "playback"),
+                          .invalidFormat(context: "capture resampling"))
+        XCTAssertNotEqual(AudioSessionError.microphonePermissionDenied,
+                          .activationFailed("x"))
+    }
+}

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -138,6 +138,18 @@ Make OpenGlasses a daily-driver app **even with the glasses off**: a first-class
 
 **Suggested sequence:** Standalone Chat (front door) → Projects (scoped contexts the chat lives in) → Embedding upgrade (sharper retrieval for those contexts) → Image Generation (independent; can land any time). Image gen and the embedding upgrade are independent of the chat/projects pair.
 
+## Round 9 — reliability & connectivity hardening
+
+Three self-contained hardening workstreams over already-shipped paths (the gateway client, the live-audio managers, the speech stack). Each is mostly a deterministic, fully-testable core plus a thin live edge that is device-/backend-pending — same posture as the rest of the speech/agent work. Independent of each other; ship in any order. All 📋 Planned (diarization was already drafted).
+
+| Plan | Title | Effort | Reuses | Strategic fit |
+|---|---|---|---|---|
+| [Gateway Device Pairing](gateway-device-pairing.md) | Setup-code → approval → per-device token over the protocol-v3 handshake; live `PairingStatus` in Settings; per-device identity & revocation | ~2–3 days core + UI | OpenClawEventClient (v3 handshake), GatewayConfig/multi-gateway, KeychainService, scan_code (QR) | Replaces shared-secret onboarding with scan-and-approve; per-device revocation. Folds in a latent multi-gateway handshake-token fix. **Backend prereq:** gateway must support the pairing handshake; degrades to today's shared-token flow otherwise. |
+| [Audio-Session Resilience](audio-session-resilience.md) | Remove 9 force-unwrapped `AVAudioFormat` inits in the two realtime audio managers; typed errors; mic-permission gating; `setActive` fallback | ~1 day | WakeWordService (the reference pattern), GeminiLive/OpenAIRealtime audio managers | Kills a latent hard crash on Bluetooth/LE-Audio mic routes mid-call; graceful session degradation. No happy-path behaviour change, no new dependency. |
+| [Speaker Diarization](speaker-diarization.md) | Deepgram "who said what" — diarized live captions + batch-diarized recordings, speaker naming, brain attribution | ~3–4 days | shared audio engine, AmbientCaptionService, AudioRecordingService/MeetingAssistant, KeychainService, BrainStore | Closes the long-standing diarization gap; turns transcripts into attributed records. Off by default (cloud egress); HIPAA mode hard-disables. (Drafted earlier — listed here for the round.) |
+
+**Suggested sequence:** Audio-Session Resilience (smallest, pure win) → Speaker Diarization (deterministic core first) → Gateway Device Pairing (gate on confirming backend support).
+
 ## Dependency graph
 
 ```

--- a/docs/plans/audio-session-resilience.md
+++ b/docs/plans/audio-session-resilience.md
@@ -1,0 +1,127 @@
+# Plan — Audio-Session Resilience (realtime managers: no force-unwrap, graceful fallback)
+
+**Status:** 📋 Planned (not built). Small, defensive, no behaviour change on the happy path.
+The typed-error surface + format-construction helpers are headless-testable; the
+session-activation fallback is device-pending but low-risk. No new SPM dependency.
+
+The live-conversation audio paths — `GeminiLiveAudioManager` and `OpenAIRealtimeAudioManager` —
+each **force-unwrap every `AVAudioFormat(...)` initializer** (9 across the two files) and call a
+bare `try session.setActive(true)` with **no recovery path and no microphone-permission
+gating**. A `nil` format is a hard crash, and `AVAudioFormat` returning `nil` is not
+hypothetical: when the OS hands back an unexpected native input format — exactly what happens on
+some Bluetooth / iOS 26 LE-Audio mic routes (`[[reference_dat_glasses_gotchas]]`) — the
+force-unwrap traps and takes the app down mid-call. A failed `setActive` likewise throws
+straight up and aborts the session with nothing to fall back to.
+
+Meanwhile `WakeWordService` already does this correctly: explicit
+`WakeWordError.microphonePermissionDenied` gating via `AVAudioApplication.requestRecordPermission()`,
+`do/catch` around session configuration, and a `setActive` fallback. **This plan brings the two
+realtime managers up to `WakeWordService`'s standard** — it copies a pattern already proven in
+the codebase, it does not invent one.
+
+## What we fix
+- **No more hard crash on an unexpected audio format** — every `AVAudioFormat(...)` becomes a
+  `guard let … else { throw }`, so a `nil` format surfaces as a typed, logged error and ends the
+  session cleanly instead of trapping.
+- **Graceful session activation** — if the preferred category/mode/options fail to activate
+  (a route the OS won't grant), retry with a conservative `.default` configuration, then surface
+  a clear error if even that fails — rather than aborting on the first throw.
+- **Explicit mic-permission gating** — check (and, where appropriate, request) record permission
+  before configuring the session, returning a typed `microphonePermissionDenied` instead of a
+  confusing low-level `setActive` failure.
+- **Clean reconfigure** — `try? session.setActive(false, options: .notifyOthersOnDeactivation)`
+  before reconfiguring, so a stale active route doesn't make the new activation fail.
+
+## Scope — exactly two files (plus a shared helper)
+In scope (the gap):
+- `OpenGlasses/Sources/Services/GeminiLive/GeminiLiveAudioManager.swift` — 5 force-unwrapped
+  formats (capture, resample, playback), bare `setActive(true)`, no permission gate.
+- `OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeAudioManager.swift` — 4
+  force-unwrapped formats, bare `setActive(true)`, no permission gate.
+
+Out of scope (already resilient — leave them):
+- `WakeWordService.swift` — already gates permission + has `do/catch` + activation fallback; it
+  is the **reference** for this work, not a target.
+- `LiveTranslationService.swift` — already wraps `setActive` in `do/catch`; no force-unwraps.
+
+## Architecture — the seam
+A tiny shared, **pure** helper so both managers (and any future audio path) construct formats
+the same safe way and emit the same typed error:
+
+```swift
+enum AudioSessionError: LocalizedError {
+    case microphonePermissionDenied
+    case invalidFormat(context: String)   // e.g. "capture", "resample", "playback"
+    var errorDescription: String? { /* user-facing strings */ }
+}
+
+enum AudioFormatFactory {
+    /// Throws .invalidFormat(context:) instead of returning nil → no force-unwrap at call sites.
+    static func pcm(_ common: AVAudioCommonFormat,
+                    sampleRate: Double, channels: AVAudioChannelCount,
+                    interleaved: Bool, context: String) throws -> AVAudioFormat
+}
+
+enum AudioSessionActivator {
+    /// Try the preferred (category, mode, options); on failure fall back to (.default);
+    /// rethrow a typed error if both fail. Deactivates first to clear a stale route.
+    static func activate(_ session: AVAudioSession,
+                         category: AVAudioSession.Category,
+                         mode: AVAudioSession.Mode,
+                         options: AVAudioSession.CategoryOptions) throws
+}
+```
+
+Both managers replace `AVAudioFormat(...)!` with `try AudioFormatFactory.pcm(…, context:)`, gate
+on permission up front, and route session activation through `AudioSessionActivator.activate`.
+Call-site behaviour on the happy path is identical; only the failure paths change.
+
+## Files
+New (`OpenGlasses/Sources/Services/Audio/`):
+- `AudioSessionError.swift` — typed errors.
+- `AudioFormatFactory.swift` — pure throwing format constructor.
+- `AudioSessionActivator.swift` — activation with deactivate-first + `.default` fallback.
+
+Touch:
+- `GeminiLive/GeminiLiveAudioManager.swift` — replace 5 force-unwraps; gate permission; route
+  activation through the activator.
+- `OpenAIRealtime/OpenAIRealtimeAudioManager.swift` — same for its 4 force-unwraps.
+
+## Build order
+1. **Helpers + tests** — `AudioFormatFactory` (valid params → format; invalid → typed throw) and
+   `AudioSessionError`, fully unit-tested. No device, no session.
+2. **GeminiLiveAudioManager** — swap force-unwraps for `try AudioFormatFactory.pcm(…)`, add the
+   permission gate, route `setActive` through `AudioSessionActivator`. Manager methods become
+   `throws`; propagate to the existing session start with a logged error.
+3. **OpenAIRealtimeAudioManager** — identical treatment.
+4. **Activation fallback** — wire `AudioSessionActivator`'s `.default` retry (device-pending to
+   tune; logic is testable around the typed-error surface).
+
+## Tests
+- `AudioFormatFactory.pcm`: standard 16 kHz/24 kHz mono Int16 succeeds; degenerate params
+  (e.g. 0 channels / 0 sample rate) throw `.invalidFormat(context:)` with the right context
+  string. Pure, no hardware.
+- `AudioSessionError`: each case yields a non-empty, user-meaningful `errorDescription`.
+- Manager error propagation: a forced format failure (inject via the factory seam) surfaces the
+  typed error and tears the session down cleanly rather than trapping — asserted without a live
+  session.
+
+## Open questions / decisions needed
+- **Permission UX** — gate-and-fail (return `.microphonePermissionDenied`, let the caller show
+  the existing "enable mic" prompt) vs request-inline. Match whatever `WakeWordService` /
+  `AppState` already present so there's one mic-permission story, not two.
+- **Fallback aggressiveness** — one conservative `.default` retry is the floor; decide whether a
+  second retry dropping `.allowBluetooth`/`.mixWithOthers` is worth it, or whether failing fast
+  after one fallback (with a clear message) is better for a live call.
+- **Shared helper vs WakeWordService** — `WakeWordService` already embodies this logic inline.
+  Optional later cleanup: have it adopt `AudioSessionActivator` too, so there's a single
+  activation routine. Not required for this plan (don't regress a working path).
+
+## Why this matters
+These are the **live AI conversation** audio paths — the moments a crash is most visible and
+least recoverable. A force-unwrapped `AVAudioFormat` is a latent hard crash on exactly the
+Bluetooth/LE-Audio routes these glasses use, and a bare `setActive` turns a transient route
+hiccup into a dead session. The fix is small, has no happy-path behaviour change, adds no
+dependency, and simply applies a resilience pattern the codebase already trusts in
+`WakeWordService` to the two managers that skipped it — with the failure-mode logic captured in
+pure, fully-tested helpers.

--- a/docs/plans/gateway-device-pairing.md
+++ b/docs/plans/gateway-device-pairing.md
@@ -1,0 +1,164 @@
+# Plan — Gateway Device Pairing (setup-code → approval → per-device token)
+
+**Status:** 📋 Planned (not built). The deterministic core (setup-code parse/encode, auth-mode
+selection, response → pairing-state mapping, per-device identity) is fully headless-testable;
+only the live approval round-trip is gateway-pending. **Backend prerequisite** — see Open
+questions: the gateway must implement the bootstrap → approval → device-token handshake; until
+it does, this degrades cleanly to today's shared-token flow.
+
+Today a user connects to an OpenClaw gateway by pasting a **single shared gateway token**
+(`GatewayConfig.token`, a `SecureField` in `GatewaySettingsView`). Every device that connects
+uses that same secret, so: there's no way to revoke one device without rotating the token for
+all of them; the gateway can't tell "OpenGlasses on Greig's iPhone" from any other client; and
+onboarding means copy-pasting a long secret by hand. This plan adds a **per-device pairing**
+model on top of the existing protocol-v3 handshake: scan/enter a short **setup code**, the
+gateway approves the device, and the app stores a **per-device token** scoped to that gateway.
+
+## What we enable
+- **One-tap / one-scan onboarding** — enter a setup code (or scan its QR) instead of pasting a
+  raw token. The app does the bootstrap handshake and saves the resulting device token itself.
+- **Per-device identity & revocation** — each connection carries a stable `deviceId` and a
+  device-scoped token, so the gateway can list, name, and revoke individual devices without
+  affecting others.
+- **Live pairing status in Settings** — the gateway row shows *Connecting → Waiting for
+  approval → Paired* (or a clear error), instead of silently failing on a bad token.
+- **No regression** — gateways already configured with a shared token keep working unchanged;
+  pairing is an additional path, not a replacement.
+
+## How the user interacts
+1. Settings → **Gateways** → *Add* → **Pair with setup code**.
+2. Paste the setup code, or tap *Scan QR* (the gateway shows one in its admin UI).
+3. The row shows **Waiting for approval**; the user approves the device on the gateway.
+4. On approval the row flips to **Paired** and the per-device token is saved to that gateway's
+   config. Subsequent launches reconnect silently with the device token.
+5. Advanced users can still expand **Manual** and paste a shared token + host as today.
+
+## Architecture — the seam
+Extend the **existing** `OpenClawEventClient` protocol-v3 handshake rather than forking it. The
+client already: responds to a `connect.challenge` event, sends a `connect` request with
+`minProtocol/maxProtocol: 3` + `client {…}` + `auth.token`, and parses the `res` ok/error. We
+add three things to that flow:
+
+1. **Auth-mode selection** (pure) — choose the credential to send:
+   `bootstrap` (one-time, from a setup code, when not yet paired) → `device` (saved per-device
+   token) → `shared` (legacy `gateway.token`, the fallback that works today).
+2. **Pairing-response handling** — on a successful `res`/`event` that carries a device token,
+   persist it to the gateway and surface `.paired`; on a "pending approval" error, surface
+   `.waitingApproval` and keep the socket open; map other errors to `.error`.
+3. **Pairing status callback** — `onPairingStatusChange: ((PairingStatus) -> Void)?` so
+   `GatewaySettingsView` can render live state.
+
+```swift
+enum PairingStatus: Equatable {
+    case disconnected, connecting, waitingApproval, paired
+    case error(String)
+}
+
+enum GatewayAuthMode: String { case bootstrap, device, shared }
+
+/// Pure: pick which credential to present given the gateway's current state.
+enum GatewayAuthSelector {
+    static func mode(for gateway: GatewayConfig) -> GatewayAuthMode { /* … */ }
+}
+
+/// Pure: a setup code is base64(JSON { "url": …, "bootstrapToken": … }).
+enum SetupCode {
+    static func decode(_ raw: String) -> SetupCodePayload?   // trims whitespace, base64+JSON
+    static func encode(_ payload: SetupCodePayload) -> String
+}
+```
+
+## Model (SDK-free, the deterministic core)
+- `SetupCodePayload` — `url`, `bootstrapToken`. Value type. `SetupCode.decode/encode` is a pure,
+  exhaustively-tested function (trim whitespace/newlines, base64-decode, JSON-parse, validate
+  required keys; reject garbage).
+- `GatewayAuthMode` + `GatewayAuthSelector.mode(for:)` — pure precedence (`device` if paired,
+  else `bootstrap` if a setup code is present, else `shared`). Tested for every combination.
+- `PairingResponseInterpreter` — gateway `res`/`event` JSON → `(PairingStatus, deviceToken?)`.
+  Recognises an approved response carrying `result.token` (or a `device.paired` event), a
+  pending-approval error (by code/message), and generic failures. Pure → heavily tested.
+- `GatewayConfig` gains `deviceToken: String`, `deviceId: String` (stable per gateway), and a
+  transient `setupCode` used only until pairing completes (cleared on success). `isConfigured`
+  becomes true when *either* a device token *or* a shared token is present.
+
+## Credential & identity storage
+- **Device token → Keychain** (`KeychainService`), like the Anthropic/Deepgram keys — never
+  `@AppStorage`. The setup code's bootstrap token is short-lived and cleared once a device token
+  is issued.
+- **`deviceId`** — generated once per gateway (UUID), persisted, and sent as the handshake
+  `client.id` (and/or a `deviceId` param) so the gateway can name/revoke this specific device.
+
+## Fix folded in (latent multi-gateway bug)
+`sendConnectHandshake()` currently hardcodes `auth.token = Config.openClawGatewayToken` (the
+legacy global) even though `establishConnection` resolves the **active** `GatewayConfig`. With
+multiple gateways or a paired device this sends the wrong credential. This plan threads the
+resolved gateway's credential (device token / shared token, per the auth-mode selector) through
+the handshake — a correctness fix that pairing depends on anyway.
+
+## Files
+New (`OpenGlasses/Sources/Services/Gateway/`):
+- `SetupCode.swift` — `SetupCodePayload` + pure decode/encode.
+- `GatewayAuthSelector.swift` — `GatewayAuthMode` + pure selection.
+- `PairingResponseInterpreter.swift` — pure JSON → `(PairingStatus, deviceToken?)`.
+
+Touch:
+- `OpenClawEventClient.swift` — auth-mode-driven handshake credential; pairing-response handling
+  in the `res`/`event` branches; `onPairingStatusChange` callback; `startPairing(setupCode:)`.
+- `Config.swift` — `GatewayConfig.deviceToken` / `deviceId` / transient `setupCode`; Keychain
+  routing for the device token; `isConfigured` update.
+- `Views/GatewaySettingsView.swift` — "Pair with setup code" entry (paste + optional QR scan via
+  the existing `scan_code` camera path), a live `PairingStatus` row, "Manual" disclosure for the
+  shared-token path that exists today.
+
+## Build order (deterministic core first; live approval gateway-pending)
+1. **Pure core** — `SetupCode` + `GatewayAuthSelector` + `PairingResponseInterpreter` +
+   `GatewayConfig` fields, exhaustively tested (no network). This is the pairing brain.
+2. **Handshake wiring** — thread the selected credential + `deviceId` through
+   `sendConnectHandshake` (fixes the latent bug); capture a returned device token and persist it;
+   emit `PairingStatus`. Reconnect logic unchanged. (Live approval gateway-pending; the
+   interpreter is proven in 1.)
+3. **Settings UI** — setup-code entry + QR scan + live status row + Manual disclosure.
+4. **Polish** — device naming/“rename this device”, re-pair / unpair, surfacing the gateway's
+   device list if the backend exposes it.
+
+## Tests
+- `SetupCode.decode`: valid payload; whitespace/newline tolerance; non-base64; valid base64 but
+  not JSON; JSON missing `url`/`bootstrapToken`; round-trip with `encode`.
+- `GatewayAuthSelector`: paired→`device`; setup-code-present-not-paired→`bootstrap`; neither but
+  shared token→`shared`; nothing→unconfigured.
+- `PairingResponseInterpreter`: approved with `result.token`; `device.paired` event with token;
+  pending-approval error (code + message variants); generic error; ok with no token (already
+  authenticated). Asserts both the `PairingStatus` and the extracted token.
+- `GatewayConfig`: `isConfigured` true for device-token-only and shared-token-only; device token
+  routes to Keychain; `deviceId` stable across loads.
+
+## Open questions / decisions needed
+- **Backend support (prerequisite).** This requires the OpenClaw gateway to implement the
+  bootstrap → approval → device-token handshake over protocol v3 (a setup-code/bootstrap token,
+  an approval gate, a returned per-device token, and ideally a `device.paired` event). If the
+  gateway only understands shared tokens, build the deterministic core + UI behind a capability
+  check and **degrade to the existing shared-token flow** — no user-visible regression. Confirm
+  the exact field names (`result.token`, error code for pending) against the gateway before
+  wiring step 2.
+- **QR vs paste** — paste is the v1 floor (works with no camera/permissions); QR reuses the
+  existing `scan_code` camera path and is the nicer onboarding. Ship paste first.
+- **Gating** — lives entirely inside the existing gateway settings, which are already an
+  agent/gateway surface gated behind `[[feedback_agentic_toggle]]` (`agentModeEnabled`). No new
+  top-level gate.
+- **Token rotation / unpair** — define what the app does when the gateway revokes a device
+  (treat as `.error`, prompt re-pair) and provide an explicit local "unpair" that clears the
+  Keychain device token + `deviceId`.
+
+## Dependencies / prereqs
+- Existing: `OpenClawEventClient` (protocol-v3 handshake), `GatewayConfig` / multi-gateway
+  config, `KeychainService`, `GatewaySettingsView`, the `scan_code` camera path (for QR).
+- Gateway-side: the pairing handshake (see Open questions). **No new SPM dependency.**
+
+## Why this matters
+Shared secrets don't scale to an always-on, multi-device setup: you can't revoke one device,
+the gateway can't tell devices apart, and onboarding is a manual copy-paste. Per-device pairing
+makes connecting a glasses client a scan-and-approve, gives the gateway real per-device
+identity and revocation, and surfaces clear connection state instead of a silent failure on a
+bad token — all as an additive layer over the protocol-v3 handshake already shipping, with the
+hard part (code parsing, auth selection, response interpretation) a set of pure, fully-tested
+functions that degrade to today's behaviour when the backend hasn't caught up.

--- a/docs/plans/speaker-diarization.md
+++ b/docs/plans/speaker-diarization.md
@@ -60,8 +60,8 @@ protocol DiarizationProvider: AnyObject {
   `confidence`. Pure value type.
 - `DeepgramResponseParser` — **the tested core.** Deepgram JSON → `DiarizedSegment`. Computes
   the **majority speaker across the segment's words** (handles a speaker switching
-  mid-segment — the same idea as VisionClaw's Android `DeepgramSTTService`), distinguishes
-  interim vs `is_final`, tolerates missing `speaker` fields. Pure function → heavily tested.
+  mid-segment), distinguishes interim vs `is_final`, tolerates missing `speaker` fields. Pure
+  function → heavily tested.
 - `SpeakerRegistry` — stable `Int` id → optional name + a deterministic display colour;
   persists names; merges ids when two are named the same. Pure + persisted.
 - `SpeakerSegmentMerger` — coalesces consecutive same-speaker finals into readable turns for
@@ -159,7 +159,5 @@ captions, recorded meetings, and the brain's social memory. "Who said what" turn
 transcript into a usable record (assign action items, recall who proposed what, brief on a
 person from real quotes). It's cheap and low-risk: the hard part (response → labeled segments)
 is a pure, fully-testable function, it reuses the entire audio + caption + recording stack
-already built, and it degrades cleanly to today's behaviour when off. Reference: the VisionClaw
-fork's Android `DeepgramSTTService` proves the streaming-diarization shape end to end (it is a
-*reference* only — Meta-licensed sample code; the iOS client is written fresh against
-Deepgram's documented API).
+already built, and it degrades cleanly to today's behaviour when off. The iOS client is written
+fresh against Deepgram's documented streaming + batch API.


### PR DESCRIPTION
Hardens the two live-conversation audio paths (Gemini Live + OpenAI Realtime) and lands the Round 9 plan docs.

## Problem
`GeminiLiveAudioManager` and `OpenAIRealtimeAudioManager` each force-unwrapped every `AVAudioFormat(...)` init (9 total) and called a bare `try session.setActive(true)` with no fallback or mic-permission gating. A `nil` format — which happens on some Bluetooth / iOS LE-Audio mic routes these glasses use — is a hard crash mid-call, and a failed activation kills the session with nothing to fall back to. `WakeWordService` already does this right; these two skipped it.

## Change
New `OpenGlasses/Sources/Services/Audio/`:
- `AudioSessionError` — typed errors (`microphonePermissionDenied`, `invalidFormat(context:)`, `activationFailed`).
- `AudioFormatFactory` — throwing `AVAudioFormat` constructor (no force-unwrap).
- `AudioSessionActivator` — deactivate-first + conservative `.default` activation fallback.

Both managers now construct formats via the factory, gate on mic permission, and route activation through the activator. Dead `outputFormat`/`init` removed; the per-buffer resample format is built once instead of per tap.

Also includes the Round 9 plan docs (index + `audio-session-resilience.md`, `gateway-device-pairing.md`) and a CLAUDE.md plans pointer.

## Tests / verification
- New: `AudioFormatFactoryTests`, `AudioSessionErrorTests` (10).
- Full suite + **Release** build green. No happy-path behaviour change; no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)