### PR TITLE
Frame-gate tuning + model-pricing editor Settings (Plan AT / AU follow-ups)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -931,6 +931,9 @@ class AppState: ObservableObject, AppStateProtocol {
         // Health-Safety Advisor (Plan AB) — grounded long-tail reasoning for "is this safe for me?".
         HealthSafetyAdvisor.shared.llm = llmService
 
+        // Apply any saved LLM pricing overrides into the live table (Plan AU editor).
+        Config.applyModelPricingOverrides()
+
         // Projects (Plan AN) — grounds the prompt in the active project's documents.
         ProjectContextService.shared.configure(
             documentStore: documentStore,

--- a/OpenGlasses/Sources/App/Views/InsightsView.swift
+++ b/OpenGlasses/Sources/App/Views/InsightsView.swift
@@ -69,6 +69,11 @@ struct InsightsView: View {
                         }
                     }
                     row("Estimated total", Self.costLabel(usage.totalUSD))
+                    NavigationLink {
+                        ModelPricingEditorView()
+                    } label: {
+                        Label("Edit model pricing", systemImage: "slider.horizontal.3")
+                    }
                 } header: {
                     Text("Tokens & estimated cost")
                 } footer: {

--- a/OpenGlasses/Sources/App/Views/LiveVisionSettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/LiveVisionSettingsView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Advanced controls for the Content-Aware Frame Gate (Plan AT). Lets a power user
+/// turn on dropping near-duplicate camera frames before the live LLM and tune the
+/// similarity threshold + heartbeat without a rebuild. Off by default.
+struct LiveVisionSettingsView: View {
+    @State private var enabled = Config.frameDedupEnabled
+    @State private var threshold = Double(Config.frameDedupHammingThreshold)
+    @State private var heartbeat = Config.frameDedupHeartbeatSeconds
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Drop near-duplicate frames", isOn: $enabled)
+                    .onChange(of: enabled) { _, v in Config.setFrameDedupEnabled(v) }
+            } footer: {
+                Text("When on, the glasses stop sending the live AI a new frame while the scene hasn't visibly changed — saving bandwidth and tokens. Distinct views still flow.")
+            }
+
+            if enabled {
+                Section {
+                    VStack(alignment: .leading) {
+                        HStack {
+                            Text("Similarity threshold")
+                            Spacer()
+                            Text("\(Int(threshold))").foregroundStyle(.secondary)
+                        }
+                        Slider(value: $threshold, in: 1...12, step: 1)
+                            .onChange(of: threshold) { _, v in Config.setFrameDedupHammingThreshold(Int(v)) }
+                    }
+                    Stepper("Heartbeat: \(Int(heartbeat))s", value: $heartbeat, in: 5...30, step: 1)
+                        .onChange(of: heartbeat) { _, v in Config.setFrameDedupHeartbeatSeconds(v) }
+                } header: {
+                    Text("Tuning")
+                } footer: {
+                    Text("Higher threshold drops more (treats more frames as \"the same scene\"). Heartbeat forces a fresh frame through after this many seconds even if nothing changed, so the AI's view can't go stale. Defaults: 4 and 12s.")
+                }
+            }
+        }
+        .navigationTitle("Live Vision")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/OpenGlasses/Sources/App/Views/ModelPricingEditorView.swift
+++ b/OpenGlasses/Sources/App/Views/ModelPricingEditorView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// Editor for the LLM cost table (Plan AU). Lets the user correct or add per-model
+/// prices (USD per 1M tokens) when the bundled defaults drift, overriding
+/// `ModelPricing` without a rebuild. Local-only; feeds the Insights cost section.
+struct ModelPricingEditorView: View {
+    /// Rows: every bundled family (sorted) so prices are visible and editable.
+    @State private var rows: [Row] = []
+    @State private var saved = false
+
+    private struct Row: Identifiable {
+        let model: String
+        var input: String
+        var output: String
+        var id: String { model }
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                ForEach($rows) { $row in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(row.model).font(.subheadline)
+                        HStack {
+                            rateField("In / 1M", text: $row.input)
+                            rateField("Out / 1M", text: $row.output)
+                        }
+                    }
+                }
+            } header: {
+                Text("USD per 1M tokens")
+            } footer: {
+                Text("Override the bundled prices when they drift. Blank a field to fall back to the default. Estimates are local-only and never leave your device.")
+            }
+
+            Section {
+                Button {
+                    save()
+                } label: {
+                    Label(saved ? "Saved" : "Save prices", systemImage: saved ? "checkmark.circle.fill" : "square.and.arrow.down")
+                }
+                Button(role: .destructive) {
+                    Config.setModelPricingOverrides([:])
+                    load()
+                    saved = false
+                } label: {
+                    Label("Reset to defaults", systemImage: "arrow.uturn.backward")
+                }
+            }
+        }
+        .navigationTitle("Model Pricing")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear(perform: load)
+    }
+
+    private func rateField(_ title: String, text: Binding<String>) -> some View {
+        HStack(spacing: 4) {
+            Text("$")
+            TextField(title, text: text)
+                .keyboardType(.decimalPad)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    private func load() {
+        let overrides = Config.modelPricingOverrides
+        rows = ModelPricing.defaults
+            .merging(overrides) { _, o in o }
+            .sorted { $0.key < $1.key }
+            .map { Row(model: $0.key,
+                      input: trimmed($0.value.inputPer1M),
+                      output: trimmed($0.value.outputPer1M)) }
+    }
+
+    private func save() {
+        var overrides: [String: ModelPricing.Rate] = [:]
+        for row in rows {
+            guard let input = Double(row.input), let output = Double(row.output) else { continue }
+            let base = ModelPricing.defaults[row.model]
+            // Only store rows that differ from the bundled default.
+            if base?.inputPer1M != input || base?.outputPer1M != output {
+                overrides[row.model] = ModelPricing.Rate(input, output)
+            }
+        }
+        Config.setModelPricingOverrides(overrides)
+        saved = true
+    }
+
+    /// Compact number string (drops a trailing ".0").
+    private func trimmed(_ value: Double) -> String {
+        value == value.rounded() ? String(Int(value)) : String(value)
+    }
+}

--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -578,6 +578,12 @@ struct SettingsView: View {
                 } label: {
                     Label("Network Activity", systemImage: "antenna.radiowaves.left.and.right")
                 }
+
+                NavigationLink {
+                    LiveVisionSettingsView()
+                } label: {
+                    Label("Live Vision", systemImage: "camera.metering.matrix")
+                }
             } header: {
                 Text("Advanced")
             } footer: {

--- a/OpenGlasses/Sources/Services/Usage/ModelPricing.swift
+++ b/OpenGlasses/Sources/Services/Usage/ModelPricing.swift
@@ -8,7 +8,7 @@ import Foundation
 /// — the tracker reports tokens and omits the dollar figure rather than guessing.
 enum ModelPricing {
 
-    struct Rate: Equatable {
+    struct Rate: Equatable, Codable {
         let inputPer1M: Double
         let outputPer1M: Double
         init(_ inputPer1M: Double, _ outputPer1M: Double) {

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -2532,6 +2532,29 @@ struct Config {
         UserDefaults.standard.set(enabled, forKey: "contextualEmbeddingEnabled")
     }
 
+    // MARK: - Model pricing overrides (Plan AU — Settings editor)
+
+    /// User edits to the bundled `ModelPricing` table (USD per 1M tokens), keyed by
+    /// the same model-id prefixes. Persisted locally; applied over the defaults.
+    static var modelPricingOverrides: [String: ModelPricing.Rate] {
+        guard let data = UserDefaults.standard.data(forKey: "modelPricingOverrides"),
+              let dict = try? JSONDecoder().decode([String: ModelPricing.Rate].self, from: data) else { return [:] }
+        return dict
+    }
+
+    /// Persist the overrides and apply them to the live `ModelPricing` table.
+    static func setModelPricingOverrides(_ overrides: [String: ModelPricing.Rate]) {
+        if let data = try? JSONEncoder().encode(overrides) {
+            UserDefaults.standard.set(data, forKey: "modelPricingOverrides")
+        }
+        ModelPricing.overrides = overrides
+    }
+
+    /// Load persisted pricing overrides into `ModelPricing` (call once at launch).
+    static func applyModelPricingOverrides() {
+        ModelPricing.overrides = modelPricingOverrides
+    }
+
     // MARK: - Content-Aware Frame Gate (Plan AT)
 
     /// When `true`, `FrameThrottler` consults a perceptual-hash `FrameGate` after

--- a/OpenGlassesTests/ModelPricingOverridesTests.swift
+++ b/OpenGlassesTests/ModelPricingOverridesTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import OpenGlasses
+
+final class ModelPricingOverridesTests: XCTestCase {
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "modelPricingOverrides")
+        ModelPricing.overrides = [:]
+        super.tearDown()
+    }
+
+    func testRateCodableRoundTrip() throws {
+        let rate = ModelPricing.Rate(3.5, 14.25)
+        let data = try JSONEncoder().encode(rate)
+        XCTAssertEqual(try JSONDecoder().decode(ModelPricing.Rate.self, from: data), rate)
+    }
+
+    func testOverridesPersistAndApply() {
+        Config.setModelPricingOverrides(["gpt-4o": ModelPricing.Rate(99, 88)])
+        // Applied to the live table immediately…
+        XCTAssertEqual(ModelPricing.rate(for: "gpt-4o"), ModelPricing.Rate(99, 88))
+        // …and persisted for reload.
+        XCTAssertEqual(Config.modelPricingOverrides["gpt-4o"], ModelPricing.Rate(99, 88))
+
+        // Simulate a fresh launch: clear the in-memory table, re-apply from storage.
+        ModelPricing.overrides = [:]
+        Config.applyModelPricingOverrides()
+        XCTAssertEqual(ModelPricing.rate(for: "gpt-4o"), ModelPricing.Rate(99, 88))
+        // The override flows through to a cost estimate.
+        XCTAssertEqual(try XCTUnwrap(ModelPricing.estimate(model: "gpt-4o", tokensIn: 1_000_000, tokensOut: 0)), 99, accuracy: 1e-9)
+    }
+
+    func testEmptyOverridesResetToDefaults() {
+        Config.setModelPricingOverrides(["gpt-4o": ModelPricing.Rate(1, 1)])
+        Config.setModelPricingOverrides([:])
+        XCTAssertEqual(ModelPricing.rate(for: "gpt-4o"), ModelPricing.Rate(2.50, 10))  // bundled default
+        XCTAssertTrue(Config.modelPricingOverrides.isEmpty)
+    }
+}

--- a/docs/plans/consolidated-partials.md
+++ b/docs/plans/consolidated-partials.md
@@ -25,7 +25,7 @@ then strike it here.
 | Plan | Outstanding item | Notes |
 |---|---|---|
 | [AU](llm-cost-usage-tracker.md) | Streamed-Chat (`onToken`) + realtime-voice token capture | Thread usage out of the SSE reconstructors / realtime sessions; the non-streaming capture + pricing/rollup core shipped |
-| [AU](llm-cost-usage-tracker.md) | Settings pricing editor | Pure UI over the existing `ModelPricing.overrides` seam |
+| ~~[AU](llm-cost-usage-tracker.md)~~ | ~~Settings pricing editor~~ | ✅ Shipped — `ModelPricingEditorView` + persisted `Config.modelPricingOverrides` |
 | [AN](projects-scoped-contexts.md) | Shareable project export/import bundle | Persona + its scoped docs, reusing the Plan [Q](Q-vault-and-skills-library-management.md) vault export/import patterns |
 | [AB](health-safety-advisor.md) | Broader interaction-rubric coverage | More curated high-severity rules + tests; the pure rubric/grounding core shipped |
 | [AV](visual-state-memory.md) | Thumbnail injection (second flag) + BrainStore ingest of aged keyframes | Both ride the shipped ring-buffer/builder; text-only context ships today |
@@ -33,7 +33,7 @@ then strike it here.
 | [S](S-plan-then-execute-and-safety-supervisor.md) | Phase 2: LLM complexity classifier (vs keyword heuristic) + parallel-safe execution | Optional polish over the shipped supervisor/planner |
 | [O](O-document-rag.md) | Standalone `DocumentsView` (list / ingest-via-Files / delete) | Mirrors `VaultManagerView`; partially subsumed by AN's `ProjectDetailView`, a global view is still useful |
 | [AW](skill-self-evolution.md) | User-correction capture signal | An extra evolution trigger alongside the shipped tool-failure signal |
-| [AT](frame-dedup-change-gate.md) | Advanced-threshold Settings control | Trivial UI over the existing `Config.frameDedup*` flags (flipping the default *on* is device-gated → B) |
+| ~~[AT](frame-dedup-change-gate.md)~~ | ~~Advanced-threshold Settings control~~ | ✅ Shipped — `LiveVisionSettingsView` (toggle + threshold + heartbeat) under Settings → Advanced. Flipping the default *on* is still device-gated → B |
 | [AM](embedding-quality-upgrade.md) | Optional bundled MiniLM Core ML path | Gated on the `recall@k` benchmark showing a lift; the `EmbeddingBackend` seam is in place |
 | [AJ](additional-capabilities.md) | Declarative HUD widget board (#7) | Display Phase-5 concept; defer until X/Y are fully exercised and a concrete multi-widget use case exists |
 


### PR DESCRIPTION
Two small Settings surfaces from **Section A** of [consolidated-partials.md](docs/plans/consolidated-partials.md), batched per the agreed plan.

### Live Vision (Plan AT)
`LiveVisionSettingsView` under **Settings → Advanced** — a toggle for the content-aware frame gate plus a similarity-threshold slider and heartbeat stepper, over the existing `Config.frameDedup*` flags. Off by default; lets a power user turn on near-duplicate-frame dropping and tune it without a rebuild. (Flipping the *default* on is still device-gated.)

### Model pricing editor (Plan AU)
`ModelPricingEditorView`, reached from the **Insights → Tokens & estimated cost** section, edits per-model USD-per-1M-token rates. To make it persist:
- `ModelPricing.Rate` is now `Codable`.
- `Config.modelPricingOverrides` stores edits in UserDefaults and applies them to the live `ModelPricing` table; `Config.applyModelPricingOverrides()` reloads them at launch so corrected prices survive a relaunch.
- "Reset to defaults" clears the overrides.

### Tests
**16 green in Release** — 3 new `ModelPricingOverridesTests` (Rate Codable round-trip, persist→apply→reload, reset-to-defaults) + the unchanged 13 `UsageTrackerTests`. Full app compiles.

Strikes the two batched items off Section A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)