### PR TITLE
Capture token usage on the streamed-Chat path (Plan AU follow-up)

### DIFF
--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -1207,11 +1207,15 @@ class LLMService: ObservableObject {
     /// Streaming turns (Chat tab `onToken`) don't carry a usage block on this path and
     /// are not yet captured.
     private func recordUsage(provider: LLMProvider, model: String, json: [String: Any]) {
-        guard let tokens = UsageTracker.parseTokens(provider: provider, json: json),
-              tokens.tokensIn + tokens.tokensOut > 0 else { return }
+        guard let tokens = UsageTracker.parseTokens(provider: provider, json: json) else { return }
+        recordUsage(provider: provider, model: model, tokensIn: tokens.tokensIn, tokensOut: tokens.tokensOut)
+    }
+
+    /// Record already-parsed token counts (the streaming paths accumulate their own).
+    private func recordUsage(provider: LLMProvider, model: String, tokensIn: Int, tokensOut: Int) {
+        guard tokensIn + tokensOut > 0 else { return }
         Task { @MainActor in
-            UsageTracker.shared.record(provider: provider, model: model,
-                                       tokensIn: tokens.tokensIn, tokensOut: tokens.tokensOut)
+            UsageTracker.shared.record(provider: provider, model: model, tokensIn: tokensIn, tokensOut: tokensOut)
         }
     }
 
@@ -1276,7 +1280,7 @@ class LLMService: ObservableObject {
             let content: [[String: Any]]
             let stopReason: String?
             if let onToken {
-                (content, stopReason) = try await streamAnthropicContent(request: request, onToken: onToken)
+                (content, stopReason) = try await streamAnthropicContent(request: request, model: config.model, onToken: onToken)
             } else {
                 let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -1498,7 +1502,12 @@ class LLMService: ObservableObject {
                 body["tools"] = tools
             }
 
-            if onToken != nil { body["stream"] = true }
+            if onToken != nil {
+                body["stream"] = true
+                // Ask for a final usage chunk so the streamed path can record cost (Plan AU).
+                // Servers that don't support it ignore the field; we then simply record nothing.
+                body["stream_options"] = ["include_usage": true]
+            }
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
             request.timeoutInterval = 60 // 60s timeout to prevent app freezing
 
@@ -1512,7 +1521,7 @@ class LLMService: ObservableObject {
             // the reconstructed `message` (content + tool_calls) feeds the existing tool loop unchanged.
             let message: [String: Any]
             if let onToken {
-                message = try await streamOpenAIMessage(request: request, provider: provider, onToken: onToken)
+                message = try await streamOpenAIMessage(request: request, provider: provider, model: config.model, onToken: onToken)
             } else {
                 let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -1622,7 +1631,7 @@ class LLMService: ObservableObject {
     /// delta, and return a reconstructed `message` dict (same shape as `choices[].message`) so the
     /// caller's tool loop runs identically to the buffered path. Only used when a streaming caller
     /// (the Chat tab) passes `onToken`; every other caller keeps the buffered path.
-    private func streamOpenAIMessage(request: URLRequest, provider: LLMProvider, onToken: @escaping (String) -> Void) async throws -> [String: Any] {
+    private func streamOpenAIMessage(request: URLRequest, provider: LLMProvider, model: String, onToken: @escaping (String) -> Void) async throws -> [String: Any] {
         let (bytes, response) = try await URLSession.shared.bytes(for: request)
         guard let http = response as? HTTPURLResponse else { throw LLMError.invalidResponse(provider.displayName) }
         guard http.statusCode == 200 else {
@@ -1637,14 +1646,16 @@ class LLMService: ObservableObject {
 
         var fullContent = ""
         var toolAcc: [Int: (id: String, name: String, args: String)] = [:]  // tool_calls accumulate by index
+        var usage = StreamingUsageAccumulator()   // from the final include_usage chunk
 
         for try await line in bytes.lines {
             guard line.hasPrefix("data:") else { continue }
             let payload = line.dropFirst(5).trimmingCharacters(in: .whitespaces)
             if payload.isEmpty { continue }
             if payload == "[DONE]" { break }
-            guard let obj = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any],
-                  let choice = (obj["choices"] as? [[String: Any]])?.first,
+            guard let obj = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any] else { continue }
+            usage.consumeOpenAI(obj)   // the usage chunk has empty choices, so parse it before the guard
+            guard let choice = (obj["choices"] as? [[String: Any]])?.first,
                   let delta = choice["delta"] as? [String: Any] else { continue }
 
             if let chunk = delta["content"] as? String, !chunk.isEmpty {
@@ -1665,6 +1676,8 @@ class LLMService: ObservableObject {
             }
         }
 
+        recordUsage(provider: provider, model: model, tokensIn: usage.tokensIn, tokensOut: usage.tokensOut)
+
         var message: [String: Any] = ["role": "assistant", "content": fullContent]
         if !toolAcc.isEmpty {
             message["tool_calls"] = toolAcc.sorted { $0.key < $1.key }.map { _, v in
@@ -1677,7 +1690,7 @@ class LLMService: ObservableObject {
     /// Stream an Anthropic Messages response, invoking `onToken` for each text delta, and return
     /// the reconstructed content blocks + stop reason so the caller's tool loop runs identically to
     /// the buffered path. Only used when a streaming caller (the Chat tab) passes `onToken`.
-    private func streamAnthropicContent(request: URLRequest, onToken: @escaping (String) -> Void) async throws -> (content: [[String: Any]], stopReason: String?) {
+    private func streamAnthropicContent(request: URLRequest, model: String, onToken: @escaping (String) -> Void) async throws -> (content: [[String: Any]], stopReason: String?) {
         let (bytes, response) = try await URLSession.shared.bytes(for: request)
         guard let http = response as? HTTPURLResponse else { throw LLMError.invalidResponse("Anthropic") }
         guard http.statusCode == 200 else {
@@ -1691,6 +1704,7 @@ class LLMService: ObservableObject {
         var blocks: [Int: [String: Any]] = [:]   // content blocks by index
         var toolJSON: [Int: String] = [:]         // accumulated input_json per tool_use block
         var stopReason: String?
+        var usage = StreamingUsageAccumulator()   // input from message_start, output from message_delta
 
         for try await line in bytes.lines {
             guard line.hasPrefix("data:") else { continue }
@@ -1698,6 +1712,7 @@ class LLMService: ObservableObject {
             if payload.isEmpty { continue }
             guard let obj = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any],
                   let type = obj["type"] as? String else { continue }
+            usage.consumeAnthropic(obj)
 
             switch type {
             case "content_block_start":
@@ -1733,6 +1748,8 @@ class LLMService: ObservableObject {
             b["input"] = (try? JSONSerialization.jsonObject(with: Data(jsonStr.utf8)) as? [String: Any]) ?? [:]
             blocks[idx] = b
         }
+
+        recordUsage(provider: .anthropic, model: model, tokensIn: usage.tokensIn, tokensOut: usage.tokensOut)
 
         let content = blocks.sorted { $0.key < $1.key }.map { $0.value }
         return (content, stopReason)

--- a/OpenGlasses/Sources/Services/Usage/StreamingUsageAccumulator.swift
+++ b/OpenGlasses/Sources/Services/Usage/StreamingUsageAccumulator.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Accumulates token usage across a streamed (SSE) LLM response (Plan AU follow-up).
+/// The non-streaming paths read a single `usage` block; streaming splits it across
+/// events — Anthropic reports input on `message_start` and a running output on each
+/// `message_delta`; OpenAI-compatible servers emit a final chunk carrying `usage`
+/// (only when the request asked for `stream_options.include_usage`). Pure +
+/// headless-testable; the SSE reconstructors feed it each decoded event.
+struct StreamingUsageAccumulator {
+    private(set) var tokensIn = 0
+    private(set) var tokensOut = 0
+
+    var hasUsage: Bool { tokensIn + tokensOut > 0 }
+
+    /// Feed one decoded Anthropic stream event.
+    mutating func consumeAnthropic(_ event: [String: Any]) {
+        switch event["type"] as? String {
+        case "message_start":
+            if let usage = (event["message"] as? [String: Any])?["usage"] as? [String: Any] {
+                tokensIn = max(tokensIn, Self.int(usage["input_tokens"]))
+                tokensOut = max(tokensOut, Self.int(usage["output_tokens"]))
+            }
+        case "message_delta":
+            // Output is cumulative across deltas — keep the largest seen.
+            if let usage = event["usage"] as? [String: Any] {
+                tokensOut = max(tokensOut, Self.int(usage["output_tokens"]))
+            }
+        default:
+            break
+        }
+    }
+
+    /// Feed one decoded OpenAI-compatible stream chunk. Only the final chunk (empty
+    /// `choices`) carries `usage`; earlier content chunks are ignored here.
+    mutating func consumeOpenAI(_ chunk: [String: Any]) {
+        guard let usage = chunk["usage"] as? [String: Any] else { return }
+        tokensIn = max(tokensIn, Self.int(usage["prompt_tokens"]))
+        tokensOut = max(tokensOut, Self.int(usage["completion_tokens"]))
+    }
+
+    private static func int(_ value: Any?) -> Int {
+        if let i = value as? Int { return i }
+        if let n = value as? NSNumber { return n.intValue }
+        if let d = value as? Double { return Int(d) }
+        return 0
+    }
+}

--- a/OpenGlassesTests/StreamingUsageAccumulatorTests.swift
+++ b/OpenGlassesTests/StreamingUsageAccumulatorTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import OpenGlasses
+
+final class StreamingUsageAccumulatorTests: XCTestCase {
+
+    // MARK: - Anthropic
+
+    func testAnthropicSplitAcrossStartAndDeltas() {
+        var acc = StreamingUsageAccumulator()
+        acc.consumeAnthropic(["type": "message_start",
+                              "message": ["usage": ["input_tokens": 42, "output_tokens": 1]]])
+        acc.consumeAnthropic(["type": "content_block_delta", "delta": ["type": "text_delta", "text": "hi"]])
+        acc.consumeAnthropic(["type": "message_delta", "usage": ["output_tokens": 7]])
+        acc.consumeAnthropic(["type": "message_delta", "usage": ["output_tokens": 15]])  // cumulative
+        XCTAssertEqual(acc.tokensIn, 42)
+        XCTAssertEqual(acc.tokensOut, 15)
+        XCTAssertTrue(acc.hasUsage)
+    }
+
+    func testAnthropicCumulativeOutputNeverDecreases() {
+        var acc = StreamingUsageAccumulator()
+        acc.consumeAnthropic(["type": "message_delta", "usage": ["output_tokens": 20]])
+        acc.consumeAnthropic(["type": "message_delta", "usage": ["output_tokens": 18]])  // stale/lower
+        XCTAssertEqual(acc.tokensOut, 20)
+    }
+
+    func testAnthropicNoUsageEvents() {
+        var acc = StreamingUsageAccumulator()
+        acc.consumeAnthropic(["type": "content_block_start", "index": 0])
+        acc.consumeAnthropic(["type": "content_block_delta", "delta": ["type": "text_delta", "text": "x"]])
+        XCTAssertFalse(acc.hasUsage)
+        XCTAssertEqual(acc.tokensIn, 0)
+        XCTAssertEqual(acc.tokensOut, 0)
+    }
+
+    // MARK: - OpenAI
+
+    func testOpenAIFinalChunkUsage() {
+        var acc = StreamingUsageAccumulator()
+        // content chunks carry no usage…
+        acc.consumeOpenAI(["choices": [["delta": ["content": "hello"]]]])
+        // …the final include_usage chunk does (empty choices).
+        acc.consumeOpenAI(["choices": [], "usage": ["prompt_tokens": 12, "completion_tokens": 8]])
+        XCTAssertEqual(acc.tokensIn, 12)
+        XCTAssertEqual(acc.tokensOut, 8)
+    }
+
+    func testOpenAINoUsageWhenServerOmitsIt() {
+        var acc = StreamingUsageAccumulator()
+        acc.consumeOpenAI(["choices": [["delta": ["content": "hi"]]]])
+        XCTAssertFalse(acc.hasUsage)
+    }
+
+    func testCoercesNumericTypes() {
+        var acc = StreamingUsageAccumulator()
+        acc.consumeOpenAI(["usage": ["prompt_tokens": Double(10), "completion_tokens": NSNumber(value: 5)]])
+        XCTAssertEqual(acc.tokensIn, 10)
+        XCTAssertEqual(acc.tokensOut, 5)
+    }
+}

--- a/docs/plans/consolidated-partials.md
+++ b/docs/plans/consolidated-partials.md
@@ -24,7 +24,7 @@ then strike it here.
 
 | Plan | Outstanding item | Notes |
 |---|---|---|
-| [AU](llm-cost-usage-tracker.md) | Streamed-Chat (`onToken`) + realtime-voice token capture | Thread usage out of the SSE reconstructors / realtime sessions; the non-streaming capture + pricing/rollup core shipped |
+| [AU](llm-cost-usage-tracker.md) | ~~Streamed-Chat (`onToken`)~~ ✅ + realtime-voice token capture | Streamed-Chat SSE capture shipped (`StreamingUsageAccumulator`, Anthropic + OpenAI `include_usage`); realtime-voice (Gemini Live / OpenAI Realtime sessions) still pending |
 | ~~[AU](llm-cost-usage-tracker.md)~~ | ~~Settings pricing editor~~ | ✅ Shipped — `ModelPricingEditorView` + persisted `Config.modelPricingOverrides` |
 | ~~[AN](projects-scoped-contexts.md)~~ | ~~Shareable project export/import bundle~~ | ✅ Shipped — `ProjectBundle`/`ProjectBundleCodec` + `ProjectExporter`; export (share sheet) in `ProjectDetailView`, import (file picker) in `PersonasView` |
 | ~~[AB](health-safety-advisor.md)~~ | ~~Broader interaction-rubric coverage~~ | ✅ Shipped — +7 drug classes (statin/nitrate/PDE5/benzo/opioid/methotrexate/lithium) + alcohol; rules for MAOI+SSRI, PDE5+nitrate, methotrexate/lithium+NSAID, opioid+benzo, ACE+K-sparing, NSAID-in-pregnancy, alcohol+sedative, statin+grapefruit |


### PR DESCRIPTION
The non-streaming decode points record usage (from #141), but the **Chat tab's streaming path** (`onToken` / SSE) discarded it. This captures it — without touching the reconstructed `message`/`content` + tool-loop shape.

### What's in
- **`StreamingUsageAccumulator`** (pure) — folds usage across SSE events:
  - **Anthropic**: input from `message_start`, cumulative output from each `message_delta` (max-merged so a stale lower value can't reduce it).
  - **OpenAI-compatible**: from the final `include_usage` chunk (which has empty `choices`, so it's parsed *before* the choices guard).
- **`streamAnthropicContent` / `streamOpenAIMessage`** — take the `model`, feed every decoded event to the accumulator, and record once at the end via a new int-based `recordUsage` overload (shared with the non-streaming path).
- **`sendOpenAICompatible`** — sets `stream_options.include_usage` on streamed requests. Servers that don't support it simply omit the chunk → nothing recorded (graceful).

### Tests
**19 green in Release** — 6 new `StreamingUsageAccumulatorTests` (Anthropic split-across-events + cumulative-never-decreases, OpenAI final-chunk + omitted-usage, numeric coercion) + the unchanged 13 `UsageTrackerTests`.

### Deferred (last AU sub-item, stays in the backlog)
Realtime-voice token capture (Gemini Live / OpenAI Realtime sessions) — a separate session surface. Updated in [consolidated-partials.md](docs/plans/consolidated-partials.md).

> A mid-run CoreSimulator runner hang (not a code issue) was cleared with `simctl erase`; the build compiled clean throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)