### PR TITLE
Broader health-safety interaction rubric (Plan AB follow-up)

### DIFF
--- a/OpenGlasses/Sources/Services/HealthSafety/InteractionRubric.swift
+++ b/OpenGlasses/Sources/Services/HealthSafety/InteractionRubric.swift
@@ -57,7 +57,52 @@ struct InteractionRubric {
                             severity: .caution, basis: "SSRI + NSAID"))
         }
 
+        // MAOI + SSRI → serotonin syndrome (drug-drug, either direction).
+        if pair(substance, userClasses, .maoi, .ssri) {
+            hits.append(Hit(reason: "Combining an MAOI and an SSRI can cause serotonin syndrome.",
+                            severity: .high, basis: "MAOI + SSRI → serotonin syndrome"))
+        }
+        // PDE5 inhibitor + nitrate → severe hypotension.
+        if pair(substance, userClasses, .pde5Inhibitor, .nitrate) {
+            hits.append(Hit(reason: "An erectile-dysfunction drug with a nitrate can drop your blood pressure dangerously.",
+                            severity: .high, basis: "PDE5 inhibitor + nitrate → hypotension"))
+        }
+        // Methotrexate + NSAID → methotrexate toxicity.
+        if pair(substance, userClasses, .methotrexate, .nsaid) {
+            hits.append(Hit(reason: "An NSAID can raise methotrexate to toxic levels.",
+                            severity: .high, basis: "methotrexate + NSAID → toxicity"))
+        }
+        // Opioid/benzodiazepine combined → additive respiratory depression.
+        if pair(substance, userClasses, .opioid, .benzodiazepine)
+            || (substance.classes.contains(.opioid) && userClasses.contains(.opioid))
+            || (substance.classes.contains(.benzodiazepine) && userClasses.contains(.benzodiazepine)) {
+            hits.append(Hit(reason: "Combining sedatives (opioids and/or benzodiazepines) can dangerously slow your breathing.",
+                            severity: .high, basis: "opioid + benzodiazepine → respiratory depression"))
+        }
+        // Lithium + NSAID → lithium toxicity.
+        if pair(substance, userClasses, .lithium, .nsaid) {
+            hits.append(Hit(reason: "An NSAID can raise lithium to toxic levels.",
+                            severity: .high, basis: "lithium + NSAID → toxicity"))
+        }
+        // ACE/ARB + potassium-sparing diuretic → hyperkalemia (drug-drug).
+        if (!substance.classes.isDisjoint(with: [.aceInhibitor, .arb]) && userClasses.contains(.potassiumSparingDiuretic))
+            || (substance.classes.contains(.potassiumSparingDiuretic) && !userClasses.isDisjoint(with: [.aceInhibitor, .arb])) {
+            hits.append(Hit(reason: "This combination with your blood-pressure medication can raise potassium to dangerous levels.",
+                            severity: .high, basis: "ACE/ARB + potassium-sparing diuretic → hyperkalemia"))
+        }
+        // NSAID in pregnancy → caution (avoid, esp. third trimester).
+        if substance.classes.contains(.nsaid), context.conditions.contains(.pregnancy) {
+            hits.append(Hit(reason: "NSAIDs are generally avoided in pregnancy — check with your doctor.",
+                            severity: .caution, basis: "NSAID + pregnancy"))
+        }
+
         return hits.sorted { $0.severity > $1.severity }
+    }
+
+    /// True when the dangerous pair (`a`,`b`) is split across the queried substance and
+    /// the user's current meds, in either direction.
+    private func pair(_ substance: Substance, _ user: Set<DrugClass>, _ a: DrugClass, _ b: DrugClass) -> Bool {
+        (substance.classes.contains(a) && user.contains(b)) || (substance.classes.contains(b) && user.contains(a))
     }
 
     /// Check a food (for "can I eat this?") — its tags against the user's meds/conditions.
@@ -90,7 +135,17 @@ struct InteractionRubric {
             hits.append(Hit(reason: "You have gout; purine-rich foods can trigger a flare.",
                             severity: .caution, basis: "purine-rich + gout"))
         }
-        // Grapefruit + relevant meds → caution (broad CYP3A4 flag).
+        // Alcohol + sedatives → additive CNS/respiratory depression.
+        if tags.contains(.alcohol), !userClasses.isDisjoint(with: [.opioid, .benzodiazepine]) {
+            hits.append(Hit(reason: "Alcohol with your sedative medication can dangerously slow breathing and heavy sedation.",
+                            severity: .high, basis: "alcohol + opioid/benzodiazepine"))
+        }
+        // Statin + grapefruit → raised statin levels (muscle injury risk).
+        if tags.contains(.grapefruit), userClasses.contains(.statin) {
+            hits.append(Hit(reason: "Grapefruit can raise your statin levels and the risk of muscle injury.",
+                            severity: .caution, basis: "statin + grapefruit"))
+        }
+        // Grapefruit + other meds → general CYP3A4 flag.
         if tags.contains(.grapefruit), !userClasses.isEmpty {
             hits.append(Hit(reason: "Grapefruit can change how some medications are absorbed — check this one specifically.",
                             severity: .info, basis: "grapefruit + CYP3A4 substrates"))

--- a/OpenGlasses/Sources/Services/HealthSafety/SubstanceCatalog.swift
+++ b/OpenGlasses/Sources/Services/HealthSafety/SubstanceCatalog.swift
@@ -11,6 +11,13 @@ enum DrugClass: String, CaseIterable, Equatable {
     case maoi                  // phenelzine, tranylcypromine, isocarboxazid
     case potassiumSparingDiuretic // spironolactone, amiloride
     case ssri                  // sertraline, fluoxetine
+    case statin                // atorvastatin, simvastatin, rosuvastatin
+    case nitrate               // nitroglycerin, isosorbide
+    case pde5Inhibitor         // sildenafil, tadalafil
+    case benzodiazepine        // diazepam, alprazolam, lorazepam
+    case opioid                // oxycodone, morphine, tramadol, fentanyl
+    case methotrexate          // methotrexate (its own class — narrow therapeutic index)
+    case lithium               // lithium (narrow therapeutic index)
 }
 
 /// Tags for foods/labels the rubric checks against meds + conditions (Plan AB).
@@ -21,6 +28,7 @@ enum FoodTag: String, CaseIterable, Equatable {
     case highSodium            // hypertension / heart failure
     case purineRich            // organ meat, shellfish — gout
     case grapefruit            // CYP3A4 interactions
+    case alcohol               // additive CNS/respiratory depression with sedatives
 }
 
 /// Conditions the rubric uses for contraindications (Plan AB).
@@ -63,6 +71,18 @@ enum SubstanceCatalog {
         "spironolactone": .potassiumSparingDiuretic, "amiloride": .potassiumSparingDiuretic,
         "sertraline": .ssri, "zoloft": .ssri, "fluoxetine": .ssri, "prozac": .ssri,
         "citalopram": .ssri, "escitalopram": .ssri,
+        "atorvastatin": .statin, "lipitor": .statin, "simvastatin": .statin, "zocor": .statin,
+        "rosuvastatin": .statin, "crestor": .statin, "pravastatin": .statin,
+        "nitroglycerin": .nitrate, "nitroglycerine": .nitrate, "isosorbide": .nitrate, "nitrate": .nitrate,
+        "sildenafil": .pde5Inhibitor, "viagra": .pde5Inhibitor, "tadalafil": .pde5Inhibitor,
+        "cialis": .pde5Inhibitor, "vardenafil": .pde5Inhibitor,
+        "diazepam": .benzodiazepine, "valium": .benzodiazepine, "alprazolam": .benzodiazepine,
+        "xanax": .benzodiazepine, "lorazepam": .benzodiazepine, "ativan": .benzodiazepine,
+        "clonazepam": .benzodiazepine, "klonopin": .benzodiazepine,
+        "oxycodone": .opioid, "oxycontin": .opioid, "hydrocodone": .opioid, "morphine": .opioid,
+        "codeine": .opioid, "tramadol": .opioid, "fentanyl": .opioid, "oxymorphone": .opioid,
+        "methotrexate": .methotrexate,
+        "lithium": .lithium,
     ]
 
     /// food/label fragment → tag.
@@ -77,6 +97,8 @@ enum SubstanceCatalog {
         "sodium": .highSodium, "salt": .highSodium,
         "liver": .purineRich, "anchovies": .purineRich, "shellfish": .purineRich, "sardines": .purineRich,
         "grapefruit": .grapefruit,
+        "alcohol": .alcohol, "beer": .alcohol, "wine": .alcohol, "whiskey": .alcohol,
+        "vodka": .alcohol, "liquor": .alcohol, "spirits": .alcohol, "cocktail": .alcohol,
     ]
 
     /// condition fragment → tag (matched in the conditions vault file).

--- a/OpenGlassesTests/HealthSafetyTests.swift
+++ b/OpenGlassesTests/HealthSafetyTests.swift
@@ -133,4 +133,70 @@ final class HealthSafetyTests: XCTestCase {
         XCTAssertTrue(out.contains("No high-severity interactions"))
         XCTAssertFalse(HealthSafetyResponseBuilder.hasAuthoritativeWarning([]))
     }
+
+    // MARK: - Broader rubric coverage (AB follow-up)
+
+    func testNewDrugClassifications() {
+        XCTAssertEqual(SubstanceCatalog.substance(from: "atorvastatin 20mg").classes, [.statin])
+        XCTAssertEqual(SubstanceCatalog.substance(from: "sildenafil").classes, [.pde5Inhibitor])
+        XCTAssertEqual(SubstanceCatalog.substance(from: "isosorbide mononitrate").classes, [.nitrate])
+        XCTAssertEqual(SubstanceCatalog.substance(from: "oxycodone").classes, [.opioid])
+        XCTAssertEqual(SubstanceCatalog.substance(from: "Valium (diazepam)").classes, [.benzodiazepine])
+        XCTAssertEqual(SubstanceCatalog.substance(from: "methotrexate").classes, [.methotrexate])
+        XCTAssertEqual(SubstanceCatalog.substance(from: "lithium carbonate").classes, [.lithium])
+    }
+
+    func testMAOIPlusSSRIIsHigh() {
+        // Querying an SSRI while on an MAOI (and the reverse) both fire.
+        XCTAssertTrue(InteractionRubric().check(SubstanceCatalog.substance(from: "sertraline"), against: context(meds: [.maoi]))
+            .contains { $0.severity == .high && $0.basis.contains("serotonin") })
+        XCTAssertTrue(InteractionRubric().check(SubstanceCatalog.substance(from: "phenelzine"), against: context(meds: [.ssri]))
+            .contains { $0.severity == .high })
+    }
+
+    func testPDE5PlusNitrateIsHigh() {
+        let hits = InteractionRubric().check(SubstanceCatalog.substance(from: "sildenafil"), against: context(meds: [.nitrate]))
+        XCTAssertEqual(hits.first?.severity, .high)
+    }
+
+    func testMethotrexatePlusNSAIDIsHigh() {
+        let hits = InteractionRubric().check(SubstanceCatalog.substance(from: "ibuprofen"), against: context(meds: [.methotrexate]))
+        XCTAssertTrue(hits.contains { $0.severity == .high && $0.basis.contains("methotrexate") })
+    }
+
+    func testOpioidPlusBenzodiazepineIsHigh() {
+        let hits = InteractionRubric().check(SubstanceCatalog.substance(from: "oxycodone"), against: context(meds: [.benzodiazepine]))
+        XCTAssertEqual(hits.first?.severity, .high)
+    }
+
+    func testLithiumPlusNSAIDIsHigh() {
+        let hits = InteractionRubric().check(SubstanceCatalog.substance(from: "naproxen"), against: context(meds: [.lithium]))
+        XCTAssertTrue(hits.contains { $0.severity == .high && $0.basis.contains("lithium") })
+    }
+
+    func testACEPlusPotassiumSparingDiureticIsHigh() {
+        let hits = InteractionRubric().check(SubstanceCatalog.substance(from: "spironolactone"), against: context(meds: [.aceInhibitor]))
+        XCTAssertTrue(hits.contains { $0.severity == .high && $0.basis.contains("hyperkalemia") })
+    }
+
+    func testNSAIDInPregnancyIsCaution() {
+        let hits = InteractionRubric().check(SubstanceCatalog.substance(from: "ibuprofen"), against: context(meds: [], conditions: [.pregnancy]))
+        XCTAssertTrue(hits.contains { $0.severity == .caution && $0.basis.contains("pregnancy") })
+    }
+
+    func testAlcoholPlusSedativeIsHigh() {
+        let hits = InteractionRubric().checkFood([.alcohol], against: context(meds: [.opioid]))
+        XCTAssertEqual(hits.first?.severity, .high)
+    }
+
+    func testStatinPlusGrapefruitIsCaution() {
+        let hits = InteractionRubric().checkFood([.grapefruit], against: context(meds: [.statin]))
+        XCTAssertTrue(hits.contains { $0.severity == .caution && $0.basis.contains("statin") })
+    }
+
+    func testUnrelatedNewClassPairingNoHit() {
+        // A statin alone with an unrelated query shouldn't fire a high/caution drug-drug rule.
+        let hits = InteractionRubric().check(SubstanceCatalog.substance(from: "vitamin d"), against: context(meds: [.statin]))
+        XCTAssertTrue(hits.isEmpty)
+    }
 }

--- a/docs/plans/consolidated-partials.md
+++ b/docs/plans/consolidated-partials.md
@@ -27,7 +27,7 @@ then strike it here.
 | [AU](llm-cost-usage-tracker.md) | Streamed-Chat (`onToken`) + realtime-voice token capture | Thread usage out of the SSE reconstructors / realtime sessions; the non-streaming capture + pricing/rollup core shipped |
 | ~~[AU](llm-cost-usage-tracker.md)~~ | ~~Settings pricing editor~~ | ✅ Shipped — `ModelPricingEditorView` + persisted `Config.modelPricingOverrides` |
 | [AN](projects-scoped-contexts.md) | Shareable project export/import bundle | Persona + its scoped docs, reusing the Plan [Q](Q-vault-and-skills-library-management.md) vault export/import patterns |
-| [AB](health-safety-advisor.md) | Broader interaction-rubric coverage | More curated high-severity rules + tests; the pure rubric/grounding core shipped |
+| ~~[AB](health-safety-advisor.md)~~ | ~~Broader interaction-rubric coverage~~ | ✅ Shipped — +7 drug classes (statin/nitrate/PDE5/benzo/opioid/methotrexate/lithium) + alcohol; rules for MAOI+SSRI, PDE5+nitrate, methotrexate/lithium+NSAID, opioid+benzo, ACE+K-sparing, NSAID-in-pregnancy, alcohol+sedative, statin+grapefruit |
 | [AV](visual-state-memory.md) | Thumbnail injection (second flag) + BrainStore ingest of aged keyframes | Both ride the shipped ring-buffer/builder; text-only context ships today |
 | [U](U-structured-capture-flows.md) | No-code capture-flow author UI | JSON-authored flows ship today; the editor is the fast-follow |
 | [S](S-plan-then-execute-and-safety-supervisor.md) | Phase 2: LLM complexity classifier (vs keyword heuristic) + parallel-safe execution | Optional polish over the shipped supervisor/planner |


### PR DESCRIPTION
Extends the deterministic `InteractionRubric` from [Plan AB](docs/plans/health-safety-advisor.md) with more well-established high-severity interactions — on the same pure, headless-tested core (no behaviour change to grounding, authority, or the disclaimer).

### What's added
- **`SubstanceCatalog`** — 7 new drug classes (`statin`, `nitrate`, `pde5Inhibitor`, `benzodiazepine`, `opioid`, `methotrexate`, `lithium`) with brand/generic synonyms, plus an `alcohol` food tag.
- **`InteractionRubric`** — new rules, each citing a clinical basis:
  - MAOI + SSRI → **high** (serotonin syndrome)
  - PDE5 inhibitor + nitrate → **high** (hypotension)
  - methotrexate + NSAID, lithium + NSAID → **high** (toxicity)
  - opioid + benzodiazepine (and same-class doubling) → **high** (respiratory depression)
  - ACE/ARB + potassium-sparing diuretic → **high** (hyperkalemia)
  - NSAID in pregnancy → caution
  - alcohol + sedative → **high**; statin + grapefruit → caution
  - A `pair(...)` helper fires drug-drug rules in **either direction** (queried substance vs the user's current meds).

### Tests
**25 green in Release** — the original 14 plus 11 new (new-class classification + each new rule + an unrelated-pairing no-hit guard).

Strikes the AB broader-rubric item off Section A of [consolidated-partials.md](docs/plans/consolidated-partials.md). The advisor stays **advisory only** with the mandatory disclaimer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)