### PR TITLE
Watch + Shortcuts: take a photo / record video on the glasses

### DIFF
--- a/OpenGlasses/Sources/App/Intents/CaptureIntents.swift
+++ b/OpenGlasses/Sources/App/Intents/CaptureIntents.swift
@@ -1,0 +1,77 @@
+import AppIntents
+
+/// Shortcut: silently take a photo on the glasses and save it (no LLM, no TTS).
+///
+/// Distinct from `TakePhotoIntent`, which captures *and describes* the scene. This one is the plain
+/// "snap a photo on my glasses" action — it saves to Documents/Photos and drops a timestamped note
+/// into the caption stream, with a soft tone + haptic. Available as a Shortcuts action and addable
+/// to Siri / the Action button; deliberately not in `OpenGlassesShortcuts` so it doesn't push past
+/// iOS's 10 App-Shortcut cap (the describe-photo phrase already covers "take a photo").
+struct CaptureGlassesPhotoIntent: AppIntent {
+    static var title: LocalizedStringResource = "Capture Glasses Photo"
+    static var description = IntentDescription("Take a photo on the glasses and save it")
+
+    static var isDiscoverable: Bool { true }
+    static var openAppWhenRun: Bool = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        guard let appState = AppStateProvider.shared else {
+            throw IntentError.appNotRunning
+        }
+        guard appState.isConnected else {
+            throw IntentError.glassesNotConnected
+        }
+        await appState.capturePhotoSilently()
+        return .result()
+    }
+
+    enum IntentError: Error, CustomLocalizedStringResourceConvertible {
+        case appNotRunning
+        case glassesNotConnected
+
+        var localizedStringResource: LocalizedStringResource {
+            switch self {
+            case .appNotRunning: return "OpenGlasses is not running. Open the app first."
+            case .glassesNotConnected: return "Connect your glasses first."
+            }
+        }
+    }
+}
+
+/// Shortcut: start/stop glasses video recording.
+///
+/// Toggles the same recorder the in-app record button drives. Returns the resulting state so a
+/// Shortcut can branch on it. A Shortcuts action (and Action-button / Siri-addable); not in
+/// `OpenGlassesShortcuts` to respect the 10 App-Shortcut cap.
+struct RecordGlassesVideoIntent: AppIntent {
+    static var title: LocalizedStringResource = "Record Glasses Video"
+    static var description = IntentDescription("Start or stop recording video on the glasses")
+
+    static var isDiscoverable: Bool { true }
+    static var openAppWhenRun: Bool = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ReturnsValue<Bool> {
+        guard let appState = AppStateProvider.shared else {
+            throw IntentError.appNotRunning
+        }
+        guard appState.isConnected else {
+            throw IntentError.glassesNotConnected
+        }
+        await appState.toggleRecording()
+        return .result(value: appState.videoRecorder.isRecording)
+    }
+
+    enum IntentError: Error, CustomLocalizedStringResourceConvertible {
+        case appNotRunning
+        case glassesNotConnected
+
+        var localizedStringResource: LocalizedStringResource {
+            switch self {
+            case .appNotRunning: return "OpenGlasses is not running. Open the app first."
+            case .glassesNotConnected: return "Connect your glasses first."
+            }
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/WatchConnectivityManager.swift
+++ b/OpenGlasses/Sources/Services/WatchConnectivityManager.swift
@@ -57,6 +57,7 @@ class WatchConnectivityManager: NSObject, ObservableObject {
             "isProcessing": appState.isProcessing,
             "isListening": appState.isListening,
             "isRecording": appState.transcriptionService.isRecording,
+            "isVideoRecording": appState.videoRecorder.isRecording,
             "lastResponse": String(appState.lastResponse.prefix(200)),
             "deviceName": appState.glassesService.deviceName ?? "",
             "batteryLevel": appState.glassesService.batteryLevel ?? 0,
@@ -133,6 +134,9 @@ extension WatchConnectivityManager: WCSessionDelegate {
                 // injected into the caption stream.
                 await appState.capturePhotoSilently()
 
+            case "toggleVideo":
+                await appState.toggleRecording()
+
             default:
                 NSLog("[WatchConn] Unknown userInfo command: %@", command)
             }
@@ -193,6 +197,20 @@ extension WatchConnectivityManager: WCSessionDelegate {
                 replyHandler([
                     "status": "completed",
                     "response": appState.lastResponse
+                ])
+
+            case "capturePhoto":
+                // Silent glasses photo — no LLM, no TTS. Saved to Documents/Photos/ with a
+                // timestamped caption note. Transcription/listening keep running.
+                await appState.capturePhotoSilently()
+                replyHandler(["status": "captured"])
+
+            case "toggleVideo":
+                // Start/stop glasses video recording. Reflect the new state back to the Watch.
+                await appState.toggleRecording()
+                replyHandler([
+                    "status": appState.videoRecorder.isRecording ? "recording" : "stopped",
+                    "isVideoRecording": appState.videoRecorder.isRecording
                 ])
 
             case "connect":

--- a/OpenGlassesWatch/WatchConnectivityService.swift
+++ b/OpenGlassesWatch/WatchConnectivityService.swift
@@ -11,6 +11,7 @@ class WatchConnectivityService: NSObject, ObservableObject {
     @Published var isConnected = false
     @Published var isListening = false
     @Published var isRecording = false
+    @Published var isVideoRecording = false
     @Published var isProcessing = false
     @Published var lastResponse = ""
     @Published var status = "idle"
@@ -104,6 +105,9 @@ class WatchConnectivityService: NSObject, ObservableObject {
                     self?.isRecording = recording
                     self?.persistSharedState()
                 }
+                if let videoRecording = reply["isVideoRecording"] as? Bool {
+                    self?.isVideoRecording = videoRecording
+                }
                 if let response = reply["response"] as? String {
                     self?.lastResponse = response
                     completion(nil)
@@ -156,6 +160,9 @@ extension WatchConnectivityService: WCSessionDelegate {
             }
             if let recording = applicationContext["isRecording"] as? Bool {
                 self.isRecording = recording
+            }
+            if let videoRecording = applicationContext["isVideoRecording"] as? Bool {
+                self.isVideoRecording = videoRecording
             }
             if let status = applicationContext["status"] as? String {
                 self.status = status

--- a/OpenGlassesWatch/WatchMainView.swift
+++ b/OpenGlassesWatch/WatchMainView.swift
@@ -46,6 +46,23 @@ struct WatchMainView: View {
         )
     }
 
+    private var videoBinding: Binding<Bool> {
+        Binding(
+            get: { connectivity.isVideoRecording },
+            set: { _ in
+                errorMessage = nil
+                connectivity.sendCommand("toggleVideo") { error in
+                    if let error {
+                        errorMessage = error
+                        errorFeedbackTrigger += 1
+                    } else {
+                        feedbackTrigger += 1
+                    }
+                }
+            }
+        )
+    }
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -56,8 +73,14 @@ struct WatchMainView: View {
                     // Listen toggle
                     listenRow
 
-                    // Record toggle
+                    // Record toggle (transcription)
                     recordRow
+
+                    // Take a photo on the glasses
+                    photoRow
+
+                    // Record video on the glasses
+                    videoRow
 
                     Divider()
 
@@ -187,6 +210,48 @@ struct WatchMainView: View {
             }
         }
         .disabled(!connectivity.isReachable)
+        .tint(.red)
+    }
+
+    // MARK: - Glasses Photo
+
+    private var photoRow: some View {
+        Button {
+            errorMessage = nil
+            connectivity.sendCommand("capturePhoto") { error in
+                if let error {
+                    errorMessage = error
+                    errorFeedbackTrigger += 1
+                } else {
+                    feedbackTrigger += 1
+                }
+            }
+        } label: {
+            Label {
+                Text("Photo")
+                    .font(.body)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } icon: {
+                Image(systemName: "camera.fill")
+                    .foregroundStyle(accentColor)
+            }
+        }
+        .disabled(!connectivity.isReachable || !connectivity.isConnected || connectivity.isProcessing)
+    }
+
+    // MARK: - Glasses Video Toggle
+
+    private var videoRow: some View {
+        Toggle(isOn: videoBinding) {
+            Label {
+                Text(connectivity.isVideoRecording ? "Recording Video" : "Video")
+                    .font(.body)
+            } icon: {
+                Image(systemName: connectivity.isVideoRecording ? "video.fill" : "video")
+                    .foregroundStyle(connectivity.isVideoRecording ? .red : .secondary)
+            }
+        }
+        .disabled(!connectivity.isReachable || !connectivity.isConnected)
         .tint(.red)
     }
 


### PR DESCRIPTION
Adds glasses **photo + video capture from the Apple Watch**, and a Shortcuts/Siri action for **video** (photo already had one). Closes the three gaps found when checking whether the watch could capture on the glasses.

## Watch app
- **Photo button** → sends `capturePhoto` → phone `capturePhotoSilently()` (saves to Documents/Photos, drops a caption note, soft tone + haptic; no LLM).
- **Video toggle** → sends `toggleVideo` → phone `toggleRecording()` (glasses video), with `isVideoRecording` reflected back to the watch via both the reply and `applicationContext`.

## Phone bridge (`WatchConnectivityManager`)
- `capturePhoto` + `toggleVideo` added to the **real-time** message handler (the path the watch UI uses); `toggleVideo` added to the complications/`userInfo` handler. `capturePhoto` previously existed *only* in the complications path, so the watch UI couldn't actually trigger it.
- `isVideoRecording` added to the status context pushed to the watch.

## App Intents (`CaptureIntents.swift`) — Shortcuts/Siri
- **`CaptureGlassesPhotoIntent`** — silent "take a photo on my glasses" (distinct from the existing describe-photo `TakePhotoIntent`).
- **`RecordGlassesVideoIntent`** — start/stop glasses video; returns the resulting state so a Shortcut can branch on it.
- Both are discoverable **Shortcuts actions** but deliberately **not** added to `OpenGlassesShortcuts`: that provider already sits at iOS's **10 App-Shortcut cap**, and "take a photo" is already a built-in phrase there. The new intents are parameterless, so no metadata-halting `appintentsmetadataprocessor` risk.

## Why no new Siri *phrase* for photo
A "take a photo on glasses" App Shortcut already exists (`TakePhotoIntent` → "OpenGlasses take a photo"). Video gets a Shortcuts action rather than an auto-phrase to respect the 10-cap.

## Build
- Phone **Debug + Release** green — `appintentsmetadataprocessor` writes `Metadata.appintents` cleanly with the new intents.
- Watch **Debug** green (watchOS simulator).
- Pure wiring/UI/intents — no headless-testable core, consistent with the existing watch/intent code (no tests there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)