### PR TITLE
Fix Xcode Cloud: install XcodeGen from GitHub release, not Homebrew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ Config/Info/Info.personal.plist
 xcuserdata/
 *.xcuserstate
 *.pbxproj.backup
+
+# Xcode Cloud post-clone tool downloads (XcodeGen release)
+.ci-tools/

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -11,13 +11,39 @@ cd "${CI_PRIMARY_REPOSITORY_PATH:-$(dirname "$0")/..}"
 defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
 defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
 
-if ! command -v xcodegen >/dev/null 2>&1 && command -v brew >/dev/null 2>&1; then
-  brew install xcodegen
-fi
+# --- XcodeGen (no Homebrew) -------------------------------------------------
+# Xcode Cloud's network can't resolve ghcr.io — Homebrew's bottle + portable-ruby host. So
+# `brew install xcodegen` dies inside Homebrew auto-update with
+#   curl: (6) Could not resolve host: ghcr.io
+# which (under `set -e`) aborts this whole script. Install XcodeGen from its GitHub *release*
+# instead: github.com is reachable (the repo was just cloned from it), and the release archive is
+# self-contained (`xcodegen/bin/xcodegen` + `share/`).
+#
+# When bumping, keep this in step with the version developers use locally.
+XCODEGEN_VERSION="2.45.4"
+
 if ! command -v xcodegen >/dev/null 2>&1; then
-  echo "xcodegen required to generate OpenGlasses.xcodeproj" >&2
+  echo "ci_post_clone: installing XcodeGen ${XCODEGEN_VERSION} from the GitHub release…"
+  tools_dir="$PWD/.ci-tools/xcodegen-${XCODEGEN_VERSION}"
+  rm -rf "$tools_dir"
+  mkdir -p "$tools_dir"
+  curl -fsSL "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip" \
+    -o "$tools_dir/xcodegen.zip"
+  unzip -oq "$tools_dir/xcodegen.zip" -d "$tools_dir"
+  xcodegen_bin="$(find "$tools_dir" -type f -name xcodegen -path '*/bin/*' | head -n 1)"
+  if [ -n "$xcodegen_bin" ]; then
+    chmod +x "$xcodegen_bin"
+    PATH="$(dirname "$xcodegen_bin"):$PATH"
+    export PATH
+  fi
+fi
+
+if ! command -v xcodegen >/dev/null 2>&1; then
+  echo "ci_post_clone: xcodegen unavailable after GitHub-release install" >&2
   exit 1
 fi
+echo "ci_post_clone: $(xcodegen --version 2>&1 | head -n 1)"
+
 ./Scripts/generate-xcodeproj.sh
 
 # Xcode Cloud requires a committed Package.resolved and will NOT resolve packages
@@ -31,3 +57,4 @@ fi
 RESOLVED_DST="OpenGlasses.xcodeproj/project.xcworkspace/xcshareddata/swiftpm"
 mkdir -p "$RESOLVED_DST"
 cp ci_scripts/Package.resolved "$RESOLVED_DST/Package.resolved"
+echo "ci_post_clone: complete"


### PR DESCRIPTION
## The failure

Xcode Cloud's **Archive – iOS** failed in `ci_post_clone.sh`. The real cause (from the CI log):

```
==> Auto-updating Homebrew...
==> Downloading https://ghcr.io/v2/homebrew/core/portable-ruby/blobs/...
curl: (6) Could not resolve host: ghcr.io
Error: Failed to upgrade Homebrew Portable Ruby!
Command exited with non-zero exit-code: 1
```

`brew install xcodegen` triggers Homebrew **auto-update**, which fetches portable-ruby from **`ghcr.io`** — and Xcode Cloud's sandbox **can't resolve `ghcr.io`**. Under `set -e`, that non-zero aborts the whole post-clone script. (Homebrew *bottles* also live on ghcr.io, so even disabling auto-update wouldn't reliably fix it.)

## The fix

Stop using Homebrew for XcodeGen. Download the **XcodeGen GitHub release** (`github.com` is reachable — the repo was just cloned from it) and put its self-contained `xcodegen/bin/xcodegen` on `PATH`. Pinned to **2.45.4**; runtime download dir (`.ci-tools/`) is gitignored.

## Verified locally

- `sh -n` syntax check passes.
- **Fallback path** (xcodegen hidden from `PATH`): downloads, extracts, `xcodegen --version` → 2.45.4.
- **Full script** happy path: generates the project and copies `Package.resolved`, exits 0.

No app code touched. Once merged, re-run the Xcode Cloud build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)