### PR TITLE
Embedding-based skill retrieval (default off)

### DIFF
--- a/OpenGlasses/Sources/Services/ClawHubService.swift
+++ b/OpenGlasses/Sources/Services/ClawHubService.swift
@@ -604,13 +604,19 @@ class InstalledSkillStore: ObservableObject {
         return items.count
     }
 
-    /// Generate prompt context from all enabled installed skills.
-    func promptContext() -> String? {
+    /// Generate prompt context from the enabled installed skills.
+    ///
+    /// When `turn` is supplied and `Config.skillRetrievalEnabled` is on (and the enabled set is past
+    /// the `skillRetrievalMinCount` floor), only the skills relevant to the turn are injected — an
+    /// exact name match plus the top-K by embedding similarity over name+description. Otherwise every
+    /// enabled skill is dumped, the original behaviour. Each installed skill's body is the full
+    /// `SKILL.md`, so trimming the set is the biggest single prompt-size win. See [[SkillRetriever]].
+    func promptContext(for turn: String? = nil) -> String? {
         let enabled = installedSkills.filter(\.enabled)
         guard !enabled.isEmpty else { return nil }
 
         var context = "INSTALLED SKILLS (from ClawHub):\n"
-        for skill in enabled {
+        for skill in Self.retrieved(enabled, turn: turn) {
             // Strip the YAML frontmatter, keep the markdown body
             let body = stripFrontmatter(skill.content)
             context += "\n--- \(skill.name) ---\n"
@@ -618,6 +624,30 @@ class InstalledSkillStore: ObservableObject {
             context += "\n"
         }
         return context
+    }
+
+    /// Narrow the enabled skills to those relevant to `turn`, or pass them through unchanged when
+    /// retrieval is off / not applicable. Ranks on the compact name+description (not the full body),
+    /// which is what the sentence embedding can meaningfully compare; the ranking is the pure
+    /// `SkillRetriever`.
+    private static func retrieved(_ skills: [InstalledSkill], turn: String?) -> [InstalledSkill] {
+        guard Config.skillRetrievalEnabled,
+              let turn, !turn.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return skills }
+        let embedder = Embedder()
+        guard embedder.isAvailable, let turnVec = embedder.embed(turn) else { return skills }
+
+        let candidates = skills.map {
+            SkillCandidate(id: $0.slug, trigger: $0.name,
+                           matchText: "\($0.name) \($0.description)", source: .installed)
+        }
+        let selected = SkillRetriever.select(
+            turn: turn, candidates: candidates,
+            similarity: { c in embedder.embed(c.matchText).map { Embedder.cosineSimilarity(turnVec, $0) } ?? 0 },
+            topK: Config.skillRetrievalTopK, minCount: Config.skillRetrievalMinCount
+        )
+        let keepSlugs = Set(selected.map(\.id))
+        return skills.filter { keepSlugs.contains($0.slug) }
     }
 
     // MARK: - Persistence

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -169,7 +169,7 @@ class LLMService: ObservableObject {
     /// Build the full system prompt, optionally including location, tools, memory, and vision context.
     /// When `promptSections` is provided (from the ConversationClassifier), irrelevant sections are
     /// stripped to reduce token count. When nil, all sections are included (backward compatible).
-    private static func buildSystemPrompt(locationContext: String?, includeTools: Bool, includeOpenClaw: Bool, hasImage: Bool, nativeToolNames: [String] = [], gatewayToolNames: [String] = [], memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil) async -> String {
+    private static func buildSystemPrompt(locationContext: String?, includeTools: Bool, includeOpenClaw: Bool, hasImage: Bool, nativeToolNames: [String] = [], gatewayToolNames: [String] = [], memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil, turn: String? = nil) async -> String {
         // Agent personality mode: soul.md + skills.md + memory.md replace the standard prompt
         var prompt: String
         if Config.agentModeEnabled, let agentContext, !agentContext.isEmpty {
@@ -409,7 +409,7 @@ class LLMService: ObservableObject {
             prompt += "\n\n\(nowPlaying)"
         }
         // Inject voice-taught skills
-        if shouldInclude(.tools), let skills = VoiceSkillStore.shared.promptContext() {
+        if shouldInclude(.tools), let skills = VoiceSkillStore.shared.promptContext(for: turn) {
             prompt += "\n\n\(skills)"
         }
         // Inject Field Assist vault content when a session is active.
@@ -422,7 +422,7 @@ class LLMService: ObservableObject {
             prompt += "\n\n\(social)"
         }
         // Inject installed ClawHub skills
-        if shouldInclude(.openClaw), let skillContext = InstalledSkillStore.shared.promptContext() {
+        if shouldInclude(.openClaw), let skillContext = InstalledSkillStore.shared.promptContext(for: turn) {
             prompt += "\n\n\(skillContext)"
         }
         // Always append the prompt-injection / untrusted-content policy. This is a security
@@ -467,7 +467,7 @@ class LLMService: ObservableObject {
         let includeTools = hasNativeTools || includeOpenClaw
         let nativeToolNames = nativeToolRouter?.registry.toolNames ?? []
         let gatewayToolNames = openClawBridge?.availableToolNames ?? []
-        let fullPrompt = await Self.buildSystemPrompt(locationContext: locationContext, includeTools: includeTools, includeOpenClaw: includeOpenClaw, hasImage: imageData != nil, nativeToolNames: nativeToolNames, gatewayToolNames: gatewayToolNames, memoryContext: memoryContext, agentContext: agentContext, playbookContext: playbookContext, nowPlayingContext: nowPlayingContext, shortcutsContext: shortcutsContext, promptSections: promptSections)
+        let fullPrompt = await Self.buildSystemPrompt(locationContext: locationContext, includeTools: includeTools, includeOpenClaw: includeOpenClaw, hasImage: imageData != nil, nativeToolNames: nativeToolNames, gatewayToolNames: gatewayToolNames, memoryContext: memoryContext, agentContext: agentContext, playbookContext: playbookContext, nowPlayingContext: nowPlayingContext, shortcutsContext: shortcutsContext, promptSections: promptSections, turn: text)
 
         var toolsLabel = ""
         if hasNativeTools { toolsLabel += " [NativeTools]" }
@@ -2092,7 +2092,8 @@ class LLMService: ObservableObject {
             includeOpenClaw: false,
             hasImage: false,
             nativeToolNames: nativeToolNames,
-            memoryContext: memoryContext
+            memoryContext: memoryContext,
+            turn: text
         )
 
         // If a cloud model config is selected as the agent, route through it

--- a/OpenGlasses/Sources/Services/NativeTools/VoiceSkillsTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/VoiceSkillsTool.swift
@@ -113,8 +113,41 @@ class VoiceSkillStore {
     }
 
     /// Generate the [LEARNED_SKILLS] prompt block for injection into the system prompt.
-    func promptContext() -> String? {
+    ///
+    /// When `turn` is supplied and `Config.skillRetrievalEnabled` is on (and the library is past the
+    /// `skillRetrievalMinCount` floor), only the skills relevant to the turn are injected — exact
+    /// trigger matches plus the top-K by embedding similarity. Otherwise every skill is dumped, the
+    /// original behaviour. See [[SkillRetriever]].
+    func promptContext(for turn: String? = nil) -> String? {
         let skills = all()
+        guard !skills.isEmpty else { return nil }
+        return Self.formatBlock(Self.retrieved(skills, turn: turn))
+    }
+
+    /// Narrow a skill set to those relevant to `turn`, or pass it through unchanged when retrieval is
+    /// off / not applicable. The embedding model is built per-call (skills are few); the ranking
+    /// itself is the pure `SkillRetriever`.
+    private static func retrieved(_ skills: [VoiceSkill], turn: String?) -> [VoiceSkill] {
+        guard Config.skillRetrievalEnabled,
+              let turn, !turn.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return skills }
+        let embedder = Embedder()
+        guard embedder.isAvailable, let turnVec = embedder.embed(turn) else { return skills }
+
+        let candidates = skills.map {
+            SkillCandidate(id: $0.id, trigger: $0.trigger,
+                           matchText: "\($0.trigger) \($0.instruction)", source: .voice)
+        }
+        let selected = SkillRetriever.select(
+            turn: turn, candidates: candidates,
+            similarity: { c in embedder.embed(c.matchText).map { Embedder.cosineSimilarity(turnVec, $0) } ?? 0 },
+            topK: Config.skillRetrievalTopK, minCount: Config.skillRetrievalMinCount
+        )
+        let keepIds = Set(selected.map(\.id))
+        return skills.filter { keepIds.contains($0.id) }
+    }
+
+    private static func formatBlock(_ skills: [VoiceSkill]) -> String? {
         guard !skills.isEmpty else { return nil }
         var block = "\nLEARNED SKILLS (voice-taught by the user — apply automatically when trigger is detected):"
         for skill in skills {

--- a/OpenGlasses/Sources/Services/Skills/SkillRetriever.swift
+++ b/OpenGlasses/Sources/Services/Skills/SkillRetriever.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// A skill reduced to what retrieval needs: a `trigger` phrase to exact-match against the user's
+/// turn, a compact `matchText` to rank by similarity, and a `source` so the caller knows which
+/// prompt block it belongs in. Deliberately neutral so voice-taught and installed skills rank in one
+/// pool against one budget.
+struct SkillCandidate: Equatable, Identifiable {
+    enum Source: Equatable { case voice, installed }
+    let id: String
+    let trigger: String      // exact phrase / name; never dropped if it appears in the turn
+    let matchText: String    // trigger + summary, used only for similarity ranking
+    let source: Source
+}
+
+/// Selects the skills worth injecting for the current turn, so a growing skill bank doesn't bloat
+/// every system prompt. Both skill stores dump their whole library today; that's fine for a handful
+/// but degrades as the library grows (most relevantly once Skill Self-Evolution starts adding
+/// skills). Pure: the embedding similarity is **injected**, so the ranking logic is fully testable
+/// without a model.
+///
+/// Two rules, applied in order:
+///   1. **Never drop an exact trigger match.** A skill whose `trigger` substring-appears in the turn
+///      is always kept — this preserves the existing exact-trigger behaviour, even past the budget.
+///   2. **Fill the rest by relevance.** Remaining slots up to `topK` go to the highest-similarity
+///      candidates.
+///
+/// Below `minCount` total candidates (or with an empty turn) retrieval is a **no-op** — it returns
+/// everything, exactly reproducing today's dump-all behaviour. Output preserves the input order so
+/// the formatted block is deterministic.
+enum SkillRetriever {
+
+    static func select(
+        turn: String,
+        candidates: [SkillCandidate],
+        similarity: (SkillCandidate) -> Float,
+        topK: Int,
+        minCount: Int
+    ) -> [SkillCandidate] {
+        let trimmedTurn = turn.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Below the floor, or nothing to match against → preserve dump-all behaviour.
+        guard candidates.count > minCount, !trimmedTurn.isEmpty else { return candidates }
+
+        let loweredTurn = trimmedTurn.lowercased()
+
+        // Rule 1: exact trigger matches are always kept, regardless of similarity or budget.
+        var kept = Set<Int>()
+        for (i, c) in candidates.enumerated() {
+            let trigger = c.trigger.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trigger.isEmpty, loweredTurn.contains(trigger) { kept.insert(i) }
+        }
+
+        // Rule 2: fill the remaining budget by injected similarity among the rest.
+        if kept.count < topK {
+            let ranked = candidates.enumerated()
+                .filter { !kept.contains($0.offset) }
+                .map { (offset: $0.offset, score: similarity($0.element)) }
+                .sorted { $0.score != $1.score ? $0.score > $1.score : $0.offset < $1.offset }
+            for entry in ranked.prefix(topK - kept.count) { kept.insert(entry.offset) }
+        }
+
+        // Stable output: original order.
+        return candidates.enumerated()
+            .filter { kept.contains($0.offset) }
+            .map { $0.element }
+    }
+}

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -2453,6 +2453,34 @@ struct Config {
         UserDefaults.standard.set(enabled, forKey: "userMemoryEnabled")
     }
 
+    // MARK: - Skill Retrieval
+
+    /// When `true`, the skill stores inject only the skills relevant to the current turn (exact
+    /// trigger matches + top-K by embedding similarity) instead of dumping the whole library.
+    /// Default **off** — dump-all is the current behaviour and is fine for a small library; retrieval
+    /// only earns its keep once the bank grows (e.g. via Skill Self-Evolution). See [[SkillRetriever]].
+    static var skillRetrievalEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "skillRetrievalEnabled")   // defaults to false
+    }
+
+    static func setSkillRetrievalEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: "skillRetrievalEnabled")
+    }
+
+    /// Soft budget: how many skills to inject when retrieval is on (exact trigger matches are always
+    /// kept and may exceed this). Falls back to a sensible default when unset.
+    static var skillRetrievalTopK: Int {
+        let v = UserDefaults.standard.integer(forKey: "skillRetrievalTopK")
+        return v > 0 ? v : 6
+    }
+
+    /// Floor below which retrieval is a no-op (dumping a handful is cheaper than ranking them).
+    static var skillRetrievalMinCount: Int {
+        let key = "skillRetrievalMinCount"
+        if UserDefaults.standard.object(forKey: key) == nil { return 8 }
+        return UserDefaults.standard.integer(forKey: key)
+    }
+
     // MARK: - Siri "Ask a Question" Behavior
 
     /// When `true`, the Siri "Ask OpenGlasses a question" intent brings the app to

--- a/OpenGlassesTests/SkillRetrieverTests.swift
+++ b/OpenGlassesTests/SkillRetrieverTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Headless tests for the skill-retrieval pure core: exact-trigger keep + top-K-by-similarity
+/// selection, with the similarity function injected so no embedding model is needed. No store, no UI.
+final class SkillRetrieverTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func candidate(_ id: String, trigger: String = "", text: String = "") -> SkillCandidate {
+        SkillCandidate(id: id, trigger: trigger, matchText: text.isEmpty ? id : text, source: .voice)
+    }
+
+    /// A similarity function backed by an explicit id→score table (default 0).
+    private func sim(_ scores: [String: Float]) -> (SkillCandidate) -> Float {
+        { scores[$0.id] ?? 0 }
+    }
+
+    private func ids(_ candidates: [SkillCandidate]) -> [String] { candidates.map(\.id) }
+
+    // MARK: - No-op below the floor
+
+    func testBelowMinCountReturnsAllUnchanged() {
+        let cands = [candidate("a"), candidate("b"), candidate("c")]
+        let out = SkillRetriever.select(turn: "anything", candidates: cands,
+                                        similarity: sim([:]), topK: 1, minCount: 5)
+        XCTAssertEqual(ids(out), ["a", "b", "c"])   // count (3) <= minCount (5) → dump all
+    }
+
+    func testAtMinCountIsStillNoOp() {
+        let cands = [candidate("a"), candidate("b")]
+        let out = SkillRetriever.select(turn: "x", candidates: cands,
+                                        similarity: sim([:]), topK: 1, minCount: 2)
+        XCTAssertEqual(ids(out), ["a", "b"])        // count == minCount → not "past the floor"
+    }
+
+    func testEmptyTurnReturnsAll() {
+        let cands = (0..<5).map { candidate("s\($0)") }
+        let out = SkillRetriever.select(turn: "   ", candidates: cands,
+                                        similarity: sim([:]), topK: 1, minCount: 1)
+        XCTAssertEqual(out.count, 5)                // no turn → can't rank → dump all
+    }
+
+    func testEmptyCandidatesReturnsEmpty() {
+        let out = SkillRetriever.select(turn: "hi", candidates: [],
+                                        similarity: sim([:]), topK: 3, minCount: 0)
+        XCTAssertTrue(out.isEmpty)
+    }
+
+    // MARK: - Exact trigger keep
+
+    func testExactTriggerMatchAlwaysIncludedDespiteZeroSimilarity() {
+        let cands = [
+            candidate("hit", trigger: "expense this", text: "irrelevant"),
+            candidate("a"), candidate("b"), candidate("c"), candidate("d"),
+        ]
+        // topK=1 and "hit" has zero similarity, but its trigger appears in the turn → kept.
+        let out = SkillRetriever.select(turn: "please expense this receipt", candidates: cands,
+                                        similarity: sim(["a": 0.9]), topK: 1, minCount: 2)
+        XCTAssertTrue(ids(out).contains("hit"))
+    }
+
+    func testTriggerMatchKeptEvenBeyondTopKBudget() {
+        let cands = [
+            candidate("t1", trigger: "log water"),
+            candidate("t2", trigger: "log food"),
+            candidate("t3", trigger: "log mood"),
+            candidate("x1"), candidate("x2"),
+        ]
+        // All three triggers appear in the turn; topK is only 1 — every trigger match still survives.
+        let out = SkillRetriever.select(turn: "log water, log food, and log mood",
+                                        candidates: cands, similarity: sim([:]), topK: 1, minCount: 2)
+        XCTAssertEqual(Set(ids(out)), ["t1", "t2", "t3"])
+    }
+
+    func testCaseInsensitiveTriggerMatch() {
+        let cands = [candidate("hit", trigger: "Stand Up Meeting")] + (0..<4).map { candidate("f\($0)") }
+        let out = SkillRetriever.select(turn: "start my stand up meeting now", candidates: cands,
+                                        similarity: sim([:]), topK: 1, minCount: 2)
+        XCTAssertTrue(ids(out).contains("hit"))
+    }
+
+    func testBlankTriggerNotForceIncluded() {
+        // An empty trigger must not be treated as "matches everything" (an empty string is a
+        // substring of any turn). Give the others real similarity so the budget is filled by them —
+        // the only way "blank" could appear here is via a (wrong) trigger force-match.
+        let cands = [candidate("blank", trigger: "")] + (1...4).map { candidate("f\($0)") }
+        let out = SkillRetriever.select(
+            turn: "hello world", candidates: cands,
+            similarity: sim(["f1": 0.9, "f2": 0.8, "f3": 0.7, "f4": 0.6]),
+            topK: 2, minCount: 2)
+        XCTAssertEqual(Set(ids(out)), ["f1", "f2"])     // budget filled by similarity; blank not force-kept
+    }
+
+    // MARK: - Top-K by similarity
+
+    func testFillsRemainingBudgetByHighestSimilarity() {
+        let cands = [candidate("a"), candidate("b"), candidate("c"), candidate("d"), candidate("e")]
+        let out = SkillRetriever.select(
+            turn: "rank me", candidates: cands,
+            similarity: sim(["a": 0.1, "b": 0.9, "c": 0.5, "d": 0.8, "e": 0.2]),
+            topK: 2, minCount: 1)
+        XCTAssertEqual(Set(ids(out)), ["b", "d"])   // the two highest scores
+    }
+
+    func testTopKBudgetRespectedWithoutTriggerMatches() {
+        let cands = (0..<6).map { candidate("s\($0)") }
+        let scores = Dictionary(uniqueKeysWithValues: (0..<6).map { ("s\($0)", Float($0)) })
+        let out = SkillRetriever.select(turn: "go", candidates: cands,
+                                        similarity: sim(scores), topK: 3, minCount: 1)
+        XCTAssertEqual(out.count, 3)
+        XCTAssertEqual(Set(ids(out)), ["s5", "s4", "s3"])   // top 3 by score
+    }
+
+    func testTriggerMatchesCountAgainstBudget() {
+        let cands = [
+            candidate("trig", trigger: "report"),
+            candidate("a"), candidate("b"), candidate("c"),
+        ]
+        // topK=2: the trigger match takes one slot, leaving one for the best similarity ("b").
+        let out = SkillRetriever.select(turn: "make a report", candidates: cands,
+                                        similarity: sim(["a": 0.2, "b": 0.9, "c": 0.1]),
+                                        topK: 2, minCount: 1)
+        XCTAssertEqual(Set(ids(out)), ["trig", "b"])
+    }
+
+    // MARK: - Stable ordering
+
+    func testOutputPreservesOriginalOrder() {
+        let cands = [candidate("a"), candidate("b"), candidate("c"), candidate("d")]
+        let out = SkillRetriever.select(turn: "go", candidates: cands,
+                                        similarity: sim(["d": 0.9, "a": 0.8]), topK: 2, minCount: 1)
+        XCTAssertEqual(ids(out), ["a", "d"])        // selected {a,d} returned in input order, not score order
+    }
+
+    func testSimilarityTiesBreakByOriginalOrder() {
+        let cands = (0..<5).map { candidate("s\($0)") }
+        // All equal similarity; topK=2 → the first two in original order win the tie-break.
+        let out = SkillRetriever.select(turn: "go", candidates: cands,
+                                        similarity: { _ in 0.5 }, topK: 2, minCount: 1)
+        XCTAssertEqual(ids(out), ["s0", "s1"])
+    }
+}

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -183,11 +183,12 @@ prompt-injection edge behind a default-off flag. 📋 Planned.
 
 | Plan | Title | Effort | Reuses | Strategic fit |
 |---|---|---|---|---|
-| [Typed Memory Taxonomy](memory-taxonomy.md) | Type memories as preference / project / episodic / semantic; recall each kind on its own terms (preferences always, project while active, semantic by relevance, episodic by recency) | ~3–4 days | BrainStore (`ingest`, `brain.sqlite`), Embedder, FieldSessionService, LLMService prompt builder | Closes the "no typed long-term memory" gap — the assistant remembers *how you like things done* and *what you're mid-way through*, not just facts that happen to match. Pairs with Visual State Memory (episodic) + Embedding Upgrade (semantic). |
+| [Typed Memory Taxonomy](memory-taxonomy.md) | **Re-scoped after a code audit** — most of the taxonomy already exists (`SemanticMemoryStore` facts + relevance retrieval + diary/episodic; `UserMemoryStore` preferences). Now targets only the real gaps: **project-scoped memory** (active-job context) + **relevance retrieval for `UserMemoryStore`** (it still dumps-all) | ~2–3 days | BrainStore (`brain.sqlite`), Embedder, FieldSessionService, SemanticMemoryStore (pattern to mirror) | Holds "what you're mid-way through" as a scoped context and stops the JSON fact store bloating every prompt — without duplicating the stores that already work. |
 
 **Related (folded into Round 10):** embedding-based **skill retrieval** lives in the
 [Skill Self-Evolution](skill-self-evolution.md) plan — it rides the same `Embedder` seam and only earns
-its keep once evolution grows the skill bank.
+its keep once evolution grows the skill bank. 🚧 **Its core shipped first** (`feat/skill-retrieval`):
+`SkillRetriever` + `for turn:` store overloads + default-off `skillRetrieval*` flags.
 
 **Suggested sequence:** independent of Round 10; can land any time. If sequencing with Round 10, do the
 [Embedding Quality Upgrade](embedding-quality-upgrade.md) first so both the taxonomy's semantic recall

--- a/docs/plans/memory-taxonomy.md
+++ b/docs/plans/memory-taxonomy.md
@@ -1,185 +1,147 @@
-# Plan — Typed Memory Taxonomy (episodic / semantic / preference / project recall)
+# Plan — Typed Memory Taxonomy (project-scoped recall + relevance over the existing stores)
 
-**Status:** 📋 Planned (not built). A typed layer over the existing on-device memory stores that adds
-the two memory kinds we don't model today — **preferences** and **project state** — and a
-*differentiated* recall policy so the right kind of memory reaches the prompt for the right reason.
-The classifier, the retrieval policy, and the store round-trip are pure and headless-testable;
-embedding similarity rides the existing `Embedder`. **Zero LLM calls** (pattern-based classification,
-mirroring `BrainRelationExtractor`'s precision-over-recall posture). No new SPM dependency. Strictly
-on-device, never synced to the gateway — same posture as `BrainStore`.
+**Status:** 📋 Planned (not built). **Re-scoped after auditing the code** — most of what an earlier
+draft proposed already exists, so this plan now targets only the genuine gaps. The classifier and the
+selection logic are pure and headless-testable; the wiring into the prompt builder is the live edge.
+**Zero LLM calls** (pattern-based, precision-over-recall, mirroring `BrainRelationExtractor`). No new
+SPM dependency. Strictly on-device.
 
-## The problem
-OpenGlasses already has three memory substrates, but each answers only one shape of question:
-- **`BrainStore`** (`brain.sqlite`) — a relational graph: entities, typed edges ("Alice works_at
-  Acme"), person **encounters**, and follow-up **needs**. Great for "who works at Acme?".
-- **`SemanticMemoryStore`** — flat facts retrieved by vector similarity ("what facts resemble this?").
-- **`DocumentStore`** — passages from loaded files.
+## What already exists (and why the original plan shrank)
+An audit of the memory subsystem found three of the four "kinds" already modelled, plus the
+relevance-retrieval mechanism the first draft proposed to build:
 
-What none of them models is the **kind** of a memory, and two kinds in particular are simply absent:
-- **Preferences** — "I prefer metric units", "always read me the urgent line first", "I take my
-  coffee black". Durable, low-volume, and they should bias *every* turn — but today they'd land as an
-  undifferentiated fact (if at all) and only surface when a query happens to resemble them.
-- **Project state** — "I'm mid-way through the walk-in cooler job at Site 7; compressor swap is next".
-  Ongoing, scoped to an active context, and should clear/yield when the user switches projects.
+- **`SemanticMemoryStore`** (SQLite + embeddings) already holds key→value **facts** with vectors, and
+  `systemPromptContext(query:)` **already relevance-filters** them via `semanticSearch` (top-8 by
+  cosine) — exactly the "differentiated recall" idea. It also has an **agent diary**
+  (`writeDiary` / `relevantDiary(for:)`) which *is* episodic memory, already retrieved by relevance.
+- **`UserMemoryStore`** (JSON) holds the same key→value **facts/preferences**, LLM-managed via
+  `[REMEMBER: key = value]` — but **dumps all of them** into every prompt (char-budgeted, sorted by
+  key); it has **no** relevance retrieval.
+- **`BrainStore`** (graph) holds typed relations, encounters, and needs.
 
-Without a kind dimension, recall is one-size-fits-all: everything competes in the same vector top-k.
-Preferences get out-ranked by a topically-closer fact; project state isn't pinned while a job is
-active; episodic events ("what did I do this morning") aren't retrievable by recency. The fix isn't a
-bigger model — it's **typing** the memory and recalling each kind on its own terms.
+So against the four kinds an earlier draft wanted to introduce:
+
+| Kind | Reality |
+|---|---|
+| **semantic** facts | ✅ already modelled (both stores) |
+| **episodic** | ✅ already exists (the diary, relevance-retrieved) |
+| **preference** | ✅ already captured as facts (LLM-tagged) |
+| **project state (active-scoped)** | ❌ **genuinely missing** — the gap this plan fills |
+
+A standalone `TypedMemoryStore` would therefore largely **duplicate `SemanticMemoryStore`**. Dropped.
+What's actually missing is narrow and concrete.
+
+## The two real gaps
+1. **Project-scoped memory.** Nothing models "what I'm in the middle of" as a first-class, *active-job*
+   memory that's injected while a project is active and yields when it changes. Facts are durable and
+   global; project state is transient and scoped. A field tech mid-way through a walk-in cooler job at
+   Site 7 should have "compressor swap is next" surface while that job is open — and stop competing for
+   prompt space once it's done.
+2. **`UserMemoryStore` still dumps everything.** `SemanticMemoryStore` already retrieves by relevance;
+   `UserMemoryStore.systemPromptContext()` does not. As the user accumulates facts (up to the 3000-char
+   budget), every prompt carries all of them. This is the same bloat the
+   [skill retrieval](skill-self-evolution.md) companion fixes for skills — and the fix is the same
+   shape (embed the turn, keep the relevant, always-keep the cheap/durable ones).
 
 ## What we build
-A typed memory record with a deterministic classifier, a differentiated retrieval policy, and a
-formatter that assembles the per-turn memory block:
+### Gap 1 — Project-scoped memory (pure core + thin store extension)
+- **`ProjectMemory`** — `{ id, projectTag, text, createdAt }`. A note scoped to a project/job.
+- **`ProjectMemoryScope`** (pure) — given `(records, activeProject)` returns the records eligible for
+  injection: those whose `projectTag` matches the active project (and none when no project is active).
+  Pure, trivially tested.
+- **`ProjectMemoryFormatter`** (pure) — eligible records → a `# Current project` block. Empty → "".
+- Persistence rides `BrainStore`'s `brain.sqlite` (one un-synced on-device DB) via a small
+  `project_memory` table — no new store class, no new file, no gateway exposure.
+- **Active project** comes from `FieldSessionService` (an active job session); when none is active the
+  block is empty. An explicit "I'm working on X" can seed a record via the classifier (below).
 
-1. **Classify** incoming text (the same text `BrainStore.ingest` already sees) into one of four kinds —
-   `preference`, `project`, `episodic`, `semantic` — by pattern, no LLM.
-2. **Store** it as a typed `MemoryRecord` with salience + timestamps, alongside (not replacing) the
-   graph edges the brain already extracts.
-3. **Recall** per-kind when building the prompt: **always** inject preferences (capped), inject the
-   **active project's** state, inject the top-k **semantic** facts by embedding similarity to the
-   turn, and the most **recent episodic** events — each with its own budget.
-4. **Decay/scope**: episodic ages out; preferences persist; project state is scoped to a project tag
-   and yields when the active project changes.
+### Gap 2 — Relevance retrieval for `UserMemoryStore`
+- Bring `UserMemoryStore` up to the behaviour `SemanticMemoryStore` already has: a `for turn:`
+  overload on `systemPromptContext` that, when `Config.userMemoryRetrievalEnabled` is on and the set is
+  past a floor, injects only the facts relevant to the turn (embedding similarity over `key + value`),
+  always keeping the shortest/most-durable few. Reuses the same `Embedder` seam and the same
+  selection shape as `SkillRetriever` — consider a shared pure ranker so memory and skills don't carry
+  two copies of the logic.
+- Default **off**; below the floor it dumps all (today's behaviour, unchanged).
 
-### The deterministic core (pure, tested)
-- **`MemoryRecord`** — `{ id, kind, text, subject?, projectTag?, salience, createdAt, lastAccessedAt }`.
-  `kind ∈ {preference, project, episodic, semantic}`. Pure value type.
-- **`MemoryClassifier`** — `classify(_ text:) -> MemoryKind` by cue patterns:
-  - *preference*: first-person durable cues — "I prefer/like/want/always/never/usually", "call me…",
-    "use … units".
-  - *project*: progress/state cues tied to work — "working on", "mid-way", "next step is", "still need
-    to", "on the … job", an active `FieldSessionService` job in scope.
-  - *episodic*: a past event with a time/place — past-tense + temporal marker ("this morning",
-    "yesterday", "at the…"), or a logged encounter.
-  - *semantic*: the default (a durable fact) when nothing else fires.
-  Precision over recall: an unclear line falls to `semantic` (the safe, already-handled bucket).
-- **`MemoryRetrievalPolicy`** — pure ranking. Given `(query, candidates, similarity, budgets, now,
-  activeProject)` returns the selected records: all `preference` up to `maxPreferences`; `project`
-  records for `activeProject`; top-`k` `semantic` by injected cosine similarity; most-recent
-  `episodic` within a recency window. Stable ordering; time + similarity injected so it's
-  deterministic.
-- **`MemoryContextBuilder`** — pure formatter: selected records → a `# What I remember` block with
-  per-kind subheadings (`Preferences`, `Current project`, `Relevant facts`, `Recently`). Empty input
-  → "".
-
-## How it flows (live edge)
-1. `BrainStore.ingest(text:)` already runs on new memory text. A parallel call hands the **same text**
-   to `MemoryClassifier` → a `MemoryRecord` is stored in `TypedMemoryStore`. (The graph edges and the
-   typed record are complementary, not either/or.)
-2. When `LLMService` assembles the system prompt, a new `TypedMemoryStore.promptContext(for: turn)`
-   runs `MemoryRetrievalPolicy` over the candidates (embedding the turn via `Embedder`) and
-   `MemoryContextBuilder` formats the result — injected alongside the existing social/vault/skill
-   blocks.
-3. `lastAccessedAt` is bumped on inject so a salience/decay pass can favour what actually gets used.
-4. Active project comes from `FieldSessionService` (a job session) or an explicit "I'm working on X"
-   classified as `project`; switching projects scopes which `project` records are eligible.
+### Optional glue — a lightweight kind tag (only if it earns its keep)
+- **`MemoryClassifier`** (pure, zero LLM) — `classify(_ text:) -> MemoryKind` where
+  `MemoryKind ∈ {preference, project, episodic, semantic}`, used **only** to route an incoming memory:
+  a `project` cue seeds a `ProjectMemory`; an `episodic` cue could seed the diary; everything else stays
+  a fact. This is routing, not a new store — it adds the *one* dimension the stores don't have, without
+  duplicating them. Build it only if Gap 1's seeding needs it; otherwise the `FieldSessionService`
+  signal is enough.
 
 ## Scope
 In:
-- `Sources/Services/Brain/MemoryRecord.swift`, `MemoryClassifier.swift`, `MemoryRetrievalPolicy.swift`,
-  `MemoryContextBuilder.swift` (pure core).
-- `Sources/Services/Brain/TypedMemoryStore.swift` — SQLite persistence (a `memory_records` table; reuse
-  `brain.sqlite` so it stays one on-device, un-synced DB), `add`, `records(kind:)`,
-  `promptContext(for:)`, salience bump, decay sweep.
-- `BrainStore.ingest` — add the parallel classify-and-store call (cheap, additive).
-- `LLMService` system-prompt builder — inject the typed-memory block (behind a flag; default off
-  reproduces today's behaviour exactly).
-- `Config` — `typedMemoryEnabled` (default off), `memoryMaxPreferences`, `memorySemanticTopK`,
-  `memoryEpisodicWindow`.
+- `Sources/Services/Brain/ProjectMemory.swift`, `ProjectMemoryScope.swift`,
+  `ProjectMemoryFormatter.swift` (pure core) + a `project_memory` table in `BrainStore`.
+- `UserMemoryStore.systemPromptContext(for turn:)` relevance overload + `Config.userMemoryRetrievalEnabled`.
+- `(optional)` `Sources/Services/Brain/MemoryClassifier.swift` for routing only.
+- Prompt wiring: inject the project block (when a job is active) and pass the turn to
+  `UserMemoryStore`, behind default-off flags so today's prompt is reproduced exactly.
 
 Out (deferred):
-- An LLM-based classifier or summariser — start pattern-based; the heuristic is the testable core, and
-  an LLM pass can refine kinds later if the signal warrants it (surfaces in the
-  [cost tracker](llm-cost-usage-tracker.md)).
-- Cross-device sync of typed memory — local-first, like the brain; rides the existing export/import
-  later.
-- Migrating `SemanticMemoryStore`'s existing flat facts into typed records — new memories are typed
-  going forward; a back-fill is a separate follow-up.
-- A user-facing memory editor (review/forget by kind) — read path first; a "Memory" surface in
-  Settings is a fast follow once the kinds prove useful.
+- A standalone `TypedMemoryStore` — **explicitly not building**; it duplicates `SemanticMemoryStore`.
+- Re-typing existing facts/diary entries — new memories route going forward; no back-fill.
+- Consolidating `UserMemoryStore` and `SemanticMemoryStore` into one — they coexist today; unifying
+  them is its own plan, not a prerequisite here.
+- A user-facing memory editor by kind — read path first.
 
 ## Architecture — the seam
 ```swift
-enum MemoryKind: String, Codable { case preference, project, episodic, semantic }
-
-struct MemoryRecord: Identifiable, Equatable {
-    let id: UUID
-    let kind: MemoryKind
-    let text: String
-    let subject: String?        // person/org the memory is about, if any
-    let projectTag: String?     // scopes `project` records to an active job
-    let salience: Double
-    let createdAt: Date
-    var lastAccessedAt: Date
+struct ProjectMemory: Identifiable, Equatable {
+    let id: UUID; let projectTag: String; let text: String; let createdAt: Date
 }
 
-enum MemoryClassifier {                                   // pure; zero LLM
-    static func classify(_ text: String) -> MemoryKind    // defaults to .semantic
+enum ProjectMemoryScope {                              // pure
+    static func eligible(_ records: [ProjectMemory], activeProject: String?) -> [ProjectMemory]
+}
+enum ProjectMemoryFormatter {                          // pure
+    static func block(_ records: [ProjectMemory]) -> String   // "# Current project…" or ""
 }
 
-enum MemoryRetrievalPolicy {                              // pure; similarity + now injected
-    static func select(query: String,
-                       candidates: [MemoryRecord],
-                       similarity: (String) -> Float,     // turn↔record cosine, via Embedder
-                       activeProject: String?,
-                       now: Date,
-                       maxPreferences: Int, semanticTopK: Int, episodicWindow: TimeInterval)
-        -> [MemoryRecord]
-}
-
-enum MemoryContextBuilder {                               // pure formatter
-    static func block(_ records: [MemoryRecord], now: Date) -> String   // "# What I remember…"
-}
+// Gap 2 reuses the SkillRetriever-shaped selection (similarity injected) over user-memory facts,
+// ideally via one shared pure ranker rather than a second copy.
 ```
-`TypedMemoryStore` owns the SQLite table and is the only piece that touches I/O or the `Embedder`; the
-decisions that matter — what kind a memory is, which records to recall, how to present them — are pure
-and fully tested. With `typedMemoryEnabled == false`, the prompt is assembled exactly as today.
+The decisions that matter — which project records are eligible, which facts are relevant — are pure and
+tested; the only live edge is reading the active job and embedding the turn. With both flags off, the
+prompt is assembled exactly as today.
 
 ## Build order
-1. **Pure core + tests** — `MemoryClassifier`, `MemoryRetrievalPolicy`, `MemoryContextBuilder`. Fully
-   deterministic; no store, no embedding model.
-2. **`TypedMemoryStore`** — `memory_records` table in `brain.sqlite` + round-trip / query-by-kind /
-   decay-sweep tests.
-3. **Ingest hook** — classify-and-store alongside `BrainStore.ingest` (additive, cheap).
-4. **Prompt injection** — `promptContext(for:)` wired into `LLMService` behind `typedMemoryEnabled`;
-   embedding the turn via the existing `Embedder`.
-5. **(Fast follow)** salience/decay tuning + an optional Settings "Memory" review surface.
+1. **Pure core + tests** — `ProjectMemoryScope`, `ProjectMemoryFormatter` (and `MemoryClassifier` only
+   if needed). Deterministic; no store, no model.
+2. **`project_memory` table** in `BrainStore` + round-trip / scoping tests.
+3. **Project block wiring** — inject when `FieldSessionService` has an active job, behind a flag.
+4. **`UserMemoryStore` relevance overload** — mirror `SemanticMemoryStore`; ideally factor the ranker
+   shared with `SkillRetriever`.
 
 ## Tests
-- `MemoryClassifier`: preference cues → `.preference`; project/progress cues → `.project`;
-  past-tense + temporal marker → `.episodic`; an ordinary fact → `.semantic`; ambiguous → `.semantic`
-  (never a confident wrong kind).
-- `MemoryRetrievalPolicy.select`: all preferences included up to the cap; only the active project's
-  `project` records pass; semantic results are the top-k by injected similarity; episodic respects the
-  recency window and drops older; stable ordering; empty candidates → empty.
-- `MemoryContextBuilder.block`: empty → ""; per-kind subheadings appear only when that kind has
-  records; relative "Recently" labels computed from injected `now`.
-- `TypedMemoryStore`: add/query-by-kind round-trips; `lastAccessedAt` bumps on recall; decay sweep
-  drops aged episodic but never preferences; project scoping.
+- `ProjectMemoryScope.eligible`: only the active project's records pass; no active project → empty;
+  multiple projects don't bleed.
+- `ProjectMemoryFormatter.block`: empty → ""; formats eligible records under one heading.
+- `UserMemoryStore` retrieval: below floor → all (unchanged); above floor → relevant subset + always
+  the shortest/durable few; empty turn → all.
+- `(if built)` `MemoryClassifier`: project cue → `.project`; preference cue → `.preference`; ambiguous
+  → `.semantic` (never a confident wrong kind).
 
 ## Open questions / decisions needed
-- **Reuse vs. new store** — put `memory_records` in `brain.sqlite` (one un-synced on-device DB, my
-  default) or alongside `SemanticMemoryStore`? Reusing the brain DB keeps the "never synced to the
-  gateway" guarantee in one place.
-- **Classifier reach** — how aggressive the preference/project cues should be. Start narrow
-  (high-precision first-person cues) so the always-injected `preference` bucket can't fill with noise;
-  widen only once the signal proves clean, exactly as `BrainRelationExtractor` was tuned.
-- **Budget split** — how many of each kind to inject before the block competes with the rest of the
-  system prompt. Preferences are few and cheap to always include; semantic top-k and episodic window
-  are the tunable knobs.
-- **Active-project source** — derive solely from `FieldSessionService`, or also from an explicit
-  "I'm working on X" the classifier tags `project`? Probably both, with the session taking precedence.
-- **Decay curve** — does episodic age purely by time, or by time × inverse-access? Keep it simple
-  (time window) first; add access-weighting only if recall feels stale.
+- **Shared ranker.** Gap 2 and `SkillRetriever` want the same "keep exact/durable + top-K by injected
+  similarity" logic. Factor one pure ranker both call, or keep them separate for clarity? Leaning
+  shared, since divergence is the real risk.
+- **Project lifecycle.** Does a project's memory delete on job close, or persist (archived) for "what
+  did I do on the Site 7 job"? Probably archive-not-delete, with only the *active* job injected.
+- **Classifier necessity.** If `FieldSessionService` already names the active job, project seeding may
+  not need a text classifier at all — prefer the explicit signal; add the classifier only if free-text
+  "I'm working on X" capture proves worth it.
+- **Two fact stores.** `UserMemoryStore` (JSON, dump-all) and `SemanticMemoryStore` (SQLite, retrieval)
+  overlap. This plan only teaches the former to retrieve; whether they should merge is a separate call.
 
 ## Why this matters
-It closes the one real gap surfaced by surveying adjacent agent-memory work: the assistant has a graph
-and a vector index but **no typed long-term memory** — so it can't reliably remember *how you like
-things done* or *what you're in the middle of*. Typing the memory and recalling each kind on its own
-terms (preferences always, project while active, semantic by relevance, episodic by recency) is what
-turns "facts that happen to match" into memory that behaves the way a person's would. The hard parts —
-classification, differentiated recall, presentation — land as a pure, fully-tested core with zero LLM
-calls; the only live edge is wiring the block into the prompt behind a default-off flag. Pairs
-naturally with [Visual State Memory](visual-state-memory.md) (its aged keyframe descriptions become
-`episodic` records) and the [Embedding Quality Upgrade](embedding-quality-upgrade.md) (sharper
-semantic recall through the same `Embedder` seam).
+The audit turned a big speculative feature into a small, honest one: the assistant already remembers
+facts, preferences, and past events with relevance — what it *can't* do is hold "what you're in the
+middle of" as a scoped, active context, and its JSON fact store still bloats every prompt. Both gaps
+are real, both land as pure tested cores over stores that already exist, and neither duplicates working
+infrastructure. Pairs with [Visual State Memory](visual-state-memory.md) (aged keyframe descriptions →
+diary/episodic) and the [Embedding Quality Upgrade](embedding-quality-upgrade.md) (sharper similarity
+through the same `Embedder` seam that both gaps use).

--- a/docs/plans/skill-self-evolution.md
+++ b/docs/plans/skill-self-evolution.md
@@ -114,6 +114,12 @@ the decisions that matter (when to evolve, is it a dup, is it well-formed) are p
 
 ## Companion: embedding-based skill retrieval
 
+**Status: 🚧 core shipped on `feat/skill-retrieval` (ahead of the rest of this plan).** The pure
+`SkillRetriever` + `SkillCandidate`, `for turn:` overloads on both skill stores, the three
+`Config.skillRetrieval*` flags (default off), and the `turn`-threading into `LLMService` are built and
+tested. The evolution loop above is still 📋 Planned; retrieval shipped first because it stands alone
+and fixes a bloat issue that exists today.
+
 Evolution has a tail problem. Every approved skill is injected into **every** system prompt, because
 both skill stores dump their whole library unconditionally today:
 - `VoiceSkillStore.promptContext()` emits a `LEARNED SKILLS` block listing *all* voice skills.


### PR DESCRIPTION
## What

Both skill stores dump their **entire** library into every system prompt today (`VoiceSkillStore.promptContext` / `InstalledSkillStore.promptContext`). That's fine for a handful, but it bloats the prompt and dilutes attention as the bank grows — most relevantly once Skill Self-Evolution starts adding skills.

This adds a pure `SkillRetriever` that injects only the skills relevant to the current turn:

- **Never drop an exact trigger match** — a skill whose `trigger` appears in the turn is always kept (preserves today's exact-trigger behaviour).
- **Fill the rest by relevance** — remaining budget up to `topK` goes to the highest embedding-similarity candidates. Similarity is **injected**, so the ranking is fully testable without a model.
- **No-op below a floor** — under `minCount` candidates, or with an empty turn, it returns everything: today's dump-all behaviour, unchanged.

## Changes

- `SkillRetriever` + `SkillCandidate` — pure core (`Sources/Services/Skills/`)
- `for turn:` overloads on `VoiceSkillStore` (ranks on trigger+instruction) and `InstalledSkillStore` (ranks on name+description; the body is the full SKILL.md, so trimming the *set* is the big token win) via the existing `Embedder`
- `turn` threaded through `LLMService.buildSystemPrompt` and passed at both call sites
- `Config.skillRetrieval{Enabled,TopK,MinCount}` — **`Enabled` defaults to `false`**, so behaviour is byte-identical until switched on

## Safety / behaviour

Default-off flag; zero behaviour change until enabled. The exact-trigger guarantee is preserved even past the budget.

## Tests

- `SkillRetrieverTests` — 13 cases (floor no-op, empty turn/candidates, exact-trigger keep incl. case-insensitive + blank-trigger guard + beyond-budget, top-K selection, budget accounting, stable ordering, tie-breaks)
- Full suite green: **1216 tests, 0 failures** (Debug)

## Docs

Revises the plan docs to on-disk reality: re-scopes the memory-taxonomy plan (most of it already exists in `SemanticMemoryStore` / `UserMemoryStore`) to the genuine gaps, and marks this retrieval core shipped under Skill Self-Evolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)