### PR TITLE
Audio-session coordinator: adopt the always-on wake-word baseline

### DIFF
--- a/OpenGlasses/Sources/Services/Audio/AudioSessionCoordinator.swift
+++ b/OpenGlasses/Sources/Services/Audio/AudioSessionCoordinator.swift
@@ -26,6 +26,18 @@ final class AudioSessionCoordinator: @unchecked Sendable {
         stateQueue.sync { ledger.current?.owner }
     }
 
+    /// Record `owner` as the current holder **without** performing activation — for subsystems
+    /// that manage their own hand-tuned session configuration (notably the always-on wake-word
+    /// listener, whose `mixWithOthers` pause/resume behaviour must stay exactly as-is) but still
+    /// need the coordinator to know who owns the mic. Supersedes any prior holder, just like
+    /// `acquire`. Return the lease to `release` later.
+    @discardableResult
+    func assumeOwnership(_ owner: AudioSessionOwner) -> AudioSessionLease {
+        let lease = stateQueue.sync { ledger.acquire(owner, token: UUID()).lease }
+        NSLog("[AudioCoordinator] ownership assumed by %@ (self-activated)", owner.rawValue)
+        return lease
+    }
+
     /// Acquire the shared session for `owner`, configuring and activating it. Supersedes any prior
     /// holder. On activation failure the lease is rolled back (so a failed acquire never leaves the
     /// caller recorded as owner) and the error is rethrown.

--- a/OpenGlasses/Sources/Services/WakeWordService.swift
+++ b/OpenGlasses/Sources/Services/WakeWordService.swift
@@ -49,6 +49,10 @@ class WakeWordService: NSObject, ObservableObject {
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
     private var audioSessionConfigured: Bool = false
+    /// Our claim on the shared session with the coordinator. Wake word is the always-on baseline
+    /// owner: it self-activates with its tuned config and registers ownership so a live session
+    /// (Gemini/OpenAI) supersedes it cleanly, and its release deactivates only if still current.
+    private var sessionLease: AudioSessionLease?
     /// When true, don't start continuous wake word listening — only listen when explicitly triggered.
     /// Set to true when CarPlay is active so we don't hold a recording session open.
     var carPlayMode: Bool = false
@@ -216,6 +220,10 @@ class WakeWordService: NSObject, ObservableObject {
                 audioSessionConfigured = true
                 print("🎤 Mic source: \(useGlassesMic ? "glasses (Bluetooth)" : "phone (built-in)")")
             }
+
+            // Register as the baseline owner. We self-activated above (keeping the tuned
+            // mixWithOthers config), so this only records ownership; it supersedes any prior lease.
+            sessionLease = AudioSessionCoordinator.shared.assumeOwnership(.wakeWord)
 
             let route = audioSession.currentRoute
             for input in route.inputs {
@@ -391,11 +399,19 @@ class WakeWordService: NSObject, ObservableObject {
         cleanupAudioEngine()
         isListening = false
         audioSessionConfigured = false
-        do {
-            try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-            print("🎤 Audio session deactivated (CarPlay voice ended)")
-        } catch {
-            print("🎤 Failed to deactivate audio session: \(error)")
+        if let lease = sessionLease {
+            // Release through the coordinator: it deactivates only if wake word is still the
+            // current owner, so this can't tear down a live Gemini/OpenAI session that preempted us.
+            sessionLease = nil
+            AudioSessionCoordinator.shared.release(lease)
+            print("🎤 Audio session released (CarPlay voice ended)")
+        } else {
+            do {
+                try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+                print("🎤 Audio session deactivated (CarPlay voice ended)")
+            } catch {
+                print("🎤 Failed to deactivate audio session: \(error)")
+            }
         }
     }
 

--- a/OpenGlassesTests/AudioSessionLedgerTests.swift
+++ b/OpenGlassesTests/AudioSessionLedgerTests.swift
@@ -66,6 +66,25 @@ final class AudioSessionLedgerTests: XCTestCase {
         XCTAssertEqual([g1, g2, g3], [1, 2, 3])
     }
 
+    /// The real handoff this enables: the always-on wake-word baseline is preempted by a live
+    /// session, the live session's release deactivates, and wake word re-assumes ownership.
+    func testWakeWordToLiveSessionHandoff() {
+        var ledger = AudioSessionLedger()
+        // Wake word is the baseline owner.
+        let wake1 = ledger.acquire(.wakeWord, token: UUID()).lease
+        // A live session starts, preempting wake word.
+        let gemini = ledger.acquire(.geminiLive, token: UUID())
+        XCTAssertEqual(gemini.preempted, wake1)
+        // Wake word's stale teardown (if any) must not deactivate the live session.
+        XCTAssertEqual(ledger.release(wake1), .superseded(by: .geminiLive))
+        XCTAssertEqual(ledger.current, gemini.lease)
+        // Live session ends → deactivate; then wake word re-assumes the baseline.
+        XCTAssertEqual(ledger.release(gemini.lease), .deactivate)
+        XCTAssertNil(ledger.current)
+        let wake2 = ledger.acquire(.wakeWord, token: UUID()).lease
+        XCTAssertEqual(ledger.current, wake2)
+    }
+
     func testReacquireBySameOwnerSupersedesItsOwnEarlierLease() {
         var ledger = AudioSessionLedger()
         let first = ledger.acquire(.geminiLive, token: tokenA).lease

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -153,7 +153,7 @@ Three self-contained hardening workstreams over already-shipped paths (the gatew
 
 **Follow-up:** [Audio-Session Resilience P2](audio-session-resilience-p2.md) continues the #114 workstream — interruption/route-change recovery and Bluetooth-input selection in the two realtime managers. Same posture: pure policy core first, live wiring device-pending.
 
-**Follow-up:** [Audio-Session Lease Coordinator](audio-session-lease-coordinator.md) — single owner of the shared `AVAudioSession` across the mic-contending subsystems. 🚧 Foundation shipped: pure `AudioSessionLedger` (generation-gated, stale-release-suppressing; 8 tests) + `AudioSessionCoordinator` seam + adopted in the two realtime managers. Broad adoption (always-on wake word, TTS, live translation, transcription, AppState orchestration) is the documented next increment.
+**Follow-up:** [Audio-Session Lease Coordinator](audio-session-lease-coordinator.md) — single owner of the shared `AVAudioSession` across the mic-contending subsystems. 🚧 Foundation + realtime + wake-word shipped: pure `AudioSessionLedger` (generation-gated, stale-release-suppressing; 9 tests) + `AudioSessionCoordinator` seam (`acquire`/`release` + register-only `assumeOwnership`); adopted in the two realtime managers and the always-on wake-word baseline (all three exclusive owners now arbitrated by one ledger, wake word's tuned `mixWithOthers` activation untouched). Remaining adoption (TTS duck, live translation, transcription, trimming AppState orchestration) is the documented next increment.
 
 ## Dependency graph
 

--- a/docs/plans/audio-session-lease-coordinator.md
+++ b/docs/plans/audio-session-lease-coordinator.md
@@ -1,9 +1,18 @@
 # Plan — Audio-Session Lease Coordinator (single owner of the shared `AVAudioSession`)
 
-**Status:** 🚧 Foundation + first adopters shipped (this branch). The deterministic `AudioSessionLedger`
-core is headless-tested; the live `AudioSessionCoordinator` seam is in place and adopted by the two
-realtime managers. Broad adoption (always-on wake word, TTS, live translation, transcription,
+**Status:** 🚧 Foundation + realtime + wake-word adopters shipped. The deterministic
+`AudioSessionLedger` core is headless-tested; the live `AudioSessionCoordinator` seam is in place and
+adopted by the two realtime managers (`acquire`/`release`) and the always-on wake-word baseline
+(`assumeOwnership`/`release`). Remaining adoption (TTS duck, live translation, transcription, trimming
 AppState orchestration) is the documented next increment. No new SPM dependency.
+
+**Update (wake-word increment):** `WakeWordService` now registers as the baseline `.wakeWord` owner
+via a new register-only `AudioSessionCoordinator.assumeOwnership(_:)` — it keeps its hand-tuned
+`mixWithOthers` activation and pause/resume **exactly as-is** (those must not change) and only records
+ownership after a successful `configureAudioSession`, so a live session supersedes it cleanly and its
+CarPlay-dismissal deactivation now routes through `release` (deactivates only if still current — it
+can no longer tear down a live session that preempted it). All three exclusive owners
+(`.wakeWord`/`.geminiLive`/`.openAIRealtime`) are now arbitrated by one ledger.
 
 Follow-up to [Audio-Session Resilience P2](audio-session-resilience-p2.md). P2 made each realtime
 manager *self-heal*; this plan makes the **whole app agree on who owns the mic**.
@@ -52,10 +61,14 @@ Wraps the ledger behind a serial state queue and performs the real work:
   They're the highest-contention exclusive owners, already reworked in P2, and *should* deactivate on
   stop so the listener resumes cleanly — the lowest-risk, most-correct first adoption.
 
-**Deferred (documented next increments — the risky/always-on live edge):**
-- **`WakeWordService`** — the always-on baseline owner with the reference-counted pause/resume hold.
-  It should acquire `.wakeWord` (lowest precedence) and yield to a live session, but it's the
-  highest-risk path (core always-on UX) and earns its own careful step.
+**Now adopted (wake-word increment):**
+- **`WakeWordService`** — registers as the baseline `.wakeWord` owner via the register-only
+  `assumeOwnership(_:)` after each successful `configureAudioSession`, and routes its
+  CarPlay-dismissal deactivation through `release`. Its tuned `mixWithOthers` activation and
+  reference-counted `pauseOtherAudio`/`resumeOtherAudio` hold are **untouched** — they manage the
+  `mixWithOthers` option while wake word owns the session, not ownership itself.
+
+**Deferred (documented next increments):**
 - **`LiveTranslationService`** — uses `.measurement` + `.mixWithOthers` by design (gentle
   coexistence) and never deactivates on stop; routing it through the coordinator changes that
   semantic, so it needs a deliberate decision.
@@ -70,8 +83,9 @@ Wraps the ledger behind a serial state queue and performs the real work:
 2. **Coordinator** — serial-queue wrapper + real activation/deactivation through `AudioSessionActivator`. ✅
 3. **Realtime adoption** — acquire/release in both managers; reset re-acquires (same owner, new
    generation) so a mid-session reset never double-deactivates. ✅
-4. **(Next)** wake-word adoption with precedence, then translation/transcription/TTS, then trim
-   `switchMode`.
+4. **Wake-word adoption** — register-only `assumeOwnership(.wakeWord)` after each successful
+   `configureAudioSession`; deactivation through `release`; tuned activation + pause/resume untouched. ✅
+5. **(Next)** TTS duck + translation/transcription, then trim `switchMode`.
 
 ## Tests
 - `AudioSessionLedger`: acquire on free session (no preemption, generation 1); second acquire


### PR DESCRIPTION
Follow-up to #119. Wires `WakeWordService` — the always-on baseline mic owner — into the lease coordinator so all three exclusive owners (`.wakeWord`, `.geminiLive`, `.openAIRealtime`) are arbitrated by **one ledger**.

## Why register-only, not route activation
The wake-word session config is hand-tuned — `mixWithOthers` plus the reference-counted `pauseOtherAudio`/`resumeOtherAudio` hold that pauses/resumes music while the agent listens and speaks. That behaviour must not change. So rather than route its `setActive` through the coordinator (which would alter the tuned config), this adds a **register-only** path:

- **`AudioSessionCoordinator.assumeOwnership(_:)`** — records an owner in the ledger **without** performing activation, for subsystems that self-activate with their own tuned config. Supersedes any prior holder, returns a lease.

## WakeWordService changes
- Registers `.wakeWord` ownership after each successful `configureAudioSession` (covers `reconfigureAudioSession` / `reconfigureAudioSessionIfNeeded`). Its tuned activation and the `pauseOtherAudio`/`resumeOtherAudio` toggles are **untouched** — they manage the `mixWithOthers` option while wake word owns the session, not ownership itself.
- Routes its CarPlay-dismissal `deactivateAudioSession` through `coordinator.release`, so it deactivates **only if wake word is still current** — it can no longer tear down a live Gemini/OpenAI session that preempted it (a latent bug in the old unconditional `setActive(false)`).

## Net effect
A live session supersedes wake word on acquire, its release deactivates, and wake word re-assumes the baseline on restart — **ownership is explicit, not timing-dependent**.

## Tests / build
- +1 ledger test: the wake word → live session → wake word handoff (preempt → stale release suppressed → deactivate → re-assume). **29 audio tests total.**
- Debug + **Release** builds green (simulator, `CODE_SIGNING_ALLOWED=NO`).

## Still deferred (next increments)
TTS as a non-exclusive "duck", `LiveTranslationService` (`.measurement`/`.mixWithOthers` coexistence), `TranscriptionService` (rides the wake-word engine), and trimming `AppState.switchMode`'s manual stop→sleep→start now that owners hand off through the coordinator.

Plan: `docs/plans/audio-session-lease-coordinator.md`; index updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)