### PR TITLE
DAT 0.8.0 adoption (clearDisplay + typed capture errors) + doc/plan updates

### DIFF
--- a/OpenGlasses/Sources/Services/CameraErrorPolicy.swift
+++ b/OpenGlasses/Sources/Services/CameraErrorPolicy.swift
@@ -1,0 +1,57 @@
+import Foundation
+import MWDATCamera
+
+/// Pure mapping from the DAT SDK's typed camera `StreamError` (0.8.0 unified `DatError` model) to a
+/// user-facing message and a capture-recovery decision.
+///
+/// Replaces fragile `String(describing:).contains(...)` matching with the typed enum, and decides
+/// whether a *pending photo capture* should be abandoned immediately when an error arrives — so a
+/// terminal condition (hinges closed, thermal/battery shutdown, device gone) falls back to the latest
+/// video frame at once instead of hanging on the capture timeout. Pure and fully unit-testable.
+enum CameraErrorPolicy {
+
+    /// A short, user-facing message for a typed camera stream error.
+    static func message(for error: StreamError) -> String {
+        switch error {
+        case .hingesClosed:
+            return "Glasses hinges are closed — open them to use the camera."
+        case .thermalCritical, .thermalEmergency:
+            return "Glasses are too hot — let them cool down."
+        case .batteryCritical:
+            return "Glasses battery is too low — charge them to use the camera."
+        case .peakPowerShutdown:
+            return "Glasses hit a power limit — try again in a moment."
+        case .permissionDenied:
+            return "Camera permission is required."
+        case .deviceNotConnected:
+            return "Glasses disconnected — check the Bluetooth connection."
+        case .deviceNotFound:
+            return "Glasses not found — check that they're connected."
+        case .timeout:
+            return "The glasses camera timed out — try again."
+        case .videoStreamingError:
+            return "Glasses video streaming hit an error — try again."
+        case .internalError:
+            return "The glasses camera hit an internal error — try again."
+        @unknown default:
+            return error.errorDescription ?? "The glasses camera hit an error."
+        }
+    }
+
+    /// Whether a pending photo capture should be abandoned (fall back to the latest frame / fail)
+    /// the moment this error arrives, rather than waiting for the capture timeout. `true` for
+    /// terminal conditions where the photo will not arrive; `false` for transient errors where the
+    /// capture (or the existing timeout backstop) may still resolve.
+    static func abortsCapture(_ error: StreamError) -> Bool {
+        switch error {
+        case .hingesClosed, .timeout, .thermalCritical, .thermalEmergency,
+             .peakPowerShutdown, .batteryCritical, .permissionDenied,
+             .deviceNotConnected, .deviceNotFound:
+            return true
+        case .internalError, .videoStreamingError:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/CameraService.swift
+++ b/OpenGlasses/Sources/Services/CameraService.swift
@@ -242,9 +242,22 @@ class CameraService: ObservableObject {
 
         errorListenerToken = session.errorPublisher.listen { [weak self] error in
             Task { @MainActor in
-                let message = Self.friendlyErrorMessage(error)
+                guard let self else { return }
+                let message = CameraErrorPolicy.message(for: error)
                 NSLog("[Camera] Error: %@", message)
-                self?.onDebugEvent?("Camera error: \(message)")
+                self.onDebugEvent?("Camera error: \(message)")
+
+                // Fail a pending capture fast on a terminal error (hinges closed, thermal/battery
+                // shutdown, device gone) instead of waiting out the 5s timeout below.
+                if CameraErrorPolicy.abortsCapture(error), let cont = self.photoContinuation {
+                    self.photoContinuation = nil
+                    if let fallback = self.latestFrameAsJPEG() {
+                        NSLog("[Camera] Terminal error during capture — using latest video frame")
+                        cont.resume(returning: fallback)
+                    } else {
+                        cont.resume(throwing: CameraError.captureFailed)
+                    }
+                }
             }
         }
     }
@@ -572,22 +585,7 @@ class CameraService: ObservableObject {
         // No-op: audio session management is handled by WakeWordService
     }
 
-    // MARK: - Error Mapping
-
-    /// Map StreamSession errors to user-friendly descriptions.
-    private static func friendlyErrorMessage(_ error: any Error) -> String {
-        let description = String(describing: error).lowercased()
-        if description.contains("hingesclosed") {
-            return "Glasses hinges are closed — open them to use the camera"
-        } else if description.contains("thermalcritical") || description.contains("thermal") {
-            return "Glasses are too hot — let them cool down"
-        } else if description.contains("permission") {
-            return "Camera permission required"
-        } else if description.contains("devicenotavailable") || description.contains("notavailable") {
-            return "Glasses camera not available — check Bluetooth connection"
-        }
-        return error.localizedDescription
-    }
+    // Error mapping now lives in the pure, typed `CameraErrorPolicy` (DAT 0.8.0 unified errors).
 }
 
 enum CameraError: LocalizedError {

--- a/OpenGlasses/Sources/Services/GlassesDisplayService.swift
+++ b/OpenGlasses/Sources/Services/GlassesDisplayService.swift
@@ -336,8 +336,8 @@ final class GlassesDisplayService: ObservableObject {
     private func renderClear() async throws {
         // Nothing to clear if we never started a session.
         guard let display else { return }
-        let empty = FlexBox(direction: .column) {}
-        try await display.send(empty)
+        // DAT 0.8.0: explicit clear instead of sending an empty FlexBox.
+        try await display.clearDisplay()
     }
 
     private func renderScreen(_ screen: HUDScreen) async throws {

--- a/OpenGlassesTests/CameraErrorPolicyTests.swift
+++ b/OpenGlassesTests/CameraErrorPolicyTests.swift
@@ -1,0 +1,43 @@
+import MWDATCamera
+import XCTest
+@testable import OpenGlasses
+
+/// Tests the pure typed-error policy that replaced string-matching on DAT camera errors and decides
+/// when a pending photo capture should fail fast (DAT 0.8.0 unified `DatError` model). All
+/// `StreamError` cases are constructible without touching `Wearables` (`DeviceIdentifier` is a String).
+final class CameraErrorPolicyTests: XCTestCase {
+
+    /// Cases that should abandon a pending capture immediately (the photo won't arrive).
+    private let terminal: [StreamError] = [
+        .hingesClosed, .timeout, .thermalCritical, .thermalEmergency,
+        .peakPowerShutdown, .batteryCritical, .permissionDenied,
+        .deviceNotConnected("dev"), .deviceNotFound("dev"),
+    ]
+    /// Transient cases where the capture or the timeout backstop may still resolve.
+    private let transient: [StreamError] = [.internalError, .videoStreamingError]
+
+    func testTerminalErrorsAbortCapture() {
+        for error in terminal {
+            XCTAssertTrue(CameraErrorPolicy.abortsCapture(error), "\(error) should abort a pending capture")
+        }
+    }
+
+    func testTransientErrorsDoNotAbortCapture() {
+        for error in transient {
+            XCTAssertFalse(CameraErrorPolicy.abortsCapture(error), "\(error) should not abort a pending capture")
+        }
+    }
+
+    func testEveryErrorHasANonEmptyMessage() {
+        for error in terminal + transient {
+            XCTAssertFalse(CameraErrorPolicy.message(for: error).isEmpty, "\(error) should map to a message")
+        }
+    }
+
+    func testMessagesAreSpecificForKeyConditions() {
+        XCTAssertTrue(CameraErrorPolicy.message(for: .hingesClosed).localizedCaseInsensitiveContains("hinge"))
+        XCTAssertTrue(CameraErrorPolicy.message(for: .thermalCritical).localizedCaseInsensitiveContains("hot"))
+        XCTAssertTrue(CameraErrorPolicy.message(for: .batteryCritical).localizedCaseInsensitiveContains("battery"))
+        XCTAssertTrue(CameraErrorPolicy.message(for: .permissionDenied).localizedCaseInsensitiveContains("permission"))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ OpenGlasses ships App Intents + Siri Shortcuts, so you can drive it straight fro
 | "Hey Siri, OpenGlasses take a photo" | Captures via the glasses and describes the scene |
 | "Hey Siri, OpenGlasses describe surroundings" | Accessibility scene description |
 
+Beyond the pre-made phrases above, **Capture Glasses Photo** (a silent capture saved to your library) and **Record Glasses Video** are available as **Shortcuts actions** you can add to Siri, the Action button, or your own automations.
+
 The first time, iOS surfaces these in the **Shortcuts** app and the Siri phrase picker (you can rename the phrase to anything you like). A **persona name** can ride in the phrase ("ask Claude…") because it's a fixed, resolvable choice; the **question** can't (iOS only lets App Shortcut phrases embed fixed choices, not free-form text), so it's asked **two-step** — Siri prompts and awaits your spoken reply. Consecutive asks within a few minutes continue the **same conversation thread**, and Siri shows the answer in a result card. The intent runs in the background and speaks the result — no need to bring the app forward. If Siri ever says OpenGlasses isn't running, enable **Settings → Voice → Open App for Siri Questions** to have it launch the app first.
 
 ### On-Device Local LLM
@@ -300,7 +302,7 @@ Assign models to **Fast**, **Balanced**, and **Best** tiers, then let OpenGlasse
 ### CarPlay & Apple Watch
 
 - **CarPlay** — hands-free voice assistant on your car's display.
-- **Apple Watch** — companion app and widget for quick control and glanceable status.
+- **Apple Watch** — companion app and widget for quick control and glanceable status, including **taking a photo or starting/stopping a video recording on the glasses** straight from your wrist.
 
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -166,11 +166,32 @@ fully-testable core first with the model/device edge deferred — same posture a
 | [Content-Aware Frame Gate](frame-dedup-change-gate.md) | dHash perceptual gate that drops near-duplicate frames before the LLM (adaptive threshold + heartbeat) | ~1–2 days | FrameThrottler, Gemini Live frame path | Cuts the biggest repeated live-session cost — static-scene frames — with a <1 ms/frame pure gate. Foundation for visual state memory. |
 | [LLM Cost & Usage Tracker](llm-cost-usage-tracker.md) | Per-session/model token + estimated-spend tracking, surfaced in Insights | ~2–3 days | LLMService usage blocks, InsightsView/InsightsService, on-device SQLite | Table-stakes for a BYO-key multi-provider app; the data already arrives and is discarded today. |
 | [Visual State Memory](visual-state-memory.md) | Rolling keyframe scene memory ("what was I just looking at") injected into the live agent | ~3–4 days | Frame Gate (keyframe source), analyzeFrame/structured vision, GeminiLiveSessionManager, BrainStore | Turns stateless per-frame vision into scene continuity — the point of always-on glasses. |
-| [Skill Self-Evolution](skill-self-evolution.md) | Learn new skills from failed turns; **propose → human-approve**, Agent-Mode-gated, Plan-R-screened | ~1.5–2 wks | AgentRunner/NativeToolRouter, InstalledSkillStore, Plan R screen, `agentModeEnabled` | The one genuinely self-improving capability; the assistant gets better at what *this* user keeps needing. |
+| [Skill Self-Evolution](skill-self-evolution.md) | Learn new skills from failed turns; **propose → human-approve**, Agent-Mode-gated, Plan-R-screened. **+ companion: embedding-based skill retrieval** — inject only the skills relevant to the turn (via `Embedder`) once the bank grows | ~1.5–2 wks | AgentRunner/NativeToolRouter, InstalledSkillStore, Plan R screen, `Embedder`, `agentModeEnabled` | The one genuinely self-improving capability; the assistant gets better at what *this* user keeps needing. |
 
 **Suggested sequence:** Frame Gate (cheap, foundational) → Cost Tracker (independent, high-value) →
 Visual State Memory (rides the Frame Gate) → Skill Self-Evolution (largest, safety-sensitive; sequence
 last). The Frame Gate and Cost Tracker are small single-PR wins; the latter two are richer features.
+
+## Round 11 — adaptive long-term memory
+
+A typed memory layer surfaced by surveying adjacent agent-memory work, mapped onto OpenGlasses' three
+existing on-device stores (`BrainStore` graph, `SemanticMemoryStore` vectors, `DocumentStore`
+passages). The gap those three leave is a **kind** dimension — nothing models user **preferences** or
+**project state**, and recall is one-size-fits-all. Same posture as the rest: a deterministic,
+fully-testable core (classifier + retrieval policy + formatter, **zero LLM calls**) with the
+prompt-injection edge behind a default-off flag. 📋 Planned.
+
+| Plan | Title | Effort | Reuses | Strategic fit |
+|---|---|---|---|---|
+| [Typed Memory Taxonomy](memory-taxonomy.md) | Type memories as preference / project / episodic / semantic; recall each kind on its own terms (preferences always, project while active, semantic by relevance, episodic by recency) | ~3–4 days | BrainStore (`ingest`, `brain.sqlite`), Embedder, FieldSessionService, LLMService prompt builder | Closes the "no typed long-term memory" gap — the assistant remembers *how you like things done* and *what you're mid-way through*, not just facts that happen to match. Pairs with Visual State Memory (episodic) + Embedding Upgrade (semantic). |
+
+**Related (folded into Round 10):** embedding-based **skill retrieval** lives in the
+[Skill Self-Evolution](skill-self-evolution.md) plan — it rides the same `Embedder` seam and only earns
+its keep once evolution grows the skill bank.
+
+**Suggested sequence:** independent of Round 10; can land any time. If sequencing with Round 10, do the
+[Embedding Quality Upgrade](embedding-quality-upgrade.md) first so both the taxonomy's semantic recall
+and skill retrieval get the sharper transformer embeddings.
 
 ## Dependency graph
 

--- a/docs/plans/memory-taxonomy.md
+++ b/docs/plans/memory-taxonomy.md
@@ -1,0 +1,185 @@
+# Plan — Typed Memory Taxonomy (episodic / semantic / preference / project recall)
+
+**Status:** 📋 Planned (not built). A typed layer over the existing on-device memory stores that adds
+the two memory kinds we don't model today — **preferences** and **project state** — and a
+*differentiated* recall policy so the right kind of memory reaches the prompt for the right reason.
+The classifier, the retrieval policy, and the store round-trip are pure and headless-testable;
+embedding similarity rides the existing `Embedder`. **Zero LLM calls** (pattern-based classification,
+mirroring `BrainRelationExtractor`'s precision-over-recall posture). No new SPM dependency. Strictly
+on-device, never synced to the gateway — same posture as `BrainStore`.
+
+## The problem
+OpenGlasses already has three memory substrates, but each answers only one shape of question:
+- **`BrainStore`** (`brain.sqlite`) — a relational graph: entities, typed edges ("Alice works_at
+  Acme"), person **encounters**, and follow-up **needs**. Great for "who works at Acme?".
+- **`SemanticMemoryStore`** — flat facts retrieved by vector similarity ("what facts resemble this?").
+- **`DocumentStore`** — passages from loaded files.
+
+What none of them models is the **kind** of a memory, and two kinds in particular are simply absent:
+- **Preferences** — "I prefer metric units", "always read me the urgent line first", "I take my
+  coffee black". Durable, low-volume, and they should bias *every* turn — but today they'd land as an
+  undifferentiated fact (if at all) and only surface when a query happens to resemble them.
+- **Project state** — "I'm mid-way through the walk-in cooler job at Site 7; compressor swap is next".
+  Ongoing, scoped to an active context, and should clear/yield when the user switches projects.
+
+Without a kind dimension, recall is one-size-fits-all: everything competes in the same vector top-k.
+Preferences get out-ranked by a topically-closer fact; project state isn't pinned while a job is
+active; episodic events ("what did I do this morning") aren't retrievable by recency. The fix isn't a
+bigger model — it's **typing** the memory and recalling each kind on its own terms.
+
+## What we build
+A typed memory record with a deterministic classifier, a differentiated retrieval policy, and a
+formatter that assembles the per-turn memory block:
+
+1. **Classify** incoming text (the same text `BrainStore.ingest` already sees) into one of four kinds —
+   `preference`, `project`, `episodic`, `semantic` — by pattern, no LLM.
+2. **Store** it as a typed `MemoryRecord` with salience + timestamps, alongside (not replacing) the
+   graph edges the brain already extracts.
+3. **Recall** per-kind when building the prompt: **always** inject preferences (capped), inject the
+   **active project's** state, inject the top-k **semantic** facts by embedding similarity to the
+   turn, and the most **recent episodic** events — each with its own budget.
+4. **Decay/scope**: episodic ages out; preferences persist; project state is scoped to a project tag
+   and yields when the active project changes.
+
+### The deterministic core (pure, tested)
+- **`MemoryRecord`** — `{ id, kind, text, subject?, projectTag?, salience, createdAt, lastAccessedAt }`.
+  `kind ∈ {preference, project, episodic, semantic}`. Pure value type.
+- **`MemoryClassifier`** — `classify(_ text:) -> MemoryKind` by cue patterns:
+  - *preference*: first-person durable cues — "I prefer/like/want/always/never/usually", "call me…",
+    "use … units".
+  - *project*: progress/state cues tied to work — "working on", "mid-way", "next step is", "still need
+    to", "on the … job", an active `FieldSessionService` job in scope.
+  - *episodic*: a past event with a time/place — past-tense + temporal marker ("this morning",
+    "yesterday", "at the…"), or a logged encounter.
+  - *semantic*: the default (a durable fact) when nothing else fires.
+  Precision over recall: an unclear line falls to `semantic` (the safe, already-handled bucket).
+- **`MemoryRetrievalPolicy`** — pure ranking. Given `(query, candidates, similarity, budgets, now,
+  activeProject)` returns the selected records: all `preference` up to `maxPreferences`; `project`
+  records for `activeProject`; top-`k` `semantic` by injected cosine similarity; most-recent
+  `episodic` within a recency window. Stable ordering; time + similarity injected so it's
+  deterministic.
+- **`MemoryContextBuilder`** — pure formatter: selected records → a `# What I remember` block with
+  per-kind subheadings (`Preferences`, `Current project`, `Relevant facts`, `Recently`). Empty input
+  → "".
+
+## How it flows (live edge)
+1. `BrainStore.ingest(text:)` already runs on new memory text. A parallel call hands the **same text**
+   to `MemoryClassifier` → a `MemoryRecord` is stored in `TypedMemoryStore`. (The graph edges and the
+   typed record are complementary, not either/or.)
+2. When `LLMService` assembles the system prompt, a new `TypedMemoryStore.promptContext(for: turn)`
+   runs `MemoryRetrievalPolicy` over the candidates (embedding the turn via `Embedder`) and
+   `MemoryContextBuilder` formats the result — injected alongside the existing social/vault/skill
+   blocks.
+3. `lastAccessedAt` is bumped on inject so a salience/decay pass can favour what actually gets used.
+4. Active project comes from `FieldSessionService` (a job session) or an explicit "I'm working on X"
+   classified as `project`; switching projects scopes which `project` records are eligible.
+
+## Scope
+In:
+- `Sources/Services/Brain/MemoryRecord.swift`, `MemoryClassifier.swift`, `MemoryRetrievalPolicy.swift`,
+  `MemoryContextBuilder.swift` (pure core).
+- `Sources/Services/Brain/TypedMemoryStore.swift` — SQLite persistence (a `memory_records` table; reuse
+  `brain.sqlite` so it stays one on-device, un-synced DB), `add`, `records(kind:)`,
+  `promptContext(for:)`, salience bump, decay sweep.
+- `BrainStore.ingest` — add the parallel classify-and-store call (cheap, additive).
+- `LLMService` system-prompt builder — inject the typed-memory block (behind a flag; default off
+  reproduces today's behaviour exactly).
+- `Config` — `typedMemoryEnabled` (default off), `memoryMaxPreferences`, `memorySemanticTopK`,
+  `memoryEpisodicWindow`.
+
+Out (deferred):
+- An LLM-based classifier or summariser — start pattern-based; the heuristic is the testable core, and
+  an LLM pass can refine kinds later if the signal warrants it (surfaces in the
+  [cost tracker](llm-cost-usage-tracker.md)).
+- Cross-device sync of typed memory — local-first, like the brain; rides the existing export/import
+  later.
+- Migrating `SemanticMemoryStore`'s existing flat facts into typed records — new memories are typed
+  going forward; a back-fill is a separate follow-up.
+- A user-facing memory editor (review/forget by kind) — read path first; a "Memory" surface in
+  Settings is a fast follow once the kinds prove useful.
+
+## Architecture — the seam
+```swift
+enum MemoryKind: String, Codable { case preference, project, episodic, semantic }
+
+struct MemoryRecord: Identifiable, Equatable {
+    let id: UUID
+    let kind: MemoryKind
+    let text: String
+    let subject: String?        // person/org the memory is about, if any
+    let projectTag: String?     // scopes `project` records to an active job
+    let salience: Double
+    let createdAt: Date
+    var lastAccessedAt: Date
+}
+
+enum MemoryClassifier {                                   // pure; zero LLM
+    static func classify(_ text: String) -> MemoryKind    // defaults to .semantic
+}
+
+enum MemoryRetrievalPolicy {                              // pure; similarity + now injected
+    static func select(query: String,
+                       candidates: [MemoryRecord],
+                       similarity: (String) -> Float,     // turn↔record cosine, via Embedder
+                       activeProject: String?,
+                       now: Date,
+                       maxPreferences: Int, semanticTopK: Int, episodicWindow: TimeInterval)
+        -> [MemoryRecord]
+}
+
+enum MemoryContextBuilder {                               // pure formatter
+    static func block(_ records: [MemoryRecord], now: Date) -> String   // "# What I remember…"
+}
+```
+`TypedMemoryStore` owns the SQLite table and is the only piece that touches I/O or the `Embedder`; the
+decisions that matter — what kind a memory is, which records to recall, how to present them — are pure
+and fully tested. With `typedMemoryEnabled == false`, the prompt is assembled exactly as today.
+
+## Build order
+1. **Pure core + tests** — `MemoryClassifier`, `MemoryRetrievalPolicy`, `MemoryContextBuilder`. Fully
+   deterministic; no store, no embedding model.
+2. **`TypedMemoryStore`** — `memory_records` table in `brain.sqlite` + round-trip / query-by-kind /
+   decay-sweep tests.
+3. **Ingest hook** — classify-and-store alongside `BrainStore.ingest` (additive, cheap).
+4. **Prompt injection** — `promptContext(for:)` wired into `LLMService` behind `typedMemoryEnabled`;
+   embedding the turn via the existing `Embedder`.
+5. **(Fast follow)** salience/decay tuning + an optional Settings "Memory" review surface.
+
+## Tests
+- `MemoryClassifier`: preference cues → `.preference`; project/progress cues → `.project`;
+  past-tense + temporal marker → `.episodic`; an ordinary fact → `.semantic`; ambiguous → `.semantic`
+  (never a confident wrong kind).
+- `MemoryRetrievalPolicy.select`: all preferences included up to the cap; only the active project's
+  `project` records pass; semantic results are the top-k by injected similarity; episodic respects the
+  recency window and drops older; stable ordering; empty candidates → empty.
+- `MemoryContextBuilder.block`: empty → ""; per-kind subheadings appear only when that kind has
+  records; relative "Recently" labels computed from injected `now`.
+- `TypedMemoryStore`: add/query-by-kind round-trips; `lastAccessedAt` bumps on recall; decay sweep
+  drops aged episodic but never preferences; project scoping.
+
+## Open questions / decisions needed
+- **Reuse vs. new store** — put `memory_records` in `brain.sqlite` (one un-synced on-device DB, my
+  default) or alongside `SemanticMemoryStore`? Reusing the brain DB keeps the "never synced to the
+  gateway" guarantee in one place.
+- **Classifier reach** — how aggressive the preference/project cues should be. Start narrow
+  (high-precision first-person cues) so the always-injected `preference` bucket can't fill with noise;
+  widen only once the signal proves clean, exactly as `BrainRelationExtractor` was tuned.
+- **Budget split** — how many of each kind to inject before the block competes with the rest of the
+  system prompt. Preferences are few and cheap to always include; semantic top-k and episodic window
+  are the tunable knobs.
+- **Active-project source** — derive solely from `FieldSessionService`, or also from an explicit
+  "I'm working on X" the classifier tags `project`? Probably both, with the session taking precedence.
+- **Decay curve** — does episodic age purely by time, or by time × inverse-access? Keep it simple
+  (time window) first; add access-weighting only if recall feels stale.
+
+## Why this matters
+It closes the one real gap surfaced by surveying adjacent agent-memory work: the assistant has a graph
+and a vector index but **no typed long-term memory** — so it can't reliably remember *how you like
+things done* or *what you're in the middle of*. Typing the memory and recalling each kind on its own
+terms (preferences always, project while active, semantic by relevance, episodic by recency) is what
+turns "facts that happen to match" into memory that behaves the way a person's would. The hard parts —
+classification, differentiated recall, presentation — land as a pure, fully-tested core with zero LLM
+calls; the only live edge is wiring the block into the prompt behind a default-off flag. Pairs
+naturally with [Visual State Memory](visual-state-memory.md) (its aged keyframe descriptions become
+`episodic` records) and the [Embedding Quality Upgrade](embedding-quality-upgrade.md) (sharper
+semantic recall through the same `Embedder` seam).

--- a/docs/plans/skill-self-evolution.md
+++ b/docs/plans/skill-self-evolution.md
@@ -112,6 +112,54 @@ the decisions that matter (when to evolve, is it a dup, is it well-formed) are p
 - **Edit-on-approve** — let the user tweak the wording before accepting; treat the LLM output as a
   draft, not a verdict.
 
+## Companion: embedding-based skill retrieval
+
+Evolution has a tail problem. Every approved skill is injected into **every** system prompt, because
+both skill stores dump their whole library unconditionally today:
+- `VoiceSkillStore.promptContext()` emits a `LEARNED SKILLS` block listing *all* voice skills.
+- `InstalledSkillStore.promptContext()` does the same for ClawHub/installed skills.
+
+That's fine at three skills. But the whole point of evolution is that the bank **grows** with what
+this user keeps needing — and a 30-skill dump bloats the prompt, burns tokens, and dilutes attention
+across instructions that are irrelevant to the turn at hand. The fix is to inject only the skills
+**relevant to the current turn**, selected on-device with the `Embedder` we already ship.
+
+### The deterministic core (pure, tested)
+- **`SkillRetriever`** — `select(turn:, candidates:, similarity:, topK:, alwaysIncludeTriggerMatches:)
+  -> [skill]`. Pure ranking:
+  - **Always** include any skill whose explicit `trigger` substring-matches the turn — an exact
+    voice trigger must *never* be dropped by a similarity cutoff (the current behaviour is exact-match
+    on trigger, and we preserve it).
+  - Then fill the remaining budget with the top-`k` candidates by injected cosine similarity between
+    the turn and the skill's `trigger + instruction` text.
+  - Stable, deterministic ordering; similarity injected so it's testable without a model.
+- A unified `SkillCandidate` view (`{ id, trigger, body, source }`) so voice, installed/ClawHub, and
+  `evolved` skills rank in one pool against one budget.
+
+### How it flows
+`promptContext()` gains a `for turn:` variant on both stores that runs the candidates through
+`SkillRetriever` (embedding the turn via `Embedder`) and formats only the survivors — same block
+shape as today, fewer lines. Gated by `skillRetrievalEnabled` (default off) **and** a count floor: below
+`skillRetrievalMinCount` skills, dump-all is cheaper and clearer, so retrieval only kicks in once the
+library is large enough to matter — which is exactly when evolution has been doing its job.
+
+### Scope (additive to this plan)
+In: `Sources/Services/Skills/SkillRetriever.swift` (+ `SkillCandidate`); `for turn:` overloads on
+`VoiceSkillStore`/`InstalledSkillStore`/`EvolvedSkillStore`; `Config.skillRetrievalEnabled`,
+`skillRetrievalTopK`, `skillRetrievalMinCount`. Out: re-ranking by recency/usage (start with
+relevance only); a cross-store usage counter (a later salience signal).
+
+### Tests
+- `SkillRetriever.select`: a turn containing a skill's `trigger` always includes it regardless of
+  similarity; the rest are the top-k by injected similarity; below `minCount` → all returned (today's
+  behaviour, no change); empty candidates → empty; ties break stably.
+
+### Why fold it in here
+Retrieval isn't worth building for a hand-curated handful of skills — dump-all is fine there. It
+becomes necessary *because* evolution grows the bank, so it belongs with the feature that creates the
+pressure. It also rides the same `Embedder` seam as the [memory taxonomy](memory-taxonomy.md)'s
+semantic recall, and the same default-off-flag posture as the rest of this plan.
+
 ## Why this matters
 It's the one genuinely *self-improving* capability in the set: the assistant gets better at the things
 *this* user keeps needing, by harvesting fixes that are already sitting in the transcript. The risk —


### PR DESCRIPTION
Adopts the genuinely-useful DAT 0.8.0 APIs (the rest of 0.8.0's "unlocks" turned out automatic or non-existent — see below), refreshes the public README for recently-shipped capture features, and folds in in-progress plan docs.

## DAT 0.8.0 adoption (code)
- **`Display.clearDisplay()`** — blank the HUD with the real API instead of sending an empty `FlexBox`.
- **`CameraErrorPolicy`** (pure, 4 tests) — typed `StreamError` → user-facing message + a capture-recovery decision, replacing fragile `String(describing:).contains(...)` matching.
- **Fast-fail photo capture** — the camera error listener (which previously only *logged*) now resolves a **pending capture immediately** on a terminal `StreamError` (hinges closed / thermal / battery / peak-power / device gone), falling back to the latest video frame instead of hanging the full 5 s timeout. Directly improves the watch/Shortcuts capture path.

### Reality check on the other 0.8.0 "unlocks"
Verified against the 0.8.0 `.swiftinterface` (ground truth):
- **WiFi transport** — no app-facing API; the SDK negotiates it transparently. Nothing to build.
- **Meta Glasses** — `DeviceType.metaGlasses` is recognized and `supportsDisplay()` gating already covers it. Automatic.
- **`CaptureError`** — *declared* but **not emitted by any public API**; camera errors arrive on `errorPublisher` as `StreamError` (what this PR handles).
- **MockDeviceKit multi-glasses** — UI-test infra (`Wearables` fatals in unit tests); deferred.

## Docs
- **README** (public): Apple Watch now notes **taking a photo / recording video on the glasses from the wrist**; the Siri section documents the **Capture Glasses Photo** + **Record Glasses Video** Shortcuts actions.
- **Plans**: new **Typed Memory Taxonomy** plan, expanded **Skill Self-Evolution**, index updated.

## Build / test
- Debug + **Release** green; 4 new `CameraErrorPolicy` tests pass (all `StreamError` cases construct without `Wearables`).

Note: the DAT conventions reference (`.claude/rules/dat-conventions.md`) is gitignored, so it was refreshed to 0.8.0 locally only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)