### PR TITLE
Realtime-voice token capture — completes the cost tracker (Plan AU)

### DIFF
--- a/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveService.swift
+++ b/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveService.swift
@@ -19,6 +19,10 @@ class GeminiLiveService: ObservableObject {
     @Published var isModelSpeaking: Bool = false
     @Published var reconnecting: Bool = false
 
+    /// Converts Gemini Live's cumulative `usageMetadata` totals into per-message deltas
+    /// for the cost tracker (Plan AU).
+    private var usageMeter = CumulativeUsageMeter()
+
     // Callbacks
     var onAudioReceived: ((Data) -> Void)?
     var onTurnComplete: (() -> Void)?
@@ -370,6 +374,13 @@ class GeminiLiveService: ObservableObject {
         guard let data = text.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return
+        }
+
+        // Token usage (cumulative) → record the delta for the cost tracker (Plan AU).
+        if let cumulative = RealtimeUsage.geminiCumulative(json) {
+            let d = usageMeter.delta(tokensIn: cumulative.tokensIn, tokensOut: cumulative.tokensOut)
+            UsageTracker.shared.record(provider: .gemini, model: Config.geminiLiveModel,
+                                       tokensIn: d.tokensIn, tokensOut: d.tokensOut)
         }
 
         // Setup complete

--- a/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeService.swift
+++ b/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeService.swift
@@ -388,6 +388,14 @@ class OpenAIRealtimeService: ObservableObject {
             isModelSpeaking = false
             currentResponseId = nil
             responseLatencyLogged = false
+            // Record this response's token usage for the cost tracker (Plan AU).
+            if let usage = RealtimeUsage.openAIResponseUsage(json) {
+                let model = self.model
+                Task { @MainActor in
+                    UsageTracker.shared.record(provider: .openai, model: model,
+                                               tokensIn: usage.tokensIn, tokensOut: usage.tokensOut)
+                }
+            }
             onTurnComplete?()
 
         case "input_audio_buffer.speech_started":

--- a/OpenGlasses/Sources/Services/Usage/RealtimeUsage.swift
+++ b/OpenGlasses/Sources/Services/Usage/RealtimeUsage.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Pure extraction of token usage from the realtime voice sessions (Plan AU follow-up).
+/// OpenAI Realtime reports **per-response** usage on `response.done`; Gemini Live reports
+/// **cumulative** session totals in `usageMetadata`. Headless-testable; the session
+/// managers feed it each decoded server message and record the result via `UsageTracker`.
+enum RealtimeUsage {
+
+    /// OpenAI Realtime `response.done` → that response's `(input, output)` tokens, or nil.
+    static func openAIResponseUsage(_ event: [String: Any]) -> (tokensIn: Int, tokensOut: Int)? {
+        guard let usage = (event["response"] as? [String: Any])?["usage"] as? [String: Any] else { return nil }
+        let tIn = int(usage["input_tokens"])
+        let tOut = int(usage["output_tokens"])
+        return (tIn + tOut > 0) ? (tIn, tOut) : nil
+    }
+
+    /// Gemini Live `usageMetadata` → the **cumulative** `(input, output)` totals so far, or nil.
+    /// Output prefers `responseTokenCount`, falling back to `candidatesTokenCount`.
+    static func geminiCumulative(_ message: [String: Any]) -> (tokensIn: Int, tokensOut: Int)? {
+        guard let meta = message["usageMetadata"] as? [String: Any] else { return nil }
+        let tIn = int(meta["promptTokenCount"])
+        let tOut = meta["responseTokenCount"] != nil ? int(meta["responseTokenCount"])
+                                                      : int(meta["candidatesTokenCount"])
+        return (tIn + tOut > 0) ? (tIn, tOut) : nil
+    }
+
+    private static func int(_ value: Any?) -> Int {
+        if let i = value as? Int { return i }
+        if let n = value as? NSNumber { return n.intValue }
+        if let d = value as? Double { return Int(d) }
+        return 0
+    }
+}
+
+/// Converts a stream of **cumulative** usage totals (Gemini Live) into the per-update
+/// delta to record, so a growing session total isn't double-counted. Pure value type.
+struct CumulativeUsageMeter {
+    private var lastIn = 0
+    private var lastOut = 0
+
+    /// The newly-added `(input, output)` since the last cumulative reading. Never negative
+    /// (a reset or lower reading yields 0 for that component).
+    mutating func delta(tokensIn: Int, tokensOut: Int) -> (tokensIn: Int, tokensOut: Int) {
+        let dIn = max(0, tokensIn - lastIn)
+        let dOut = max(0, tokensOut - lastOut)
+        if tokensIn >= lastIn { lastIn = tokensIn }
+        if tokensOut >= lastOut { lastOut = tokensOut }
+        return (dIn, dOut)
+    }
+}

--- a/OpenGlassesTests/RealtimeUsageTests.swift
+++ b/OpenGlassesTests/RealtimeUsageTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import OpenGlasses
+
+final class RealtimeUsageTests: XCTestCase {
+
+    // MARK: - OpenAI Realtime (per-response)
+
+    func testOpenAIResponseUsage() {
+        let event: [String: Any] = [
+            "type": "response.done",
+            "response": ["usage": ["input_tokens": 120, "output_tokens": 45, "total_tokens": 165]]
+        ]
+        let u = RealtimeUsage.openAIResponseUsage(event)
+        XCTAssertEqual(u?.tokensIn, 120)
+        XCTAssertEqual(u?.tokensOut, 45)
+    }
+
+    func testOpenAINoUsageBlock() {
+        XCTAssertNil(RealtimeUsage.openAIResponseUsage(["type": "response.done", "response": [:]]))
+        XCTAssertNil(RealtimeUsage.openAIResponseUsage(["type": "response.done"]))
+    }
+
+    // MARK: - Gemini Live (cumulative)
+
+    func testGeminiCumulativePrefersResponseTokenCount() {
+        let msg: [String: Any] = ["usageMetadata": ["promptTokenCount": 30, "responseTokenCount": 12, "candidatesTokenCount": 99]]
+        let u = RealtimeUsage.geminiCumulative(msg)
+        XCTAssertEqual(u?.tokensIn, 30)
+        XCTAssertEqual(u?.tokensOut, 12)   // responseTokenCount wins
+    }
+
+    func testGeminiCumulativeFallsBackToCandidates() {
+        let msg: [String: Any] = ["usageMetadata": ["promptTokenCount": 30, "candidatesTokenCount": 8]]
+        XCTAssertEqual(RealtimeUsage.geminiCumulative(msg)?.tokensOut, 8)
+    }
+
+    func testGeminiNoUsageMetadata() {
+        XCTAssertNil(RealtimeUsage.geminiCumulative(["serverContent": [:]]))
+    }
+
+    // MARK: - CumulativeUsageMeter
+
+    func testMeterReturnsDeltas() {
+        var meter = CumulativeUsageMeter()
+        XCTAssertEqual(meter.delta(tokensIn: 30, tokensOut: 10).tokensIn, 30)
+        // Second cumulative reading → only the new tokens.
+        let d2 = meter.delta(tokensIn: 50, tokensOut: 25)
+        XCTAssertEqual(d2.tokensIn, 20)
+        XCTAssertEqual(d2.tokensOut, 15)
+        // No change → zero delta.
+        let d3 = meter.delta(tokensIn: 50, tokensOut: 25)
+        XCTAssertEqual(d3.tokensIn, 0)
+        XCTAssertEqual(d3.tokensOut, 0)
+    }
+
+    func testMeterNeverNegativeOnReset() {
+        var meter = CumulativeUsageMeter()
+        _ = meter.delta(tokensIn: 100, tokensOut: 40)
+        // A lower reading (session reset) yields 0, not a negative.
+        let d = meter.delta(tokensIn: 5, tokensOut: 2)
+        XCTAssertEqual(d.tokensIn, 0)
+        XCTAssertEqual(d.tokensOut, 0)
+        // And subsequent growth resumes from the higher baseline.
+        let d2 = meter.delta(tokensIn: 110, tokensOut: 45)
+        XCTAssertEqual(d2.tokensIn, 10)
+        XCTAssertEqual(d2.tokensOut, 5)
+    }
+}

--- a/docs/plans/consolidated-partials.md
+++ b/docs/plans/consolidated-partials.md
@@ -24,7 +24,7 @@ then strike it here.
 
 | Plan | Outstanding item | Notes |
 |---|---|---|
-| [AU](llm-cost-usage-tracker.md) | ~~Streamed-Chat (`onToken`)~~ ✅ + realtime-voice token capture | Streamed-Chat SSE capture shipped (`StreamingUsageAccumulator`, Anthropic + OpenAI `include_usage`); realtime-voice (Gemini Live / OpenAI Realtime sessions) still pending |
+| ~~[AU](llm-cost-usage-tracker.md)~~ | ~~Streamed-Chat + realtime-voice token capture~~ | ✅ Shipped — streamed-Chat SSE (`StreamingUsageAccumulator`) + realtime voice (`RealtimeUsage` + `CumulativeUsageMeter`: OpenAI Realtime `response.done`, Gemini Live cumulative `usageMetadata`) |
 | ~~[AU](llm-cost-usage-tracker.md)~~ | ~~Settings pricing editor~~ | ✅ Shipped — `ModelPricingEditorView` + persisted `Config.modelPricingOverrides` |
 | ~~[AN](projects-scoped-contexts.md)~~ | ~~Shareable project export/import bundle~~ | ✅ Shipped — `ProjectBundle`/`ProjectBundleCodec` + `ProjectExporter`; export (share sheet) in `ProjectDetailView`, import (file picker) in `PersonasView` |
 | ~~[AB](health-safety-advisor.md)~~ | ~~Broader interaction-rubric coverage~~ | ✅ Shipped — +7 drug classes (statin/nitrate/PDE5/benzo/opioid/methotrexate/lithium) + alcohol; rules for MAOI+SSRI, PDE5+nitrate, methotrexate/lithium+NSAID, opioid+benzo, ACE+K-sparing, NSAID-in-pregnancy, alcohol+sedative, statin+grapefruit |


### PR DESCRIPTION
Captures token usage from the **realtime voice sessions** (Gemini Live / OpenAI Realtime) — the last LLM path the [cost tracker](docs/plans/llm-cost-usage-tracker.md) didn't see. With this, **every** path feeds the tracker: non-streaming (#141), streamed-Chat (#153), and now realtime voice.

### What's in
- **`RealtimeUsage`** (pure):
  - `openAIResponseUsage` — **per-response** `(input, output)` from the `response.done` event's `response.usage`.
  - `geminiCumulative` — **cumulative** session totals from `usageMetadata` (output prefers `responseTokenCount`, falls back to `candidatesTokenCount`).
- **`CumulativeUsageMeter`** (pure) — turns Gemini's growing cumulative totals into the per-message **delta** to record, so a growing session total isn't double-counted; never negative on a reset.
- **`OpenAIRealtimeService`** — records each `response.done`'s usage.
- **`GeminiLiveService`** — meters the cumulative `usageMetadata` and records the delta (it's `@MainActor`, so it calls `UsageTracker` directly).

### Tests
**7 green in Release** — OpenAI per-response parse (+ missing block), Gemini cumulative (responseTokenCount-vs-candidates, missing metadata), and the meter (deltas, no-change → 0, reset → 0 then resume).

### Note
This **completes every AU sub-item** — the realtime row is struck in [consolidated-partials.md](docs/plans/consolidated-partials.md). The pure parsing/metering is tested headlessly; live token counts on a real voice session remain device-validated, like the rest of the realtime edge (and realtime audio is billed differently from text, so the dollar estimate is approximate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)