### PR TITLE
Round 12 audit hardening: store integrity, safety gate, realtime resilience, wake word, LLM hygiene, prompt de-dup (BB–BG P1)

### DIFF
--- a/OpenGlasses/Sources/App/Views/MCPServerSettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/MCPServerSettingsView.swift
@@ -39,8 +39,25 @@ struct MCPServerSettingsView: View {
                     }
                     LabeledContent("Endpoints", value: "/see_glasses, /glasses_status, /send_to_glasses")
                 }
+                Section("Access token") {
+                    Text(server.accessToken)
+                        .font(.system(.footnote, design: .monospaced))
+                        .textSelection(.enabled)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Button {
+                        UIPasteboard.general.string = server.accessToken
+                    } label: {
+                        Label("Copy token", systemImage: "doc.on.doc")
+                    }
+                    Button(role: .destructive) {
+                        server.regenerateToken()
+                    } label: {
+                        Label("Regenerate token", systemImage: "arrow.clockwise")
+                    }
+                }
                 Section {
-                    Text("Point your Claude Code MCP bridge at the LAN URL above. For remote access, run `cloudflared tunnel --url http://localhost:\(server.port)` on this network and use the public URL.")
+                    Text("Every request must send `Authorization: Bearer <token>`. Configure your Claude Code MCP bridge with the LAN URL and this token. Keep it on your trusted local network — these endpoints expose the live camera, so don't put them behind a public tunnel.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/OpenGlasses/Sources/Services/AgentDocumentStore.swift
+++ b/OpenGlasses/Sources/Services/AgentDocumentStore.swift
@@ -217,8 +217,10 @@ class AgentDocumentStore: ObservableObject {
     <!-- You can also edit it directly to teach the agent facts. -->
     """
 
-    init() {
-        documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+    /// `directory` is injectable so tests can point at a temp folder instead of the app's documents.
+    init(directory: URL? = nil) {
+        documentsDir = directory
+            ?? FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         loadAll()
     }
 
@@ -282,12 +284,29 @@ class AgentDocumentStore: ObservableObject {
         memory = load(.memory)
     }
 
+    /// Documents whose file exists on disk but could not be read (e.g. file protection during a
+    /// locked-device background launch). Their on-disk content may be perfectly fine, so `save`
+    /// must not overwrite it without preserving the original first.
+    private var unreadable: Set<DocumentType> = []
+
     private func load(_ type: DocumentType) -> String {
         let url = path(for: type)
-        if let content = try? String(contentsOf: url, encoding: .utf8), !content.isEmpty {
-            return content
+        if FileManager.default.fileExists(atPath: url.path) {
+            do {
+                // An empty file is a valid, possibly intentional state — not "first run".
+                let content = try String(contentsOf: url, encoding: .utf8)
+                unreadable.remove(type)
+                return content
+            } catch {
+                // Transient read failure: serve the default in-memory, but leave the file alone —
+                // treating this as "first run" would clobber the agent's accumulated documents.
+                unreadable.insert(type)
+                NSLog("[AgentDocs] Read failed for %@ (%@) — keeping the file untouched",
+                      type.filename, error.localizedDescription)
+                return type.defaultContent
+            }
         }
-        // First run: create default
+        // Genuine first run: create the default.
         let defaultContent = type.defaultContent
         try? defaultContent.write(to: url, atomically: true, encoding: .utf8)
         return defaultContent
@@ -295,7 +314,33 @@ class AgentDocumentStore: ObservableObject {
 
     func save(_ type: DocumentType, content: String) {
         let url = path(for: type)
-        try? content.write(to: url, atomically: true, encoding: .utf8)
+        // If the last load couldn't read this file, its on-disk content may still be the user's
+        // real document — move it aside (rename needs no read access) before writing.
+        if unreadable.contains(type) {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyyMMdd-HHmmss"
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            let aside = url.appendingPathExtension("unreadable-\(formatter.string(from: Date()))")
+            do {
+                try FileManager.default.moveItem(at: url, to: aside)
+                NSLog("[AgentDocs] Preserved unreadable %@ as %@", type.filename, aside.lastPathComponent)
+            } catch {
+                NSLog("[AgentDocs] Could not preserve unreadable %@ (%@) — keeping edit in-memory only",
+                      type.filename, error.localizedDescription)
+                switch type {
+                case .soul: soul = content
+                case .skills: skills = content
+                case .memory: memory = content
+                }
+                return
+            }
+            unreadable.remove(type)
+        }
+        do {
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            NSLog("[AgentDocs] Save failed for %@: %@", type.filename, error.localizedDescription)
+        }
         switch type {
         case .soul: soul = content
         case .skills: skills = content

--- a/OpenGlasses/Sources/Services/ConversationStore.swift
+++ b/OpenGlasses/Sources/Services/ConversationStore.swift
@@ -81,8 +81,18 @@ class ConversationStore: ObservableObject {
     /// Key for persisting the active thread ID across restarts.
     private static let activeThreadKey = "conversationStore_activeThreadId"
 
-    init() {
-        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+    /// True after a read failure on an existing conversations file (e.g. file protection while
+    /// locked): the on-disk data may be intact, so saves are suppressed until a load succeeds.
+    private var saveBlocked = false
+
+    /// Serializes encrypted saves so an older snapshot can never finish after — and overwrite —
+    /// a newer one.
+    private var pendingSaveTask: Task<Void, Never>?
+
+    /// `directory` is injectable so tests can point at a temp folder instead of the app's documents.
+    init(directory: URL? = nil) {
+        let docs = directory
+            ?? FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         storageURL = docs.appendingPathComponent("conversations.json")
         loadThreads()
         restoreActiveSession()
@@ -443,14 +453,28 @@ class ConversationStore: ObservableObject {
     // MARK: - Persistence
 
     private func save() {
+        // While locked, `threads` is deliberately empty (or a lone session started pre-unlock) —
+        // writing now would encrypt that over the user's full history. Same for the async
+        // encrypted-load window, which also runs with `isLocked == true`.
+        guard !isLocked else {
+            NSLog("[ConversationStore] Save skipped — store is locked")
+            return
+        }
+        // After a failed read of an existing file, the on-disk data may be intact — never write.
+        guard !saveBlocked else {
+            NSLog("[ConversationStore] Save skipped — last load failed to read the existing file")
+            return
+        }
         do {
             let data = try JSONEncoder().encode(threads)
 
             if encryption.isEnabled {
-                // Encrypt async on background, write result
+                // Encrypt async on background, write result. Chained on the previous save so
+                // writes land in submission order.
                 let url = storageURL
                 let enc = encryption
-                Task {
+                pendingSaveTask = Task { [previous = pendingSaveTask] in
+                    await previous?.value
                     do {
                         let encrypted = try await enc.encrypt(data)
                         var output = Data("OGENC1".utf8)
@@ -491,12 +515,23 @@ class ConversationStore: ObservableObject {
             return
         }
 
-        do {
-            let data = try Data(contentsOf: storageURL)
-            threads = try JSONDecoder().decode([ConversationThread].self, from: data)
-            NSLog("[ConversationStore] Loaded %d threads", threads.count)
-        } catch {
-            NSLog("[ConversationStore] Load failed: %@", error.localizedDescription)
+        switch JSONStore.loadArray(ConversationThread.self, at: storageURL, name: "conversations") {
+        case .loaded(let decoded):
+            threads = decoded
+            saveBlocked = false
+            NSLog("[ConversationStore] Loaded %d threads", decoded.count)
+        case .recovered(let decoded, _):
+            threads = decoded
+            saveBlocked = false
+            NSLog("[ConversationStore] Recovered %d threads (original blob backed up)", decoded.count)
+        case .corrupt:
+            // Original preserved in StoreRecovery — start fresh rather than crash-loop.
+            threads = []
+            saveBlocked = false
+        case .unreadable:
+            saveBlocked = true
+        case .absent:
+            break
         }
     }
 

--- a/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveService.swift
+++ b/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveService.swift
@@ -40,6 +40,19 @@ class GeminiLiveService: ObservableObject {
     private let maxReconnectAttempts = 10
     private let maxBackoffSeconds: Double = 30
     private var reconnectTask: Task<Void, Never>?
+    /// True from the moment a reconnect is scheduled until its task starts running — coalesces the
+    /// duplicate `scheduleReconnect` calls that a single failure triggers from close + error +
+    /// receive-loop, so `reconnectAttempts` advances once per cycle (Plan BD).
+    private var reconnectPending = false
+    /// The 15s connect-timeout task; cancelled on resolve so a stale timer can't fail a later
+    /// attempt (Plan BD).
+    private var connectTimeoutTask: Task<Void, Never>?
+    private var reconnectPolicy: RealtimeReconnect.Policy {
+        .init(maxAttempts: maxReconnectAttempts, maxBackoffSeconds: maxBackoffSeconds)
+    }
+    /// Called when reconnection is exhausted or the session dies terminally — the session manager
+    /// plays an audible cue (Plan BD: voice-first apps must not fail silently).
+    var onReconnectExhausted: (() -> Void)?
 
     // Latency tracking
     private var lastUserSpeechEnd: Date?
@@ -127,14 +140,17 @@ class GeminiLiveService: ObservableObject {
             self.webSocketTask = self.urlSession.webSocketTask(with: url)
             self.webSocketTask?.resume()
 
-            // Timeout after 15 seconds
-            Task {
+            // Timeout after 15 seconds. Stored + cancelled on resolve so a stale timer from a
+            // prior attempt can't resolve a later attempt's continuation (Plan BD).
+            self.connectTimeoutTask?.cancel()
+            self.connectTimeoutTask = Task { [weak self] in
                 try? await Task.sleep(nanoseconds: 15_000_000_000)
+                guard let self, !Task.isCancelled else { return }
                 await MainActor.run {
-                    self.resolveConnect(success: false)
                     if self.connectionState == .connecting || self.connectionState == .settingUp {
                         self.connectionState = .error("Connection timed out")
                     }
+                    self.resolveConnect(success: false)
                 }
             }
         }
@@ -147,6 +163,10 @@ class GeminiLiveService: ObservableObject {
         reconnectTask?.cancel()
         reconnectTask = nil
         reconnecting = false
+        reconnectPending = false
+        reconnectAttempts = 0   // a fresh session must not inherit an exhausted counter (Plan BD)
+        connectTimeoutTask?.cancel()
+        connectTimeoutTask = nil
         receiveTask?.cancel()
         receiveTask = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
@@ -170,22 +190,29 @@ class GeminiLiveService: ObservableObject {
             NSLog("[Gemini] Intentional disconnect — not reconnecting")
             return
         }
-        guard reconnectAttempts < maxReconnectAttempts else {
+        // Coalesce the duplicate triggers a single failure fires (close + error + receive-loop):
+        // only the first schedules; the rest are no-ops until the pending attempt runs (Plan BD).
+        guard !reconnectPending else { return }
+
+        guard let delay = reconnectPolicy.delay(forAttempt: reconnectAttempts + 1) else {
             NSLog("[Gemini] Max reconnect attempts (%d) reached — giving up", maxReconnectAttempts)
             connectionState = .error("Connection lost after \(maxReconnectAttempts) reconnect attempts")
             reconnecting = false
+            onReconnectExhausted?()
             return
         }
 
         reconnecting = true
+        reconnectPending = true
         reconnectAttempts += 1
-        let delay = min(pow(2.0, Double(reconnectAttempts - 1)), maxBackoffSeconds)
         NSLog("[Gemini] Reconnect attempt %d/%d in %.0fs (reason: %@)",
               reconnectAttempts, maxReconnectAttempts, delay, reason ?? "unknown")
 
+        reconnectTask?.cancel()
         reconnectTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             guard let self, !Task.isCancelled else { return }
+            self.reconnectPending = false
 
             // Clean up old socket
             self.receiveTask?.cancel()
@@ -199,8 +226,12 @@ class GeminiLiveService: ObservableObject {
                 self.reconnecting = false
                 NSLog("[Gemini] Reconnected successfully")
                 self.onReconnected?()
+            } else {
+                // connect() may have failed via a timeout that fires NO close/error event — the old
+                // code stalled here forever. Drive the next attempt ourselves; if a close/error did
+                // fire, it already set reconnectPending, so this coalesces to a single reschedule.
+                self.scheduleReconnect(reason: "retry failed")
             }
-            // If connect fails, the onClose/onError handlers will trigger another scheduleReconnect
         }
     }
 
@@ -262,6 +293,8 @@ class GeminiLiveService: ObservableObject {
     // MARK: - Private
 
     private func resolveConnect(success: Bool) {
+        connectTimeoutTask?.cancel()
+        connectTimeoutTask = nil
         if let cont = connectContinuation {
             connectContinuation = nil
             cont.resume(returning: success)
@@ -390,13 +423,17 @@ class GeminiLiveService: ObservableObject {
             return
         }
 
-        // GoAway — server will close soon
+        // GoAway — the server sends this before its session time limit, i.e. on EVERY long session.
+        // The old code fired the fatal onDisconnected path (reconnecting == false), so the session
+        // manager tore the session down right before the close it should have ridden through. Now we
+        // proactively schedule a reconnect so a long conversation survives the server's rotation.
         if let goAway = json["goAway"] as? [String: Any] {
             let timeLeft = goAway["timeLeft"] as? [String: Any]
             let seconds = timeLeft?["seconds"] as? Int ?? 0
-            connectionState = .disconnected
             isModelSpeaking = false
-            onDisconnected?("Server closing (time left: \(seconds)s)")
+            NSLog("[Gemini] goAway received (time left: %ds) — scheduling reconnect", seconds)
+            scheduleReconnect(reason: "server rotating connection")   // sets reconnecting = true first
+            onDisconnected?("Server rotating connection (time left: \(seconds)s)")
             return
         }
 

--- a/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift
+++ b/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import UIKit
+import AVFoundation
 
 /// Coordinator that ties all Gemini Live components together:
 /// AudioManager → GeminiLiveService (audio), GeminiLiveService → AudioManager (playback),
@@ -30,6 +31,16 @@ class GeminiLiveSessionManager: ObservableObject {
     private let frameThrottler = FrameThrottler()
     private var toolCallRouter: ToolCallRouter?
     private var stateObservation: Task<Void, Never>?
+
+    /// Local, network-independent speech for terminal session cues (Plan BD) — never ElevenLabs,
+    /// since the network may be exactly what failed.
+    private let localCueSynth = AVSpeechSynthesizer()
+
+    private func speakLocalCue(_ text: String) {
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        localCueSynth.speak(utterance)
+    }
 
     // Camera frame source — set by AppState to the existing CameraService's periodic captures
     var onRequestVideoFrame: (() async -> UIImage?)?
@@ -182,7 +193,20 @@ class GeminiLiveSessionManager: ObservableObject {
                 if !self.geminiService.reconnecting {
                     self.stopSession()
                     self.errorMessage = "Connection lost: \(reason ?? "Unknown error")"
+                    // Voice-first: the phone may be pocketed, so a visual banner isn't enough (Plan BD).
+                    self.speakLocalCue("Voice session disconnected.")
                 }
+            }
+        }
+
+        // Reconnection exhausted → terminal. Speak an audible cue and surface the error.
+        geminiService.onReconnectExhausted = { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                guard self.isActive else { return }
+                self.stopSession()
+                self.errorMessage = "Voice session lost — couldn't reconnect."
+                self.speakLocalCue("Voice session lost. I couldn't reconnect.")
             }
         }
 
@@ -442,81 +466,12 @@ class GeminiLiveSessionManager: ObservableObject {
             if let router = nativeToolRouter {
                 let names = router.registry.toolNames
                 toolSection += "\nBuilt-in tools: \(names.joined(separator: ", "))."
-                toolSection += """
-
-            - get_weather: Get current weather and forecast.
-            - get_datetime: Get current date, time, day of week.
-            - daily_briefing: Combined daily briefing (date, weather, news).
-            - calculate: Evaluate math expressions.
-            - convert_units: Convert between units.
-            - set_timer: Set a countdown timer.
-            - pomodoro: Start/stop/check Pomodoro focus sessions.
-            - save_note / list_notes: Save and retrieve notes.
-            - web_search: Search the web.
-            - get_news: Get latest news headlines.
-            - translate: Translate text between languages.
-            - translate_sign_menu: Translate visible signs/menus from camera view.
-            - ask_local_phrase: Generate traveler phrases in local language with pronunciation.
-            - define_word: Look up word definitions.
-            - find_nearby: Search for nearby places.
-            - where_am_i: Describe current location with reverse-geocoded place context and GPS coordinates.
-            - open_app: Open iOS apps (Music, Podcasts, Maps, Google Maps, etc).
-            - get_directions: Directions via Apple Maps or Google Maps.
-            - identify_song: Identify a song using Shazam.
-            - music_control: Play, pause, skip, previous, now-playing info.
-            - convert_currency: Convert currencies with live rates.
-            - phone_call: Make a phone call.
-            - send_message: Open Messages with pre-filled text.
-            - copy_to_clipboard: Copy text to clipboard.
-            - flashlight: Toggle flashlight on/off.
-            - device_info: Check battery, storage, low power mode.
-            - save_location / list_saved_locations: Bookmark current spot, find saved spots with distance.
-            - step_count: Today's steps, distance, floors climbed.
-            - emergency_info: Local emergency numbers, GPS coordinates, nearest hospital guidance.
-            - calendar: View schedule, next meeting, create events with reminders.
-            - lookup_contact: Find contact phone/email by name.
-            - reminder: Create/list/complete Apple Reminders with notifications.
-            - set_alarm: Set alarm for specific clock time, list/cancel alarms.
-            - brightness: Adjust screen brightness.
-            - smart_home: Control HomeKit devices — lights, switches, thermostats, locks, scenes.
-            - run_shortcut: Run Apple Shortcuts by name.
-            - vehicle_status: Vehicle / EV charge %, range, charging state, plug status (via Home Assistant).
-            - summarize_conversation: Summarize current conversation or extract action items.
-            - face_recognition: Remember/forget/list known faces. Auto-recognizes people when camera is active.
-            - memory_rewind: Recall what was said recently — transcribes last few minutes of audio.
-            - geofence: Create location-based reminders that trigger when entering/leaving a place.
-            - send_via: Send messages via WhatsApp, Telegram, or Email (not iMessage).
-            - meeting_summary: Summarize a recent meeting from ambient captions with action items.
-            - fitness_coach: Fitness coaching — start/stop workouts, log exercises, check form via camera, workout history from HealthKit.
-            - openclaw_skills: Discover and manage OpenClaw skills. List available skills, check gateway status.
-            - field_session: Start/pause/resume/end/query a Field Assist session for grounded domain-specific technical support (refrigeration, etc.). Loads a knowledge vault and emits an audit log. Actions: start, pause, resume, end, status, list, escalate, export (work-order PDF + audit JSON).
-            - procedure_runner: Run a guided step-by-step procedure inside an active Field Assist session. Actions: list, start, next, previous, repeat, status, complete. Pass 'choice' to 'next' when the active step (shown under ACTIVE PROCEDURE in this prompt) offers branch choices.
-            - project_note: Notes scoped to the ACTIVE field job — what the user is mid-way through. 'save' a note ("compressor swap is next") that resurfaces on later turns while the job is active; 'list'/'clear' the job's notes. Params: text.
-            - capture_flow: Run a structured, typed capture flow (inspection / work-order form) inside an active session — steps collect validated values (reading, enum, barcode, photo) bound to fields, producing an audit-ready record. Actions: list, start, answer, skip, back, status, finish, cancel. Read the returned step prompt aloud; pass the user's spoken value verbatim to 'answer'. Params: flow_id, asset_id, value.
-            - domain_calc: Refrigeration math grounded in vault PT charts — pt_lookup, superheat, subcool. Temps °F, pressures PSIG. Params: operation, refrigerant, and the relevant pressures/temps.
-            - equipment_lookup: Look up an error code/fault/model in the active session's vault — read aloud (query) or via on-device camera OCR (omit query or set use_camera). Returns the matching reference section with its source.
-            - safety_assessment: Run a High-Energy Control Assessment (HECA) on the current job-site view — detects the 13 high-energy SIF hazards and whether each has a DIRECT control; returns a summary + HECA score. Use for "assess this site", "is this safe?". Actions: run, last, score, history, export (PDF), ask (advisor follow-up — pass question). Advisory only.
-            - reading_assist: Read text in front of the user via the glasses camera (on-device OCR). Modes: read, simplify (level 1-5), translate (target_language), define. Use for 'read this', 'simplify this', 'translate this sign', 'what does this word mean'.
-            - health_vault: Query/update the user's Personal Health Vault (biometrics, conditions, diet, labs, medications, wearables). 'query' grounds a health question in their own notes (cite the file); 'log' records a new entry. Never fabricate health data.
-            - health_check: "Is this safe for me?" over the Health Vault — 'can_i_take' a medication or 'can_i_eat' a food. Deterministic high-severity interaction check against the user's meds/conditions/allergies + grounded advisory. Cites the vault; defers to a pharmacist/doctor. Param: subject.
-            - notes_vault: The user's personal notes / second brain. 'log' to remember ("note that…"), 'query' to recall. Files: general, people, ideas, todos. Answers only from recorded notes.
-            - document_knowledge: Private on-device knowledge base of the user's documents (manuals, contracts, reports). 'query' retrieves relevant passages to ground an answer (cite the document, answer only from what's returned); 'ingest_scan' saves a document seen through the glasses; 'ingest_text' saves provided text; 'list'/'forget' manage saved docs.
-            - study: Study Mode — turn a document into flashcards + a quiz and review hands-free. Actions: scan (OCR a page via the glasses camera; repeat then make_deck), make_deck (from scanned pages, 'deck' name, or raw 'text'), list, quiz, answer (via 'value'), review, flip, grade (via 'value'), stop. Use for "study this page", "make flashcards from X", "quiz me".
-            - smart_capture: Capture a business card, receipt, or event flyer (mode: contact/receipt/event) and extract structured details, then chain to contacts/calendar/notes_vault to act.
-            - identify_medication: Read a medication label via camera OCR and cross-check the user's recorded medications. Reports label text + match status; no clinical claims. Needs Medical Compliance.
-            - aircraft_overhead: Report aircraft flying near the user using live ADS-B data + their location. Use for "what's flying overhead?". Param: radius_miles (default 25).
-            - live_coach: Real-time one-sentence coaching from the glasses camera. Actions: start (domain: sports_tactics/cooking_form/posture/guitar/climbing/custom), stop, status. Use for "coach my form", "watch my technique".
-            - code_agent: Hands-free control of a REMOTE coding agent (on the user's gateway, not the phone). Actions: start (prompt, optional project), status, cancel, confirm, deny. Requires Agent Mode. Use for "have the agent add a feature", "ask the agent to fix the test".
-            - network_calc: IP subnet/CIDR math (IPv4/IPv6) — operation 'subnet' with a 'cidr' returns network, broadcast, netmask, usable range/count.
-            - navigation_assist: Spoken walking guidance for low-vision users (hazards/landmarks, clock positions). Actions: start, stop, status. An aid, not a cane/guide-dog replacement.
-            - first_aid: Hands-free first-aid coaching — speaks steps and paces CPR. Actions: start (cpr/choking/bleeding/recovery/march), next, back, aed (nearest defibrillator), stop. Advisory only; always reminds to call emergency services.
-            - identify_color: Name the dominant color of what the user sees (on-device). Use for "what color is this?".
-            - identify_money: Identify a banknote's currency and denomination from the camera, for low-vision support. Use for "how much is this note?".
-            - vision_assess: Structured visual assessment with a typed result card (kind selects the type). Use kind 'instrument_reading' to read a number off a gauge, thermometer, refractometer, scale, or meter. Optional note adds context.
-            - photo_log: Capture a glasses-camera photo, attach it to the session audit log with a caption, and return it for analysis. Use to document gauge readings and evidence.
-            - escalate_to_expert: Escalate the active session to a human expert when you can't safely resolve it or the technician asks for a person. Actions: request (reason), status, resolve, cancel. Live video is Phase 5 — for now it's logged and the expert pool is notified.
-            - teleprompter: Hands-free teleprompter on the in-lens HUD — shows a script a window at a time and (audio-paced) auto-advances by listening to you read. Actions: start (text=the script, or script=a saved script name, or document=a saved knowledge-base document; optional mode audio_paced/voice/auto_scroll), stop, pause, resume, next, back, restart, faster, slower, list, save (text + optional title), scan (capture a printed page via the glasses camera + OCR — repeat for pages, then start). Use for "start the teleprompter", "read my speech", "teleprompt my saved doc", "scan this script", "faster/slower".
-            """
+                // Plan BG P1: generated from each NativeTool's own `description` — the single source
+                // shared with Direct Mode and the tool schemas, so the three can no longer drift.
+                let descriptions = router.registry.toolDescriptions(for: names)
+                if !descriptions.isEmpty {
+                    toolSection += "\n\n" + SystemPromptBuilder.toolLines(descriptions)
+                }
 
                 // Inject user-defined custom tool descriptions
                 let customTools = Config.customTools.filter { Config.isToolEnabled($0.name) }

--- a/OpenGlasses/Sources/Services/HighImpactToolPolicy.swift
+++ b/OpenGlasses/Sources/Services/HighImpactToolPolicy.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Deterministic, **agent-mode-independent** confirmation floor for tools that take irreversible,
+/// security-relevant physical actions (docs/plans/BC-unconditional-safety-gate.md).
+///
+/// The full `SafetySupervisor` (geofence, quiet hours, plan validation) is an agentic feature and
+/// stays gated behind `Config.agentModeEnabled`. But confirmation before *unlocking a door* is a
+/// user-safety floor, not an agentic feature: the audit found that with agent mode off (the
+/// default) `smart_home action:unlock` executed with no confirmation, so a prompt-injected sign or
+/// web result could open a lock. This policy runs regardless of agent mode.
+///
+/// It classifies only the narrow set of *direct-actuation* verbs on security-relevant device
+/// classes. Reads, listing, and low-stakes actuation (turning a light on) pass through — the goal
+/// is a floor against catastrophic actions, not a confirmation prompt on every tool call. The
+/// messaging tools are already gated by their URL-scheme tap and are intentionally not duplicated
+/// here.
+enum HighImpactToolPolicy {
+
+    enum Verdict: Equatable {
+        case proceed
+        case requiresConfirmation(summary: String)
+    }
+
+    /// Security-relevant `smart_home` (HomeKit) actions that must be confirmed. Turning a light
+    /// on/off is deliberately excluded; unlocking, opening, and disarming are not.
+    private static let securityActuationVerbs: Set<String> = [
+        "unlock", "lock", "open", "close", "disarm", "arm",
+    ]
+
+    /// Home Assistant domains/services that actuate physical security devices. HA calls are free
+    /// text, so we match on substrings of the command / service.
+    private static let homeAssistantSecurityHints: [String] = [
+        "unlock", "lock.", "open", "cover.", "garage", "alarm", "disarm", "arm_",
+    ]
+
+    /// Classify a tool call. Anything not explicitly matched proceeds — this is a floor, not an
+    /// allowlist.
+    static func evaluate(tool: String, args: [String: Any]) -> Verdict {
+        switch tool {
+        case "smart_home":
+            let action = (args["action"] as? String)?
+                .lowercased().trimmingCharacters(in: .whitespaces) ?? ""
+            guard securityActuationVerbs.contains(action) else { return .proceed }
+            let device = (args["device"] as? String).map { " (\($0))" } ?? ""
+            return .requiresConfirmation(summary: "\(action.capitalized) smart-home device\(device)")
+
+        case "home_assistant":
+            let command = homeAssistantCommandText(args).lowercased()
+            guard homeAssistantSecurityHints.contains(where: command.contains) else { return .proceed }
+            return .requiresConfirmation(summary: "Home Assistant: \(homeAssistantCommandText(args))")
+
+        default:
+            return .proceed
+        }
+    }
+
+    /// True when a tool has any actuation verb worth a floor-level confirmation — used to decide
+    /// whether to consult `evaluate` at all.
+    static func mayRequireConfirmation(tool: String) -> Bool {
+        tool == "smart_home" || tool == "home_assistant"
+    }
+
+    private static func homeAssistantCommandText(_ args: [String: Any]) -> String {
+        if let text = args["text"] as? String, !text.isEmpty { return text }
+        if let service = args["service"] as? String, !service.isEmpty {
+            let entity = (args["entity_id"] as? String).map { " \($0)" } ?? ""
+            return service + entity
+        }
+        return args.sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: " ")
+    }
+}

--- a/OpenGlasses/Sources/Services/LLM/HistoryHygiene.swift
+++ b/OpenGlasses/Sources/Services/LLM/HistoryHygiene.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Pure hygiene passes over the Anthropic-shaped `[[String: Any]]` conversation history
+/// (docs/plans/BF-llm-turn-hygiene.md). No I/O — each function takes a history and returns a
+/// cleaned copy so it can be unit-tested against fixture transcripts.
+///
+/// The three problems it solves, all found by the round-12 audit:
+///  1. A `tool_use` block with no matching `tool_result` makes Anthropic reject EVERY later request
+///     with a 400 — one malformed or interrupted tool call bricks the whole conversation.
+///  2. Full base64 images pile up in history and are re-uploaded (and re-billed) every turn.
+///  3. The token estimator counts an image block at the 50-token floor, so image weight never
+///     triggers compaction.
+enum HistoryHygiene {
+
+    /// A synthetic result inserted for a `tool_use` that never got one.
+    static let interruptedToolResult = "Error: tool execution was interrupted; no result was produced."
+
+    /// Placeholder that replaces a pruned image so the turn still reads coherently.
+    static let prunedImagePlaceholder = "[earlier photo omitted to save context]"
+
+    // MARK: - Dangling tool_use repair
+
+    /// Ensure every assistant `tool_use` block is answered by a `tool_result` in the immediately
+    /// following user turn (Anthropic's required shape). Missing ids — a skipped/malformed block, a
+    /// partially-answered turn, or a turn that threw mid-execution — get a synthetic error result
+    /// merged into that single following user message, so the request is valid.
+    static func repairDanglingToolUse(_ history: [[String: Any]]) -> [[String: Any]] {
+        var out: [[String: Any]] = []
+        var i = 0
+        while i < history.count {
+            let message = history[i]
+            i += 1
+            out.append(message)
+
+            guard (message["role"] as? String) == "assistant",
+                  let blocks = message["content"] as? [[String: Any]] else { continue }
+            let toolUseIds = blocks
+                .filter { $0["type"] as? String == "tool_use" }
+                .compactMap { $0["id"] as? String }
+            guard !toolUseIds.isEmpty else { continue }
+
+            // Consume the immediately-following user tool_result message if there is one, so all
+            // results for this assistant turn land in a single user message.
+            var resultBlocks: [[String: Any]] = []
+            var answered = Set<String>()
+            if i < history.count,
+               (history[i]["role"] as? String) == "user",
+               let nextBlocks = history[i]["content"] as? [[String: Any]],
+               nextBlocks.contains(where: { $0["type"] as? String == "tool_result" }) {
+                resultBlocks = nextBlocks
+                for block in nextBlocks where block["type"] as? String == "tool_result" {
+                    if let id = block["tool_use_id"] as? String { answered.insert(id) }
+                }
+                i += 1   // consume it — we re-emit it (possibly extended) below
+            }
+
+            for id in toolUseIds where !answered.contains(id) {
+                resultBlocks.append(["type": "tool_result", "tool_use_id": id, "content": interruptedToolResult])
+            }
+            if !resultBlocks.isEmpty {
+                out.append(["role": "user", "content": resultBlocks])
+            }
+        }
+        return out
+    }
+
+    // MARK: - Image pruning
+
+    /// Replace the image blocks in all but the newest `keepLast` image-bearing user messages with a
+    /// short text placeholder, so old frames stop being re-uploaded every turn. The newest image(s)
+    /// and all text are preserved.
+    static func pruneImages(_ history: [[String: Any]], keepLast: Int = 1) -> [[String: Any]] {
+        // Indices of messages that carry at least one image block, oldest → newest.
+        let imageIndices = history.indices.filter { messageHasImage(history[$0]) }
+        guard imageIndices.count > keepLast else { return history }
+        let pruneUpTo = imageIndices.count - keepLast
+        let indicesToPrune = Set(imageIndices.prefix(pruneUpTo))
+
+        var out = history
+        for i in indicesToPrune {
+            out[i] = stripImages(from: out[i])
+        }
+        return out
+    }
+
+    private static func messageHasImage(_ message: [String: Any]) -> Bool {
+        guard let blocks = message["content"] as? [[String: Any]] else { return false }
+        return blocks.contains { $0["type"] as? String == "image" }
+    }
+
+    private static func stripImages(from message: [String: Any]) -> [String: Any] {
+        guard let blocks = message["content"] as? [[String: Any]] else { return message }
+        var newBlocks: [[String: Any]] = []
+        var replacedAny = false
+        for block in blocks {
+            if block["type"] as? String == "image" {
+                replacedAny = true
+            } else {
+                newBlocks.append(block)
+            }
+        }
+        if replacedAny {
+            newBlocks.append(["type": "text", "text": prunedImagePlaceholder])
+        }
+        var out = message
+        out["content"] = newBlocks
+        return out
+    }
+
+    // MARK: - Token estimation
+
+    /// Estimate the token weight of a history, counting image blocks by their base64 payload size
+    /// (~1.5k chars per 1k tokens) instead of the flat 50-token floor a text-only estimate applies.
+    static func estimatedTokens(_ history: [[String: Any]]) -> Int {
+        history.reduce(0) { $0 + estimatedTokens(forMessage: $1) }
+    }
+
+    static func estimatedTokens(forMessage message: [String: Any]) -> Int {
+        if let text = message["content"] as? String {
+            return max(text.count / 4, 50)
+        }
+        guard let blocks = message["content"] as? [[String: Any]] else { return 50 }
+        var tokens = 0
+        for block in blocks {
+            switch block["type"] as? String {
+            case "text":
+                tokens += max((block["text"] as? String ?? "").count / 4, 1)
+            case "image":
+                let base64 = (block["source"] as? [String: Any])?["data"] as? String ?? ""
+                // A JPEG this size costs roughly base64Bytes / 1500 tokens on Anthropic vision.
+                tokens += max(base64.count / 1500, 1)
+            case "tool_result":
+                let content = block["content"] as? String ?? ""
+                tokens += max(content.count / 4, 1)
+            default:
+                tokens += 1
+            }
+        }
+        return max(tokens, 50)
+    }
+}

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -169,7 +169,7 @@ class LLMService: ObservableObject {
     /// Build the full system prompt, optionally including location, tools, memory, and vision context.
     /// When `promptSections` is provided (from the ConversationClassifier), irrelevant sections are
     /// stripped to reduce token count. When nil, all sections are included (backward compatible).
-    private static func buildSystemPrompt(locationContext: String?, includeTools: Bool, includeOpenClaw: Bool, hasImage: Bool, nativeToolNames: [String] = [], gatewayToolNames: [String] = [], memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil, turn: String? = nil) async -> String {
+    private static func buildSystemPrompt(locationContext: String?, includeTools: Bool, includeOpenClaw: Bool, hasImage: Bool, nativeToolNames: [String] = [], nativeToolDescriptions: [(name: String, description: String)] = [], gatewayToolNames: [String] = [], memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil, turn: String? = nil) async -> String {
         // Agent personality mode: soul.md + skills.md + memory.md replace the standard prompt
         var prompt: String
         if Config.agentModeEnabled, let agentContext, !agentContext.isEmpty {
@@ -207,95 +207,12 @@ class LLMService: ObservableObject {
 
             if !nativeToolNames.isEmpty {
                 toolSection += "\nBuilt-in tools: \(nativeToolNames.joined(separator: ", "))."
-                toolSection += """
-
-            - get_weather: Get current weather and forecast.
-            - get_datetime: Get current date, time, day of week.
-            - daily_briefing: Combined daily briefing (date, weather, news) — use for "good morning" or "what's happening today".
-            - calculate: Evaluate math expressions.
-            - convert_units: Convert between units (length, weight, temp, volume, speed, etc).
-            - set_timer: Set a countdown timer with local notification.
-            - pomodoro: Start/stop/check a Pomodoro focus session (25 min work, 5 min break cycles).
-            - save_note / list_notes: Save and retrieve notes locally.
-            - web_search: Search the web via DuckDuckGo.
-            - get_news: Get latest news headlines, optionally by topic.
-            - translate: Translate text between languages.
-            - translate_sign_menu: Translate visible signs/menus from camera view. Returns ORIGINAL text first, then translation.
-            - ask_local_phrase: Generate traveler phrases in the local language with pronunciation and a polite variant.
-            - define_word: Look up word definitions.
-            - find_nearby: Search for nearby places (restaurants, cafes, pharmacies, gas stations, etc).
-            - where_am_i: Describe the user's current location with reverse-geocoded place context and GPS coordinates.
-            - open_app: Open iOS apps (Music, Podcasts, Maps, Google Maps, YouTube, Spotify, etc).
-            - get_directions: Directions via Apple Maps or Google Maps (set app='google' for Google Maps).
-            - identify_song: Identify a song playing nearby using Shazam.
-            - music_control: Play, pause, skip, previous track, or get now-playing info (Apple Music).
-            - convert_currency: Convert between currencies with live exchange rates.
-            - phone_call: Make a phone call to a number.
-            - send_message: Open Messages with a pre-filled text to a recipient.
-            - copy_to_clipboard: Copy text to clipboard (great after OCR, translation, or any result the user wants to keep).
-            - flashlight: Turn the device flashlight on/off.
-            - device_info: Check battery level, storage, and low power mode.
-            - save_location / list_saved_locations: Save current spot with a label ("remember where I parked") and find saved spots later with distance.
-            - step_count: Today's steps, walking distance, and floors climbed.
-            - emergency_info: Local emergency numbers for current country, exact GPS coordinates, and guidance to find nearest hospital.
-            - calendar: View today's schedule, next meeting, upcoming week, or create events. Events get a 15-min reminder notification.
-            - lookup_contact: Look up a contact by name to get their phone number or email. Use before phone_call or send_message.
-            - reminder: Create, list, or complete Apple Reminders with due dates and notifications. Syncs with iCloud.
-            - set_alarm: Set an alarm for a specific clock time (e.g. '7 AM tomorrow'). Also list or cancel alarms.
-            - brightness: Adjust screen brightness (0-100, or presets: max, min, dim, bright, up, down).
-            - smart_home: Control HomeKit smart home devices — lights, switches, fans, thermostats, locks, scenes. ALWAYS try this tool for smart home requests. Say 'list' to see devices.
-            - run_shortcut: Run an Apple Shortcut by name (e.g. 'Start Focus', 'Log Water', any user-created shortcut).
-            - summarize_conversation: Summarize current conversation, extract action items/to-dos. Use when user says "summarize", "recap", or "what did we discuss?"
-            - face_recognition: Remember faces ('remember this person as John'), forget faces, list known people, or toggle auto-recognition on/off.
-            - memory_rewind: Recall what was said recently. Transcribes last few minutes of ambient audio. Use for "what did they just say?" or "what happened?" Must be started first with action='start'.
-            - geofence: Location-based reminders. 'Remind me when I get to the office' or 'alert me when I leave home'. Create, list, delete geofenced alerts.
-            - send_via: Send messages via WhatsApp, Telegram, or Email. Specify channel ('whatsapp', 'telegram', 'email'), recipient, and body.
-            - meeting_summary: Summarize a recent meeting or conversation from ambient captions. Extracts key points, decisions, and action items. Requires ambient captions to be running.
-            - fitness_coach: Fitness coaching — start/stop workouts, log exercises (reps/sets/weight), check form via camera, get workout history from HealthKit, set step goals.
-            - openclaw_skills: Discover and manage OpenClaw skills. List available skills, check gateway status, search for capabilities. Only available when OpenClaw is configured.
-            - voice_skills: Voice-taught skills — save (teach a new trigger→action), list (show all), delete, clear. "Learn that when I say 'goodnight', turn off all lights."
-            - object_memory: Remember where physical objects are. Save ('remember my keys are on the counter'), find ('where are my keys?'), list, forget.
-            - contextual_note: Save notes with automatic location and time context. Search notes by keyword or location.
-            - social_context: Remember facts about people. Add facts ('remember John works at Stripe'), recall ('what do I know about John?'), list people.
-            - brain: Unified search across ALL on-device memory (facts, documents, people, notes, meetings, knowledge graph + encounter log). action 'query' for any "what do I know about…" when unsure where it lives; 'recall' to search PAST CONVERSATIONS — what you actually said in earlier sessions — and get a cited answer ("what did we decide about X?", "what did I say about Y last week?"); 'insights' for an on-device usage recap — top topics + activity over the last N days ("what have I been up to this week?"); 'person' for a dossier before/after meeting someone ("brief me on Alice"); 'link' to record relationships ('Alice works at Acme'); 'encounters' for recent sightings ("when did I last see Bob?"); 'save_need' for a follow-up ("Bob wants the deck"), 'needs' to list open follow-ups, 'resolve_need' to close one. Cites sources and says what's missing — answer only from its findings.
-            - home_assistant: Control Home Assistant smart home — toggle devices, check states, list entities, run automations, or use 'converse' action to send natural language commands directly to HA (e.g. action=converse, text="turn on the kitchen lights"). ALWAYS try this tool when asked about smart home control. Use entity IDs from the device list below when available; the tool also fuzzy-matches and falls back to HA's voice assistant.
-            - vehicle_status: Get the user's vehicle / EV charge %, range, charging state, and plug status. Reads live from Home Assistant — use for "what's my car's charge?", "is the car charging?", "how much range do I have?".
-            - scan_code: Scan QR codes or barcodes from the camera. Returns decoded content (URLs, text, product codes). Works offline.
-            - capture_photo: Capture a photo from the glasses camera for visual analysis. Use when you need to see what the user is looking at, or proactively when visual context would help your response.
-            - reading_assist: Read text in front of the user via the glasses camera (on-device OCR). Modes: read (clean + read aloud), simplify (rewrite at a reading level 1-5), translate (into target_language), define (plain-language definition of a term). Use for 'read this to me', 'simplify this', 'translate this sign', 'what does this word mean'.
-            - health_vault: Query or update the user's Personal Health Vault (their own notes on biometrics, conditions, diet, labs, medications, wearables). action 'query' (with question) grounds a health question in their data — cite the source file; action 'log' (file + entry) records a new entry. Never fabricate health data.
-            - health_check: "Is this safe for ME?" over the Health Vault. 'can_i_take' a medication/supplement ("can I take ibuprofen?") or 'can_i_eat' a food ("can I eat aged cheese?"). Cross-references known high-severity drug/food interactions deterministically against the user's meds/conditions/allergies. Advisory only; always cites the vault and defers to a pharmacist/doctor. Param: subject.
-            - notes_vault: The user's personal notes / second brain. 'log' to remember something ("note that…", "remember…"), 'query' to recall it ("what did I note about…"). Files: general, people, ideas, todos. Answers only from recorded notes.
-            - document_knowledge: Private on-device knowledge base of the user's documents (manuals, contracts, reports). action 'query' retrieves the most relevant passages to ground an answer — cite the document name and answer only from what's returned; 'ingest_scan' captures and saves a document seen through the glasses ("remember this manual"); 'ingest_text' saves provided text; 'list' shows saved documents; 'forget' deletes one. Use 'query' whenever the user asks about a document they've saved.
-            - study: Study Mode — turn a document into flashcards + a quiz and review hands-free with spaced repetition. Actions: scan (OCR a page through the glasses camera; repeat then make_deck), make_deck (from scanned pages, a document name via 'deck', or raw 'text'), list, quiz (start), answer (via 'value' — a number or the option), review (flashcards), flip, grade (right/wrong via 'value'), stop. Use for "study this page", "make flashcards from X", "quiz me".
-            - identify_medication: Read a medication label via the glasses camera (on-device OCR) and cross-check it against the user's recorded medications. Use for "what's this pill?", "is this my medication?". Reports the label text + match status; never makes clinical claims. Needs Medical Compliance.
-            - aircraft_overhead: Report aircraft flying near the user using live ADS-B data and their location. Use for "what's flying overhead?", "any planes nearby?". Param: radius_miles (1-200, default 25).
-            - live_coach: Real-time, one-sentence coaching feedback from the glasses camera. Use for "coach my squat form", "watch my knife technique", "help with my guitar". Actions: start (domain), stop, status. Domains: sports_tactics, cooking_form, posture, guitar, climbing, custom. Params: custom_prompt, interval_seconds, max_words, max_duration_minutes.
-            - code_agent: Hands-free control of a REMOTE coding agent (runs on the user's gateway, not the phone). Use for "have the agent add a dark-mode toggle", "ask the agent to fix the failing test". Actions: start (prompt, optional project), status, cancel, confirm, deny. Requires Agent Mode enabled in Settings. Progress and a final summary are spoken.
-            - network_calc: IP subnet/CIDR math for IT field work. operation 'subnet' with a 'cidr' (IPv4 or IPv6) returns network, broadcast, netmask, usable host range and count. Use for subnetting questions.
-            - navigation_assist: Spoken walking guidance for low-vision users — periodically calls out hazards/landmarks (steps, drop-offs, obstacles, oncoming people) using clock positions. Actions: start, stop, status. Use for "guide me", "navigation mode". An aid, not a cane/guide-dog replacement.
-            - first_aid: Hands-free first-aid coaching in an emergency — speaks step-by-step guidance and paces CPR with a metronome. Actions: start (protocol: cpr, choking, bleeding, recovery, march), next, back, aed (find nearest defibrillator), stop. Use for "start CPR", "someone is choking", "they're bleeding", "nearest AED". Advisory only — always reminds the user to call emergency services; not a substitute for professional care.
-            - identify_color: Name the dominant color of what the user is looking at (on-device, no network). Use for "what color is this?".
-            - identify_money: Identify a banknote's currency and denomination from the glasses camera, for low-vision support. Use for "how much is this note?", "what bill is this?".
-            - audio_recording: Start or stop audio-only recording (no camera — lighter on battery). Saves .m4a to Documents/Recordings with live transcription and a meeting assistant that sends lock screen summaries + suggested questions every 60 seconds. Saying 'take a picture' during recording adds a visual note to the transcript. Actions: start, stop, status. Use when the user says 'record this meeting', 'record audio', 'record this conversation', or 'start audio recording'.
-            - video_recording: Start or stop video+audio recording from the glasses camera and microphone. Recordings save to Photos with no time limit — ideal for interviews, meetings, procedures. Includes live transcription by default (saved as .txt alongside video). Actions: start, stop, status. Params: transcribe (bool, default true). Use when the user says 'start recording', 'record this', 'film this', 'watch what I'm doing', or 'stop recording'.
-            - medical_export: Export clinical transcripts to medical platforms or share manually. Actions: export_fhir (upload to FHIR server), export_file (create file), share (open share sheet), status (check config). Params: format (text/pdf/fhir_json/hl7), transcript (optional, uses latest recording). Use when the user says 'export the transcript', 'send to the EMR', 'share the notes', or 'upload to the health record'.
-            - qr_context: Scan a QR code and load its content as context (museum exhibits, venue info, procedures). Use at museums, venues, or workplaces. Can also load context from a URL directly.
-            - smart_capture: Capture a business card, receipt, or event flyer and extract structured details (mode: contact/receipt/event). Then chain to contacts/calendar/notes_vault to act. Use for "save this card", "log this receipt", "add this event from the flyer".
-            - vision_assess: Run a structured visual assessment of what the glasses camera sees and show a typed result card (kind selects the assessment). Use kind 'instrument_reading' to read a number off a gauge, thermometer, refractometer, scale, or meter ("what does this gauge read?", "read the thermometer"). Optional note adds context.
-            - golf_mode: Golf caddy assistant — track shots with GPS, get club recommendations, log scores, view round summary, and get course strategy. Actions: start_round, track_shot, club_recommendation, log_score, round_summary, strategy.
-            - live_translate: Start/stop continuous live translation. Listens to spoken foreign language and translates in real-time. Actions: start, stop, status, set_language.
-            - field_session: Start, pause, resume, end, or query a Field Assist session for grounded, domain-specific technical support (refrigeration, IT, electrical, automotive). Sessions load a domain knowledge vault and emit an audit log. Use 'start' when the technician begins work, 'end' when they finish, 'export' to generate a work-order PDF + audit JSON. Actions: start, pause, resume, end, status, list, escalate, export. Params: vault (e.g. 'refrigeration'), asset_id, mode ('ai_only' default), outcome, reason, format ('pdf'/'json'/'both').
-            - procedure_runner: Run a guided, step-by-step Field Assist procedure (diagnostics, checklists) inside an active session. Actions: list, start, next, previous, repeat, status, complete. When the active step offers choices, pass 'choice' with the branch id to 'next'. The current step and its choice ids are injected into this prompt under "ACTIVE PROCEDURE" — use those. Params: procedure_id, choice, outcome.
-            - project_note: Notes scoped to the ACTIVE field job — what the user is mid-way through. 'save' records a note about the current job ("compressor swap is next"); it surfaces automatically on later turns while the job is active. 'list' shows the job's notes; 'clear' removes them. For in-progress job state, not durable user facts. Params: text.
-            - capture_flow: Run a structured, typed capture flow (inspection / work-order form) inside an active session — each step collects a validated value (reading, enum choice, barcode, or photo) bound to a field, producing an audit-ready record. Actions: list, start, answer, skip, back, status, finish, cancel. After 'start', read the returned step prompt to the user; pass their spoken value verbatim to 'answer'. The runner range-checks numbers, maps spoken phrases to enum options, and re-prompts on a bad answer; 'finish' blocks until required fields are captured. Params: flow_id, asset_id, value.
-            - domain_calc: Refrigeration math grounded in the vault PT charts. Operations: pt_lookup (saturation temp at a pressure), superheat (suction line temp − sat temp at suction pressure), subcool (sat temp at liquid pressure − liquid line temp). Temps °F, pressures PSIG. Params: operation, refrigerant ('R-410A','R-32','R-454B','R-22'), pressure_psig, suction_pressure_psig, suction_line_temp_f, liquid_pressure_psig, liquid_line_temp_f.
-            - equipment_lookup: Look up an error code, fault, or model number in the active session's vault. The technician can read it aloud (query), or point the glasses at the nameplate/error display and omit query (or set use_camera) to read it via on-device OCR. Returns the matching reference section with its source. Params: query (optional), use_camera (optional bool), file (optional).
-            - safety_assessment: Run a High-Energy Control Assessment (HECA) on the current job-site view from the glasses camera — detects the 13 high-energy serious-injury/fatality hazards and whether each has a DIRECT control, and returns a summary + HECA score. Use for "assess this site", "is this safe?", "safety check". Actions: run, last, score, history, export (PDF of the latest report), ask (image-seeded safety-advisor follow-up — pass question). Advisory only — verify on site; not a certified inspection.
-            - photo_log: Capture a photo from the glasses camera and attach it to the active session's audit log with a caption (e.g. a gauge reading), and return the image for analysis. Use to document readings and evidence during a session. Params: caption.
-            - escalate_to_expert: Escalate the active Field Assist session to a human expert when you cannot safely resolve the issue or the technician asks for a person. Actions: request (with reason), status, resolve, cancel. Live expert video is not available yet — escalation is logged and the expert pool is notified.
-            - teleprompter: Hands-free teleprompter on the in-lens HUD — shows a script a window at a time and (audio-paced) auto-advances by listening to you read. Actions: start (text=the script, or script=a saved script name, or document=a saved knowledge-base document; optional mode audio_paced/voice/auto_scroll), stop, pause, resume, next, back, restart, faster, slower, list (saved scripts), save (text + optional title), scan (capture a printed page via the glasses camera + OCR — repeat for multiple pages, then start). Use for "start the teleprompter", "read my speech", "teleprompt my saved doc", "scan this script", "go faster/slower".
-            """
+                // Plan BG P1: the per-tool descriptions are generated from each NativeTool's own
+                // `description` (the same source as the machine-readable tool schemas), so this
+                // list can't drift from the real tool set or from the Gemini Live prompt.
+                if !nativeToolDescriptions.isEmpty {
+                    toolSection += "\n\n" + SystemPromptBuilder.toolLines(nativeToolDescriptions)
+                }
 
                 // Inject user-defined custom tool descriptions
                 let customTools = Config.customTools.filter { Config.isToolEnabled($0.name) }
@@ -480,8 +397,9 @@ class LLMService: ObservableObject {
         let includeOpenClaw = Config.isOpenClawConfigured && openClawBridge != nil
         let includeTools = hasNativeTools || includeOpenClaw
         let nativeToolNames = nativeToolRouter?.registry.toolNames ?? []
+        let nativeToolDescriptions = nativeToolRouter?.registry.toolDescriptions(for: nativeToolNames) ?? []
         let gatewayToolNames = openClawBridge?.availableToolNames ?? []
-        let fullPrompt = await Self.buildSystemPrompt(locationContext: locationContext, includeTools: includeTools, includeOpenClaw: includeOpenClaw, hasImage: imageData != nil, nativeToolNames: nativeToolNames, gatewayToolNames: gatewayToolNames, memoryContext: memoryContext, agentContext: agentContext, playbookContext: playbookContext, nowPlayingContext: nowPlayingContext, shortcutsContext: shortcutsContext, promptSections: promptSections, turn: text)
+        let fullPrompt = await Self.buildSystemPrompt(locationContext: locationContext, includeTools: includeTools, includeOpenClaw: includeOpenClaw, hasImage: imageData != nil, nativeToolNames: nativeToolNames, nativeToolDescriptions: nativeToolDescriptions, gatewayToolNames: gatewayToolNames, memoryContext: memoryContext, agentContext: agentContext, playbookContext: playbookContext, nowPlayingContext: nowPlayingContext, shortcutsContext: shortcutsContext, promptSections: promptSections, turn: text)
 
         var toolsLabel = ""
         if hasNativeTools { toolsLabel += " [NativeTools]" }
@@ -628,19 +546,9 @@ class LLMService: ObservableObject {
     /// This ensures the agent doesn't "forget" mid-conversation decisions or user facts
     /// even as the raw message history is trimmed for token budget.
     private func compressContextWindowIfNeeded() {
-        let estimatedTokens = conversationHistory.reduce(0) { total, msg in
-            let content: String
-            if let text = msg["content"] as? String {
-                content = text
-            } else if let parts = msg["content"] as? [[String: Any]] {
-                // Multi-part content (images + text)
-                content = parts.compactMap { $0["text"] as? String }.joined()
-            } else {
-                content = ""
-            }
-            // ~4 chars per token, minimum 50 for overhead (tool calls, images)
-            return total + max(content.count / 4, 50)
-        }
+        // Image-aware estimate (Plan BF): a base64 image block is counted by its payload size, not
+        // the old 50-token floor, so image-heavy conversations actually trigger compaction.
+        let estimatedTokens = HistoryHygiene.estimatedTokens(conversationHistory)
 
         guard estimatedTokens > maxEstimatedTokens, conversationHistory.count > 6 else { return }
 
@@ -709,17 +617,7 @@ class LLMService: ObservableObject {
     /// Compress the context window using an LLM to summarize old messages.
     /// Falls back to the heuristic compressor on failure.
     private func compressContextWindowWithLLM() async {
-        let estimatedTokens = conversationHistory.reduce(0) { total, msg in
-            let content: String
-            if let text = msg["content"] as? String {
-                content = text
-            } else if let parts = msg["content"] as? [[String: Any]] {
-                content = parts.compactMap { $0["text"] as? String }.joined()
-            } else {
-                content = ""
-            }
-            return total + max(content.count / 4, 50)
-        }
+        let estimatedTokens = HistoryHygiene.estimatedTokens(conversationHistory)   // image-aware (Plan BF)
 
         guard estimatedTokens > maxEstimatedTokens, conversationHistory.count > 6 else { return }
 
@@ -1255,10 +1153,23 @@ class LLMService: ObservableObject {
             request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
             request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
 
+            // Turn hygiene (Plan BF): drop stale images that would otherwise re-upload every turn,
+            // and repair any dangling tool_use so a single interrupted tool call can't 400 the whole
+            // conversation. Applied to the sent copy AND written back so the fixes persist.
+            conversationHistory = HistoryHygiene.repairDanglingToolUse(
+                HistoryHygiene.pruneImages(conversationHistory, keepLast: 1))
+
+            // Prompt caching (Plan BF): the system prompt + tool schemas are large and byte-stable
+            // within a session, so mark them ephemeral-cacheable. Anthropic then reads them from
+            // cache on every follow-up turn instead of re-billing full input tokens each time.
             var body: [String: Any] = [
                 "model": config.model,
                 "max_tokens": includeTools ? 1024 : Config.maxTokens,
-                "system": systemPrompt,
+                "system": [[
+                    "type": "text",
+                    "text": systemPrompt,
+                    "cache_control": ["type": "ephemeral"]
+                ]],
                 "messages": conversationHistory
             ]
 
@@ -1268,7 +1179,11 @@ class LLMService: ObservableObject {
                     let tools = ToolDeclarations.anthropicTools(registry: nativeToolRouter?.registry, includeOpenClaw: includeOpenClaw, mcpClient: nativeToolRouter?.mcpClient)
                     return (try? JSONSerialization.data(withJSONObject: tools)) ?? Data()
                 }
-                let tools = (try? JSONSerialization.jsonObject(with: toolsData)) as? [[String: Any]] ?? []
+                var tools = (try? JSONSerialization.jsonObject(with: toolsData)) as? [[String: Any]] ?? []
+                // Cache-breakpoint on the final tool caches the whole tools array as one prefix.
+                if !tools.isEmpty {
+                    tools[tools.count - 1]["cache_control"] = ["type": "ephemeral"]
+                }
                 body["tools"] = tools
             }
 
@@ -1325,9 +1240,24 @@ class LLMService: ObservableObject {
 
                 // Execute each tool call via NativeToolRouter
                 for toolUse in toolUseBlocks {
+                    // A tool_use with no matching tool_result 400s every later request (Plan BF).
+                    // If the block has an id we can still answer it with a synthetic error result,
+                    // even when name/input are malformed — never leave it dangling.
                     guard let toolId = toolUse["id"] as? String,
                           let toolName = toolUse["name"] as? String,
-                          let input = toolUse["input"] as? [String: Any] else { continue }
+                          let input = toolUse["input"] as? [String: Any] else {
+                        if let toolId = toolUse["id"] as? String {
+                            conversationHistory.append([
+                                "role": "user",
+                                "content": [[
+                                    "type": "tool_result",
+                                    "tool_use_id": toolId,
+                                    "content": "Error: malformed tool call (missing name or arguments); nothing was run."
+                                ]]
+                            ] as [String: Any])
+                        }
+                        continue
+                    }
 
                     print("🔧 [Anthropic] Tool call: \(toolName)(\(String(describing: input).prefix(100))...)")
                     toolCallStatus = .executing(toolName)
@@ -1564,19 +1494,25 @@ class LLMService: ObservableObject {
                           let functionName = function["name"] as? String,
                           let argsString = function["arguments"] as? String else { continue }
 
-                    let args = (try? JSONSerialization.jsonObject(with: Data(argsString.utf8)) as? [String: Any]) ?? [:]
-
-                    print("🔧 [OpenAI] Tool call: \(functionName)(\(String(describing: args).prefix(100))...)")
+                    // Malformed tool arguments (Plan BF): return a parse error the model can correct
+                    // on the next turn, rather than silently running the tool with empty args and
+                    // wasting a turn on the wrong action.
+                    let parsedArgs = try? JSONSerialization.jsonObject(with: Data(argsString.utf8)) as? [String: Any]
+                    print("🔧 [OpenAI] Tool call: \(functionName)(\(String(describing: parsedArgs ?? [:]).prefix(100))...)")
                     toolCallStatus = .executing(functionName)
 
                     let result: ToolResult
-                    if let router = nativeToolRouter {
-                        result = await router.handleToolCall(name: functionName, args: args)
-                    } else if let bridge = openClawBridge {
-                        let taskDesc = args["task"] as? String ?? argsString
-                        result = await bridge.delegateTask(task: taskDesc, toolName: functionName)
+                    if let args = parsedArgs {
+                        if let router = nativeToolRouter {
+                            result = await router.handleToolCall(name: functionName, args: args)
+                        } else if let bridge = openClawBridge {
+                            let taskDesc = args["task"] as? String ?? argsString
+                            result = await bridge.delegateTask(task: taskDesc, toolName: functionName)
+                        } else {
+                            result = .failure("No tool handler available")
+                        }
                     } else {
-                        result = .failure("No tool handler available")
+                        result = .failure("Could not parse the arguments for '\(functionName)' as JSON. Re-issue the call with valid JSON arguments.")
                     }
                     toolCallStatus = result.isSuccess ? .completed(functionName) : .failed(functionName, "Failed")
 
@@ -2157,12 +2093,14 @@ class LLMService: ObservableObject {
 
         let hasNativeTools = nativeToolRouter != nil
         let nativeToolNames = nativeToolRouter?.registry.toolNames ?? []
+        let nativeToolDescriptions = nativeToolRouter?.registry.toolDescriptions(for: nativeToolNames) ?? []
         let fullPrompt = await Self.buildSystemPrompt(
             locationContext: locationContext,
             includeTools: hasNativeTools,
             includeOpenClaw: false,
             hasImage: false,
             nativeToolNames: nativeToolNames,
+            nativeToolDescriptions: nativeToolDescriptions,
             memoryContext: memoryContext,
             turn: text
         )

--- a/OpenGlasses/Sources/Services/LiveTranslationService.swift
+++ b/OpenGlasses/Sources/Services/LiveTranslationService.swift
@@ -88,7 +88,11 @@ final class LiveTranslationService: ObservableObject {
             let options: AVAudioSession.CategoryOptions = usePhoneMic
                 ? [.mixWithOthers, .defaultToSpeaker]
                 : [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
-            try audioSession.setCategory(.playAndRecord, mode: .measurement, options: options)
+            // .default, not .measurement (Plan BE): as a coexisting rider we must not leave the
+            // shared session in a state the owner didn't choose. .measurement disables output
+            // processing and makes iPhone-speaker TTS extremely quiet, and it was never restored on
+            // stop. .default matches the wake-word baseline so audio coexists cleanly.
+            try audioSession.setCategory(.playAndRecord, mode: .default, options: options)
             try audioSession.setActive(true)
             print("🌍 Translation mic source: \(usePhoneMic ? "iPhone" : "glasses (Bluetooth)")")
         } catch {

--- a/OpenGlasses/Sources/Services/MCPServer/MCPGlassesServer.swift
+++ b/OpenGlasses/Sources/Services/MCPServer/MCPGlassesServer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 import Network
 import UIKit
 
@@ -10,8 +11,12 @@ import UIKit
 ///   - `GET  /glasses_status`  → `{ connected, frame_age_ms, last_frame_iso }`
 ///   - `POST /send_to_glasses` → body `{ text, mode: "tts"|"display" }` → speaks/logs, returns `{ ok }`
 ///
-/// A Mac-side MCP stdio bridge (Claude Code) proxies these over the LAN; for remote use the developer
-/// runs their own `cloudflared` tunnel. The bridge + tunnel are out of app scope by design.
+/// Every request must carry `Authorization: Bearer <token>` (Plan BC) — the token is generated per
+/// enable and shown in Settings. Without it these endpoints would be an unauthenticated LAN camera
+/// feed to anyone on the same Wi-Fi.
+///
+/// A Mac-side MCP stdio bridge (Claude Code) proxies these over the LAN. The bridge is out of app
+/// scope by design.
 @MainActor
 final class MCPGlassesServer: ObservableObject {
     static let shared = MCPGlassesServer()
@@ -26,6 +31,38 @@ final class MCPGlassesServer: ObservableObject {
 
     /// Min interval a frame is reused, so a tight Claude Code poll loop can't blow up tokens.
     private var lastServedFrameAt: Date?
+
+    /// Bearer token required on every request. Kept in the Keychain (this-device-only) and
+    /// regenerated whenever the server is started without one.
+    private static let tokenKey = "mcpServerBearerToken"
+
+    /// The current access token, generating and persisting one on first read.
+    var accessToken: String {
+        if let existing = KeychainService.string(for: Self.tokenKey), !existing.isEmpty {
+            return existing
+        }
+        let token = Self.generateToken()
+        KeychainService.setString(token, for: Self.tokenKey)
+        return token
+    }
+
+    /// Rotate the token (invalidates any existing bridge configuration).
+    @discardableResult
+    func regenerateToken() -> String {
+        let token = Self.generateToken()
+        KeychainService.setString(token, for: Self.tokenKey)
+        return token
+    }
+
+    private static func generateToken() -> String {
+        // 256 bits, URL-safe.
+        let raw = SymmetricKey(size: .bits256)
+        return raw.withUnsafeBytes { Data($0) }
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
 
     private init() {}
 
@@ -44,6 +81,7 @@ final class MCPGlassesServer: ObservableObject {
 
     func start() {
         guard listener == nil else { return }
+        _ = accessToken   // ensure a token exists before we accept connections
         do {
             let params = NWParameters.tcp
             params.allowLocalEndpointReuse = true
@@ -125,6 +163,11 @@ final class MCPGlassesServer: ObservableObject {
     // MARK: - Routing
 
     private func route(_ request: HTTPRequest) async -> Data {
+        guard Self.isAuthorized(bearer: request.bearerToken, expected: accessToken) else {
+            NSLog("[MCPServer] Rejected unauthorized %@ %@", request.method, request.path)
+            return Self.httpResponse(status: "401 Unauthorized",
+                                     json: ["error": "missing or invalid bearer token"])
+        }
         switch (request.method, request.path) {
         case ("GET", "/see_glasses"):
             return seeGlasses()
@@ -135,6 +178,16 @@ final class MCPGlassesServer: ObservableObject {
         default:
             return Self.httpResponse(status: "404 Not Found", json: ["error": "unknown endpoint"])
         }
+    }
+
+    /// Constant-time bearer-token comparison. Pure — unit-tested without a live socket.
+    static func isAuthorized(bearer: String?, expected: String) -> Bool {
+        guard !expected.isEmpty, let bearer, !bearer.isEmpty else { return false }
+        let a = Data(bearer.utf8), b = Data(expected.utf8)
+        guard a.count == b.count else { return false }
+        var diff: UInt8 = 0
+        for (x, y) in zip(a, b) { diff |= x ^ y }
+        return diff == 0
     }
 
     private func seeGlasses() -> Data {
@@ -189,6 +242,8 @@ private struct HTTPRequest {
     let method: String
     let path: String
     let body: Data?
+    /// The token from an `Authorization: Bearer <token>` header, if present.
+    let bearerToken: String?
 
     init(rawData: Data) {
         guard let headerEndRange = rawData.range(of: Data("\r\n\r\n".utf8)) else {
@@ -198,15 +253,31 @@ private struct HTTPRequest {
             method = parts.first.map(String.init) ?? ""
             path = parts.count > 1 ? String(parts[1]) : "/"
             body = nil
+            bearerToken = nil
             return
         }
         let headerData = rawData.subdata(in: rawData.startIndex..<headerEndRange.lowerBound)
         let headerText = String(data: headerData, encoding: .utf8) ?? ""
-        let firstLine = headerText.split(separator: "\r\n").first ?? ""
+        let lines = headerText.split(separator: "\r\n")
+        let firstLine = lines.first ?? ""
         let parts = firstLine.split(separator: " ")
         method = parts.first.map(String.init) ?? ""
         path = parts.count > 1 ? String(parts[1]) : "/"
+        bearerToken = Self.parseBearer(lines: lines.dropFirst())
         let bodyStart = headerEndRange.upperBound
         body = bodyStart < rawData.endIndex ? rawData.subdata(in: bodyStart..<rawData.endIndex) : nil
+    }
+
+    private static func parseBearer(lines: ArraySlice<Substring>) -> String? {
+        for line in lines {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let name = line[..<colon].trimmingCharacters(in: .whitespaces).lowercased()
+            guard name == "authorization" else { continue }
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+            if value.lowercased().hasPrefix("bearer ") {
+                return String(value.dropFirst("bearer ".count)).trimmingCharacters(in: .whitespaces)
+            }
+        }
+        return nil
     }
 }

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
@@ -254,6 +254,16 @@ final class NativeToolRegistry {
         }.sorted()
     }
 
+    /// Enabled (name, description) pairs for the given names, in the order provided — the single
+    /// source for the system-prompt tool list (Plan BG P1). Skips any name the registry doesn't
+    /// own so callers can pass a pre-filtered `toolNames` slice safely.
+    func toolDescriptions(for names: [String]) -> [(name: String, description: String)] {
+        names.compactMap { name in
+            guard let tool = tools[name] else { return nil }
+            return (name, tool.description)
+        }
+    }
+
     /// Context-aware tool names — filters out tools that aren't relevant to the current state.
     /// Reduces token usage by only including tools the LLM can actually use right now.
     func contextualToolNames(

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
@@ -50,7 +50,29 @@ final class NativeToolRouter {
     func handleToolCall(name: String, args: [String: Any]) async -> ToolResult {
         turnToolNames.append(name)   // Phase 3: track tools used this turn for skill detection
 
-        // 0. Deterministic safety supervisor (Plan S): the single pre-execution safety gate when
+        // 0a. Actuation floor (Plan BC): confirmation before irreversible, security-relevant
+        // physical actions (unlock a door, open a garage, disarm an alarm) even when agent mode is
+        // OFF — so a prompt-injected sign/web result can't silently actuate. When agent mode is on,
+        // the SafetySupervisor below (0b) already confirms these high-impact tools, so this floor
+        // only needs to cover the agent-mode-off default and would otherwise double-prompt.
+        if !Config.agentModeEnabled,
+           HighImpactToolPolicy.mayRequireConfirmation(tool: name),
+           case .requiresConfirmation(let summary) = HighImpactToolPolicy.evaluate(tool: name, args: args) {
+            if let coordinator = confirmationCoordinator {
+                NSLog("[NativeToolRouter] Actuation floor requires confirmation for %@: %@", name, summary)
+                let approved = await coordinator.requestConfirmation(toolName: name, summary: summary)
+                guard approved else {
+                    NSLog("[NativeToolRouter] User declined %@ (actuation floor)", name)
+                    return .failure("The user did NOT approve this action, so '\(name)' was not performed. Do not retry it; tell the user it was cancelled unless they explicitly ask again.")
+                }
+            } else {
+                // No confirmation UI wired (e.g. headless): fail closed rather than actuate blind.
+                NSLog("[NativeToolRouter] No confirmation coordinator; refusing high-impact %@", name)
+                return .failure("'\(name)' requires user confirmation, which isn't available right now, so it was not performed. Tell the user to try again with the app in the foreground.")
+            }
+        }
+
+        // 0b. Deterministic safety supervisor (Plan S): the single pre-execution safety gate when
         // agent mode is on. It subsumes the high-impact confirmation backstop — its
         // `needsVoiceApproval` rule reproduces it — and adds deterministic block/confirm rules
         // (geofence, quiet hours, irreversible floor). A `.block` veto short-circuits with no

--- a/OpenGlasses/Sources/Services/NativeTools/QRContextTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/QRContextTool.swift
@@ -79,8 +79,15 @@ struct QRContextTool: NativeTool {
     // MARK: - Context Loading
 
     private func loadContext(from urlString: String, createPlaybook: Bool) async -> String {
-        guard let url = URL(string: urlString) else {
-            return "Invalid URL: \(urlString)"
+        // SSRF guard (Plan BC): the URL comes from a scanned QR or an LLM arg — never let it aim
+        // at the user's private network or a metadata endpoint.
+        let url: URL
+        switch URLFetchGuard.validate(urlString) {
+        case .success(let validated):
+            url = validated
+        case .failure(let rejection):
+            NSLog("[QRContext] Blocked fetch of %@: %@", urlString, rejection.description)
+            return "Won't load that URL — \(rejection.description)."
         }
 
         do {

--- a/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeService.swift
+++ b/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeService.swift
@@ -34,6 +34,15 @@ class OpenAIRealtimeService: ObservableObject {
     private let maxReconnectAttempts = 10
     private let maxBackoffSeconds: Double = 30
     private var reconnectTask: Task<Void, Never>?
+    /// Coalesces duplicate `scheduleReconnect` triggers for one failure (Plan BD).
+    private var reconnectPending = false
+    /// Connect-timeout task, cancelled on resolve so a stale timer can't fail a later attempt.
+    private var connectTimeoutTask: Task<Void, Never>?
+    private var reconnectPolicy: RealtimeReconnect.Policy {
+        .init(maxAttempts: maxReconnectAttempts, maxBackoffSeconds: maxBackoffSeconds)
+    }
+    /// Terminal-death cue hook (Plan BD) — the session manager plays an audible cue.
+    var onReconnectExhausted: (() -> Void)?
 
     // Latency tracking
     private var lastUserSpeechEnd: Date?
@@ -132,14 +141,16 @@ class OpenAIRealtimeService: ObservableObject {
             self.webSocketTask = self.urlSession.webSocketTask(with: request)
             self.webSocketTask?.resume()
 
-            // Timeout after 15 seconds
-            Task {
+            // Timeout after 15 seconds. Stored + cancelled on resolve (Plan BD).
+            self.connectTimeoutTask?.cancel()
+            self.connectTimeoutTask = Task { [weak self] in
                 try? await Task.sleep(nanoseconds: 15_000_000_000)
+                guard let self, !Task.isCancelled else { return }
                 await MainActor.run {
-                    self.resolveConnect(success: false)
                     if self.connectionState == .connecting || self.connectionState == .settingUp {
                         self.connectionState = .error("Connection timed out")
                     }
+                    self.resolveConnect(success: false)
                 }
             }
         }
@@ -152,6 +163,10 @@ class OpenAIRealtimeService: ObservableObject {
         reconnectTask?.cancel()
         reconnectTask = nil
         reconnecting = false
+        reconnectPending = false
+        reconnectAttempts = 0   // a fresh session must not inherit an exhausted counter (Plan BD)
+        connectTimeoutTask?.cancel()
+        connectTimeoutTask = nil
         receiveTask?.cancel()
         receiveTask = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
@@ -228,20 +243,26 @@ class OpenAIRealtimeService: ObservableObject {
 
     private func scheduleReconnect(reason: String?) {
         guard !intentionalDisconnect else { return }
-        guard reconnectAttempts < maxReconnectAttempts else {
+        // Coalesce the duplicate triggers a single failure fires (Plan BD).
+        guard !reconnectPending else { return }
+
+        guard let delay = reconnectPolicy.delay(forAttempt: reconnectAttempts + 1) else {
             connectionState = .error("Connection lost after \(maxReconnectAttempts) reconnect attempts")
             reconnecting = false
+            onReconnectExhausted?()
             return
         }
 
         reconnecting = true
+        reconnectPending = true
         reconnectAttempts += 1
-        let delay = min(pow(2.0, Double(reconnectAttempts - 1)), maxBackoffSeconds)
         NSLog("[OpenAI RT] Reconnect attempt %d/%d in %.0fs", reconnectAttempts, maxReconnectAttempts, delay)
 
+        reconnectTask?.cancel()
         reconnectTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             guard let self, !Task.isCancelled else { return }
+            self.reconnectPending = false
 
             self.receiveTask?.cancel()
             self.receiveTask = nil
@@ -253,6 +274,10 @@ class OpenAIRealtimeService: ObservableObject {
                 self.reconnectAttempts = 0
                 self.reconnecting = false
                 self.onReconnected?()
+            } else {
+                // Drive the next attempt ourselves so a connect-timeout with no close/error event
+                // can't stall the machine forever (Plan BD); coalesced if close/error already fired.
+                self.scheduleReconnect(reason: "retry failed")
             }
         }
     }
@@ -260,6 +285,8 @@ class OpenAIRealtimeService: ObservableObject {
     // MARK: - Private
 
     private func resolveConnect(success: Bool) {
+        connectTimeoutTask?.cancel()
+        connectTimeoutTask = nil
         if let cont = connectContinuation {
             connectContinuation = nil
             cont.resume(returning: success)
@@ -416,10 +443,22 @@ class OpenAIRealtimeService: ObservableObject {
             }
 
         case "error":
-            if let error = json["error"] as? [String: Any],
-               let message = error["message"] as? String {
-                NSLog("[OpenAI RT] Error: %@", message)
-                connectionState = .error(message)
+            if let error = json["error"] as? [String: Any] {
+                let message = error["message"] as? String
+                let code = error["code"] as? String
+                // A recoverable error (most often a response.cancel that raced the end of a
+                // response — "no active response") must NOT flip the session into a terminal
+                // .error state, or the assistant goes silently deaf while the mic stays open
+                // (Plan BD). Only tear down + reconnect on a genuinely fatal error.
+                if RealtimeReconnect.isFatalOpenAIError(code: code, message: message) {
+                    NSLog("[OpenAI RT] Fatal error: %@ — reconnecting", message ?? code ?? "unknown")
+                    connectionState = .error(message ?? "Realtime error")
+                    isModelSpeaking = false
+                    onDisconnected?(message)
+                    scheduleReconnect(reason: message)
+                } else {
+                    NSLog("[OpenAI RT] Recoverable error (ignored): %@", message ?? code ?? "unknown")
+                }
             }
 
         case "rate_limits.updated":

--- a/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeSessionManager.swift
+++ b/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeSessionManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import UIKit
+import AVFoundation
 
 /// Coordinator for OpenAI Realtime mode — mirrors GeminiLiveSessionManager's architecture.
 /// AudioManager → OpenAIRealtimeService (audio), Service → AudioManager (playback),
@@ -20,6 +21,15 @@ class OpenAIRealtimeSessionManager: ObservableObject {
     private let audioManager = OpenAIRealtimeAudioManager()
     private let frameThrottler = FrameThrottler(interval: 2.0)  // Less frequent than Gemini — OpenAI charges per image
     private var stateObservation: Task<Void, Never>?
+
+    /// Local, network-independent speech for terminal session cues (Plan BD).
+    private let localCueSynth = AVSpeechSynthesizer()
+
+    private func speakLocalCue(_ text: String) {
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        localCueSynth.speak(utterance)
+    }
 
     // Camera frame source — set by AppState
     var onRequestVideoFrame: (() async -> UIImage?)?
@@ -142,7 +152,19 @@ class OpenAIRealtimeSessionManager: ObservableObject {
                 if !self.realtimeService.reconnecting {
                     self.stopSession()
                     self.errorMessage = "Connection lost: \(reason ?? "Unknown error")"
+                    self.speakLocalCue("Voice session disconnected.")   // Plan BD
                 }
+            }
+        }
+
+        // Reconnection exhausted → terminal. Audible cue + surfaced error (Plan BD).
+        realtimeService.onReconnectExhausted = { [weak self] in
+            guard let self else { return }
+            Task { @MainActor in
+                guard self.isActive else { return }
+                self.stopSession()
+                self.errorMessage = "Voice session lost — couldn't reconnect."
+                self.speakLocalCue("Voice session lost. I couldn't reconnect.")
             }
         }
 

--- a/OpenGlasses/Sources/Services/Persistence/JSONStore.swift
+++ b/OpenGlasses/Sources/Services/Persistence/JSONStore.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+/// Shared load helpers for the app's JSON-blob stores (docs/plans/BB-store-integrity.md).
+///
+/// The invariant enforced here: **no store may ever save over data whose load failed without
+/// first producing an on-disk backup.** Every JSON store loads through one of these helpers and
+/// switches on the result instead of `try?`-collapsing "no data yet", "data I couldn't read",
+/// and "data I couldn't decode" into one silent empty state.
+enum JSONStore {
+
+    /// Outcome of loading a persisted JSON blob.
+    ///
+    /// - `loaded`     — normal.
+    /// - `recovered`  — the strict decode failed but elements were salvaged; the original blob
+    ///                  was backed up first. Safe to continue and save.
+    /// - `corrupt`    — nothing decodable; the original blob was backed up. Start fresh, but do
+    ///                  not auto-save defaults over the slot — persist only on the next explicit
+    ///                  user action.
+    /// - `unreadable` — the bytes couldn't be read at all (e.g. file protection while the device
+    ///                  is locked). The data on disk may be perfectly fine: never write.
+    /// - `absent`     — genuinely no data yet (first run). Seeding defaults is safe.
+    enum LoadResult<T> {
+        case loaded(T)
+        case recovered(T, backup: URL?)
+        case corrupt(backup: URL?)
+        case unreadable(Error)
+        case absent
+
+        var value: T? {
+            switch self {
+            case .loaded(let v), .recovered(let v, _): return v
+            case .corrupt, .unreadable, .absent: return nil
+            }
+        }
+
+        /// False only for `.unreadable` — the one state where the persisted bytes may be intact
+        /// and writing anything would destroy data we never got to see.
+        var allowsSaving: Bool {
+            if case .unreadable = self { return false }
+            return true
+        }
+    }
+
+    /// Where corrupt blobs are preserved: `Documents/StoreRecovery/`.
+    static func defaultBackupDirectory() -> URL {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        return docs.appendingPathComponent("StoreRecovery", isDirectory: true)
+    }
+
+    /// Preserve a blob that failed to decode as `<name>-<timestamp>.corrupt.json`. Best-effort:
+    /// returns the backup URL, or nil if the backup itself couldn't be written.
+    @discardableResult
+    static func backUp(_ data: Data, name: String, directory: URL? = nil) -> URL? {
+        let dir = directory ?? defaultBackupDirectory()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        let url = dir.appendingPathComponent("\(name)-\(formatter.string(from: Date())).corrupt.json")
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try data.write(to: url, options: .atomic)
+            NSLog("[JSONStore] Backed up undecodable %@ blob to %@", name, url.lastPathComponent)
+            return url
+        } catch {
+            NSLog("[JSONStore] FAILED to back up %@ blob: %@", name, error.localizedDescription)
+            return nil
+        }
+    }
+
+    // MARK: - Decode from in-memory Data (UserDefaults-backed stores)
+
+    /// Lenient array decode: strict first; on failure salvage element-wise (one bad element drops
+    /// that element, not the collection) after backing up the original blob.
+    static func decodeArray<T: Decodable>(
+        _ type: T.Type, from data: Data?, name: String,
+        decoder: JSONDecoder = JSONDecoder(), backupDirectory: URL? = nil
+    ) -> LoadResult<[T]> {
+        guard let data else { return .absent }
+        if let decoded = try? decoder.decode([T].self, from: data) {
+            return .loaded(decoded)
+        }
+        let backup = backUp(data, name: name, directory: backupDirectory)
+        if let salvaged = try? decoder.decode([FailableDecodable<T>].self, from: data) {
+            let values = salvaged.compactMap(\.value)
+            NSLog("[JSONStore] %@: strict decode failed; salvaged %d/%d elements", name, values.count, salvaged.count)
+            return .recovered(values, backup: backup)
+        }
+        NSLog("[JSONStore] %@: blob undecodable — starting fresh (original preserved)", name)
+        return .corrupt(backup: backup)
+    }
+
+    /// Lenient string-keyed dictionary decode: strict first, then per-value salvage.
+    static func decodeDictionary<V: Decodable>(
+        _ type: V.Type, from data: Data?, name: String,
+        decoder: JSONDecoder = JSONDecoder(), backupDirectory: URL? = nil
+    ) -> LoadResult<[String: V]> {
+        guard let data else { return .absent }
+        if let decoded = try? decoder.decode([String: V].self, from: data) {
+            return .loaded(decoded)
+        }
+        let backup = backUp(data, name: name, directory: backupDirectory)
+        if let salvaged = try? decoder.decode([String: FailableDecodable<V>].self, from: data) {
+            let values = salvaged.compactMapValues(\.value)
+            NSLog("[JSONStore] %@: strict decode failed; salvaged %d/%d entries", name, values.count, salvaged.count)
+            return .recovered(values, backup: backup)
+        }
+        NSLog("[JSONStore] %@: blob undecodable — starting fresh (original preserved)", name)
+        return .corrupt(backup: backup)
+    }
+
+    // MARK: - Decode from a file (Documents/App Support stores)
+
+    /// File-backed array load. Distinguishes a missing file (`.absent`) from a read failure
+    /// (`.unreadable` — file protection, permissions), which the in-memory variants can't hit.
+    static func loadArray<T: Decodable>(
+        _ type: T.Type, at url: URL, name: String,
+        decoder: JSONDecoder = JSONDecoder(), backupDirectory: URL? = nil
+    ) -> LoadResult<[T]> {
+        switch readFile(at: url, name: name) {
+        case .success(let data):
+            return decodeArray(type, from: data, name: name, decoder: decoder, backupDirectory: backupDirectory)
+        case .failure(let outcome):
+            return outcome.asResult()
+        }
+    }
+
+    /// File-backed string-keyed dictionary load.
+    static func loadDictionary<V: Decodable>(
+        _ type: V.Type, at url: URL, name: String,
+        decoder: JSONDecoder = JSONDecoder(), backupDirectory: URL? = nil
+    ) -> LoadResult<[String: V]> {
+        switch readFile(at: url, name: name) {
+        case .success(let data):
+            return decodeDictionary(type, from: data, name: name, decoder: decoder, backupDirectory: backupDirectory)
+        case .failure(let outcome):
+            return outcome.asResult()
+        }
+    }
+
+    // MARK: - Private
+
+    private enum ReadFailure: Error {
+        case absent
+        case unreadable(Error)
+
+        func asResult<T>() -> LoadResult<T> {
+            switch self {
+            case .absent: return .absent
+            case .unreadable(let error): return .unreadable(error)
+            }
+        }
+    }
+
+    private static func readFile(at url: URL, name: String) -> Result<Data, ReadFailure> {
+        guard FileManager.default.fileExists(atPath: url.path) else { return .failure(.absent) }
+        do {
+            return .success(try Data(contentsOf: url))
+        } catch {
+            NSLog("[JSONStore] %@: file exists but read failed (%@) — leaving it untouched",
+                  name, error.localizedDescription)
+            return .failure(.unreadable(error))
+        }
+    }
+}
+
+/// Wrapper that absorbs a single element's decode failure so one bad element doesn't nuke the
+/// collection it lives in.
+struct FailableDecodable<T: Decodable>: Decodable {
+    let value: T?
+    init(from decoder: Decoder) {
+        value = try? T(from: decoder)
+    }
+}

--- a/OpenGlasses/Sources/Services/PlaybookStore.swift
+++ b/OpenGlasses/Sources/Services/PlaybookStore.swift
@@ -258,11 +258,15 @@ class PlaybookStore: ObservableObject {
     private let sessionKey = "playbookSession"
 
     init() {
-        load()
+        let result = load()
         loadSession()
         if playbooks.isEmpty {
             playbooks = Self.defaults
-            save()
+            // Persist the seed only on a genuine first run. If the stored blob failed to decode
+            // (`.corrupt`/`.recovered` — backed up by JSONStore), saving here would overwrite the
+            // user's data with factory defaults; instead the defaults stay in-memory and the slot
+            // is only written on the next explicit user action.
+            if case .absent = result { save() }
         }
     }
 
@@ -681,16 +685,21 @@ class PlaybookStore: ObservableObject {
     // MARK: - Persistence
 
     private func save() {
-        if let data = try? JSONEncoder().encode(playbooks) {
+        do {
+            let data = try JSONEncoder().encode(playbooks)
             UserDefaults.standard.set(data, forKey: storageKey)
+        } catch {
+            NSLog("[PlaybookStore] Save failed: %@", error.localizedDescription)
         }
     }
 
-    private func load() {
-        if let data = UserDefaults.standard.data(forKey: storageKey),
-           let decoded = try? JSONDecoder().decode([Playbook].self, from: data) {
-            playbooks = decoded
-        }
+    @discardableResult
+    private func load() -> JSONStore.LoadResult<[Playbook]> {
+        let result = JSONStore.decodeArray(Playbook.self,
+                                           from: UserDefaults.standard.data(forKey: storageKey),
+                                           name: "playbooks")
+        playbooks = result.value ?? []
+        return result
     }
 
     private func saveSession() {

--- a/OpenGlasses/Sources/Services/Realtime/RealtimeReconnect.swift
+++ b/OpenGlasses/Sources/Services/Realtime/RealtimeReconnect.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Pure reconnect decisions shared by the Gemini Live and OpenAI Realtime services
+/// (docs/plans/BD-realtime-session-resilience.md). No sockets, no state — just the two decisions
+/// the audit found both services getting wrong, isolated so they can be table-tested.
+enum RealtimeReconnect {
+
+    /// Backoff + give-up policy. `delay(forAttempt:)` returns the wait before a 1-based attempt, or
+    /// nil once the attempt would exceed `maxAttempts` (give up).
+    struct Policy {
+        let maxAttempts: Int
+        let maxBackoffSeconds: Double
+
+        func delay(forAttempt attempt: Int) -> Double? {
+            guard attempt >= 1, attempt <= maxAttempts else { return nil }
+            return min(pow(2.0, Double(attempt - 1)), maxBackoffSeconds)
+        }
+    }
+
+    /// Classify an OpenAI Realtime `error` event. A recoverable error (most commonly a
+    /// `response.cancel` that raced the end of a response — "no active response") must NOT push the
+    /// session into a terminal `.error` state, or the assistant goes silently deaf while the mic
+    /// stays open. Only genuinely fatal errors should tear down and reconnect.
+    static func isFatalOpenAIError(code: String?, message: String?) -> Bool {
+        let recoverableCodes: Set<String> = [
+            "response_cancel_not_active",
+            "conversation_already_has_active_response",
+            "input_audio_buffer_commit_empty",
+        ]
+        if let code = code?.lowercased(), recoverableCodes.contains(code) { return false }
+
+        let m = (message ?? "").lowercased()
+        let recoverablePhrases = [
+            "no active response",
+            "already has an active response",
+            "cancellation failed",
+            "buffer is empty",
+            "no response to cancel",
+        ]
+        if recoverablePhrases.contains(where: m.contains) { return false }
+
+        return true
+    }
+}

--- a/OpenGlasses/Sources/Services/SafetyAssessment/SafetyAssessmentStore.swift
+++ b/OpenGlasses/Sources/Services/SafetyAssessment/SafetyAssessmentStore.swift
@@ -43,13 +43,28 @@ final class SafetyAssessmentStore: ObservableObject {
 
     // MARK: - Persistence
 
+    /// True after a read failure on an existing history file — saves are suppressed so the
+    /// on-disk data (possibly intact) is never overwritten.
+    private var saveBlocked = false
+
     private func load() {
-        guard let data = try? Data(contentsOf: fileURL),
-              let reports = try? JSONDecoder().decode([SafetyReport].self, from: data) else { return }
-        history = reports
+        switch JSONStore.loadArray(SafetyReport.self, at: fileURL, name: "safety_history") {
+        case .loaded(let reports), .recovered(let reports, _):
+            history = reports
+        case .corrupt:
+            history = []   // original preserved in StoreRecovery
+        case .unreadable:
+            saveBlocked = true
+        case .absent:
+            break
+        }
     }
 
     private func persist() {
+        guard !saveBlocked else {
+            NSLog("[SafetyAssessmentStore] Save skipped — last load failed to read the existing file")
+            return
+        }
         do {
             try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
             let data = try JSONEncoder().encode(history)

--- a/OpenGlasses/Sources/Services/SemanticMemoryStore.swift
+++ b/OpenGlasses/Sources/Services/SemanticMemoryStore.swift
@@ -92,46 +92,64 @@ class SemanticMemoryStore: ObservableObject {
 
     // MARK: - Public API (legacy key-value compatible)
 
-    func remember(_ key: String, value: String) {
+    /// Returns false when the write did not reach the database — callers at a tool/spoken
+    /// boundary should say so rather than claim the fact was saved.
+    @discardableResult
+    func remember(_ key: String, value: String) -> Bool {
         let k = normalise(key)
-        guard !k.isEmpty, !value.isEmpty else { return }
+        guard !k.isEmpty, !value.isEmpty else { return false }
         let ns = activePersonaId ?? "global"
         if activePersonaId != nil {
-            if personaMemories[k] == value { return }
-            upsert(key: k, value: value, namespace: ns)
+            if personaMemories[k] == value { return true }
+            guard upsert(key: k, value: value, namespace: ns) else {
+                NSLog("[SemanticMemory] FAILED to persist persona memory %@", k)
+                return false
+            }
             refreshPersonaCache()
             trim(namespace: ns, maxChars: maxPersonaChars)
             NSLog("[SemanticMemory] Persona: %@ = %@", k, value)
         } else {
-            if memories[k] == value { return }
-            upsert(key: k, value: value, namespace: "global")
+            if memories[k] == value { return true }
+            guard upsert(key: k, value: value, namespace: "global") else {
+                NSLog("[SemanticMemory] FAILED to persist global memory %@", k)
+                return false
+            }
             refreshGlobalCache()
             trim(namespace: "global", maxChars: maxGlobalChars)
             NSLog("[SemanticMemory] Global: %@ = %@", k, value)
         }
         pushToGateway(key: k, value: value)
+        return true
     }
 
-    func rememberGlobal(_ key: String, value: String) {
+    @discardableResult
+    func rememberGlobal(_ key: String, value: String) -> Bool {
         let k = normalise(key)
-        guard !k.isEmpty, !value.isEmpty else { return }
-        if memories[k] == value { return }
-        upsert(key: k, value: value, namespace: "global")
+        guard !k.isEmpty, !value.isEmpty else { return false }
+        if memories[k] == value { return true }
+        guard upsert(key: k, value: value, namespace: "global") else {
+            NSLog("[SemanticMemory] FAILED to persist global memory %@", k)
+            return false
+        }
         refreshGlobalCache()
         trim(namespace: "global", maxChars: maxGlobalChars)
         NSLog("[SemanticMemory] Global: %@ = %@", k, value)
         pushToGateway(key: k, value: value)
+        return true
     }
 
-    func forget(_ key: String) {
+    @discardableResult
+    func forget(_ key: String) -> Bool {
         let k = normalise(key)
+        let ok: Bool
         if let pid = activePersonaId {
-            deleteMemory(key: k, namespace: pid)
+            ok = deleteMemory(key: k, namespace: pid)
             refreshPersonaCache()
         } else {
-            deleteMemory(key: k, namespace: "global")
+            ok = deleteMemory(key: k, namespace: "global")
             refreshGlobalCache()
         }
+        return ok
     }
 
     func recall(_ key: String) -> String? {
@@ -150,7 +168,7 @@ class SemanticMemoryStore: ObservableObject {
     func clearPersonaMemories() {
         guard let pid = activePersonaId else { return }
         personaMemories.removeAll()
-        exec("DELETE FROM memories WHERE namespace = '\(pid)'")
+        run("DELETE FROM memories WHERE namespace = ?", [.text(pid)])
         NSLog("[SemanticMemory] Cleared persona memories for %@", pid)
     }
 
@@ -243,8 +261,8 @@ class SemanticMemoryStore: ObservableObject {
         guard !text.isEmpty else { return }
         let id = UUID().uuidString
         let now = Date().timeIntervalSince1970
-        let t = escapedSQL(text)
-        exec("INSERT INTO diary (id, text, created_at) VALUES ('\(id)', '\(t)', \(now))")
+        run("INSERT INTO diary (id, text, created_at) VALUES (?, ?, ?)",
+            [.text(id), .text(text), .real(now)])
         // Store embedding (+ version stamp) for later search
         if let vec = embed(text) {
             writeDiaryEmbedding(id: id, vec: vec)
@@ -454,41 +472,48 @@ class SemanticMemoryStore: ObservableObject {
 
     // MARK: - Private: CRUD
 
-    private func upsert(key: String, value: String, namespace: String) {
+    @discardableResult
+    private func upsert(key: String, value: String, namespace: String) -> Bool {
         let id = "\(namespace):\(key)"
         let topic = detectTopic(key: key, value: value)
         let now = Date().timeIntervalSince1970
-        let v = escapedSQL(value)
-        exec("""
+        let ok = run("""
         INSERT INTO memories (id, key_name, value, topic, namespace, created_at)
-        VALUES ('\(id)', '\(key)', '\(v)', '\(topic)', '\(namespace)', \(now))
+        VALUES (?, ?, ?, ?, ?, ?)
         ON CONFLICT(key_name, namespace) DO UPDATE SET
             value = excluded.value,
             topic = excluded.topic,
             created_at = excluded.created_at,
             embedding = NULL
-        """)
+        """, [.text(id), .text(key), .text(value), .text(topic), .text(namespace), .real(now)])
+        guard ok else { return false }
         // Compute and store embedding (+ version stamp) synchronously (fast for short texts).
         if let vec = embed("\(key) \(value)") {
             writeMemoryEmbedding(id: id, vec: vec)
         }
+        return true
     }
 
-    private func deleteMemory(key: String, namespace: String) {
-        exec("DELETE FROM memories WHERE key_name = '\(key)' AND namespace = '\(namespace)'")
+    @discardableResult
+    private func deleteMemory(key: String, namespace: String) -> Bool {
+        run("DELETE FROM memories WHERE key_name = ? AND namespace = ?",
+            [.text(key), .text(namespace)])
     }
 
     private func fetchAllMemories(namespace: String? = nil) -> [MemoryEntry] {
         var entries: [MemoryEntry] = []
         var stmt: OpaquePointer?
         let sql: String
-        if let ns = namespace {
-            sql = "SELECT id, key_name, value, topic, namespace, created_at, expires_at FROM memories WHERE namespace = '\(ns)'"
+        if namespace != nil {
+            sql = "SELECT id, key_name, value, topic, namespace, created_at, expires_at FROM memories WHERE namespace = ?"
         } else {
             sql = "SELECT id, key_name, value, topic, namespace, created_at, expires_at FROM memories"
         }
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return entries }
         defer { sqlite3_finalize(stmt) }
+        if let ns = namespace {
+            sqlite3_bind_text(stmt, 1, ns, -1, SQLITE_TRANSIENT)
+        }
         let now = Date().timeIntervalSince1970
         while sqlite3_step(stmt) == SQLITE_ROW {
             let expiresAt = sqlite3_column_type(stmt, 6) != SQLITE_NULL ? sqlite3_column_double(stmt, 6) : nil
@@ -508,9 +533,11 @@ class SemanticMemoryStore: ObservableObject {
 
     private func fetchEmbedding(key: String, namespace: String) -> (vec: [Float], version: String?)? {
         var stmt: OpaquePointer?
-        let sql = "SELECT embedding, embedding_version FROM memories WHERE key_name = '\(key)' AND namespace = '\(namespace)'"
+        let sql = "SELECT embedding, embedding_version FROM memories WHERE key_name = ? AND namespace = ?"
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
         defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_text(stmt, 1, key, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(stmt, 2, namespace, -1, SQLITE_TRANSIENT)
         guard sqlite3_step(stmt) == SQLITE_ROW,
               sqlite3_column_type(stmt, 0) != SQLITE_NULL,
               let ptr = sqlite3_column_blob(stmt, 0) else { return nil }
@@ -607,14 +634,27 @@ class SemanticMemoryStore: ObservableObject {
         let legacyURL = docsDir.appendingPathComponent("user_memories.json")
         guard FileManager.default.fileExists(atPath: legacyURL.path) else { return }
         guard let data = try? Data(contentsOf: legacyURL),
-              let dict = try? JSONDecoder().decode([String: String].self, from: data),
-              !dict.isEmpty else { return }
+              let dict = try? JSONDecoder().decode([String: String].self, from: data) else {
+            // Transient read/decode failure — leave the file for a later attempt.
+            return
+        }
 
-        // Only migrate if semantic DB is empty
-        guard fetchAllMemories(namespace: "global").isEmpty else { return }
-        NSLog("[SemanticMemory] Migrating %d legacy memories", dict.count)
-        for (key, value) in dict { upsert(key: key, value: value, namespace: "global") }
-        refreshGlobalCache()
+        // Migrate only into an empty semantic DB; either way, retire the legacy file so it can
+        // never re-import. (It used to linger forever: `clearAll()` + relaunch resurrected every
+        // "forgotten" memory from it.)
+        if !dict.isEmpty, fetchAllMemories(namespace: "global").isEmpty {
+            NSLog("[SemanticMemory] Migrating %d legacy memories", dict.count)
+            for (key, value) in dict { upsert(key: key, value: value, namespace: "global") }
+            refreshGlobalCache()
+        }
+        let retired = legacyURL.appendingPathExtension("migrated")
+        try? FileManager.default.removeItem(at: retired)
+        do {
+            try FileManager.default.moveItem(at: legacyURL, to: retired)
+            NSLog("[SemanticMemory] Retired legacy memory file")
+        } catch {
+            NSLog("[SemanticMemory] Could not retire legacy memory file: %@", error.localizedDescription)
+        }
     }
 
     // MARK: - Private: Embedding
@@ -679,11 +719,38 @@ class SemanticMemoryStore: ObservableObject {
         return sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK
     }
 
-    private func normalise(_ key: String) -> String {
-        key.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    /// A value bound into a parameterized statement — the only safe way to put user/LLM text
+    /// into SQL. (Interpolating escaped strings broke on apostrophes in memory *keys*, which
+    /// were never escaped: `[REMEMBER: daughter's birthday = …]` silently failed to save.)
+    private enum SQLValue {
+        case text(String)
+        case real(Double)
     }
 
-    private func escapedSQL(_ s: String) -> String {
-        s.replacingOccurrences(of: "'", with: "''")
+    /// Run a parameterized (non-query) statement with positional `?` binds.
+    @discardableResult
+    private func run(_ sql: String, _ binds: [SQLValue]) -> Bool {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            NSLog("[SemanticMemory] prepare failed: %@", String(cString: sqlite3_errmsg(db)))
+            return false
+        }
+        defer { sqlite3_finalize(stmt) }
+        for (i, bind) in binds.enumerated() {
+            let idx = Int32(i + 1)
+            switch bind {
+            case .text(let s): sqlite3_bind_text(stmt, idx, s, -1, SQLITE_TRANSIENT)
+            case .real(let d): sqlite3_bind_double(stmt, idx, d)
+            }
+        }
+        let ok = sqlite3_step(stmt) == SQLITE_DONE
+        if !ok {
+            NSLog("[SemanticMemory] step failed: %@", String(cString: sqlite3_errmsg(db)))
+        }
+        return ok
+    }
+
+    private func normalise(_ key: String) -> String {
+        key.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/OpenGlasses/Sources/Services/Study/StudyStore.swift
+++ b/OpenGlasses/Sources/Services/Study/StudyStore.swift
@@ -55,19 +55,41 @@ final class StudyStore: ObservableObject {
 
     // MARK: - Persistence
 
+    /// Per-file save suppression after a read failure on an existing file (the on-disk data may
+    /// be intact — never overwrite what we couldn't read).
+    private var decksSaveBlocked = false
+    private var reviewsSaveBlocked = false
+
     private func load() {
-        if let data = try? Data(contentsOf: decksURL),
-           let d = try? JSONDecoder().decode([StudyDeck].self, from: data) {
-            decks = d
+        switch JSONStore.loadArray(StudyDeck.self, at: decksURL, name: "study_decks") {
+        case .loaded(let d), .recovered(let d, _): decks = d
+        case .corrupt: decks = []          // original preserved in StoreRecovery
+        case .unreadable: decksSaveBlocked = true
+        case .absent: break
         }
-        if let data = try? Data(contentsOf: reviewsURL),
-           let r = try? JSONDecoder().decode([String: ReviewRecord].self, from: data) {
-            reviews = r
+        switch JSONStore.loadDictionary(ReviewRecord.self, at: reviewsURL, name: "study_reviews") {
+        case .loaded(let r), .recovered(let r, _): reviews = r
+        case .corrupt: reviews = [:]
+        case .unreadable: reviewsSaveBlocked = true
+        case .absent: break
         }
     }
 
-    private func persistDecks() { write(decks, to: decksURL) }
-    private func persistReviews() { write(reviews, to: reviewsURL) }
+    private func persistDecks() {
+        guard !decksSaveBlocked else {
+            NSLog("[StudyStore] Deck save skipped — last load failed to read the existing file")
+            return
+        }
+        write(decks, to: decksURL)
+    }
+
+    private func persistReviews() {
+        guard !reviewsSaveBlocked else {
+            NSLog("[StudyStore] Review save skipped — last load failed to read the existing file")
+            return
+        }
+        write(reviews, to: reviewsURL)
+    }
 
     private func write<T: Encodable>(_ value: T, to url: URL) {
         do {

--- a/OpenGlasses/Sources/Services/SystemPromptBuilder.swift
+++ b/OpenGlasses/Sources/Services/SystemPromptBuilder.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Generates the "TOOLS" prose list injected into every system prompt from the single source of
+/// truth — each `NativeTool`'s own `name` + `description` (docs/plans/BG-spine-refactor.md, P1).
+///
+/// This block used to be maintained by hand in *two* places (`LLMService.buildSystemPrompt` and
+/// `GeminiLiveSessionManager.buildSystemInstruction`), and the audit found the two copies had
+/// already drifted from each other and from the real tool set. Since the machine-readable tool
+/// schemas (`ToolDeclarations`) are already generated from these same descriptions, the prose is
+/// now generated too — so the model's instructions can never disagree with the tools it's given.
+enum SystemPromptBuilder {
+
+    /// One "- name: description" line per tool, newest-safe (descriptions are flattened to a single
+    /// line). `tools` should be the enabled (name, description) pairs in the order to present.
+    static func toolLines(_ tools: [(name: String, description: String)]) -> String {
+        tools
+            .map { "- \($0.name): \(flatten($0.description))" }
+            .joined(separator: "\n")
+    }
+
+    /// Collapse a multi-line tool description into one line so it reads as a single bullet.
+    private static func flatten(_ description: String) -> String {
+        description
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+}

--- a/OpenGlasses/Sources/Services/Teleprompter/TeleprompterScriptStore.swift
+++ b/OpenGlasses/Sources/Services/Teleprompter/TeleprompterScriptStore.swift
@@ -80,17 +80,21 @@ final class TeleprompterScriptStore: ObservableObject {
         save()
     }
 
-    /// Drain any scripts shared in via the Share Extension (PR B) and save them (newest
+    /// Import any scripts shared in via the Share Extension (PR B) and save them (newest
     /// first). Called on init and on app foreground. Returns the number imported.
+    /// The inbox is cleared only after the store's save commits — a failed save leaves the
+    /// shares in the app-group container for the next attempt instead of losing them.
     @discardableResult
     func importPendingShares() -> Int {
-        let pending = SharedTeleprompterInbox.drain()
+        let pending = SharedTeleprompterInbox.peek()
         guard !pending.isEmpty else { return 0 }
         for item in pending {
             let title = item.title.isEmpty ? SavedScript.deriveTitle(from: item.text) : item.title
             scripts.insert(SavedScript(title: title, text: item.text), at: 0)
         }
-        save()
+        if save() {
+            SharedTeleprompterInbox.remove(pending)
+        }
         return pending.count
     }
 
@@ -110,14 +114,36 @@ final class TeleprompterScriptStore: ObservableObject {
 
     // MARK: - Persistence
 
+    /// True after a read failure on an existing scripts file — saves are suppressed so the
+    /// on-disk data (possibly intact) is never overwritten.
+    private var saveBlocked = false
+
     private func load() {
-        guard let data = try? Data(contentsOf: fileURL),
-              let decoded = try? JSONDecoder().decode([SavedScript].self, from: data) else { return }
-        scripts = decoded
+        switch JSONStore.loadArray(SavedScript.self, at: fileURL, name: "teleprompter_scripts") {
+        case .loaded(let decoded), .recovered(let decoded, _):
+            scripts = decoded
+        case .corrupt:
+            scripts = []   // original preserved in StoreRecovery
+        case .unreadable:
+            saveBlocked = true
+        case .absent:
+            break
+        }
     }
 
-    private func save() {
-        guard let data = try? JSONEncoder().encode(scripts) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+    @discardableResult
+    private func save() -> Bool {
+        guard !saveBlocked else {
+            NSLog("[TeleprompterScriptStore] Save skipped — last load failed to read the existing file")
+            return false
+        }
+        do {
+            let data = try JSONEncoder().encode(scripts)
+            try data.write(to: fileURL, options: .atomic)
+            return true
+        } catch {
+            NSLog("[TeleprompterScriptStore] Save failed: %@", error.localizedDescription)
+            return false
+        }
     }
 }

--- a/OpenGlasses/Sources/Services/URLFetchGuard.swift
+++ b/OpenGlasses/Sources/Services/URLFetchGuard.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Blocks server-side-request-forgery-shaped fetches (docs/plans/BC-unconditional-safety-gate.md).
+///
+/// Tools that fetch a URL supplied by untrusted input — a scanned QR code, an LLM tool argument —
+/// must not be pointed at the user's private network or a cloud metadata endpoint. Without this,
+/// a malicious QR could aim a fetch at `http://192.168.1.1/…` or `169.254.169.254` and exfiltrate
+/// the response back through the model. Pure and headless-testable.
+enum URLFetchGuard {
+
+    enum Rejection: Error, Equatable, CustomStringConvertible {
+        case invalidURL
+        case disallowedScheme(String)
+        case privateOrReservedHost(String)
+        case missingHost
+
+        var description: String {
+            switch self {
+            case .invalidURL: return "not a valid URL"
+            case .disallowedScheme(let s): return "scheme '\(s)' is not allowed (only http/https)"
+            case .privateOrReservedHost(let h): return "host '\(h)' is on a private or reserved network"
+            case .missingHost: return "URL has no host"
+            }
+        }
+    }
+
+    /// Validate a URL string for outbound fetch. Returns the parsed `URL` or a `Rejection`.
+    static func validate(_ urlString: String) -> Result<URL, Rejection> {
+        guard let url = URL(string: urlString.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return .failure(.invalidURL)
+        }
+        let scheme = (url.scheme ?? "").lowercased()
+        guard scheme == "http" || scheme == "https" else {
+            return .failure(.disallowedScheme(scheme.isEmpty ? "(none)" : scheme))
+        }
+        guard let host = url.host, !host.isEmpty else {
+            return .failure(.missingHost)
+        }
+        if isBlockedHost(host) {
+            return .failure(.privateOrReservedHost(host))
+        }
+        return .success(url)
+    }
+
+    /// True for loopback, link-local, private, and other reserved hosts that a public fetch must
+    /// never target. Covers literal IPv4/IPv6 and obvious hostname forms (`localhost`, `*.local`).
+    /// DNS names that *resolve* to private space are not caught here (that needs resolution); the
+    /// literal + suffix checks stop the direct-address SSRF a QR/LLM arg realistically uses.
+    static func isBlockedHost(_ rawHost: String) -> Bool {
+        var host = rawHost.lowercased()
+        // Strip IPv6 brackets.
+        if host.hasPrefix("["), host.hasSuffix("]") { host = String(host.dropFirst().dropLast()) }
+
+        if host == "localhost" || host.hasSuffix(".localhost") { return true }
+        if host.hasSuffix(".local") { return true }          // mDNS / Bonjour
+        if host.hasSuffix(".internal") { return true }        // common metadata alias
+
+        if let v4 = IPv4(host) { return v4.isPrivateOrReserved }
+        if isBlockedIPv6(host) { return true }
+        return false
+    }
+
+    // MARK: - IPv4
+
+    private struct IPv4 {
+        let octets: [UInt8]
+        init?(_ s: String) {
+            let parts = s.split(separator: ".", omittingEmptySubsequences: false)
+            guard parts.count == 4 else { return nil }
+            var out: [UInt8] = []
+            for p in parts {
+                guard let n = UInt8(p) else { return nil }
+                out.append(n)
+            }
+            octets = out
+        }
+
+        var isPrivateOrReserved: Bool {
+            let (a, b) = (octets[0], octets[1])
+            switch a {
+            case 0: return true               // 0.0.0.0/8 "this network"
+            case 10: return true              // 10.0.0.0/8 private
+            case 127: return true             // loopback
+            case 169 where b == 254: return true   // link-local (incl. 169.254.169.254 metadata)
+            case 172 where (16...31).contains(b): return true  // 172.16.0.0/12 private
+            case 192 where b == 168: return true   // 192.168.0.0/16 private
+            case 100 where (64...127).contains(b): return true // 100.64.0.0/10 CGNAT
+            case 255 where octets == [255, 255, 255, 255]: return true
+            default: return a >= 224          // multicast + reserved (224+)
+            }
+        }
+    }
+
+    // MARK: - IPv6
+
+    private static func isBlockedIPv6(_ host: String) -> Bool {
+        guard host.contains(":") else { return false }
+        let h = host
+        if h == "::1" || h == "::" { return true }            // loopback / unspecified
+        if h.hasPrefix("fe80") { return true }                // link-local
+        if h.hasPrefix("fc") || h.hasPrefix("fd") { return true }  // unique local fc00::/7
+        // IPv4-mapped (::ffff:a.b.c.d) — reuse the IPv4 rules on the tail.
+        if let mapped = h.split(separator: ":").last, mapped.contains("."),
+           let v4 = IPv4(String(mapped)) {
+            return v4.isPrivateOrReserved
+        }
+        return false
+    }
+}

--- a/OpenGlasses/Sources/Services/Vault/VaultStore.swift
+++ b/OpenGlasses/Sources/Services/Vault/VaultStore.swift
@@ -53,13 +53,32 @@ final class VaultStore {
 
     /// Append a timestamped entry to a vault file. Creates the file if missing.
     /// Format: trailing blank line + ISO date heading + entry text.
+    /// Throws when an existing file can't be read (file protection, encoding) — rewriting the
+    /// file from a failed read would replace the accumulated log with just this entry.
     @discardableResult
     func append(_ filename: String, entry: String, date: Date = Date()) throws -> URL {
-        let existing = read(filename) ?? ""
+        let existing = try readStrict(filename) ?? ""
         let iso = ISO8601DateFormatter().string(from: date)
         let separator = existing.isEmpty ? "" : "\n\n"
         let appended = "\(existing)\(separator)## \(iso)\n\n\(entry)"
         return try write(filename, contents: appended)
+    }
+
+    /// Like `read`, but distinguishes "file genuinely absent" (nil) from "file exists but the
+    /// read failed" (throws).
+    private func readStrict(_ filename: String) throws -> String? {
+        let fm = FileManager.default
+        let overlayURL = overlayRoot.appendingPathComponent(filename)
+        if fm.fileExists(atPath: overlayURL.path) {
+            return try String(contentsOf: overlayURL, encoding: .utf8)
+        }
+        if let bundleRoot {
+            let bundleURL = bundleRoot.appendingPathComponent(filename)
+            if fm.fileExists(atPath: bundleURL.path) {
+                return try String(contentsOf: bundleURL, encoding: .utf8)
+            }
+        }
+        return nil
     }
 
     /// Read all manifest files, returning [filename: contents]. Missing files are skipped.

--- a/OpenGlasses/Sources/Services/WakeWordService.swift
+++ b/OpenGlasses/Sources/Services/WakeWordService.swift
@@ -2,6 +2,7 @@ import Foundation
 import AVFoundation
 import Speech
 import CallKit
+import os.lock
 
 /// Handles wake word detection using iOS Speech Recognition
 /// Listens for "Hey Claude" to trigger voice queries
@@ -30,12 +31,12 @@ class WakeWordService: NSObject, ObservableObject {
     /// Whether the mic is currently paused due to silence (glasses in case).
     @Published var pausedForSilence: Bool = false
 
-    /// Silence detection: number of consecutive low-RMS buffers.
-    private var silentBufferCount: Int = 0
     /// RMS threshold below which a buffer is considered "silent".
     /// Glasses mic in a closed case typically produces near-zero signal.
     private let silenceRMSThreshold: Float = 0.005
-    /// Number of consecutive silent buffers before declaring silence (~60 seconds at typical buffer rate).
+    /// Number of consecutive silent buffers before declaring silence. At 1024-frame buffers this is
+    /// ~13s at 48kHz (Bluetooth) / ~38s at 16kHz — well short of a literal minute (comment corrected
+    /// per Plan BE); tune here if the in-case mic shutoff feels too eager.
     private let silenceBufferThreshold: Int = 600
     /// Whether silence was already reported (prevents repeated callbacks).
     private var silenceReported: Bool = false
@@ -46,7 +47,9 @@ class WakeWordService: NSObject, ObservableObject {
     /// to ignore the resulting cancellation error instead of auto-restarting a competing recognizer.
     private var suppressAutoRestart = false
     private var speechRecognizer: SFSpeechRecognizer?
-    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest? {
+        didSet { tapState.setRequest(recognitionRequest) }   // keep the tap's view in sync (Plan BE)
+    }
     private var recognitionTask: SFSpeechRecognitionTask?
     private var audioSessionConfigured: Bool = false
     /// Our claim on the shared session with the coordinator. Wake word is the always-on baseline
@@ -66,6 +69,18 @@ class WakeWordService: NSObject, ObservableObject {
 
     /// Multiple audio buffer consumers keyed by ID (transcription, captions, rewind, etc.)
     private var audioBufferForwarders: [String: @Sendable (AVAudioPCMBuffer) -> Void] = [:]
+
+    /// Lock-guarded state the audio-render thread reads from the tap (Plan BE). The tap block used
+    /// to touch `@MainActor` storage (`recognitionRequest`, `audioBufferForwarders`) directly from
+    /// the Core Audio thread while the main actor mutated them — a torn read / EXC_BAD_ACCESS on
+    /// the app's hottest path. The tap now only ever touches this box; the main actor publishes
+    /// changes into it under the same lock.
+    private let tapState = WakeTapState()
+
+    /// Owned NotificationCenter observer tokens (Plan BE). Discarding these leaked a fresh
+    /// interruption+route observer pair on every reconfigure, so after N glasses reconnects one
+    /// route change fired N duplicate handlers.
+    private var sessionObservers: [NSObjectProtocol] = []
 
     /// All active wake phrases from all enabled personas.
     private var allWakePhrases: [String] { Config.allActiveWakePhrases }
@@ -234,30 +249,35 @@ class WakeWordService: NSObject, ObservableObject {
             }
             print("🎤 Audio session configured: .playAndRecord with Bluetooth")
 
-            // Handle audio interruptions (phone calls, Siri, etc.)
-            NotificationCenter.default.addObserver(
-                forName: AVAudioSession.interruptionNotification,
-                object: audioSession,
-                queue: nil
-            ) { [weak self] notification in
-                Task { @MainActor in
-                    self?.handleAudioInterruption(notification)
-                }
-            }
-
-            // Handle audio route changes (Bluetooth disconnect/reconnect)
-            NotificationCenter.default.addObserver(
-                forName: AVAudioSession.routeChangeNotification,
-                object: audioSession,
-                queue: nil
-            ) { [weak self] notification in
-                Task { @MainActor in
-                    self?.handleRouteChange(notification)
-                }
-            }
+            // Handle audio interruptions + route changes. Tokens are owned and removed before any
+            // re-registration (Plan BE) — the old code discarded them, leaking a fresh pair on
+            // every reconfigure so one route change fired N duplicate handlers after N reconnects.
+            installSessionObservers(audioSession: audioSession)
         } catch {
             print("🎤 Failed to configure audio session: \(error)")
         }
+    }
+
+    /// Register the interruption + route-change observers exactly once per configuration, removing
+    /// any previously-owned tokens first so they can never accumulate.
+    private func installSessionObservers(audioSession: AVAudioSession) {
+        removeSessionObservers()
+        let interruption = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.interruptionNotification, object: audioSession, queue: nil
+        ) { [weak self] notification in
+            Task { @MainActor in self?.handleAudioInterruption(notification) }
+        }
+        let route = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.routeChangeNotification, object: audioSession, queue: nil
+        ) { [weak self] notification in
+            Task { @MainActor in self?.handleRouteChange(notification) }
+        }
+        sessionObservers = [interruption, route]
+    }
+
+    private func removeSessionObservers() {
+        for token in sessionObservers { NotificationCenter.default.removeObserver(token) }
+        sessionObservers.removeAll()
     }
 
     private func handleAudioInterruption(_ notification: Notification) {
@@ -270,6 +290,15 @@ class WakeWordService: NSObject, ObservableObject {
             print("🎤 Audio interrupted (phone call, Siri, etc.)")
             stopListening()
         case .ended:
+            // Don't fight a live session (Plan BE). If a Gemini/OpenAI realtime session now owns the
+            // shared audio session, it handles its own interruption recovery — reactivating here
+            // with our .playAndRecord/.default config would stomp its .videoChat setup and spin up a
+            // second engine contending for the mic. Only reclaim when wake word is the owner.
+            let owner = AudioSessionCoordinator.shared.currentOwner
+            guard owner == nil || owner == .wakeWord else {
+                print("🎤 Audio interruption ended — NOT restarting; session owned by \(owner!.rawValue)")
+                return
+            }
             // Only restart if Bluetooth (glasses) route is available
             let route = AVAudioSession.sharedInstance().currentRoute
             let hasBluetooth = route.inputs.contains { $0.portType == .bluetoothHFP }
@@ -351,7 +380,7 @@ class WakeWordService: NSObject, ObservableObject {
         }
         stopFired = false
         wakeWordFired = false
-        silentBufferCount = 0
+        silenceTracker.reset()
         silenceReported = false
         pausedForSilence = false
 
@@ -453,16 +482,19 @@ class WakeWordService: NSObject, ObservableObject {
         } else {
             audioBufferForwarders.removeValue(forKey: "default")
         }
+        tapState.setForwarders(audioBufferForwarders)
     }
 
     /// Add a named audio buffer consumer. Multiple consumers can listen simultaneously.
     func addAudioBufferConsumer(id: String, handler: @escaping @Sendable (AVAudioPCMBuffer) -> Void) {
         audioBufferForwarders[id] = handler
+        tapState.setForwarders(audioBufferForwarders)
     }
 
     /// Remove a named audio buffer consumer.
     func removeAudioBufferConsumer(id: String) {
         audioBufferForwarders.removeValue(forKey: id)
+        tapState.setForwarders(audioBufferForwarders)
     }
 
     private func cleanupAudioEngine() {
@@ -490,7 +522,16 @@ class WakeWordService: NSObject, ObservableObject {
         }
 
         recognitionRequest.shouldReportPartialResults = true
-        recognitionRequest.requiresOnDeviceRecognition = false
+        // On-device wake-word spotting (Plan BE): the always-on listener no longer streams mic
+        // audio to Apple's servers 24/7 — the single largest steady battery/data drain. Short-phrase
+        // spotting works well on-device (contextualStrings still apply); real queries keep server
+        // recognition in TranscriptionService. Falls back to server if the locale can't do on-device.
+        let wantsOnDevice = Config.onDeviceWakeWordEnabled
+        let canDoOnDevice = speechRecognizer?.supportsOnDeviceRecognition ?? false
+        recognitionRequest.requiresOnDeviceRecognition = wantsOnDevice && canDoOnDevice
+        if wantsOnDevice && !canDoOnDevice {
+            print("🎤 On-device wake recognition unsupported for this locale — using server recognition")
+        }
         recognitionRequest.taskHint = .search  // Short phrase detection
         // Boost recognition of all persona wake phrases
         let personaPhrases = Config.allActiveWakePhrases
@@ -545,15 +586,12 @@ class WakeWordService: NSObject, ObservableObject {
 
         print("🎤 New audio engine: \(recordingFormat.sampleRate)Hz, \(recordingFormat.channelCount)ch")
 
+        // The tap runs on the Core Audio render thread. It must NOT touch any @MainActor state —
+        // it reads everything it needs from the lock-guarded `tapState` box (Plan BE).
+        let tapState = self.tapState
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [weak self] buffer, _ in
-            self?.recognitionRequest?.append(buffer)
-            // Fan out to all registered audio consumers
-            if let forwarders = self?.audioBufferForwarders {
-                for (_, handler) in forwarders {
-                    handler(buffer)
-                }
-            }
-            // Monitor audio levels for silence detection (glasses in case)
+            tapState.dispatch(buffer)
+            // Silence detection is nonisolated and does its own (batched) main-actor hop.
             self?.checkAudioLevel(buffer: buffer)
         }
 
@@ -562,6 +600,11 @@ class WakeWordService: NSObject, ObservableObject {
     }
 
     // MARK: - Silence Detection (Glasses in Case)
+
+    /// Silence counting runs entirely on the audio thread (Plan BE); we hop to the main actor only
+    /// on a state *transition* (silence entered / audio resumed) instead of spawning a MainActor
+    /// Task per buffer (~10-15/sec, forever).
+    private let silenceTracker = SilenceTracker()
 
     private nonisolated func checkAudioLevel(buffer: AVAudioPCMBuffer) {
         guard let channelData = buffer.floatChannelData else { return }
@@ -577,24 +620,24 @@ class WakeWordService: NSObject, ObservableObject {
         }
         let rms = sqrtf(sum / Float(frames))
 
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            if rms < self.silenceRMSThreshold {
-                self.silentBufferCount += 1
-                if self.silentBufferCount >= self.silenceBufferThreshold && !self.silenceReported {
-                    self.silenceReported = true
-                    self.pausedForSilence = true
-                    NSLog("[WakeWord] Sustained silence detected (%d buffers) — glasses likely in case", self.silentBufferCount)
-                    self.onSilenceDetected?()
-                }
-            } else {
-                if self.silenceReported {
-                    NSLog("[WakeWord] Audio resumed after silence — glasses active again")
-                    self.silenceReported = false
-                    self.pausedForSilence = false
-                    self.onAudioResumed?()
-                }
-                self.silentBufferCount = 0
+        switch silenceTracker.observe(rms: rms, threshold: silenceRMSThreshold, limit: silenceBufferThreshold) {
+        case .none:
+            break
+        case .enteredSilence(let count):
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.silenceReported = true
+                self.pausedForSilence = true
+                NSLog("[WakeWord] Sustained silence detected (%d buffers) — glasses likely in case", count)
+                self.onSilenceDetected?()
+            }
+        case .resumed:
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                NSLog("[WakeWord] Audio resumed after silence — glasses active again")
+                self.silenceReported = false
+                self.pausedForSilence = false
+                self.onAudioResumed?()
             }
         }
     }
@@ -830,5 +873,69 @@ enum WakeWordError: LocalizedError {
         case .configurationError(let msg): return "Configuration error: \(msg)"
         case .activationError(let msg): return "Activation error: \(msg)"
         }
+    }
+}
+
+/// Audio-thread silence accumulator (Plan BE). Counts consecutive low-RMS buffers and reports only
+/// the two transitions the main actor cares about, so silence detection costs one locked increment
+/// per buffer instead of a spawned MainActor Task per buffer.
+final class SilenceTracker: @unchecked Sendable {
+    enum Transition: Equatable { case none, enteredSilence(count: Int), resumed }
+
+    private let lock = OSAllocatedUnfairLock<State>(initialState: State())
+    private struct State { var count = 0; var reported = false }
+
+    func observe(rms: Float, threshold: Float, limit: Int) -> Transition {
+        lock.withLock { state in
+            if rms < threshold {
+                state.count += 1
+                if state.count >= limit && !state.reported {
+                    state.reported = true
+                    return .enteredSilence(count: state.count)
+                }
+                return .none
+            } else {
+                let wasReported = state.reported
+                state.reported = false
+                state.count = 0
+                return wasReported ? .resumed : .none
+            }
+        }
+    }
+
+    /// Reset when listening restarts so a fresh session starts from silence-clear.
+    func reset() { lock.withLock { $0 = State() } }
+}
+
+/// Lock-guarded box the audio-render thread reads from the wake-word tap (Plan BE).
+///
+/// The tap runs on the Core Audio render thread and must never touch `@MainActor` state. The main
+/// actor publishes the current recognition request and forwarder set into this box under the lock;
+/// the tap reads a consistent snapshot under the same lock and never sees a torn dictionary or a
+/// half-torn-down request. `SFSpeechAudioBufferRecognitionRequest.append` is itself thread-safe;
+/// what wasn't safe was the concurrent mutation of the *references* the old tap dereferenced.
+final class WakeTapState: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock<State>(initialState: State())
+
+    private struct State {
+        var request: SFSpeechAudioBufferRecognitionRequest?
+        var forwarders: [@Sendable (AVAudioPCMBuffer) -> Void] = []
+    }
+
+    func setRequest(_ request: SFSpeechAudioBufferRecognitionRequest?) {
+        lock.withLock { $0.request = request }
+    }
+
+    func setForwarders(_ forwarders: [String: @Sendable (AVAudioPCMBuffer) -> Void]) {
+        let values = Array(forwarders.values)
+        lock.withLock { $0.forwarders = values }
+    }
+
+    /// Called from the audio thread: append to the recognizer and fan out to consumers, all from a
+    /// single locked snapshot.
+    func dispatch(_ buffer: AVAudioPCMBuffer) {
+        let snapshot = lock.withLock { $0 }
+        snapshot.request?.append(buffer)
+        for handler in snapshot.forwarders { handler(buffer) }
     }
 }

--- a/OpenGlasses/Sources/Shared/SharedTeleprompterInbox.swift
+++ b/OpenGlasses/Sources/Shared/SharedTeleprompterInbox.swift
@@ -32,27 +32,74 @@ enum SharedTeleprompterInbox {
         return container?.appendingPathComponent(fileName)
     }
 
-    /// Append a shared script to the inbox (called from the Share Extension).
+    /// Append a shared script to the inbox (called from the Share Extension). The read-modify-write
+    /// is file-coordinated: the extension and the main app run in separate processes, and an
+    /// uncoordinated append racing the app's drain used to be silently lost.
     static func append(title: String, text: String) {
         let clean = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !clean.isEmpty, let url = fileURL else { return }
-        var pending = load()
-        pending.append(PendingScript(title: title.trimmingCharacters(in: .whitespacesAndNewlines), text: clean))
-        guard let data = try? JSONEncoder().encode(pending) else { return }
-        try? data.write(to: url, options: .atomic)
+        coordinateWrite(at: url) { url in
+            var pending = load(at: url)
+            pending.append(PendingScript(title: title.trimmingCharacters(in: .whitespacesAndNewlines), text: clean))
+            guard let data = try? JSONEncoder().encode(pending) else { return }
+            try? data.write(to: url, options: .atomic)
+        }
     }
 
-    /// Return and clear all pending scripts (called from the main app).
+    /// Read all pending scripts without consuming them (called from the main app). Pair with
+    /// `remove(_:)` after the app has durably saved them — deleting the inbox before the save
+    /// commits used to lose shares from both places.
+    static func peek() -> [PendingScript] {
+        guard let url = fileURL else { return [] }
+        var result: [PendingScript] = []
+        coordinateRead(at: url) { url in
+            result = load(at: url)
+        }
+        return result
+    }
+
+    /// Remove exactly the given scripts from the inbox (coordinated), leaving anything appended
+    /// since the corresponding `peek()` in place.
+    static func remove(_ items: [PendingScript]) {
+        guard !items.isEmpty, let url = fileURL else { return }
+        coordinateWrite(at: url) { url in
+            var pending = load(at: url)
+            for item in items {
+                if let idx = pending.firstIndex(of: item) { pending.remove(at: idx) }
+            }
+            if pending.isEmpty {
+                try? FileManager.default.removeItem(at: url)
+            } else if let data = try? JSONEncoder().encode(pending) {
+                try? data.write(to: url, options: .atomic)
+            }
+        }
+    }
+
+    /// Return and clear all pending scripts. Prefer `peek()` + `remove(_:)` when the caller
+    /// persists the result — this variant consumes unconditionally.
     static func drain() -> [PendingScript] {
-        let pending = load()
-        guard !pending.isEmpty, let url = fileURL else { return [] }
-        try? FileManager.default.removeItem(at: url)
+        let pending = peek()
+        remove(pending)
         return pending
     }
 
-    private static func load() -> [PendingScript] {
-        guard let url = fileURL, let data = try? Data(contentsOf: url),
+    private static func load(at url: URL) -> [PendingScript] {
+        guard let data = try? Data(contentsOf: url),
               let decoded = try? JSONDecoder().decode([PendingScript].self, from: data) else { return [] }
         return decoded
+    }
+
+    private static func coordinateRead(at url: URL, _ body: (URL) -> Void) {
+        var coordinationError: NSError?
+        NSFileCoordinator(filePresenter: nil)
+            .coordinate(readingItemAt: url, options: [], error: &coordinationError) { body($0) }
+        if coordinationError != nil { body(url) }  // fall back to direct access rather than dropping data
+    }
+
+    private static func coordinateWrite(at url: URL, _ body: (URL) -> Void) {
+        var coordinationError: NSError?
+        NSFileCoordinator(filePresenter: nil)
+            .coordinate(writingItemAt: url, options: [], error: &coordinationError) { body($0) }
+        if coordinationError != nil { body(url) }
     }
 }

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -2313,6 +2313,19 @@ struct Config {
         UserDefaults.standard.set(enabled, forKey: "useGlassesMicForWakeWord")
     }
 
+    /// Use on-device speech recognition for the always-on wake-word listener (Plan BE). Default on:
+    /// short-phrase spotting doesn't need the server, and streaming mic audio to Apple 24/7 is the
+    /// biggest steady battery/data drain. Real queries still use server recognition.
+    static var onDeviceWakeWordEnabled: Bool {
+        let key = "onDeviceWakeWordEnabled"
+        if UserDefaults.standard.object(forKey: key) == nil { return true }
+        return UserDefaults.standard.bool(forKey: key)
+    }
+
+    static func setOnDeviceWakeWordEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: "onDeviceWakeWordEnabled")
+    }
+
     // MARK: - Audio-Only Mode
 
     /// When enabled, disables video frame streaming to save battery. Voice still works.

--- a/OpenGlassesTests/HistoryHygieneTests.swift
+++ b/OpenGlassesTests/HistoryHygieneTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan BF (docs/plans/BF-llm-turn-hygiene.md): the pure history-hygiene passes — dangling
+/// tool_use repair (the "one bad tool call 400s the whole conversation" bug), image pruning, and
+/// the image-aware token estimate.
+final class HistoryHygieneTests: XCTestCase {
+
+    // MARK: - Dangling tool_use repair
+
+    func testAppendsSyntheticResultForUnansweredToolUse() {
+        let history: [[String: Any]] = [
+            ["role": "user", "content": "what's the weather"],
+            ["role": "assistant", "content": [
+                ["type": "tool_use", "id": "call_1", "name": "get_weather", "input": [:]]
+            ]],
+            // Execution was interrupted — no tool_result followed.
+        ]
+        let repaired = HistoryHygiene.repairDanglingToolUse(history)
+        XCTAssertEqual(repaired.count, 3)
+        let last = repaired[2]
+        XCTAssertEqual(last["role"] as? String, "user")
+        let blocks = last["content"] as? [[String: Any]]
+        XCTAssertEqual(blocks?.first?["type"] as? String, "tool_result")
+        XCTAssertEqual(blocks?.first?["tool_use_id"] as? String, "call_1")
+    }
+
+    func testLeavesAnsweredToolUseUntouched() {
+        let history: [[String: Any]] = [
+            ["role": "assistant", "content": [
+                ["type": "tool_use", "id": "call_1", "name": "get_weather", "input": [:]]
+            ]],
+            ["role": "user", "content": [
+                ["type": "tool_result", "tool_use_id": "call_1", "content": "Sunny, 20°C"]
+            ]],
+        ]
+        let repaired = HistoryHygiene.repairDanglingToolUse(history)
+        XCTAssertEqual(repaired.count, 2, "a fully-answered exchange must not gain synthetic results")
+    }
+
+    func testRepairsOnlyTheUnansweredIdInAMixedBlock() {
+        let history: [[String: Any]] = [
+            ["role": "assistant", "content": [
+                ["type": "tool_use", "id": "a", "name": "x", "input": [:]],
+                ["type": "tool_use", "id": "b", "name": "y", "input": [:]]
+            ]],
+            ["role": "user", "content": [
+                ["type": "tool_result", "tool_use_id": "a", "content": "done"]
+            ]],
+        ]
+        let repaired = HistoryHygiene.repairDanglingToolUse(history)
+        // Assistant turn + one merged user turn carrying results for BOTH ids (Anthropic requires
+        // all of a turn's tool_results in a single following user message).
+        XCTAssertEqual(repaired.count, 2)
+        let results = repaired[1]["content"] as? [[String: Any]]
+        let answeredIds = Set(results?.compactMap { $0["tool_use_id"] as? String } ?? [])
+        XCTAssertEqual(answeredIds, ["a", "b"])
+        // "a" keeps its real result; "b" gets the synthetic interrupted result.
+        let bResult = results?.first { $0["tool_use_id"] as? String == "b" }
+        XCTAssertEqual(bResult?["content"] as? String, HistoryHygiene.interruptedToolResult)
+    }
+
+    // MARK: - Image pruning
+
+    private func imageMessage(_ text: String) -> [String: Any] {
+        // ~200k base64 chars ≈ a real ~150KB JPEG frame — enough to weigh well past the text floor.
+        ["role": "user", "content": [
+            ["type": "image", "source": ["type": "base64", "media_type": "image/jpeg",
+                                          "data": String(repeating: "A", count: 200_000)]],
+            ["type": "text", "text": text],
+        ]]
+    }
+
+    func testPruneKeepsNewestImageAndDropsOlder() {
+        let history = [imageMessage("first"), imageMessage("second")]
+        let pruned = HistoryHygiene.pruneImages(history, keepLast: 1)
+
+        // First message: image replaced by placeholder, text preserved.
+        let firstBlocks = pruned[0]["content"] as? [[String: Any]]
+        XCTAssertFalse(firstBlocks?.contains { $0["type"] as? String == "image" } ?? true,
+                       "old image should be pruned")
+        XCTAssertTrue(firstBlocks?.contains { ($0["text"] as? String) == "first" } ?? false,
+                      "old text is preserved")
+        XCTAssertTrue(firstBlocks?.contains { ($0["text"] as? String) == HistoryHygiene.prunedImagePlaceholder } ?? false)
+
+        // Second (newest) message keeps its image.
+        let secondBlocks = pruned[1]["content"] as? [[String: Any]]
+        XCTAssertTrue(secondBlocks?.contains { $0["type"] as? String == "image" } ?? false,
+                      "newest image must be kept")
+    }
+
+    func testPruneNoOpWhenWithinKeepLimit() {
+        let history = [imageMessage("only")]
+        let pruned = HistoryHygiene.pruneImages(history, keepLast: 1)
+        let blocks = pruned[0]["content"] as? [[String: Any]]
+        XCTAssertTrue(blocks?.contains { $0["type"] as? String == "image" } ?? false)
+    }
+
+    // MARK: - Token estimation
+
+    func testImageBlockCountsMoreThanTheFloor() {
+        // A big base64 image should be estimated well above the 50-token text floor.
+        let msg = imageMessage("look")
+        let tokens = HistoryHygiene.estimatedTokens(forMessage: msg)
+        XCTAssertGreaterThan(tokens, 50, "image weight must exceed the flat floor so compaction can see it")
+    }
+
+    func testPlainTextMessageUsesCharCountFloor() {
+        let msg: [String: Any] = ["role": "user", "content": "hi"]
+        XCTAssertEqual(HistoryHygiene.estimatedTokens(forMessage: msg), 50)
+    }
+}

--- a/OpenGlassesTests/RealtimeReconnectTests.swift
+++ b/OpenGlassesTests/RealtimeReconnectTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan BD (docs/plans/BD-realtime-session-resilience.md): the pure reconnect policy + the
+/// fatal-vs-recoverable OpenAI error classifier. (The socket wiring that consumes these — goAway →
+/// reconnect, connect-timeout reschedule, counter reset — is device-pending by house style.)
+final class RealtimeReconnectTests: XCTestCase {
+
+    // MARK: - Policy
+
+    func testBackoffIsExponentialAndCapped() {
+        let policy = RealtimeReconnect.Policy(maxAttempts: 10, maxBackoffSeconds: 30)
+        XCTAssertEqual(policy.delay(forAttempt: 1), 1)
+        XCTAssertEqual(policy.delay(forAttempt: 2), 2)
+        XCTAssertEqual(policy.delay(forAttempt: 3), 4)
+        XCTAssertEqual(policy.delay(forAttempt: 4), 8)
+        XCTAssertEqual(policy.delay(forAttempt: 6), 30, "capped at maxBackoffSeconds")
+        XCTAssertEqual(policy.delay(forAttempt: 10), 30)
+    }
+
+    func testGivesUpPastMaxAttempts() {
+        let policy = RealtimeReconnect.Policy(maxAttempts: 3, maxBackoffSeconds: 30)
+        XCTAssertNotNil(policy.delay(forAttempt: 3))
+        XCTAssertNil(policy.delay(forAttempt: 4), "attempt beyond the max should give up")
+        XCTAssertNil(policy.delay(forAttempt: 0), "attempt 0 is invalid")
+    }
+
+    // MARK: - OpenAI error classification
+
+    func testResponseCancelRaceIsRecoverable() {
+        // The app's own client-VAD response.cancel racing the end of a response.
+        XCTAssertFalse(RealtimeReconnect.isFatalOpenAIError(
+            code: "response_cancel_not_active", message: "Cancellation failed: no active response"))
+        XCTAssertFalse(RealtimeReconnect.isFatalOpenAIError(
+            code: nil, message: "Error: no active response to cancel"))
+    }
+
+    func testActiveResponseConflictIsRecoverable() {
+        XCTAssertFalse(RealtimeReconnect.isFatalOpenAIError(
+            code: "conversation_already_has_active_response",
+            message: "Conversation already has an active response"))
+    }
+
+    func testGenuineErrorsAreFatal() {
+        XCTAssertTrue(RealtimeReconnect.isFatalOpenAIError(code: "invalid_api_key", message: "Invalid API key"))
+        XCTAssertTrue(RealtimeReconnect.isFatalOpenAIError(code: nil, message: "Internal server error"))
+        XCTAssertTrue(RealtimeReconnect.isFatalOpenAIError(code: nil, message: nil),
+                      "an unclassifiable error should be treated as fatal, not silently ignored")
+    }
+
+    func testClassifierIsCaseInsensitive() {
+        XCTAssertFalse(RealtimeReconnect.isFatalOpenAIError(
+            code: "RESPONSE_CANCEL_NOT_ACTIVE", message: "NO ACTIVE RESPONSE"))
+    }
+}

--- a/OpenGlassesTests/SafetyGateTests.swift
+++ b/OpenGlassesTests/SafetyGateTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan BC (docs/plans/BC-unconditional-safety-gate.md): the unconditional actuation floor, the
+/// MCP server bearer-token check, and the SSRF URL guard.
+final class SafetyGateTests: XCTestCase {
+
+    // MARK: - HighImpactToolPolicy
+
+    func testSmartHomeUnlockRequiresConfirmation() {
+        if case .requiresConfirmation = HighImpactToolPolicy.evaluate(
+            tool: "smart_home", args: ["action": "unlock", "device": "front door"]) {} else {
+            XCTFail("unlock must require confirmation")
+        }
+    }
+
+    func testSmartHomeLightOnProceeds() {
+        XCTAssertEqual(HighImpactToolPolicy.evaluate(tool: "smart_home", args: ["action": "on", "device": "lamp"]),
+                       .proceed, "turning a light on is not a security actuation")
+    }
+
+    func testSmartHomeListProceeds() {
+        XCTAssertEqual(HighImpactToolPolicy.evaluate(tool: "smart_home", args: ["action": "list"]), .proceed)
+    }
+
+    func testSmartHomeDisarmAndOpenRequireConfirmation() {
+        for action in ["disarm", "open", "unlock", "arm"] {
+            if case .requiresConfirmation = HighImpactToolPolicy.evaluate(
+                tool: "smart_home", args: ["action": action]) {} else {
+                XCTFail("\(action) must require confirmation")
+            }
+        }
+    }
+
+    func testHomeAssistantUnlockServiceRequiresConfirmation() {
+        if case .requiresConfirmation = HighImpactToolPolicy.evaluate(
+            tool: "home_assistant", args: ["service": "lock.unlock", "entity_id": "lock.front"]) {} else {
+            XCTFail("HA lock.unlock must require confirmation")
+        }
+    }
+
+    func testHomeAssistantWeatherQueryProceeds() {
+        XCTAssertEqual(HighImpactToolPolicy.evaluate(tool: "home_assistant", args: ["text": "what's the temperature"]),
+                       .proceed)
+    }
+
+    func testUnrelatedToolProceeds() {
+        XCTAssertEqual(HighImpactToolPolicy.evaluate(tool: "get_weather", args: [:]), .proceed)
+        XCTAssertFalse(HighImpactToolPolicy.mayRequireConfirmation(tool: "get_weather"))
+        XCTAssertTrue(HighImpactToolPolicy.mayRequireConfirmation(tool: "smart_home"))
+    }
+
+    // MARK: - MCP server auth
+
+    @MainActor
+    func testMCPServerRejectsMissingOrWrongToken() {
+        XCTAssertFalse(MCPGlassesServer.isAuthorized(bearer: nil, expected: "secret"))
+        XCTAssertFalse(MCPGlassesServer.isAuthorized(bearer: "", expected: "secret"))
+        XCTAssertFalse(MCPGlassesServer.isAuthorized(bearer: "wrong", expected: "secret"))
+        XCTAssertFalse(MCPGlassesServer.isAuthorized(bearer: "secret", expected: ""))
+    }
+
+    @MainActor
+    func testMCPServerAcceptsMatchingToken() {
+        XCTAssertTrue(MCPGlassesServer.isAuthorized(bearer: "s3cr3t-token", expected: "s3cr3t-token"))
+    }
+
+    // MARK: - URLFetchGuard
+
+    func testGuardAllowsPublicHTTPS() {
+        guard case .success = URLFetchGuard.validate("https://museum.example.com/guide.json") else {
+            return XCTFail("public https should pass")
+        }
+    }
+
+    func testGuardBlocksPrivateIPv4() {
+        for host in ["http://192.168.1.1/x", "http://10.0.0.5/y", "http://172.16.3.4/z",
+                     "http://127.0.0.1/local", "http://169.254.169.254/latest/meta-data"] {
+            guard case .failure = URLFetchGuard.validate(host) else {
+                return XCTFail("\(host) must be blocked")
+            }
+        }
+    }
+
+    func testGuardBlocksLocalhostAndDotLocal() {
+        XCTAssertTrue(URLFetchGuard.isBlockedHost("localhost"))
+        XCTAssertTrue(URLFetchGuard.isBlockedHost("printer.local"))
+        XCTAssertTrue(URLFetchGuard.isBlockedHost("api.internal"))
+        XCTAssertFalse(URLFetchGuard.isBlockedHost("example.com"))
+    }
+
+    func testGuardBlocksNonHTTPSchemes() {
+        for s in ["file:///etc/passwd", "ftp://host/x", "gopher://host"] {
+            guard case .failure(.disallowedScheme) = URLFetchGuard.validate(s) else {
+                return XCTFail("\(s) scheme must be rejected")
+            }
+        }
+    }
+
+    func testGuardBlocksIPv6LoopbackAndULA() {
+        XCTAssertTrue(URLFetchGuard.isBlockedHost("[::1]"))
+        XCTAssertTrue(URLFetchGuard.isBlockedHost("[fe80::1]"))
+        XCTAssertTrue(URLFetchGuard.isBlockedHost("[fd00::1]"))
+        XCTAssertTrue(URLFetchGuard.isBlockedHost("[::ffff:192.168.0.1]"))
+    }
+
+    func testGuardBlocksCGNATAndMulticast() {
+        XCTAssertTrue(URLFetchGuard.isBlockedHost("100.64.0.1"))
+        XCTAssertTrue(URLFetchGuard.isBlockedHost("224.0.0.1"))
+        XCTAssertFalse(URLFetchGuard.isBlockedHost("8.8.8.8"))
+    }
+}

--- a/OpenGlassesTests/StoreIntegrityTests.swift
+++ b/OpenGlassesTests/StoreIntegrityTests.swift
@@ -1,0 +1,388 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan BB (docs/plans/BB-store-integrity.md): the shared `JSONStore` helper plus the store-level
+/// invariant it exists to enforce — **no code path may write over data whose last load failed
+/// without first preserving the original.**
+@MainActor
+final class StoreIntegrityTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var backupDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StoreIntegrityTests-\(UUID().uuidString)", isDirectory: true)
+        backupDir = tempDir.appendingPathComponent("backups", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        SharedTeleprompterInbox.testContainerURL = nil
+        super.tearDown()
+    }
+
+    private func backupCount() -> Int {
+        (try? FileManager.default.contentsOfDirectory(atPath: backupDir.path))?.count ?? 0
+    }
+
+    // MARK: - JSONStore core
+
+    func testDecodeArrayAbsentWhenNoData() {
+        if case .absent = JSONStore.decodeArray(SavedScript.self, from: nil, name: "t",
+                                                backupDirectory: backupDir) {} else {
+            XCTFail("nil data should be .absent")
+        }
+        XCTAssertEqual(backupCount(), 0)
+    }
+
+    func testDecodeArrayLoadsIntactBlob() throws {
+        let scripts = [SavedScript(title: "A", text: "aaa"), SavedScript(title: "B", text: "bbb")]
+        let data = try JSONEncoder().encode(scripts)
+        guard case .loaded(let decoded) = JSONStore.decodeArray(SavedScript.self, from: data, name: "t",
+                                                                backupDirectory: backupDir) else {
+            return XCTFail("intact blob should be .loaded")
+        }
+        XCTAssertEqual(decoded, scripts)
+        XCTAssertEqual(backupCount(), 0)
+    }
+
+    func testDecodeArraySalvagesGoodElementsAndBacksUp() throws {
+        let good = SavedScript(title: "Keep", text: "kept")
+        let goodJSON = String(data: try JSONEncoder().encode(good), encoding: .utf8)!
+        let blob = "[\(goodJSON), {\"bogus\": true}]".data(using: .utf8)!
+        guard case .recovered(let decoded, let backup) =
+                JSONStore.decodeArray(SavedScript.self, from: blob, name: "t", backupDirectory: backupDir) else {
+            return XCTFail("partially-bad blob should be .recovered")
+        }
+        XCTAssertEqual(decoded, [good])
+        XCTAssertNotNil(backup)
+        XCTAssertEqual(try Data(contentsOf: backup!), blob, "backup must be the original bytes")
+    }
+
+    func testDecodeArrayCorruptBacksUpOriginal() {
+        let blob = Data("not json at all".utf8)
+        guard case .corrupt(let backup) =
+                JSONStore.decodeArray(SavedScript.self, from: blob, name: "t", backupDirectory: backupDir) else {
+            return XCTFail("garbage should be .corrupt")
+        }
+        XCTAssertNotNil(backup)
+        XCTAssertEqual(try? Data(contentsOf: backup!), blob)
+    }
+
+    func testDecodeDictionarySalvagesGoodValues() {
+        let blob = """
+        {"good": {"cardID": "c1", "box": 2, "dueAt": 100, "lastReviewed": 50},
+         "bad": {"box": "nope"}}
+        """.data(using: .utf8)!
+        guard case .recovered(let decoded, _) =
+                JSONStore.decodeDictionary(ReviewRecord.self, from: blob, name: "t", backupDirectory: backupDir) else {
+            return XCTFail("partially-bad dictionary should be .recovered")
+        }
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded["good"]?.box, 2)
+    }
+
+    func testLoadArrayFileAbsent() {
+        let url = tempDir.appendingPathComponent("missing.json")
+        if case .absent = JSONStore.loadArray(SavedScript.self, at: url, name: "t",
+                                              backupDirectory: backupDir) {} else {
+            XCTFail("missing file should be .absent")
+        }
+    }
+
+    func testLoadArrayFileUnreadableBlocksSaving() throws {
+        // A directory at the file's path: exists, but Data(contentsOf:) throws.
+        let url = tempDir.appendingPathComponent("store.json")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        let result = JSONStore.loadArray(SavedScript.self, at: url, name: "t", backupDirectory: backupDir)
+        guard case .unreadable = result else {
+            return XCTFail("unreadable file should be .unreadable")
+        }
+        XCTAssertFalse(result.allowsSaving)
+        XCTAssertEqual(backupCount(), 0, "an unreadable file must not be 'backed up' (we never saw its bytes)")
+    }
+
+    // MARK: - PlaybookStore: corrupt blob must never be overwritten by factory defaults
+
+    func testPlaybookStoreDoesNotOverwriteCorruptBlobWithDefaults() {
+        defer {
+            UserDefaults.standard.removeObject(forKey: "playbooks")
+            UserDefaults.standard.removeObject(forKey: "playbookSession")
+        }
+        let corrupt = Data("{\"definitely\": \"not a playbook array\"}".utf8)
+        UserDefaults.standard.set(corrupt, forKey: "playbooks")
+
+        let store = PlaybookStore()
+
+        XCTAssertFalse(store.playbooks.isEmpty, "defaults should be served in-memory")
+        XCTAssertEqual(UserDefaults.standard.data(forKey: "playbooks"), corrupt,
+                       "the stored blob must be left for recovery, not overwritten by defaults")
+    }
+
+    func testPlaybookStoreSeedsDefaultsOnGenuineFirstRun() {
+        defer {
+            UserDefaults.standard.removeObject(forKey: "playbooks")
+            UserDefaults.standard.removeObject(forKey: "playbookSession")
+        }
+        UserDefaults.standard.removeObject(forKey: "playbooks")
+
+        let store = PlaybookStore()
+
+        XCTAssertFalse(store.playbooks.isEmpty)
+        XCTAssertNotNil(UserDefaults.standard.data(forKey: "playbooks"),
+                        "a true first run should persist the seed")
+    }
+
+    // MARK: - AgentDocumentStore: transient read failure must not clobber documents
+
+    func testAgentDocumentStoreLoadsExistingContent() throws {
+        try "my accumulated facts".write(to: tempDir.appendingPathComponent("memory.md"),
+                                         atomically: true, encoding: .utf8)
+        let store = AgentDocumentStore(directory: tempDir)
+        XCTAssertEqual(store.memory, "my accumulated facts")
+    }
+
+    func testAgentDocumentStoreTreatsEmptyFileAsValid() throws {
+        let url = tempDir.appendingPathComponent("memory.md")
+        try "".write(to: url, atomically: true, encoding: .utf8)
+        let store = AgentDocumentStore(directory: tempDir)
+        XCTAssertEqual(store.memory, "", "an emptied document is intentional, not first-run")
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "",
+                       "the file must not be re-seeded with defaults")
+    }
+
+    func testAgentDocumentStoreDoesNotClobberUnreadableFile() throws {
+        // Invalid UTF-8 makes String(contentsOf:encoding:) throw while the file clearly exists —
+        // the same shape as a file-protection read failure on a locked device.
+        let url = tempDir.appendingPathComponent("memory.md")
+        let bytes = Data([0xFF, 0xFE, 0xFD, 0x00, 0x81])
+        try bytes.write(to: url)
+
+        let store = AgentDocumentStore(directory: tempDir)
+
+        XCTAssertEqual(store.memory, AgentDocumentStore.defaultMemory,
+                       "defaults are served in-memory")
+        XCTAssertEqual(try Data(contentsOf: url), bytes,
+                       "the on-disk file must be left untouched")
+    }
+
+    func testAgentDocumentStoreSavePreservesUnreadableOriginal() throws {
+        let url = tempDir.appendingPathComponent("memory.md")
+        let bytes = Data([0xFF, 0xFE, 0xFD])
+        try bytes.write(to: url)
+
+        let store = AgentDocumentStore(directory: tempDir)
+        store.save(.memory, content: "fresh content")
+
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "fresh content")
+        let preserved = try FileManager.default.contentsOfDirectory(atPath: tempDir.path)
+            .filter { $0.hasPrefix("memory.md.unreadable-") }
+        XCTAssertEqual(preserved.count, 1, "the unreadable original must be moved aside, not destroyed")
+        XCTAssertEqual(try Data(contentsOf: tempDir.appendingPathComponent(preserved[0])), bytes)
+    }
+
+    // MARK: - SemanticMemoryStore: SQL safety + migration retirement
+
+    func testMemoryWithApostropheRoundTrips() {
+        let store = SemanticMemoryStore(directory: tempDir)
+        XCTAssertTrue(store.remember("Daughter's birthday", value: "June 3"))
+        XCTAssertEqual(store.recall("daughter's birthday"), "June 3")
+
+        // Persisted, not just cached: a second store over the same directory sees it.
+        let reopened = SemanticMemoryStore(directory: tempDir)
+        XCTAssertEqual(reopened.recall("daughter's birthday"), "June 3")
+    }
+
+    func testForgetWithApostropheActuallyDeletes() {
+        let store = SemanticMemoryStore(directory: tempDir)
+        XCTAssertTrue(store.remember("dog's vet", value: "Dr. Smith"))
+        XCTAssertTrue(store.forget("dog's vet"))
+        XCTAssertNil(store.recall("dog's vet"))
+        XCTAssertNil(SemanticMemoryStore(directory: tempDir).recall("dog's vet"))
+    }
+
+    func testHostileValueIsStoredVerbatim() {
+        let store = SemanticMemoryStore(directory: tempDir)
+        let value = #"it's "quoted" 🎉 '); DROP TABLE memories; --"#
+        XCTAssertTrue(store.remember("hostile", value: value))
+        XCTAssertEqual(store.recall("hostile"), value)
+        // The table survived the attempt.
+        XCTAssertTrue(store.remember("still works", value: "yes"))
+    }
+
+    func testLegacyMemoryFileIsRetiredAfterMigration() throws {
+        let legacy = tempDir.appendingPathComponent("user_memories.json")
+        try #"{"favourite colour": "green"}"#.write(to: legacy, atomically: true, encoding: .utf8)
+
+        let store = SemanticMemoryStore(directory: tempDir)
+        XCTAssertEqual(store.recall("favourite colour"), "green", "legacy memories migrate")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacy.path),
+                       "the legacy file must be retired after migration")
+
+        // The old bug: clearAll + relaunch re-imported the legacy file, resurrecting
+        // deliberately-forgotten memories.
+        store.clearAll()
+        let relaunched = SemanticMemoryStore(directory: tempDir)
+        XCTAssertNil(relaunched.recall("favourite colour"), "cleared memories must stay cleared")
+    }
+
+    // MARK: - ConversationStore
+
+    func testConversationStoreLeavesCorruptFileForRecovery() throws {
+        let url = tempDir.appendingPathComponent("conversations.json")
+        let corrupt = Data("<<<garbage>>>".utf8)
+        try corrupt.write(to: url)
+
+        let store = ConversationStore(directory: tempDir)
+
+        XCTAssertTrue(store.threads.isEmpty)
+        XCTAssertEqual(try Data(contentsOf: url), corrupt,
+                       "init must not save over the corrupt file")
+    }
+
+    func testConversationStoreBlocksSavesWhenFileUnreadable() throws {
+        // A directory at the storage path: exists, unreadable as data.
+        let url = tempDir.appendingPathComponent("conversations.json")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+
+        let store = ConversationStore(directory: tempDir)
+        _ = store.startThread(mode: "direct")
+        store.appendMessage(role: "user", content: "hello")
+
+        var isDir: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir))
+        XCTAssertTrue(isDir.boolValue, "the unreadable item must survive every save attempt")
+    }
+
+    func testConversationStoreRoundTrips() {
+        let store = ConversationStore(directory: tempDir)
+        _ = store.startThread(mode: "direct")
+        store.appendMessage(role: "user", content: "hello")
+
+        let reopened = ConversationStore(directory: tempDir)
+        XCTAssertEqual(reopened.threads.count, 1)
+        XCTAssertEqual(reopened.threads.first?.messages.first?.content, "hello")
+    }
+
+    // MARK: - Teleprompter share inbox: drain must not outrun the save
+
+    func testInboxPeekDoesNotConsume() {
+        SharedTeleprompterInbox.testContainerURL = tempDir
+        SharedTeleprompterInbox.append(title: "A", text: "aaa")
+        SharedTeleprompterInbox.append(title: "B", text: "bbb")
+
+        XCTAssertEqual(SharedTeleprompterInbox.peek().count, 2)
+        XCTAssertEqual(SharedTeleprompterInbox.peek().count, 2, "peek must not consume")
+    }
+
+    func testInboxRemoveRemovesOnlyGivenItems() {
+        SharedTeleprompterInbox.testContainerURL = tempDir
+        SharedTeleprompterInbox.append(title: "A", text: "aaa")
+        SharedTeleprompterInbox.append(title: "B", text: "bbb")
+
+        let all = SharedTeleprompterInbox.peek()
+        SharedTeleprompterInbox.remove([all[0]])
+
+        let remaining = SharedTeleprompterInbox.peek()
+        XCTAssertEqual(remaining.map(\.title), ["B"], "items appended since the peek must survive")
+    }
+
+    func testImportClearsInboxOnlyAfterSuccessfulSave() throws {
+        SharedTeleprompterInbox.testContainerURL = tempDir
+        SharedTeleprompterInbox.append(title: "Talk", text: "script body")
+
+        // Scripts file is unreadable → the store's save is suppressed → the share must stay
+        // in the inbox for the next attempt instead of being lost from both places.
+        let scriptsURL = tempDir.appendingPathComponent("teleprompter_scripts.json")
+        try FileManager.default.createDirectory(at: scriptsURL, withIntermediateDirectories: true)
+
+        _ = TeleprompterScriptStore(directory: tempDir)
+
+        XCTAssertEqual(SharedTeleprompterInbox.peek().count, 1,
+                       "a failed save must leave the share in the inbox")
+    }
+
+    func testImportClearsInboxAfterSuccessfulSave() {
+        SharedTeleprompterInbox.testContainerURL = tempDir
+        SharedTeleprompterInbox.append(title: "Talk", text: "script body")
+
+        let store = TeleprompterScriptStore(directory: tempDir)
+
+        XCTAssertEqual(store.scripts.count, 1)
+        XCTAssertTrue(SharedTeleprompterInbox.peek().isEmpty,
+                      "committed shares are removed from the inbox")
+    }
+
+    // MARK: - StudyStore / SafetyAssessmentStore: corrupt files preserved, unreadable blocks saves
+
+    func testStudyStorePreservesCorruptDecksFile() throws {
+        let decksURL = tempDir.appendingPathComponent("decks.json")
+        let corrupt = Data("junk".utf8)
+        try corrupt.write(to: decksURL)
+
+        let store = StudyStore(directory: tempDir)
+
+        XCTAssertTrue(store.decks.isEmpty)
+        XCTAssertEqual(try Data(contentsOf: decksURL), corrupt)
+    }
+
+    func testStudyStoreBlocksReviewSaveWhenFileUnreadable() throws {
+        let reviewsURL = tempDir.appendingPathComponent("reviews.json")
+        try FileManager.default.createDirectory(at: reviewsURL, withIntermediateDirectories: true)
+
+        let store = StudyStore(directory: tempDir)
+        store.saveReviewRecord(ReviewRecord(cardID: "c1", box: 1, dueAt: 0, lastReviewed: 0))
+
+        var isDir: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: reviewsURL.path, isDirectory: &isDir))
+        XCTAssertTrue(isDir.boolValue, "unreadable reviews file must not be overwritten")
+    }
+
+    func testSafetyStorePreservesCorruptHistory() throws {
+        let historyURL = tempDir.appendingPathComponent("history.json")
+        let corrupt = Data("not reports".utf8)
+        try corrupt.write(to: historyURL)
+
+        let store = SafetyAssessmentStore(directory: tempDir)
+
+        XCTAssertTrue(store.history.isEmpty)
+        XCTAssertEqual(try Data(contentsOf: historyURL), corrupt)
+    }
+
+    // MARK: - VaultStore: append must not clobber a log it couldn't read
+
+    func testVaultAppendThrowsOnUnreadableExistingFile() throws {
+        let manifest = VaultManifest(
+            id: "test_vault", name: "Test", version: "1.0.0", files: ["log.md"],
+            proceduresDir: nil, gating: .init(iap: nil), promptRules: [],
+            sourceAttributionFormat: nil, sourceAttributionRequired: false
+        )
+        let store = VaultStore(manifest: manifest, bundleRoot: nil, overlayRoot: tempDir)
+        let logURL = tempDir.appendingPathComponent("log.md")
+        let bytes = Data([0xFF, 0xFE, 0xFD])   // invalid UTF-8: read throws, file exists
+        try bytes.write(to: logURL)
+
+        XCTAssertThrowsError(try store.append("log.md", entry: "new entry"),
+                             "append must not rebuild the log from a failed read")
+        XCTAssertEqual(try Data(contentsOf: logURL), bytes, "the log must be untouched")
+    }
+
+    func testVaultAppendStillWorksNormally() throws {
+        let manifest = VaultManifest(
+            id: "test_vault", name: "Test", version: "1.0.0", files: ["log.md"],
+            proceduresDir: nil, gating: .init(iap: nil), promptRules: [],
+            sourceAttributionFormat: nil, sourceAttributionRequired: false
+        )
+        let store = VaultStore(manifest: manifest, bundleRoot: nil, overlayRoot: tempDir)
+
+        try store.append("log.md", entry: "first")
+        try store.append("log.md", entry: "second")
+
+        let contents = try XCTUnwrap(store.read("log.md"))
+        XCTAssertTrue(contents.contains("first"))
+        XCTAssertTrue(contents.contains("second"))
+    }
+}

--- a/OpenGlassesTests/SystemPromptBuilderTests.swift
+++ b/OpenGlassesTests/SystemPromptBuilderTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan BG P1 (docs/plans/BG-spine-refactor.md): the system-prompt tool list is generated from each
+/// NativeTool's own description, so it can't drift from the real tool set or between Direct Mode and
+/// Gemini Live.
+@MainActor
+final class SystemPromptBuilderTests: XCTestCase {
+
+    func testToolLinesRenderNameAndDescription() {
+        let out = SystemPromptBuilder.toolLines([
+            ("get_weather", "Get current weather."),
+            ("calculate", "Evaluate math expressions."),
+        ])
+        XCTAssertEqual(out, "- get_weather: Get current weather.\n- calculate: Evaluate math expressions.")
+    }
+
+    func testMultilineDescriptionIsFlattened() {
+        let out = SystemPromptBuilder.toolLines([
+            ("brain", "Unified search.\n  action 'query' for facts.\n  action 'recall' for conversations."),
+        ])
+        XCTAssertEqual(out, "- brain: Unified search. action 'query' for facts. action 'recall' for conversations.")
+        XCTAssertFalse(out.contains("\n  "), "internal newlines/indentation must be collapsed")
+    }
+
+    func testEmptyInputProducesEmptyString() {
+        XCTAssertEqual(SystemPromptBuilder.toolLines([]), "")
+    }
+
+    /// The whole point of BG P1: every enabled tool appears exactly once, sourced from the registry
+    /// — no hand-maintained list to fall out of sync.
+    func testEveryRegisteredToolAppearsExactlyOnce() {
+        let registry = NativeToolRegistry(locationService: LocationService())
+        let names = registry.toolNames
+        XCTAssertFalse(names.isEmpty, "registry should have tools")
+
+        let pairs = registry.toolDescriptions(for: names)
+        XCTAssertEqual(pairs.count, names.count, "every enabled tool must resolve to a description")
+
+        let lines = SystemPromptBuilder.toolLines(pairs)
+        for name in names {
+            let occurrences = lines.components(separatedBy: "- \(name): ").count - 1
+            XCTAssertEqual(occurrences, 1, "\(name) should appear exactly once in the generated list")
+        }
+    }
+
+    func testDescriptionsComeFromTheToolItself() {
+        let registry = NativeToolRegistry(locationService: LocationService())
+        // Sample a stable, always-registered tool and confirm the generated line matches its own
+        // description property (not a hand-copied string).
+        guard let weather = registry.tool(named: "get_weather") else {
+            return XCTFail("get_weather should be registered")
+        }
+        let line = SystemPromptBuilder.toolLines(registry.toolDescriptions(for: ["get_weather"]))
+        XCTAssertTrue(line.contains(weather.description.split(whereSeparator: \.isNewline).first.map(String.init) ?? ""),
+                      "generated line should reflect the tool's own description")
+    }
+}

--- a/OpenGlassesTests/WakeWordHardeningTests.swift
+++ b/OpenGlassesTests/WakeWordHardeningTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import AVFoundation
+@testable import OpenGlasses
+
+/// Plan BE (docs/plans/BE-wake-word-hardening.md): the headless-testable pieces — the audio-thread
+/// silence tracker, the lock-guarded tap-state box, and the on-device recognition flag. (Live
+/// wake-word accuracy and audio-session recovery are device-pending by house style.)
+final class WakeWordHardeningTests: XCTestCase {
+
+    // MARK: - SilenceTracker
+
+    func testSilenceTrackerReportsEnteredSilenceOnceAtLimit() {
+        let tracker = SilenceTracker()
+        // Below-threshold buffers accumulate; the transition fires exactly at the limit.
+        for i in 1..<3 {
+            XCTAssertEqual(tracker.observe(rms: 0.0, threshold: 0.005, limit: 3), .none, "buffer \(i)")
+        }
+        guard case .enteredSilence(let count) = tracker.observe(rms: 0.0, threshold: 0.005, limit: 3) else {
+            return XCTFail("third silent buffer should cross the limit")
+        }
+        XCTAssertEqual(count, 3)
+        // Further silence does not re-report.
+        XCTAssertEqual(tracker.observe(rms: 0.0, threshold: 0.005, limit: 3), .none)
+    }
+
+    func testSilenceTrackerReportsResumeOnlyAfterSilence() {
+        let tracker = SilenceTracker()
+        // Loud from the start → no resume event (never was silent).
+        XCTAssertEqual(tracker.observe(rms: 1.0, threshold: 0.005, limit: 3), .none)
+
+        for _ in 0..<3 { _ = tracker.observe(rms: 0.0, threshold: 0.005, limit: 3) }
+        XCTAssertEqual(tracker.observe(rms: 1.0, threshold: 0.005, limit: 3), .resumed)
+        // Second loud buffer is not another resume.
+        XCTAssertEqual(tracker.observe(rms: 1.0, threshold: 0.005, limit: 3), .none)
+    }
+
+    func testSilenceTrackerResetClearsState() {
+        let tracker = SilenceTracker()
+        for _ in 0..<3 { _ = tracker.observe(rms: 0.0, threshold: 0.005, limit: 3) }
+        tracker.reset()
+        // After reset, a loud buffer should NOT report a resume (we're back to silence-clear).
+        XCTAssertEqual(tracker.observe(rms: 1.0, threshold: 0.005, limit: 3), .none)
+    }
+
+    // MARK: - WakeTapState (data-race surface)
+
+    func testTapStateDispatchesToForwardersUnderConcurrentMutation() {
+        let box = WakeTapState()
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 256)!
+        buffer.frameLength = 256
+
+        let received = NSCountedSet()
+        let lock = NSLock()
+        box.setForwarders(["a": { _ in lock.lock(); received.add("a"); lock.unlock() }])
+
+        // Hammer dispatch from one queue while another swaps forwarders — must not crash and must
+        // keep delivering. (Under TSAN this is the regression guard for the tap/main-actor race.)
+        let dispatchExp = expectation(description: "dispatch")
+        let mutateExp = expectation(description: "mutate")
+        DispatchQueue.global().async {
+            for _ in 0..<2000 { box.dispatch(buffer) }
+            dispatchExp.fulfill()
+        }
+        DispatchQueue.global().async {
+            for i in 0..<2000 {
+                box.setForwarders(["a": { _ in lock.lock(); received.add("a"); lock.unlock() },
+                                   "b\(i % 3)": { _ in }])
+            }
+            mutateExp.fulfill()
+        }
+        wait(for: [dispatchExp, mutateExp], timeout: 10)
+        XCTAssertGreaterThan(received.count(for: "a"), 0, "forwarder should have received buffers")
+    }
+
+    func testTapStateNilRequestIsSafe() {
+        let box = WakeTapState()
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 128)!
+        buffer.frameLength = 128
+        box.setRequest(nil)
+        box.setForwarders([:])
+        box.dispatch(buffer)   // no request, no forwarders → must be a safe no-op
+    }
+
+    // MARK: - Config flag
+
+    func testOnDeviceWakeWordDefaultsOn() {
+        UserDefaults.standard.removeObject(forKey: "onDeviceWakeWordEnabled")
+        XCTAssertTrue(Config.onDeviceWakeWordEnabled)
+    }
+
+    func testOnDeviceWakeWordTogglePersists() {
+        defer { UserDefaults.standard.removeObject(forKey: "onDeviceWakeWordEnabled") }
+        Config.setOnDeviceWakeWordEnabled(false)
+        XCTAssertFalse(Config.onDeviceWakeWordEnabled)
+        Config.setOnDeviceWakeWordEnabled(true)
+        XCTAssertTrue(Config.onDeviceWakeWordEnabled)
+    }
+}


### PR DESCRIPTION
Implements the actionable findings from the six-track code audit as one PR (plans **BB–BG P1** in `docs/plans/`). Every fix ships a deterministic, headless-testable core; the live/device edges are deferred per house style.

**1441 tests pass, 0 failures. Release build green.**

## BB — Store integrity & data-loss hardening
The audit's highest-severity findings were silent, permanent user-data loss.
- New `JSONStore` helper: backup-on-corrupt (`Documents/StoreRecovery/`), element-wise salvage decode, and a distinct **unreadable** state (file exists but read failed — e.g. file protection on a locked device) that suppresses saves so intact data is never overwritten.
- **PlaybookStore** no longer overwrites a failed-to-decode blob with factory defaults on launch.
- **AgentDocumentStore** no longer clobbers `soul.md`/`memory.md` on a transient read failure; moves an unreadable original aside before writing.
- **SemanticMemoryStore**: parameterized SQL — memories whose *key* contained an apostrophe were silently never saved (`[REMEMBER: daughter's birthday …]`); `remember`/`forget` now report success; legacy `user_memories.json` retired after migration so `clearAll()` can't resurrect it.
- Same amplification pattern fixed in ConversationStore (+ encrypted-mode serialization & lock-window), TeleprompterScriptStore (peek/remove so a failed save doesn't lose the share), StudyStore, SafetyAssessmentStore, VaultStore.append.

## BC — Unconditional safety gate & MCP auth
- `HighImpactToolPolicy`: confirmation before security-relevant actuation (`smart_home` unlock/open/disarm, `home_assistant`) **even with Agent Mode off** — a prompt-injected sign/web result could previously unlock a door with no confirmation.
- `MCPGlassesServer` now requires `Authorization: Bearer <token>` (256-bit, Keychain, shown in Settings); dropped the public-tunnel suggestion for the unauthenticated camera endpoint.
- `URLFetchGuard`: blocks SSRF-shaped fetches (private/loopback/link-local/metadata) in `QRContextTool`.

## BD — Realtime session resilience (Gemini Live + OpenAI Realtime)
- Pure `RealtimeReconnect` (backoff/give-up policy + fatal-vs-recoverable OpenAI error classifier).
- Gemini `goAway` now reconnects instead of dying — every long session previously ended at the server's rotation.
- An OpenAI recoverable error (the app's own `response.cancel` race) no longer flips the session into a terminal deaf state; only fatal errors reconnect.
- Connect-timeout schedules the next attempt (open-but-mute socket no longer stalls forever); counter reset on a fresh session; timeout task cancelled on resolve; duplicate triggers coalesced.
- Audible local-TTS cue on terminal disconnect / reconnect-exhaustion (voice-first: the phone may be pocketed).

## BE — Wake-word hardening
- `WakeTapState`: lock-guarded box so the audio-render tap never touches `@MainActor` state — fixes a real data race on the app's hottest path.
- Owned NotificationCenter observer tokens (were leaking a pair per glasses reconnect).
- On-device wake recognition (`Config.onDeviceWakeWordEnabled`, default on) — stops streaming mic audio to Apple's servers 24/7.
- Interruption recovery consults `AudioSessionCoordinator` so it can't stomp a live Gemini/OpenAI session; `LiveTranslationService` drops the TTS-quieting `.measurement` mode.
- `SilenceTracker` moves per-buffer counting off the main actor.

## BF — LLM turn hygiene
- `HistoryHygiene`: repair dangling `tool_use` (one interrupted tool call used to 400 **every** later request), prune old base64 images that re-upload each turn, image-aware token estimate so compaction sees image weight.
- Synthetic error `tool_result` on skipped/malformed blocks; parse-error result for malformed OpenAI tool args instead of silently running with empty args.
- Anthropic `cache_control` on the system prompt + tool schemas.

## BG P1 — Registry-generated tool prompts
- `SystemPromptBuilder.toolLines` generates the tool list from each `NativeTool`'s own `description`, deleting the two hand-maintained, already-drifting prose lists in `LLMService` and `GeminiLiveSessionManager`. Removes the CLAUDE.md "update both prompts" rule.

## Notes
- Deferred (own PRs): BG Phases 2–5 (flow-engine extraction, provider adapters, twin-audio-manager merge, Config split) — large structural refactors.
- Plan docs for BB–BG were added in #156; this is the implementation.
- New test suites: `StoreIntegrityTests`, `SafetyGateTests`, `RealtimeReconnectTests`, `WakeWordHardeningTests`, `HistoryHygieneTests`, `SystemPromptBuilderTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)