### PR TITLE
User-correction capture signal for skill evolution (Plan AW follow-up)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2773,6 +2773,12 @@ class AppState: ObservableObject, AppStateProtocol {
             if conversationStore.activeThreadId == nil {
                 conversationStore.startThread(mode: currentMode.rawValue, personaId: activePersona?.id)
             }
+            // User-correction signal (Plan AW): before logging this turn, if it corrects the
+            // previous answer, feed it to the skill-evolution loop (Agent-Mode-gated, no-op otherwise).
+            if let prev = conversationStore.lastExchange() {
+                await SkillEvolutionService.shared.noteUserTurn(
+                    message: query, priorPrompt: prev.prompt, priorResponse: prev.response)
+            }
             conversationStore.appendMessage(role: "user", content: query, imageAttached: imageData != nil)
         }
 

--- a/OpenGlasses/Sources/Services/ConversationStore.swift
+++ b/OpenGlasses/Sources/Services/ConversationStore.swift
@@ -141,6 +141,17 @@ class ConversationStore: ObservableObject {
         return threads.filter { $0.personaId == personaId }
     }
 
+    /// The most recent completed exchange in the active thread — the last assistant
+    /// reply and the user prompt that preceded it (Plan AW user-correction signal).
+    /// `nil` when there's no assistant turn yet.
+    func lastExchange() -> (prompt: String, response: String)? {
+        guard let thread = threads.first(where: { $0.id == activeThreadId }) else { return nil }
+        let msgs = thread.messages
+        guard let assistantIdx = msgs.lastIndex(where: { $0.role == "assistant" }) else { return nil }
+        let prompt = msgs[..<assistantIdx].last(where: { $0.role == "user" })?.content ?? ""
+        return (prompt, msgs[assistantIdx].content)
+    }
+
     /// Append a message to the active thread.
     func appendMessage(role: String, content: String, imageAttached: Bool = false) {
         guard let idx = threads.firstIndex(where: { $0.id == activeThreadId }) else { return }

--- a/OpenGlasses/Sources/Services/Skills/SkillEvolutionService.swift
+++ b/OpenGlasses/Sources/Services/Skills/SkillEvolutionService.swift
@@ -49,6 +49,20 @@ final class SkillEvolutionService: ObservableObject {
         samples.append(sample)
     }
 
+    /// Capture a **user-correction** signal (Plan AW): when a new user message corrects
+    /// the assistant's previous answer, record it against that prior exchange and let the
+    /// loop evolve if the batch now warrants it. No-op when the message isn't a correction,
+    /// there was no prior answer, or Agent Mode is off.
+    @discardableResult
+    func noteUserTurn(message: String, priorPrompt: String, priorResponse: String) async -> SkillDraft? {
+        guard Config.agentModeEnabled,
+              !priorResponse.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              UserCorrectionDetector.detect(message) != nil else { return nil }
+        record(FailureSample(kind: .userCorrection, prompt: priorPrompt, response: priorResponse,
+                             userCorrection: message, at: Date()))
+        return await evolveIfNeeded()
+    }
+
     /// If the accumulated batch warrants it, propose one skill and enqueue it for review. Returns the
     /// enqueued draft (tests/telemetry) or nil. The batch is consumed whenever the analyzer runs, so a
     /// no-op proposal doesn't re-trigger immediately.

--- a/OpenGlasses/Sources/Services/Skills/UserCorrectionDetector.swift
+++ b/OpenGlasses/Sources/Services/Skills/UserCorrectionDetector.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Detects when a user message is **correcting** the assistant's previous answer — a
+/// skill-gap signal that complements the tool-failure signal (Plan AW). Pure +
+/// headless-testable.
+///
+/// Deliberately **high-precision**: it matches only correction-specific phrasings, not
+/// bare "no" / "actually" (which appear constantly in normal speech — "no problem",
+/// "actually that's perfect"). Missing a few corrections is fine; a false positive
+/// would pollute the human-reviewed proposal bank.
+enum UserCorrectionDetector {
+
+    struct Correction: Equatable { let matchedPhrase: String }
+
+    /// Correction-specific phrases. A match anywhere in the (lowercased) message counts.
+    private static let phrases = [
+        "that's wrong", "thats wrong", "that is wrong",
+        "that's not right", "thats not right", "that is not right",
+        "that's incorrect", "thats incorrect", "that's not correct", "that is incorrect",
+        "that's not what i", "thats not what i", "that is not what i",
+        "not what i meant", "not what i asked", "not what i said",
+        "i meant", "i didn't ask", "i didnt ask", "i didn't say", "i didnt say",
+        "you're wrong", "youre wrong", "you got that wrong", "you misunderstood",
+        "no, that's", "no that's wrong", "wrong answer",
+    ]
+
+    /// The correction match, or `nil` if the message doesn't read as a correction.
+    static func detect(_ message: String) -> Correction? {
+        let m = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard m.count >= 3 else { return nil }
+        for phrase in phrases where m.contains(phrase) {
+            return Correction(matchedPhrase: phrase)
+        }
+        return nil
+    }
+}

--- a/OpenGlassesTests/UserCorrectionDetectorTests.swift
+++ b/OpenGlassesTests/UserCorrectionDetectorTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import OpenGlasses
+
+final class UserCorrectionDetectorTests: XCTestCase {
+
+    // MARK: - Detector (pure)
+
+    func testDetectsCorrections() {
+        let positives = [
+            "No, that's wrong",
+            "that's not what I meant",
+            "I meant the other one",
+            "you're wrong about that",
+            "that's incorrect",
+            "not what I asked",
+            "you misunderstood me",
+        ]
+        for p in positives {
+            XCTAssertNotNil(UserCorrectionDetector.detect(p), "should detect: \(p)")
+        }
+    }
+
+    func testIgnoresNonCorrections() {
+        let negatives = [
+            "no problem",
+            "no thanks",
+            "actually that's perfect",
+            "yes please",
+            "thanks, that's right",
+            "I said yes to that",   // bare "i said" isn't a correction phrase
+            "",
+            "ok",
+        ]
+        for n in negatives {
+            XCTAssertNil(UserCorrectionDetector.detect(n), "should NOT detect: \(n)")
+        }
+    }
+
+    // MARK: - noteUserTurn wiring
+
+    @MainActor
+    private func makeStore() -> EvolvedSkillStore {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return EvolvedSkillStore(directory: dir)
+    }
+
+    @MainActor
+    func testNoteUserTurnRecordsCorrectionWhenAgentModeOn() async {
+        let key = "agentModeEnabled"
+        let prior = UserDefaults.standard.bool(forKey: key)
+        defer { UserDefaults.standard.set(prior, forKey: key) }
+        UserDefaults.standard.set(true, forKey: key)
+
+        let service = SkillEvolutionService(store: makeStore())
+        await service.noteUserTurn(message: "No, that's wrong — I meant Celsius",
+                                   priorPrompt: "what's 20 degrees", priorResponse: "20 degrees Fahrenheit is…")
+        XCTAssertEqual(service.samples.count, 1)
+        XCTAssertEqual(service.samples.first?.kind, .userCorrection)
+        XCTAssertEqual(service.samples.first?.prompt, "what's 20 degrees")
+    }
+
+    @MainActor
+    func testNoteUserTurnIgnoresNonCorrectionOrNoPriorAnswer() async {
+        let key = "agentModeEnabled"
+        let prior = UserDefaults.standard.bool(forKey: key)
+        defer { UserDefaults.standard.set(prior, forKey: key) }
+        UserDefaults.standard.set(true, forKey: key)
+
+        let service = SkillEvolutionService(store: makeStore())
+        // Not a correction → no sample.
+        await service.noteUserTurn(message: "thanks!", priorPrompt: "p", priorResponse: "r")
+        // A correction but no prior answer → no sample.
+        await service.noteUserTurn(message: "that's wrong", priorPrompt: "p", priorResponse: "   ")
+        XCTAssertTrue(service.samples.isEmpty)
+    }
+
+    @MainActor
+    func testNoteUserTurnNoOpWhenAgentModeOff() async {
+        let key = "agentModeEnabled"
+        let prior = UserDefaults.standard.bool(forKey: key)
+        defer { UserDefaults.standard.set(prior, forKey: key) }
+        UserDefaults.standard.set(false, forKey: key)
+
+        let service = SkillEvolutionService(store: makeStore())
+        await service.noteUserTurn(message: "that's wrong", priorPrompt: "p", priorResponse: "r")
+        XCTAssertTrue(service.samples.isEmpty)
+    }
+}

--- a/docs/plans/consolidated-partials.md
+++ b/docs/plans/consolidated-partials.md
@@ -32,7 +32,7 @@ then strike it here.
 | [U](U-structured-capture-flows.md) | No-code capture-flow author UI | JSON-authored flows ship today; the editor is the fast-follow |
 | [S](S-plan-then-execute-and-safety-supervisor.md) | Phase 2: LLM complexity classifier (vs keyword heuristic) + parallel-safe execution | Optional polish over the shipped supervisor/planner |
 | [O](O-document-rag.md) | Standalone `DocumentsView` (list / ingest-via-Files / delete) | Mirrors `VaultManagerView`; partially subsumed by AN's `ProjectDetailView`, a global view is still useful |
-| [AW](skill-self-evolution.md) | User-correction capture signal | An extra evolution trigger alongside the shipped tool-failure signal |
+| ~~[AW](skill-self-evolution.md)~~ | ~~User-correction capture signal~~ | ✅ Shipped — pure `UserCorrectionDetector` + `SkillEvolutionService.noteUserTurn` (records a `.userCorrection` sample against the prior exchange), wired into `sendTextMessage`; Agent-Mode-gated |
 | ~~[AT](frame-dedup-change-gate.md)~~ | ~~Advanced-threshold Settings control~~ | ✅ Shipped — `LiveVisionSettingsView` (toggle + threshold + heartbeat) under Settings → Advanced. Flipping the default *on* is still device-gated → B |
 | [AM](embedding-quality-upgrade.md) | Optional bundled MiniLM Core ML path | Gated on the `recall@k` benchmark showing a lift; the `EmbeddingBackend` seam is in place |
 | [AJ](additional-capabilities.md) | Declarative HUD widget board (#7) | Display Phase-5 concept; defer until X/Y are fully exercised and a concrete multi-widget use case exists |


### PR DESCRIPTION
Adds the deferred **user-correction signal** to the [Skill Self-Evolution](docs/plans/skill-self-evolution.md) loop — a second skill-gap signal alongside the shipped tool-failure one. When the user corrects the assistant's previous answer, that's evidence of a gap worth proposing a skill for.

### What's in
- **`UserCorrectionDetector`** (pure) — **high-precision** by design: matches only correction-specific phrasings (`that's wrong`, `I meant…`, `not what I asked`, `you misunderstood`, …), and deliberately **not** bare "no"/"actually" (which appear constantly in normal speech). A false positive would pollute the human-reviewed proposal bank, so it errs toward missing some.
- **`SkillEvolutionService.noteUserTurn`** — records a `.userCorrection` `FailureSample` against the *prior* exchange and runs `evolveIfNeeded`. No-op when Agent Mode is off, there was no prior answer, or the message isn't a correction.
- **`ConversationStore.lastExchange()`** — the last assistant reply plus the user prompt that preceded it.
- Wired into `AppState.sendTextMessage`, before the new user turn is logged.

The `.userCorrection` sample kind already existed in the model — this fills in the detector + wiring that was deferred.

### Tests
**22 green in Release** — 5 new `UserCorrectionDetectorTests` (positive/negative detection incl. tricky negatives like "no problem"/"actually that's perfect", and `noteUserTurn` recording / gating / Agent-Mode-off no-op) + the unchanged 17 `SkillEvolutionTests`.

Strikes the AW item off Section A of [consolidated-partials.md](docs/plans/consolidated-partials.md). Stays **Agent-Mode-gated and human-reviewed** — nothing self-authored is applied without approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)