### PR TITLE
Audio-session lease coordinator: single owner of the shared AVAudioSession

### DIFF
--- a/OpenGlasses/Sources/Services/Audio/AudioSessionCoordinator.swift
+++ b/OpenGlasses/Sources/Services/Audio/AudioSessionCoordinator.swift
@@ -1,0 +1,84 @@
+import AVFoundation
+import Foundation
+
+/// Single arbiter of the shared `AVAudioSession` across the app's audio subsystems.
+///
+/// Subsystems `acquire` the session for a given `AudioSessionOwner` instead of calling
+/// `setActive(true)` themselves, and `release` it when done. Acquiring supersedes any prior holder
+/// (last-acquire-wins); releasing deactivates the session **only** if no newer owner has acquired it
+/// since — the stale-release suppression that keeps a preempted subsystem's late teardown from
+/// killing the session a newer one is using. The arbitration logic is the pure `AudioSessionLedger`;
+/// this type adds the serial-queue safety and the real activation/deactivation.
+///
+/// Activation goes through `AudioSessionActivator`, so the preferred → `.default` fallback and
+/// deactivate-first-to-clear-a-stale-route behaviour are unchanged.
+final class AudioSessionCoordinator: @unchecked Sendable {
+    static let shared = AudioSessionCoordinator()
+
+    private let stateQueue = DispatchQueue(label: "audio.session.coordinator.state")
+    private let deactivationQueue = DispatchQueue(label: "audio.session.coordinator.deactivation", qos: .userInitiated)
+    private var ledger = AudioSessionLedger()
+
+    private init() {}
+
+    /// The owner currently recognised as holding the shared session, or `nil` if it's free.
+    var currentOwner: AudioSessionOwner? {
+        stateQueue.sync { ledger.current?.owner }
+    }
+
+    /// Acquire the shared session for `owner`, configuring and activating it. Supersedes any prior
+    /// holder. On activation failure the lease is rolled back (so a failed acquire never leaves the
+    /// caller recorded as owner) and the error is rethrown.
+    ///
+    /// - Parameter configure: run after `setCategory` and before `setActive` — for non-fatal hints
+    ///   like `setPreferredSampleRate` (call them with `try?` inside).
+    @discardableResult
+    func acquire(
+        _ owner: AudioSessionOwner,
+        category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions,
+        configure: (AVAudioSession) -> Void = { _ in }
+    ) throws -> AudioSessionLease {
+        let token = UUID()
+        let lease = stateQueue.sync { ledger.acquire(owner, token: token).lease }
+        do {
+            try AudioSessionActivator.activate(
+                AVAudioSession.sharedInstance(),
+                category: category,
+                mode: mode,
+                options: options,
+                configure: configure
+            )
+            NSLog("[AudioCoordinator] acquired by %@", owner.rawValue)
+            return lease
+        } catch {
+            // Roll the lease back if it's still ours so a failed acquire doesn't leave us "owner".
+            stateQueue.sync {
+                if ledger.current == lease { _ = ledger.release(lease) }
+            }
+            throw error
+        }
+    }
+
+    /// Release `lease`. Deactivates the shared session only if `lease` is still the current owner;
+    /// a stale release (a newer owner has acquired since) is ignored.
+    func release(_ lease: AudioSessionLease) {
+        let decision = stateQueue.sync { ledger.release(lease) }
+        switch decision {
+        case .deactivate:
+            deactivationQueue.async {
+                do {
+                    try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+                    NSLog("[AudioCoordinator] deactivated (released by %@)", lease.owner.rawValue)
+                } catch {
+                    NSLog("[AudioCoordinator] deactivate failed (%@): %@", lease.owner.rawValue, error.localizedDescription)
+                }
+            }
+        case .superseded(let by):
+            NSLog("[AudioCoordinator] stale release ignored: %@ superseded by %@", lease.owner.rawValue, by.rawValue)
+        case .alreadyReleased:
+            break
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/Audio/AudioSessionLedger.swift
+++ b/OpenGlasses/Sources/Services/Audio/AudioSessionLedger.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// A subsystem that can hold the shared `AVAudioSession`.
+///
+/// The app has several mic/audio subsystems that each activate the one shared session; the
+/// coordinator built on this ledger arbitrates them so only one is the recognised owner at a time.
+/// (Adoption is incremental — the realtime managers route through the coordinator first; the
+/// always-on wake-word path and the gentler coexisting services follow.)
+enum AudioSessionOwner: String, Sendable, CaseIterable {
+    case wakeWord
+    case transcription
+    case liveTranslation
+    case geminiLive
+    case openAIRealtime
+    case expertCall
+}
+
+/// A claim on the shared session: who holds it, an opaque token identifying this exact claim, and a
+/// monotonically increasing generation so a later claim always sorts after an earlier one.
+struct AudioSessionLease: Equatable, Sendable {
+    let owner: AudioSessionOwner
+    let token: UUID
+    let generation: UInt64
+}
+
+/// What the holder of a lease should do when it releases.
+enum AudioSessionReleaseDecision: Equatable {
+    /// This lease is still the active one — actually deactivate the shared session.
+    case deactivate
+    /// A different owner has since acquired the session — do nothing (a stale release must not
+    /// tear the session out from under whoever holds it now). Carries the current owner.
+    case superseded(by: AudioSessionOwner)
+    /// Nobody holds the session — nothing to deactivate.
+    case alreadyReleased
+}
+
+/// The deterministic "single owner" guarantee for the shared `AVAudioSession`, as a pure value type.
+///
+/// Last-acquire-wins: acquiring supersedes any prior holder and bumps the generation. The crucial
+/// invariant is on **release** — a lease only deactivates the session if it is *still the current
+/// lease*. That is what stops a preempted owner's late, asynchronous teardown (an interruption
+/// reset, a delayed `stopCapture`) from deactivating the session a newer owner just acquired — the
+/// exact race that leaves the shared session dead mid-conversation when subsystems each manage it
+/// independently.
+///
+/// Pure and single-threaded by construction; the live `AudioSessionCoordinator` wraps it behind a
+/// serial queue and performs the actual activation/deactivation.
+struct AudioSessionLedger {
+    /// The lease currently recognised as owning the session, or `nil` when it's free.
+    private(set) var current: AudioSessionLease?
+    private var generation: UInt64 = 0
+
+    init() {}
+
+    /// Make `owner` the current holder, superseding any previous lease.
+    /// - Parameter token: an opaque identity for this claim (the coordinator passes a fresh `UUID`;
+    ///   tests pass a fixed one).
+    /// - Returns: the new lease, and the lease it preempted (`nil` if the session was free).
+    @discardableResult
+    mutating func acquire(_ owner: AudioSessionOwner, token: UUID) -> (lease: AudioSessionLease, preempted: AudioSessionLease?) {
+        let preempted = current
+        generation &+= 1
+        let lease = AudioSessionLease(owner: owner, token: token, generation: generation)
+        current = lease
+        return (lease, preempted)
+    }
+
+    /// Decide what releasing `lease` should do, clearing ownership only if `lease` is still current.
+    mutating func release(_ lease: AudioSessionLease) -> AudioSessionReleaseDecision {
+        guard let active = current else { return .alreadyReleased }
+        if active == lease {
+            current = nil
+            return .deactivate
+        }
+        return .superseded(by: active.owner)
+    }
+}

--- a/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveAudioManager.swift
+++ b/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveAudioManager.swift
@@ -29,6 +29,8 @@ final class GeminiLiveAudioManager {
     private var useIPhoneMode = false
     /// Bumped on every (re)start and teardown; tags tap buffers so stale ones are dropped.
     private var audioGraphGeneration: UInt64 = 0
+    /// Our claim on the shared session, held while the conversation owns the mic.
+    private var sessionLease: AudioSessionLease?
 
     // Accumulate resampled PCM into ~100ms chunks before sending
     private let sendQueue = DispatchQueue(label: "audio.accumulator")
@@ -55,8 +57,10 @@ final class GeminiLiveAudioManager {
             throw AudioSessionError.microphonePermissionDenied
         }
         let mode: AVAudioSession.Mode = useIPhoneMode ? .voiceChat : .videoChat
-        try AudioSessionActivator.activate(
-            session,
+        // Acquire the shared session through the coordinator (single owner); supersedes any prior
+        // holder and lets a clean `release` deactivate it for whoever runs next (e.g. wake word).
+        sessionLease = try AudioSessionCoordinator.shared.acquire(
+            .geminiLive,
             category: .playAndRecord,
             mode: mode,
             options: [.defaultToSpeaker, .allowBluetoothHFP, .allowBluetoothA2DP]
@@ -246,6 +250,12 @@ final class GeminiLiveAudioManager {
             tearDownEngineGraphOnQueue(flushPendingAudio: true)
         }
         removeObservers()
+        // Release our claim on the shared session; the coordinator deactivates it only if no newer
+        // owner has acquired since (so a late stop can't stomp the next session).
+        if let lease = sessionLease {
+            sessionLease = nil
+            AudioSessionCoordinator.shared.release(lease)
+        }
     }
 
     // MARK: - Audio Interruption & Route Change Handling

--- a/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeAudioManager.swift
+++ b/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeAudioManager.swift
@@ -33,6 +33,8 @@ final class OpenAIRealtimeAudioManager {
     private var useIPhoneMode = false
     /// Bumped on every (re)start and teardown; tags tap buffers so stale ones are dropped.
     private var audioGraphGeneration: UInt64 = 0
+    /// Our claim on the shared session, held while the conversation owns the mic.
+    private var sessionLease: AudioSessionLease?
 
     // Audio format: 24kHz PCM16 mono for both directions
     static let sampleRate: Double = 24000
@@ -78,8 +80,10 @@ final class OpenAIRealtimeAudioManager {
             throw AudioSessionError.microphonePermissionDenied
         }
         let mode: AVAudioSession.Mode = useIPhoneMode ? .voiceChat : .videoChat
-        try AudioSessionActivator.activate(
-            session,
+        // Acquire the shared session through the coordinator (single owner); supersedes any prior
+        // holder and lets a clean `release` deactivate it for whoever runs next (e.g. wake word).
+        sessionLease = try AudioSessionCoordinator.shared.acquire(
+            .openAIRealtime,
             category: .playAndRecord,
             mode: mode,
             options: [.defaultToSpeaker, .allowBluetoothHFP, .allowBluetoothA2DP]
@@ -276,6 +280,12 @@ final class OpenAIRealtimeAudioManager {
             tearDownEngineGraphOnQueue(flushPendingAudio: true)
         }
         removeObservers()
+        // Release our claim on the shared session; the coordinator deactivates it only if no newer
+        // owner has acquired since (so a late stop can't stomp the next session).
+        if let lease = sessionLease {
+            sessionLease = nil
+            AudioSessionCoordinator.shared.release(lease)
+        }
     }
 
     // MARK: - Audio Interruption & Route Change Handling

--- a/OpenGlassesTests/AudioSessionLedgerTests.swift
+++ b/OpenGlassesTests/AudioSessionLedgerTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests the pure "single owner" arbitration for the shared `AVAudioSession`. The decisive
+/// property is stale-release suppression: a preempted owner releasing must NOT deactivate the
+/// session a newer owner now holds.
+final class AudioSessionLedgerTests: XCTestCase {
+
+    private let tokenA = UUID()
+    private let tokenB = UUID()
+
+    func testAcquireOnFreeSessionHasNoPreemptedLease() {
+        var ledger = AudioSessionLedger()
+        let result = ledger.acquire(.wakeWord, token: tokenA)
+        XCTAssertNil(result.preempted)
+        XCTAssertEqual(result.lease.owner, .wakeWord)
+        XCTAssertEqual(result.lease.generation, 1)
+        XCTAssertEqual(ledger.current, result.lease)
+    }
+
+    func testSecondAcquirePreemptsFirstAndBumpsGeneration() {
+        var ledger = AudioSessionLedger()
+        let first = ledger.acquire(.wakeWord, token: tokenA).lease
+        let second = ledger.acquire(.geminiLive, token: tokenB)
+        XCTAssertEqual(second.preempted, first)
+        XCTAssertEqual(second.lease.owner, .geminiLive)
+        XCTAssertGreaterThan(second.lease.generation, first.generation)
+        XCTAssertEqual(ledger.current, second.lease)
+    }
+
+    func testReleasingCurrentLeaseDeactivatesAndFreesSession() {
+        var ledger = AudioSessionLedger()
+        let lease = ledger.acquire(.geminiLive, token: tokenA).lease
+        XCTAssertEqual(ledger.release(lease), .deactivate)
+        XCTAssertNil(ledger.current)
+    }
+
+    func testStaleReleaseAfterPreemptionIsSuppressed() {
+        var ledger = AudioSessionLedger()
+        let old = ledger.acquire(.geminiLive, token: tokenA).lease
+        let new = ledger.acquire(.openAIRealtime, token: tokenB).lease
+        // The preempted owner's late teardown must not deactivate the new owner's session.
+        XCTAssertEqual(ledger.release(old), .superseded(by: .openAIRealtime))
+        XCTAssertEqual(ledger.current, new, "the newer lease must still own the session")
+    }
+
+    func testReleaseWhenNobodyHoldsIsAlreadyReleased() {
+        var ledger = AudioSessionLedger()
+        let lease = ledger.acquire(.wakeWord, token: tokenA).lease
+        _ = ledger.release(lease)
+        XCTAssertEqual(ledger.release(lease), .alreadyReleased)
+    }
+
+    func testDoubleReleaseOfSameLeaseDeactivatesOnceThenIsNoOp() {
+        var ledger = AudioSessionLedger()
+        let lease = ledger.acquire(.geminiLive, token: tokenA).lease
+        XCTAssertEqual(ledger.release(lease), .deactivate)
+        XCTAssertEqual(ledger.release(lease), .alreadyReleased)
+    }
+
+    func testGenerationIsMonotonicAcrossAcquires() {
+        var ledger = AudioSessionLedger()
+        let g1 = ledger.acquire(.wakeWord, token: UUID()).lease.generation
+        let g2 = ledger.acquire(.wakeWord, token: UUID()).lease.generation
+        let g3 = ledger.acquire(.geminiLive, token: UUID()).lease.generation
+        XCTAssertEqual([g1, g2, g3], [1, 2, 3])
+    }
+
+    func testReacquireBySameOwnerSupersedesItsOwnEarlierLease() {
+        var ledger = AudioSessionLedger()
+        let first = ledger.acquire(.geminiLive, token: tokenA).lease
+        let second = ledger.acquire(.geminiLive, token: tokenB).lease
+        // The first lease (e.g. before an interruption reset) is now stale even for the same owner.
+        XCTAssertEqual(ledger.release(first), .superseded(by: .geminiLive))
+        XCTAssertEqual(ledger.current, second)
+        XCTAssertEqual(ledger.release(second), .deactivate)
+    }
+}

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -153,6 +153,8 @@ Three self-contained hardening workstreams over already-shipped paths (the gatew
 
 **Follow-up:** [Audio-Session Resilience P2](audio-session-resilience-p2.md) continues the #114 workstream — interruption/route-change recovery and Bluetooth-input selection in the two realtime managers. Same posture: pure policy core first, live wiring device-pending.
 
+**Follow-up:** [Audio-Session Lease Coordinator](audio-session-lease-coordinator.md) — single owner of the shared `AVAudioSession` across the mic-contending subsystems. 🚧 Foundation shipped: pure `AudioSessionLedger` (generation-gated, stale-release-suppressing; 8 tests) + `AudioSessionCoordinator` seam + adopted in the two realtime managers. Broad adoption (always-on wake word, TTS, live translation, transcription, AppState orchestration) is the documented next increment.
+
 ## Dependency graph
 
 ```

--- a/docs/plans/audio-session-lease-coordinator.md
+++ b/docs/plans/audio-session-lease-coordinator.md
@@ -1,0 +1,99 @@
+# Plan — Audio-Session Lease Coordinator (single owner of the shared `AVAudioSession`)
+
+**Status:** 🚧 Foundation + first adopters shipped (this branch). The deterministic `AudioSessionLedger`
+core is headless-tested; the live `AudioSessionCoordinator` seam is in place and adopted by the two
+realtime managers. Broad adoption (always-on wake word, TTS, live translation, transcription,
+AppState orchestration) is the documented next increment. No new SPM dependency.
+
+Follow-up to [Audio-Session Resilience P2](audio-session-resilience-p2.md). P2 made each realtime
+manager *self-heal*; this plan makes the **whole app agree on who owns the mic**.
+
+## The problem
+Seven subsystems each activate the one shared `AVAudioSession` independently — `WakeWordService`
+(always-on baseline, with a reference-counted `pauseOtherAudio`/`resumeOtherAudio` hold),
+`GeminiLiveAudioManager`, `OpenAIRealtimeAudioManager`, `LiveTranslationService`,
+`TranscriptionService` (rides the wake-word engine), and `TextToSpeechService` (ducks via the
+wake-word hold). There is **no central ownership**: each calls `setActive(true)` on its own, and the
+only mutual exclusion is `AppState.switchMode`'s manual *stop-old → sleep 500 ms → start-new* dance.
+Two failure modes fall out of that:
+- A preempted subsystem's **late, asynchronous teardown** (an interruption reset, a delayed
+  `stopCapture`) calls `setActive(false)` and **deactivates the session a newer owner just acquired**.
+- After a live session ends, whether the session is left active or deactivated is incidental, so the
+  always-on listener's resume depends on timing rather than a defined handoff.
+
+## What we build
+A single arbiter the subsystems go through instead of touching `setActive` directly.
+
+### Deterministic core — `AudioSessionLedger` (pure, tested)
+Last-acquire-wins ownership with the one invariant that matters:
+- `acquire(owner, token)` supersedes any prior holder and bumps a monotonic generation; returns the
+  new lease + the lease it preempted.
+- `release(lease)` returns `.deactivate` **only if `lease` is still current**, else
+  `.superseded(by:)` (a newer owner holds it — do nothing) or `.alreadyReleased`.
+
+That release rule *is* the fix: a preempted owner can never tear the session out from under whoever
+took it. Fully unit-tested (`AudioSessionLedgerTests`) — no hardware, no session.
+
+### Live seam — `AudioSessionCoordinator` (singleton)
+Wraps the ledger behind a serial state queue and performs the real work:
+- `acquire(owner, category, mode, options, configure)` → `ledger.acquire` + `AudioSessionActivator.activate`
+  (preferred → `.default` fallback preserved); rolls the lease back and rethrows on activation failure.
+- `release(lease)` → `ledger.release`; on `.deactivate`, `setActive(false, .notifyOthersOnDeactivation)`
+  on a dedicated deactivation queue; `.superseded` / `.alreadyReleased` are logged no-ops.
+- `currentOwner` snapshot for diagnostics.
+
+## Scope
+**In (this PR):**
+- `AudioSessionLedger.swift` (pure core: `AudioSessionOwner`, `AudioSessionLease`,
+  `AudioSessionReleaseDecision`, the ledger) + `AudioSessionLedgerTests`.
+- `AudioSessionCoordinator.swift` (live singleton seam).
+- **Adopt in the two realtime managers** — `GeminiLiveAudioManager` / `OpenAIRealtimeAudioManager`
+  acquire (`.geminiLive` / `.openAIRealtime`) in `setupAudioSession` and release in `stopCapture`.
+  They're the highest-contention exclusive owners, already reworked in P2, and *should* deactivate on
+  stop so the listener resumes cleanly — the lowest-risk, most-correct first adoption.
+
+**Deferred (documented next increments — the risky/always-on live edge):**
+- **`WakeWordService`** — the always-on baseline owner with the reference-counted pause/resume hold.
+  It should acquire `.wakeWord` (lowest precedence) and yield to a live session, but it's the
+  highest-risk path (core always-on UX) and earns its own careful step.
+- **`LiveTranslationService`** — uses `.measurement` + `.mixWithOthers` by design (gentle
+  coexistence) and never deactivates on stop; routing it through the coordinator changes that
+  semantic, so it needs a deliberate decision.
+- **`TranscriptionService`** — reuses the wake-word engine; follows wake-word adoption.
+- **`TextToSpeechService`** — a ducking rider, not an exclusive owner; map onto the coordinator as a
+  non-exclusive "duck" rather than a session claim.
+- **`AppState.switchMode`** — once owners hand off through the coordinator, the manual
+  *stop → sleep 500 ms → start* can be tightened/removed.
+
+## Build order
+1. **Ledger + tests** — pure arbitration, fully tested. ✅
+2. **Coordinator** — serial-queue wrapper + real activation/deactivation through `AudioSessionActivator`. ✅
+3. **Realtime adoption** — acquire/release in both managers; reset re-acquires (same owner, new
+   generation) so a mid-session reset never double-deactivates. ✅
+4. **(Next)** wake-word adoption with precedence, then translation/transcription/TTS, then trim
+   `switchMode`.
+
+## Tests
+- `AudioSessionLedger`: acquire on free session (no preemption, generation 1); second acquire
+  preempts + bumps generation; release-current → `.deactivate` + frees; **stale release after
+  preemption → `.superseded(by:)`, current unchanged**; release when free → `.alreadyReleased`;
+  double-release → deactivate once then no-op; generation monotonic; re-acquire by the same owner
+  supersedes its own earlier lease. Pure, no hardware.
+
+## Open questions / decisions needed
+- **Precedence enforcement** — today the coordinator is pure last-acquire-wins (acquire always
+  succeeds, preempting). Should a low-precedence acquire (wake word) be *rejected* while a high one
+  (a live call) holds, or always granted? Last-acquire-wins matches the existing `switchMode` flow
+  (which tears down first); enforced precedence is a later option once wake word is wired.
+- **Preemption callback** — should the coordinator notify a preempted owner so it can tear itself
+  down, rather than relying on `AppState` to stop it first? Useful once >2 subsystems participate.
+- **TTS modelling** — exclusive lease vs a non-exclusive "duck" that nests under the current owner
+  (its current `pauseHoldCount` behaviour). Lean duck.
+
+## Why this matters
+With every subsystem managing the shared session independently, "who owns the mic" is implicit and
+timing-dependent — the root of sessions going silent after a preemption. A single ledger with
+generation-gated release makes ownership explicit and makes the dangerous case (a stale teardown
+deactivating a live session) structurally impossible. Landing the pure core + the two realtime
+adopters first keeps the always-on wake-word path — the riskiest to disturb — for a deliberate
+follow-up, with the hard part (the arbitration invariant) already proven in tests.


### PR DESCRIPTION
Follow-up to #118. Seven subsystems each activate the one shared `AVAudioSession` independently — `WakeWordService` (always-on baseline), the two realtime managers, `LiveTranslationService`, `TranscriptionService`, `TextToSpeechService` — with the only mutual exclusion being `AppState.switchMode`'s manual *stop-old → sleep 500 ms → start-new*. That lets a preempted subsystem's late, async teardown (an interruption reset, a delayed `stopCapture`) call `setActive(false)` and **deactivate the session a newer owner just acquired**.

## Deterministic core (pure, tested)
- **`AudioSessionLedger`** — last-acquire-wins ownership with a monotonic generation. The decisive rule is on **release**: a lease deactivates the session **only if it's still the current lease**, else `.superseded(by:)` / `.alreadyReleased`. That makes a stale teardown stomping a live session structurally impossible.

## Live seam
- **`AudioSessionCoordinator`** (singleton) wraps the ledger behind a serial state queue and does the real work: activation through `AudioSessionActivator` (preferred → `.default` fallback preserved), generation-gated deactivation on a dedicated queue, lease roll-back + rethrow on activation failure, `currentOwner` snapshot for diagnostics.

## First adopters
- `GeminiLiveAudioManager` / `OpenAIRealtimeAudioManager` acquire (`.geminiLive` / `.openAIRealtime`) in `setupAudioSession` and release in `stopCapture`. Highest-contention exclusive owners, already reworked in #114/#118, and they *should* deactivate on stop so the wake-word listener resumes cleanly. A mid-session interruption reset re-acquires (same owner, new generation) → never double-deactivates.

## Deferred — documented next increments (the risky always-on edge)
- **Wake word** — baseline owner with the reference-counted pause/resume hold; highest-risk path, earns its own step.
- **Live translation** — `.measurement` + `.mixWithOthers` gentle coexistence; routing it changes that semantic.
- **Transcription** — rides the wake-word engine; follows wake-word adoption.
- **TTS** — a ducking rider, map as a non-exclusive "duck" not a session claim.
- **`AppState.switchMode`** — trim the manual stop→sleep→start once owners hand off through the coordinator.

## Tests / build
- **8 new ledger tests** (28 audio tests total) — acquire/preempt/generation, release-current → deactivate, **stale release after preemption → suppressed**, double-release no-op, re-acquire-by-same-owner.
- Debug + **Release** builds green (simulator, `CODE_SIGNING_ALLOWED=NO`).

Plan: `docs/plans/audio-session-lease-coordinator.md`; index updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)