### PR TITLE
Project export / import bundle (Plan AN follow-up)

### DIFF
--- a/OpenGlasses/Sources/App/Views/PersonasView.swift
+++ b/OpenGlasses/Sources/App/Views/PersonasView.swift
@@ -7,6 +7,9 @@ struct PersonasView: View {
     @State private var editingPersona: Persona? = nil
     @State private var showAddSheet = false
     @State private var projectForDetail: Persona? = nil   // Plan AN — project detail surface
+    @State private var importingProject = false
+    @State private var importMessage: String?
+    @EnvironmentObject private var appState: AppState
 
     var body: some View {
         List {
@@ -85,13 +88,20 @@ struct PersonasView: View {
         .navigationTitle("Personas")
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
-                Button {
-                    showAddSheet = true
+                Menu {
+                    Button { showAddSheet = true } label: { Label("New persona", systemImage: "plus") }
+                    Button { importingProject = true } label: { Label("Import project…", systemImage: "square.and.arrow.down") }
                 } label: {
                     Image(systemName: "plus")
                 }
             }
         }
+        .fileImporter(isPresented: $importingProject, allowedContentTypes: [.json]) { result in
+            handleImport(result)
+        }
+        .alert("Project import", isPresented: .constant(importMessage != nil)) {
+            Button("OK") { importMessage = nil }
+        } message: { Text(importMessage ?? "") }
         .sheet(isPresented: $showAddSheet) {
             PersonaEditorView(persona: nil) { newPersona in
                 personas.append(newPersona)
@@ -121,6 +131,25 @@ struct PersonasView: View {
     private func deletePersona(_ persona: Persona) {
         personas.removeAll { $0.id == persona.id }
         Config.setSavedPersonas(personas)
+    }
+
+    private func handleImport(_ result: Result<URL, Error>) {
+        guard case let .success(url) = result else {
+            if case let .failure(error) = result { importMessage = error.localizedDescription }
+            return
+        }
+        let scoped = url.startAccessingSecurityScopedResource()
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+        do {
+            let bundle = try ProjectBundleCodec.decode(Data(contentsOf: url))
+            Task {
+                let imported = await ProjectExporter.importBundle(bundle, into: appState.documentStore)
+                personas = Config.savedPersonas
+                importMessage = "Imported \"\(imported.name)\" with \(bundle.documents.count) document\(bundle.documents.count == 1 ? "" : "s")."
+            }
+        } catch {
+            importMessage = error.localizedDescription
+        }
     }
 
     private func modelName(for modelId: String) -> String {

--- a/OpenGlasses/Sources/App/Views/Projects/ProjectDetailView.swift
+++ b/OpenGlasses/Sources/App/Views/Projects/ProjectDetailView.swift
@@ -9,6 +9,8 @@ struct ProjectDetailView: View {
     let project: Persona
 
     @Environment(\.dismiss) private var dismiss
+    @State private var shareItem: ShareItem?
+    @State private var exportError: String?
 
     private var documentStore: DocumentStore { appState.documentStore }
     private var store: ConversationStore { appState.conversationStore }
@@ -83,6 +85,31 @@ struct ProjectDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .navigationDestination(for: String.self) { id in
             ChatThreadView(threadId: id)
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    exportProject()
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                }
+                .accessibilityLabel("Export project")
+            }
+        }
+        .sheet(item: $shareItem) { item in
+            ShareSheet(items: item.items)
+        }
+        .alert("Export failed", isPresented: .constant(exportError != nil)) {
+            Button("OK") { exportError = nil }
+        } message: { Text(exportError ?? "") }
+    }
+
+    private func exportProject() {
+        do {
+            let url = try ProjectExporter.exportFile(persona: project, store: documentStore)
+            shareItem = ShareItem(items: [url])
+        } catch {
+            exportError = error.localizedDescription
         }
     }
 }

--- a/OpenGlasses/Sources/Services/Projects/ProjectBundle.swift
+++ b/OpenGlasses/Sources/Services/Projects/ProjectBundle.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// A portable snapshot of a Project (Plan AN) — a `Persona` plus its scoped documents'
+/// text — for export/import between devices. Pure `Codable`; the live read/write of the
+/// `DocumentStore` + persona list lives in `ProjectExporter`.
+struct ProjectBundle: Codable, Equatable {
+    /// Bumped if the on-disk shape changes; decode rejects unknown future versions.
+    static let currentVersion = 1
+
+    var version: Int
+    var persona: Persona
+    var documents: [BundledDocument]
+
+    init(persona: Persona, documents: [BundledDocument], version: Int = ProjectBundle.currentVersion) {
+        self.version = version
+        self.persona = persona
+        self.documents = documents
+    }
+
+    /// One document carried by value (name + type + full reconstructed text), so the
+    /// importer can re-ingest it into the new device's store.
+    struct BundledDocument: Codable, Equatable {
+        let name: String
+        let sourceType: String
+        let text: String
+    }
+}
+
+/// Pure JSON encode/decode for a `ProjectBundle` (Plan AN). Headless-testable round-trip;
+/// rejects a bundle from a newer schema version rather than silently mis-importing.
+enum ProjectBundleCodec {
+    enum CodecError: LocalizedError, Equatable {
+        case unsupportedVersion(Int)
+        var errorDescription: String? {
+            switch self {
+            case .unsupportedVersion(let v):
+                return "This project bundle (v\(v)) was made by a newer version of OpenGlasses."
+            }
+        }
+    }
+
+    static func encode(_ bundle: ProjectBundle) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(bundle)
+    }
+
+    static func decode(_ data: Data) throws -> ProjectBundle {
+        let bundle = try JSONDecoder().decode(ProjectBundle.self, from: data)
+        guard bundle.version <= ProjectBundle.currentVersion else {
+            throw CodecError.unsupportedVersion(bundle.version)
+        }
+        return bundle
+    }
+
+    /// Suggested export filename for a project, sanitised for the filesystem.
+    static func filename(for persona: Persona) -> String {
+        let safe = persona.name
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+        let base = safe.isEmpty ? "project" : safe.lowercased()
+        return "\(base).ogproject.json"
+    }
+}

--- a/OpenGlasses/Sources/Services/Projects/ProjectExporter.swift
+++ b/OpenGlasses/Sources/Services/Projects/ProjectExporter.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Exports / imports a Project (Plan AN) — a `Persona` plus its namespace-scoped
+/// documents — as a `ProjectBundle`. `@MainActor` because it reads/writes the
+/// `DocumentStore` and the persona list; the serialization is the pure
+/// `ProjectBundleCodec`, and re-ID-ing on import keeps it pure-testable.
+@MainActor
+enum ProjectExporter {
+
+    /// Build a bundle for `persona`, reconstructing each scoped document's full text.
+    static func makeBundle(persona: Persona, store: DocumentStore) -> ProjectBundle {
+        let docs = store.list(namespace: persona.id).compactMap { ref -> ProjectBundle.BundledDocument? in
+            guard let text = store.fullText(documentId: ref.id), !text.isEmpty else { return nil }
+            return ProjectBundle.BundledDocument(name: ref.name, sourceType: ref.sourceType, text: text)
+        }
+        return ProjectBundle(persona: persona, documents: docs)
+    }
+
+    /// Write a bundle to a temp file for the share sheet; returns the file URL.
+    static func exportFile(persona: Persona, store: DocumentStore) throws -> URL {
+        let bundle = makeBundle(persona: persona, store: store)
+        let data = try ProjectBundleCodec.encode(bundle)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(ProjectBundleCodec.filename(for: persona))
+        try data.write(to: url)
+        return url
+    }
+
+    /// Import a bundle: register the persona under a **fresh id** (so it never collides
+    /// with an existing one) and re-ingest its documents into that new namespace.
+    /// Returns the imported persona. Pure w.r.t. ids — `newId` is injected for testing.
+    @discardableResult
+    static func importBundle(_ bundle: ProjectBundle,
+                             into store: DocumentStore,
+                             newId: String = UUID().uuidString,
+                             addPersona: (Persona) -> Void = { Config.addPersona($0) }) async -> Persona {
+        var persona = bundle.persona
+        persona.id = newId
+        addPersona(persona)
+        for doc in bundle.documents {
+            _ = await store.ingest(name: doc.name, text: doc.text, sourceType: doc.sourceType, namespace: newId)
+        }
+        return persona
+    }
+}

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -1525,6 +1525,17 @@ struct Config {
         setSavedPersonas(personas)
     }
 
+    /// Append a persona (e.g. an imported Project, Plan AN). Replaces any with the same id.
+    static func addPersona(_ persona: Persona) {
+        var personas = savedPersonas
+        if let idx = personas.firstIndex(where: { $0.id == persona.id }) {
+            personas[idx] = persona
+        } else {
+            personas.append(persona)
+        }
+        setSavedPersonas(personas)
+    }
+
     /// Uninstall a built-in persona mode.
     static func uninstallPersonaMode(_ id: String) {
         var personas = savedPersonas

--- a/OpenGlassesTests/ProjectBundleTests.swift
+++ b/OpenGlassesTests/ProjectBundleTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import OpenGlasses
+
+final class ProjectBundleTests: XCTestCase {
+
+    private func persona(id: String, name: String) -> Persona {
+        Persona(id: id, name: name, wakePhrase: "hey \(name.lowercased())",
+                alternativeWakePhrases: [], modelId: "m", presetId: "p", enabled: true,
+                icon: nil, isBuiltIn: nil, soulOverride: "be terse",
+                chattinessRaw: nil, allowedTools: nil, ownedTaskIds: nil)
+    }
+
+    // MARK: - Codec (pure)
+
+    func testCodecRoundTrip() throws {
+        let bundle = ProjectBundle(
+            persona: persona(id: "proj-1", name: "Spanish Tutor"),
+            documents: [.init(name: "Verbs", sourceType: "text", text: "ser vs estar")])
+        let data = try ProjectBundleCodec.encode(bundle)
+        XCTAssertEqual(try ProjectBundleCodec.decode(data), bundle)
+    }
+
+    func testDecodeRejectsNewerVersion() throws {
+        var bundle = ProjectBundle(persona: persona(id: "x", name: "X"), documents: [])
+        bundle.version = ProjectBundle.currentVersion + 1
+        let data = try JSONEncoder().encode(bundle)
+        XCTAssertThrowsError(try ProjectBundleCodec.decode(data)) { error in
+            XCTAssertEqual(error as? ProjectBundleCodec.CodecError, .unsupportedVersion(bundle.version))
+        }
+    }
+
+    func testFilenameSanitised() {
+        XCTAssertEqual(ProjectBundleCodec.filename(for: persona(id: "1", name: "My Project!")), "my-project.ogproject.json")
+        XCTAssertEqual(ProjectBundleCodec.filename(for: persona(id: "1", name: "   ")), "project.ogproject.json")
+    }
+
+    // MARK: - Export / import over a real store
+
+    @MainActor
+    private func makeStore() -> DocumentStore {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return DocumentStore(directory: dir)
+    }
+
+    private let body = """
+    To reset the thermostat, hold the power button for ten seconds until the screen blinks.
+    The unit then restarts and returns to factory defaults; open the app for Wi-Fi setup.
+    """
+
+    @MainActor
+    func testExportThenImportRoundTripsDocumentsIntoNewNamespace() async throws {
+        let store = makeStore()
+        let source = persona(id: "src", name: "Field Site")
+        _ = await store.ingest(name: "Manual", text: body, namespace: "src")
+        _ = await store.ingest(name: "Notes", text: body, namespace: "src")
+
+        let bundle = ProjectExporter.makeBundle(persona: source, store: store)
+        XCTAssertEqual(bundle.documents.count, 2)
+        XCTAssertEqual(Set(bundle.documents.map(\.name)), ["Manual", "Notes"])
+        XCTAssertFalse(bundle.documents.contains { $0.text.isEmpty })
+
+        // Import into the same store under a fresh id; capture the persona via the closure.
+        var added: Persona?
+        let imported = await ProjectExporter.importBundle(bundle, into: store, newId: "dst", addPersona: { added = $0 })
+        XCTAssertEqual(imported.id, "dst")
+        XCTAssertEqual(imported.name, "Field Site")
+        XCTAssertEqual(added?.id, "dst")
+        // Documents re-ingested into the new namespace, originals untouched.
+        XCTAssertEqual(store.documentCount(namespace: "dst"), 2)
+        XCTAssertEqual(store.documentCount(namespace: "src"), 2)
+    }
+
+    @MainActor
+    func testEmptyProjectExportsNoDocuments() {
+        let store = makeStore()
+        let bundle = ProjectExporter.makeBundle(persona: persona(id: "empty", name: "Empty"), store: store)
+        XCTAssertTrue(bundle.documents.isEmpty)
+        XCTAssertEqual(bundle.persona.name, "Empty")
+    }
+}

--- a/docs/plans/consolidated-partials.md
+++ b/docs/plans/consolidated-partials.md
@@ -26,7 +26,7 @@ then strike it here.
 |---|---|---|
 | [AU](llm-cost-usage-tracker.md) | Streamed-Chat (`onToken`) + realtime-voice token capture | Thread usage out of the SSE reconstructors / realtime sessions; the non-streaming capture + pricing/rollup core shipped |
 | ~~[AU](llm-cost-usage-tracker.md)~~ | ~~Settings pricing editor~~ | ✅ Shipped — `ModelPricingEditorView` + persisted `Config.modelPricingOverrides` |
-| [AN](projects-scoped-contexts.md) | Shareable project export/import bundle | Persona + its scoped docs, reusing the Plan [Q](Q-vault-and-skills-library-management.md) vault export/import patterns |
+| ~~[AN](projects-scoped-contexts.md)~~ | ~~Shareable project export/import bundle~~ | ✅ Shipped — `ProjectBundle`/`ProjectBundleCodec` + `ProjectExporter`; export (share sheet) in `ProjectDetailView`, import (file picker) in `PersonasView` |
 | [AB](health-safety-advisor.md) | Broader interaction-rubric coverage | More curated high-severity rules + tests; the pure rubric/grounding core shipped |
 | [AV](visual-state-memory.md) | Thumbnail injection (second flag) + BrainStore ingest of aged keyframes | Both ride the shipped ring-buffer/builder; text-only context ships today |
 | [U](U-structured-capture-flows.md) | No-code capture-flow author UI | JSON-authored flows ship today; the editor is the fast-follow |


### PR DESCRIPTION
Makes a **Project portable between devices** — a `Persona` plus its namespace-scoped documents — closing the last deferred item of [Plan AN](docs/plans/projects-scoped-contexts.md).

### What's in
- **`ProjectBundle`** (pure `Codable`) + **`ProjectBundleCodec`** — versioned JSON encode/decode that **rejects a newer-schema bundle** rather than mis-importing, plus a sanitised export filename (`my-project.ogproject.json`).
- **`ProjectExporter`** (`@MainActor`) — `makeBundle` reconstructs each scoped document's full text via `DocumentStore.fullText`; `importBundle` registers the persona under a **fresh id** (never collides with an existing project) and re-ingests its documents into that new namespace.
- **UI** — "Export project" share sheet in `ProjectDetailView`; "Import project…" file picker in `PersonasView`. New `Config.addPersona` helper.

### Tests
**13 green in Release** — 5 new `ProjectBundleTests` (codec round-trip, version guard, filename sanitisation, and a full **export → import round-trip over a real `DocumentStore`** proving docs land in the new namespace and the source project is untouched) + the unchanged 8 `ProjectScopingTests`.

Strikes the AN export/import item off Section A of [consolidated-partials.md](docs/plans/consolidated-partials.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)