### PR TITLE
docs/plans: Round 10 — live-vision efficiency & self-improvement (4 plans)

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -155,6 +155,23 @@ Three self-contained hardening workstreams over already-shipped paths (the gatew
 
 **Follow-up:** [Audio-Session Lease Coordinator](audio-session-lease-coordinator.md) — single owner of the shared `AVAudioSession` across the mic-contending subsystems. 🚧 Foundation + all exclusive owners + coexisting riders shipped: pure `AudioSessionLedger` (generation-gated, stale-release-suppressing, + non-exclusive coexisting holds; 13 tests) + `AudioSessionCoordinator` seam (`acquire`/`release`, register-only `assumeOwnership`, `beginCoexisting`/`endCoexisting` + `audioActivity`). Exclusive owners (wake word + the two realtime managers) are arbitrated by one ledger; coexisting riders (live translation, TTS) register without preempting or deactivating, so the coordinator is the complete source of truth. Only remaining item: trimming `AppState.switchMode`'s hardware-settling sleep (on-device validation needed).
 
+## Round 10 — live-vision efficiency & self-improvement
+
+Four self-contained capabilities surfaced by surveying adjacent multimodal-agent work, mapped onto
+OpenGlasses' live-vision path, multi-provider billing, and static skills. Each is a deterministic,
+fully-testable core first with the model/device edge deferred — same posture as the rest. All 📋 Planned.
+
+| Plan | Title | Effort | Reuses | Strategic fit |
+|---|---|---|---|---|
+| [Content-Aware Frame Gate](frame-dedup-change-gate.md) | dHash perceptual gate that drops near-duplicate frames before the LLM (adaptive threshold + heartbeat) | ~1–2 days | FrameThrottler, Gemini Live frame path | Cuts the biggest repeated live-session cost — static-scene frames — with a <1 ms/frame pure gate. Foundation for visual state memory. |
+| [LLM Cost & Usage Tracker](llm-cost-usage-tracker.md) | Per-session/model token + estimated-spend tracking, surfaced in Insights | ~2–3 days | LLMService usage blocks, InsightsView/InsightsService, on-device SQLite | Table-stakes for a BYO-key multi-provider app; the data already arrives and is discarded today. |
+| [Visual State Memory](visual-state-memory.md) | Rolling keyframe scene memory ("what was I just looking at") injected into the live agent | ~3–4 days | Frame Gate (keyframe source), analyzeFrame/structured vision, GeminiLiveSessionManager, BrainStore | Turns stateless per-frame vision into scene continuity — the point of always-on glasses. |
+| [Skill Self-Evolution](skill-self-evolution.md) | Learn new skills from failed turns; **propose → human-approve**, Agent-Mode-gated, Plan-R-screened | ~1.5–2 wks | AgentRunner/NativeToolRouter, InstalledSkillStore, Plan R screen, `agentModeEnabled` | The one genuinely self-improving capability; the assistant gets better at what *this* user keeps needing. |
+
+**Suggested sequence:** Frame Gate (cheap, foundational) → Cost Tracker (independent, high-value) →
+Visual State Memory (rides the Frame Gate) → Skill Self-Evolution (largest, safety-sensitive; sequence
+last). The Frame Gate and Cost Tracker are small single-PR wins; the latter two are richer features.
+
 ## Dependency graph
 
 ```

--- a/docs/plans/frame-dedup-change-gate.md
+++ b/docs/plans/frame-dedup-change-gate.md
@@ -1,0 +1,97 @@
+# Plan — Content-Aware Frame Gate (drop near-duplicate frames before the LLM)
+
+**Status:** 📋 Planned (not built). Small, deterministic, flag-gated — no behaviour change when off.
+The hashing + gating logic is pure and fully headless-testable; only the wiring into the live frame
+path touches the device. No new SPM dependency.
+
+## The problem
+`FrameThrottler` ([Sources/Services/GeminiLive/FrameThrottler.swift](../../OpenGlasses/Sources/Services/GeminiLive/FrameThrottler.swift))
+is **purely time-based**: at the default 1 fps it forwards a frame every `interval` seconds **even
+when the scene hasn't changed**. While the user sits still or stares at one object, Gemini Live (and
+any frame-consuming vision path) receives a stream of near-identical frames — wasted upload
+bandwidth, wasted input tokens, and a context window diluted with redundant images. A static minute
+is 60 essentially-identical frames.
+
+## What we build
+A cheap **content gate** in front of the existing time throttle: after the time check passes, compute
+a perceptual hash of the candidate frame and **skip it if it's visually indistinguishable from the
+last frame we actually sent**. Plus two refinements so a long static scene still stays fresh:
+- **Adaptive threshold** — an EMA of recent inter-frame change raises the similarity bar in static
+  scenes (drop more) and lowers it in busy scenes (keep more).
+- **Heartbeat / force-send** — after `N` seconds with nothing sent (everything deduped), send one
+  frame anyway so the model's visual context can't go stale.
+
+### The deterministic core
+- **`PerceptualHash`** — 64-bit **dHash**: downscale the frame to 9×8 grayscale, set one bit per
+  adjacent-pixel gradient, return a `UInt64`. Pure function of pixel bytes.
+- **`FrameGate`** — holds the last sent hash + an EMA of recent Hamming distances, and returns a
+  decision (`.send` / `.drop`) for each candidate given the configured threshold, adaptive factor,
+  and heartbeat deadline. Pure, time injected (no `Date()` inside).
+
+`FrameThrottler.submit` runs the time gate first (unchanged), then consults `FrameGate`; only `.send`
+frames call `onThrottledFrame`. Diagnostics gain a `dedupRatio`.
+
+## Scope
+In:
+- `Sources/Services/Vision/PerceptualHash.swift` (pure dHash + Hamming).
+- `Sources/Services/Vision/FrameGate.swift` (pure decision: threshold + EMA + heartbeat).
+- `Sources/Services/GeminiLive/FrameThrottler.swift` — consult the gate after the time check; expose
+  `dedupRatio`.
+- `Config` — `frameDedupEnabled` (default off initially), `frameDedupHammingThreshold`,
+  `frameDedupHeartbeatSeconds`.
+
+Out (deferred / not this plan):
+- Semantic (embedding/cosine) gating — dHash is the cheap edge pass; an embedding tier is a later,
+  heavier option only if dHash proves too coarse.
+- The `analyzeFrame` / structured-vision single-shot paths — they already capture one deliberate
+  frame; the gate targets the *streaming* path. Revisit if a burst mode lands there.
+
+## Architecture — the seam
+```swift
+enum PerceptualHash {
+    /// 64-bit dHash of a frame's luma. Pure; nil if the image can't be read.
+    static func dhash(_ image: UIImage) -> UInt64?
+    static func hamming(_ a: UInt64, _ b: UInt64) -> Int  // popcount(a ^ b)
+}
+
+struct FrameGate {                       // value type, time injected
+    enum Decision: Equatable { case send, drop }
+    mutating func evaluate(hash: UInt64, now: TimeInterval) -> Decision
+    var dedupRatio: Double { get }
+}
+```
+`FrameThrottler` owns a `FrameGate` and calls `PerceptualHash.dhash` on the (already time-throttled)
+frame; the gate's EMA + heartbeat live entirely in the value type. When `frameDedupEnabled == false`
+the throttler bypasses the gate → byte-for-byte today's behaviour.
+
+## Build order
+1. **`PerceptualHash` + tests** — known images → known hashes/distances; identical vs shifted vs
+   distinct. Pure.
+2. **`FrameGate` + tests** — first frame always `.send`; near-duplicate `.drop`; distinct `.send`;
+   heartbeat forces `.send` after the deadline; adaptive factor raises/lowers the effective
+   threshold from the EMA. Time injected, fully deterministic.
+3. **Wire into `FrameThrottler`** behind `frameDedupEnabled`; add `dedupRatio` to the existing
+   diagnostics log.
+4. **(Off→on)** flip the default after on-device sanity-checking that motion still flows at the
+   expected rate.
+
+## Tests
+- `PerceptualHash.dhash`: a solid image and a 1px-shifted copy hash within a small Hamming distance;
+  an inverted/distinct image is far. `hamming` is symmetric and `== popcount(xor)`.
+- `FrameGate`: see build order — every branch (first/dup/distinct/heartbeat/adaptive) asserted with
+  injected timestamps and hashes. No `UIImage` needed (operate on `UInt64`).
+
+## Open questions / decisions needed
+- **Threshold default** — dHash Hamming ≤ ~3–5 of 64 is "same scene"; pick a conservative default and
+  expose it in Settings (advanced) so it can be tuned without a rebuild.
+- **Heartbeat length** — long enough to actually save (e.g. 10–15 s) without letting the model lose
+  the scene; tie loosely to `geminiLiveVideoFrameInterval`.
+- **Where else** — once proven on Gemini Live, the same gate could front any future continuous
+  frame→LLM path (live captions vision, agent vision loop). Keep it a reusable component.
+
+## Why this matters
+The streaming-vision path is the single biggest repeated cost in a live session, and most of those
+frames are redundant. A <1 ms/frame perceptual-hash gate cuts the static-scene waste with zero model
+involvement, keeps the context window full of *distinct* views instead of duplicates, and is a pure,
+fully-tested value type with a flag so the happy path is unchanged until we choose to turn it on. It's
+also the **keyframe source** the [Visual State Memory](visual-state-memory.md) plan builds on.

--- a/docs/plans/llm-cost-usage-tracker.md
+++ b/docs/plans/llm-cost-usage-tracker.md
@@ -1,0 +1,96 @@
+# Plan — LLM Cost & Usage Tracker (per-session/model token + spend)
+
+**Status:** 📋 Planned (not built). Net-new — OpenGlasses currently tracks **no** API usage or cost.
+Deterministic core (pricing × tokens) is pure and fully headless-testable; the only live wiring is
+reading each provider's usage block in `LLMService`. Surfaces in the existing `InsightsView`. No new
+SPM dependency.
+
+## The problem
+OpenGlasses is a **multi-provider, bring-your-own-key** app — Anthropic, Gemini, OpenAI, plus custom
+endpoints, each with different per-token pricing. A user pointing it at their own paid keys has **no
+idea what a session costs** and no running total. `LLMService` doesn't even parse the `usage` block
+the providers already return, so the data is being thrown away.
+
+## What we build
+A small usage-accounting layer:
+- **Capture** the token counts every provider already reports (Anthropic `usage.input_tokens` /
+  `output_tokens`; OpenAI `usage.prompt_tokens` / `completion_tokens`; Gemini
+  `usageMetadata.promptTokenCount` / `candidatesTokenCount`).
+- **Price** them with a per-model table → a `UsageRecord` (session, model, tokens in/out, est. USD,
+  timestamp).
+- **Persist** records locally (SQLite, like the other on-device stores) and roll them up.
+- **Surface** a "Tokens & estimated cost" section in [InsightsView](../../OpenGlasses/Sources/App/Views/InsightsView.swift),
+  which already shows a 7/30/90-day recap — by model, with a total.
+
+### The deterministic core
+- **`ModelPricing`** — `[modelId: (inputPer1M: Double, outputPer1M: Double)]`, seeded with the
+  shipped models and overridable; an `estimate(model:tokensIn:tokensOut:) -> Double?` (nil for an
+  unknown/unpriced model rather than a wrong number).
+- **`UsageRecord`** — the row type.
+- **`UsageRollup`** — pure aggregation: given records + a window, produce per-model + total
+  tokens/cost. No I/O.
+
+## Scope
+In:
+- `Sources/Services/Usage/ModelPricing.swift` (pure pricing).
+- `Sources/Services/Usage/UsageModels.swift` (`UsageRecord`, `UsageRollup` result).
+- `Sources/Services/Usage/UsageStore.swift` (SQLite persist + window query + rollup).
+- `Sources/Services/LLMService.swift` — parse the usage block per provider, hand a `UsageRecord` to
+  the store. One small addition per provider response path.
+- `Sources/App/Views/InsightsView.swift` — a "Usage & Cost" section (per-model rows + total) over the
+  existing day-window picker; a Settings affordance to edit/override pricing.
+
+Out:
+- Realtime (Gemini Live / OpenAI Realtime) audio-token billing — different meter; record what those
+  APIs report if available, otherwise mark the session as "realtime (untracked tokens)" rather than
+  guessing.
+- Hard budget enforcement / cutoffs — surface spend first; an optional soft budget warning is a
+  follow-up.
+
+## Architecture — the seam
+```swift
+enum ModelPricing {
+    struct Rate { let inputPer1M: Double; let outputPer1M: Double }
+    static func estimate(model: String, tokensIn: Int, tokensOut: Int) -> Double?  // nil if unpriced
+}
+
+struct UsageRecord { let sessionId: String; let model: String
+                     let tokensIn: Int; let tokensOut: Int; let costUSD: Double?; let at: Date }
+
+enum UsageRollup {
+    struct ModelTotal { let model: String; let tokensIn: Int; let tokensOut: Int; let costUSD: Double? }
+    static func rollup(_ records: [UsageRecord], since: Date) -> (perModel: [ModelTotal], totalUSD: Double?)
+}
+```
+`LLMService` builds a `UsageRecord` from the parsed usage and the active `sessionId`; `UsageStore`
+persists and answers the rollup for `InsightsView`. Pricing lives in one table, overridable from
+Settings (so a price change doesn't need a release).
+
+## Build order
+1. **`ModelPricing` + `UsageRollup` + tests** — pure: known tokens × known rates → known cost;
+   unknown model → nil; multi-model + multi-record rollups sum correctly; window filtering. No I/O.
+2. **`UsageStore`** — SQLite insert + windowed fetch (mirrors the existing on-device stores);
+   round-trip + window tests.
+3. **`LLMService` capture** — parse usage per provider; emit a record. Guard each parse (a missing
+   usage block records 0/0, never crashes).
+4. **`InsightsView` surface** — per-model rows + total under the day picker; Settings pricing editor.
+
+## Tests
+- `ModelPricing.estimate`: each shipped model prices correctly at a known token count; unknown model
+  → nil; zero tokens → 0.
+- `UsageRollup`: empty → zero/empty; multiple records across models aggregate; records outside the
+  window are excluded; a single unpriced model makes `totalUSD` nil-aware (report tokens, omit its $).
+- `UsageStore`: insert/fetch round-trips; window query boundaries; survives restart.
+
+## Open questions / decisions needed
+- **Pricing source of truth** — bundle a default table (accepting it drifts) + let Settings override,
+  vs. fetch remotely. Start bundled + overridable; revisit if drift bites. (Note the existing
+  per-region IAP pricing is a *separate* concern — this is API token cost.)
+- **Unpriced models** — report tokens and omit the dollar figure (chosen) rather than guess.
+- **Privacy** — usage records are local-only and never leave the device; make that explicit in the UI.
+
+## Why this matters
+For a BYO-key multi-provider app this is a missing table-stakes feature: users can't see what they're
+spending. The data already arrives in every response and is currently discarded. The fix is a pure,
+fully-tested pricing/rollup core plus a tiny capture hook and a section in a view that already exists —
+high value, low risk, squarely in the deterministic-core-first house style.

--- a/docs/plans/skill-self-evolution.md
+++ b/docs/plans/skill-self-evolution.md
@@ -1,0 +1,121 @@
+# Plan — Skill Self-Evolution (learn new skills from failed turns, with human review)
+
+**Status:** 📋 Planned (not built). The largest of these four plans and the most
+safety-sensitive. **Agent-Mode-gated** and **human-in-the-loop by design** — the loop *proposes*
+skills, the user *approves* them; nothing self-authored is injected into the always-on assistant
+unreviewed. The trigger, dedup, and proposal-validation are pure and headless-testable; the LLM
+analysis + review UI are the live edge. No new SPM dependency.
+
+## The problem
+OpenGlasses' skills are **static**: `InstalledSkillStore`, `VoiceSkillStore`, OpenClaw skills, and the
+`ShortcutsCatalog` are all hand-curated and injected into prompts as-is. When the agent repeatedly
+fumbles the same kind of task — a tool it keeps calling wrong, a phrasing the user keeps correcting,
+a workflow it forgets — there's no mechanism to **learn** from those failures. The knowledge to fix
+it exists in the transcript; nothing harvests it.
+
+## What we build
+A closed-but-supervised improvement loop:
+1. **Capture** unsatisfactory turns as `FailureSample`s — a tool call that errored, an explicit user
+   correction ("no, that's wrong" / "I meant…"), a retried/abandoned request.
+2. **Trigger** evolution when enough accumulate (batch size **or** failure rate over a window).
+3. **Analyse** the batch with one LLM call that proposes a small, named **skill** — a `SKILL.md`-style
+   instruction ("when the user asks X, do Y; avoid Z") addressing the recurring failure.
+4. **Dedup** the proposal against existing skills (name overlap + token similarity) so we don't pile
+   up near-duplicates.
+5. **Review** — surface the proposal in a "Suggested Skills" inbox. The user **approves** (→ added to
+   `InstalledSkillStore`, injected like any installed skill) or **dismisses** (recorded so it isn't
+   re-proposed). Never auto-applied.
+
+### The deterministic core (pure, tested)
+- **`FailureSample`** — `{ kind, prompt, response, toolName?, userCorrection?, at }`. `kind` ∈
+  `{toolError, userCorrection, retry, abandoned}`.
+- **`EvolutionTrigger`** — `shouldEvolve(samples, now) -> Bool`: true when `count ≥ batchThreshold`
+  **or** `failureRate(window) ≥ rateThreshold`. Pure; time injected.
+- **`SkillDeduplicator`** — `isDuplicate(candidate, existing) -> Bool` via name-token **Jaccard** +
+  body token-overlap above a threshold. Pure.
+- **`SkillProposal`** — parse + **validate** the LLM's output: slug rules (`^[a-z][a-z0-9-]+$`),
+  required fields, length caps, auto-name `dyn-NNN` when unnamed. Reject malformed proposals (never
+  surface garbage for review). Pure.
+
+## Safety posture (non-negotiable)
+- **Agent-Mode-gated** — the whole feature is behind `agentModeEnabled`; off by default, like every
+  other autonomous/gateway capability.
+- **Human-in-the-loop** — proposals are *suggestions*. A self-authored instruction only ever enters
+  the prompt after explicit user approval. This is the key divergence from a fully-autonomous evolver:
+  an always-on assistant must not silently rewrite its own behaviour.
+- **Screened** — an approved skill is still routed through the existing prompt-injection / tool-poison
+  screens (Plan R) before it can take effect, exactly like an imported skill.
+- **Reversible** — approved evolved skills are tagged `source: evolved`, listed separately, and
+  one-tap removable; dismissals are remembered.
+
+## Scope
+In:
+- `Sources/Services/Skills/FailureSample.swift`, `EvolutionTrigger.swift`, `SkillDeduplicator.swift`,
+  `SkillProposal.swift` (pure core).
+- `Sources/Services/Skills/SkillEvolutionService.swift` — collect samples from the agent loop, run the
+  trigger, make the LLM call, dedup, enqueue proposals for review. Agent-Mode-gated.
+- `Sources/Services/Skills/EvolvedSkillStore.swift` — pending proposals + approved/dismissed state
+  (SQLite), feeding `InstalledSkillStore` on approval.
+- Capture hooks: `AgentRunner` / `NativeToolRouter` (tool errors) and `AppState` (user corrections /
+  retries) emit `FailureSample`s.
+- A "Suggested Skills" review surface (Settings) — approve / edit / dismiss.
+
+Out (deferred):
+- Fully-autonomous apply (no review) — explicitly **not** building; review is the safety boundary.
+- Evolving *tool definitions* or code — proposals are prompt-level instructions only.
+- Cross-device sync of evolved skills — local first; rides the existing skills export/import later.
+- RL-style scoring/reward of skills — start with explicit user approve/dismiss as the signal.
+
+## Architecture — the seam
+```swift
+struct FailureSample { enum Kind { case toolError, userCorrection, retry, abandoned }
+    let kind: Kind; let prompt: String; let response: String
+    let toolName: String?; let userCorrection: String?; let at: Date }
+
+enum EvolutionTrigger {
+    static func shouldEvolve(_ samples: [FailureSample], now: Date,
+                             batchThreshold: Int, rateThreshold: Double, window: TimeInterval) -> Bool
+}
+enum SkillDeduplicator { static func isDuplicate(_ candidate: SkillDraft, against existing: [SkillDraft]) -> Bool }
+enum SkillProposal { static func validate(_ raw: String, existingNames: Set<String>) -> SkillDraft? }  // nil = reject
+```
+`SkillEvolutionService` orchestrates these and is the only piece that calls the LLM or touches stores;
+the decisions that matter (when to evolve, is it a dup, is it well-formed) are pure and tested.
+
+## Build order
+1. **Pure core + tests** — `EvolutionTrigger`, `SkillDeduplicator`, `SkillProposal`. Fully
+   deterministic; no LLM, no store.
+2. **`EvolvedSkillStore`** — pending/approved/dismissed persistence + round-trip tests.
+3. **Capture hooks** — emit `FailureSample`s from tool errors + user corrections (cheap, additive,
+   Agent-Mode-gated).
+4. **`SkillEvolutionService`** — wire trigger → LLM analysis → dedup → enqueue. (LLM edge.)
+5. **Review UI** — Suggested Skills inbox; approval routes through the Plan R screen into
+   `InstalledSkillStore` tagged `evolved`.
+
+## Tests
+- `EvolutionTrigger`: under threshold and low rate → false; batch threshold reached → true; high
+  failure rate in-window → true; old samples outside the window don't count. Time injected.
+- `SkillDeduplicator`: identical/near-identical name+body → duplicate; distinct → not; threshold
+  boundaries.
+- `SkillProposal.validate`: valid slug + fields → draft; bad slug / missing field / over-length →
+  nil; unnamed → auto `dyn-NNN` not colliding with `existingNames`.
+
+## Open questions / decisions needed
+- **What counts as a failure** — start conservative (explicit tool errors + explicit user
+  corrections); add "retry/abandoned" heuristics only once the signal proves clean (false positives
+  pollute the skill bank).
+- **Review friction vs. value** — a proposal the user must read is the safety cost; keep proposals
+  short, few, and high-confidence (dedup hard, require a real recurring pattern) so the inbox is rare
+  and worth opening.
+- **Which model analyses** — reuse the active provider, or pin a stronger model for the analysis step
+  (it's infrequent). Surfaces in the [cost tracker](llm-cost-usage-tracker.md).
+- **Edit-on-approve** — let the user tweak the wording before accepting; treat the LLM output as a
+  draft, not a verdict.
+
+## Why this matters
+It's the one genuinely *self-improving* capability in the set: the assistant gets better at the things
+*this* user keeps needing, by harvesting fixes that are already sitting in the transcript. The risk —
+an always-on agent rewriting its own instructions — is contained by making the loop **propose, not
+apply**, gating it behind Agent Mode, and running approvals through the existing safety screen. The
+hard logic (when to evolve, dedup, validate) lands as a pure, fully-tested core; the LLM and the
+review inbox are the deferred live edge.

--- a/docs/plans/visual-state-memory.md
+++ b/docs/plans/visual-state-memory.md
@@ -1,0 +1,110 @@
+# Plan — Visual State Memory (rolling keyframe scene memory for the live agent)
+
+**Status:** 📋 Planned (not built). Builds on [Content-Aware Frame Gate](frame-dedup-change-gate.md)
+(its distinct frames are the keyframe source). The buffer + context-builder are pure and
+headless-testable; per-keyframe description and prompt injection are the live edge. No new SPM
+dependency.
+
+## The problem
+OpenGlasses' live vision is **stateless per frame**. Gemini Live sees the current throttled frame and
+nothing about what came just before — so the agent can't answer "what was I *just* looking at?",
+can't notice that a scene changed, and re-derives context from scratch every turn. We have a rich
+*audio* continuity story (`MemoryRewindService` rolling buffer, `AmbientCaptionService` transcript)
+but **no visual continuity track**. The glasses are a camera first; the agent should remember what it
+saw.
+
+## What we build
+A short, rolling **visual state memory**: a per-session ring buffer of *keyframes* — only the
+visually-distinct frames (from the change gate), each with a one-line description and a timestamp —
+plus a builder that turns the last few into a compact **"Recent Visual Context"** block injected into
+the live agent's prompt. The agent gains temporal scene awareness ("a kitchen 30 s ago → now a
+laptop") without us re-sending every frame.
+
+### The deterministic core
+- **`Keyframe`** — `{ id, capturedAt, description, thumbnailRef }` (the image is referenced, not
+  inlined, so the buffer stays light).
+- **`VisualStateMemory`** — a fixed-capacity ring buffer (`maxKeyframes`), session-scoped, evicting
+  oldest. Pure data structure: `add`, `recent(n)`, `latestDescription`, `reset`. No timers, no I/O.
+- **`VisualContextBuilder`** — pure formatter: the last `N` keyframes → a `# Recent Visual Context`
+  text with **relative** labels (`[T-30s] …`, `[Now] …`), and (optionally) a small multi-image
+  message with the most recent at higher detail and older ones at "low" detail. Time is injected so
+  the relative labels are deterministic.
+
+## How it flows (live edge)
+1. The change gate emits a **distinct** frame (a "major" change).
+2. A **cheap, throttled describe** runs on that frame only — one short `analyzeFrame` /
+   structured-vision call ("one line: what is the user looking at?"). Keyframes are rare (only on
+   real scene change), so this is a small, bounded cost — not per-frame.
+3. The `Keyframe` (description + thumbnail) is appended to `VisualStateMemory`.
+4. On the next agent turn, `VisualContextBuilder` injects the compact "Recent Visual Context" text
+   into the system/turn prompt (and, behind a flag, the recent thumbnails).
+5. Optionally, evicted/aged keyframe descriptions feed `BrainStore.shared.ingest` so "what did I see
+   earlier today" is answerable after the session (the brain is the native-first memory substrate).
+
+## Scope
+In:
+- `Sources/Services/Vision/Keyframe.swift`, `VisualStateMemory.swift` (pure ring buffer).
+- `Sources/Services/Vision/VisualContextBuilder.swift` (pure text/messages builder).
+- `Sources/Services/Vision/VisualStateService.swift` — the live glue: subscribe to the gate's
+  distinct-frame signal, run the throttled describe, push keyframes, hand the context to the session.
+- `GeminiLive/GeminiLiveSessionManager.swift` — inject the "Recent Visual Context" block when building
+  the instruction (it already assembles a system instruction per turn).
+- `Config` — `visualStateMemoryEnabled` (default off), `visualStateMaxKeyframes`,
+  `visualStateDescribeMinInterval` (rate-limit the describe), `visualStateInjectThumbnails`.
+
+Out (deferred):
+- Embeddings / semantic retrieval over keyframes ("find when I last saw my keys") — v2; the ring
+  buffer + descriptions are v1. (Pairs later with the Embedding Quality Upgrade.)
+- Cross-session persistence beyond the optional BrainStore ingest — keep the live buffer in-memory.
+- Reusing the buffer for the single-shot `analyzeFrame` path — this targets the *live* agent.
+
+## Architecture — the seam
+```swift
+struct Keyframe: Identifiable, Equatable {
+    let id: UUID; let capturedAt: Date; let description: String; let thumbnailRef: URL?
+}
+
+final class VisualStateMemory {                 // session-scoped, fixed capacity
+    init(maxKeyframes: Int)
+    func add(_ k: Keyframe); func recent(_ n: Int) -> [Keyframe]
+    var latestDescription: String? { get };     func reset()
+}
+
+enum VisualContextBuilder {                      // pure; `now` injected
+    static func summaryText(_ keyframes: [Keyframe], now: Date) -> String   // "# Recent Visual Context…"
+}
+```
+`VisualStateService` owns the memory + the describe throttle and is the only place that touches the
+camera/LLM; everything testable is in the pure buffer + builder. With
+`visualStateMemoryEnabled == false`, the session instruction is built exactly as today.
+
+## Build order
+1. **`VisualStateMemory` + `VisualContextBuilder` + tests** — pure: eviction at capacity, `recent(n)`
+   ordering, relative-timestamp formatting with an injected `now`, empty/one/many cases. No device.
+2. **`VisualStateService`** — wire to the change gate's distinct-frame output + a rate-limited
+   describe; push keyframes. (Describe + camera are device-pending to validate.)
+3. **Prompt injection** — add the context block to `GeminiLiveSessionManager`'s instruction builder
+   behind the flag; optional thumbnails behind a second flag.
+4. **(Optional) BrainStore ingest** of aged keyframe descriptions for after-session recall.
+
+## Tests
+- `VisualStateMemory`: capacity eviction (oldest drops), `recent(n)` returns the last n in order,
+  `latestDescription`, `reset` clears, session isolation.
+- `VisualContextBuilder.summaryText`: empty → ""; relative labels computed from injected `now`
+  (`[T-30s]`, `[Now]`); only described keyframes appear; respects the max-in-context cap.
+
+## Open questions / decisions needed
+- **Describe budget** — keyframes are rare (gate-driven), but each describe is an LLM call. Rate-limit
+  hard (`visualStateDescribeMinInterval`), and consider the on-device VLM path for the one-liner so it
+  stays free/offline. Surfaces in the [cost tracker](llm-cost-usage-tracker.md).
+- **Inject text vs images** — text-only is cheap and usually enough ("you were looking at X"); gate
+  thumbnails behind a flag for when the model genuinely needs to see the prior frame.
+- **Buffer depth** — 5–8 keyframes covers "the last little while" without bloating the prompt; tune
+  on-device.
+
+## Why this matters
+This turns the live agent from "what's in this one frame" into "what's been happening in front of
+you," which is the whole point of always-on glasses. It rides directly on the change gate (distinct
+frames = keyframes), keeps the expensive part (describe) rare and bounded, and lands its core as a
+pure ring buffer + formatter that's fully tested without hardware — with the model-facing injection
+behind a flag so nothing changes until we turn it on.


### PR DESCRIPTION
Four planned capabilities surfaced from surveying adjacent multimodal-agent work, mapped onto OpenGlasses' actual gaps. Each is **deterministic-core-first** with the model/device edge deferred — one PR per plan. Docs only.

| Plan | What | Core (headless-testable) | Deferred edge |
|---|---|---|---|
| [Content-Aware Frame Gate](../blob/docs/visualclaw-feature-plans/docs/plans/frame-dedup-change-gate.md) | dHash perceptual gate drops near-duplicate frames before the LLM (adaptive threshold + heartbeat) | `PerceptualHash` (dHash + Hamming), `FrameGate` (EMA + heartbeat) | wiring into `FrameThrottler` behind a flag |
| [LLM Cost & Usage Tracker](../blob/docs/visualclaw-feature-plans/docs/plans/llm-cost-usage-tracker.md) | per-session/model token + estimated spend, in Insights | `ModelPricing`, `UsageRollup` | parse each provider's usage block in `LLMService` |
| [Visual State Memory](../blob/docs/visualclaw-feature-plans/docs/plans/visual-state-memory.md) | rolling keyframe scene memory injected into the live agent | `VisualStateMemory` ring buffer, `VisualContextBuilder` | per-keyframe describe + prompt injection |
| [Skill Self-Evolution](../blob/docs/visualclaw-feature-plans/docs/plans/skill-self-evolution.md) | learn skills from failed turns; **propose → human-approve** | `EvolutionTrigger`, `SkillDeduplicator`, `SkillProposal` | LLM analysis + review inbox |

## Notes
- **Gaps confirmed against the codebase**: `FrameThrottler` is time-only (sends static-scene duplicates); `LLMService` discards the `usage` blocks (no cost tracking exists); live vision is stateless per frame; skills are entirely hand-curated.
- **Sequence**: Frame Gate (cheap, foundational) → Cost Tracker (independent, high-value) → Visual State Memory (rides the Gate) → Skill Self-Evolution (largest, safety-sensitive, last).
- **Skill Self-Evolution safety**: Agent-Mode-gated, **human-in-the-loop** (proposes, never auto-applies), and approvals route through the existing Plan R prompt-injection/tool-poison screen — an always-on assistant must not silently rewrite its own instructions.

README index updated with a Round 10 section + suggested sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)