### PR TITLE
Extract pure VoiceCommandParser from handleTranscription (BG P2 groundwork)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2275,27 +2275,13 @@ class AppState: ObservableObject, AppStateProtocol {
 
     // MARK: - Voice Commands
 
-    private static let stopPhrases = ["stop", "nevermind", "never mind", "cancel", "shut up", "be quiet", "quiet"]
-    private static let goodbyePhrases = ["goodbye", "good bye", "bye", "that's all", "thats all",
-                                          "thanks claude", "thank you claude", "i'm done", "im done",
-                                          "end conversation", "go to sleep"]
-    private static let photoPhrases = ["take a picture", "take a photo", "take photo", "take picture",
-                                        "capture photo", "snap a photo", "snap a picture", "take a snap"]
+    /// Pure recognizer for the pre-LLM voice commands (Plan BG P2 groundwork). AppState still owns
+    /// the side effects; the phrase matching + persona-prefix stripping live in a tested unit.
+    private let voiceCommandParser = VoiceCommandParser.default
 
-    private func isStopCommand(_ text: String) -> Bool {
-        let lower = text.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-        return Self.stopPhrases.contains(where: { lower == $0 || lower.hasPrefix($0 + " ") || lower.hasSuffix(" " + $0) })
-    }
-
-    private func isGoodbyeCommand(_ text: String) -> Bool {
-        let lower = text.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-        return Self.goodbyePhrases.contains(where: { lower.contains($0) })
-    }
-
-    private func isPhotoCommand(_ text: String) -> Bool {
-        let lower = text.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-        return Self.photoPhrases.contains(where: { lower.contains($0) })
-    }
+    private func isStopCommand(_ text: String) -> Bool { voiceCommandParser.isStop(text) }
+    private func isGoodbyeCommand(_ text: String) -> Bool { voiceCommandParser.isGoodbye(text) }
+    private func isPhotoCommand(_ text: String) -> Bool { voiceCommandParser.isPhoto(text) }
 
     /// Reuse an already-available live frame for vision-capable models without trying to
     /// start the camera. This avoids re-triggering fragile Meta camera permission flows.
@@ -2467,29 +2453,21 @@ class AppState: ObservableObject, AppStateProtocol {
         }
 
         // Check for persona names in the transcription (for Action Button / push-to-talk mode)
-        // e.g. "Hey Claude, what's the weather" → activate Claude persona, strip prefix
+        // e.g. "Hey Claude, what's the weather" → activate Claude persona, strip prefix.
+        // Recognition + stripping is pure (VoiceCommandParser); AppState applies the match.
         if activePersona == nil {
-            let lower = text.lowercased()
-            for persona in Config.enabledPersonas {
-                for phrase in persona.allPhrases {
-                    if lower.hasPrefix(phrase) || lower.contains(phrase) {
-                        activePersona = persona
-                        Config.setActiveModelId(persona.modelId)
-                        Config.setActivePresetId(persona.presetId)
-                        llmService.refreshActiveModel()
-                        print("🎭 Persona detected in transcription: \(persona.name)")
-                        // Strip the wake phrase from the query
-                        if let range = lower.range(of: phrase) {
-                            query = String(text[range.upperBound...])
-                                .trimmingCharacters(in: .whitespacesAndNewlines)
-                                .trimmingCharacters(in: CharacterSet(charactersIn: ","))
-                                .trimmingCharacters(in: .whitespaces)
-                        }
-                        if query.isEmpty { query = text }
-                        break
-                    }
-                }
-                if activePersona != nil { break }
+            let personas = Config.enabledPersonas
+            let personaPhrases = personas.map {
+                VoiceCommandParser.PersonaPhrases(id: $0.id, phrases: $0.allPhrases)
+            }
+            if let match = voiceCommandParser.detectPersona(in: text, personas: personaPhrases),
+               let persona = personas.first(where: { $0.id == match.personaId }) {
+                activePersona = persona
+                Config.setActiveModelId(persona.modelId)
+                Config.setActivePresetId(persona.presetId)
+                llmService.refreshActiveModel()
+                print("🎭 Persona detected in transcription: \(persona.name)")
+                query = match.query
             }
         }
 

--- a/OpenGlasses/Sources/Services/Flow/VoiceCommandParser.swift
+++ b/OpenGlasses/Sources/Services/Flow/VoiceCommandParser.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Pure recognition of the pre-LLM voice commands the conversation flow handles before falling
+/// through to the model (docs/plans/BG-spine-refactor.md, P2 groundwork).
+///
+/// This lifts the stop / goodbye / photo phrase matching and the persona-wake-prefix stripping out
+/// of `AppState.handleTranscription` into a deterministic, headless-testable unit. It holds no state
+/// and touches no services — `AppState` keeps owning the side effects; this only decides *what* a
+/// transcript is.
+struct VoiceCommandParser {
+
+    let stopPhrases: [String]
+    let goodbyePhrases: [String]
+    let photoPhrases: [String]
+
+    /// The phrase sets currently used by the live flow. Kept here as the single source so the
+    /// matching rules and the phrases live together.
+    static let `default` = VoiceCommandParser(
+        stopPhrases: ["stop", "nevermind", "never mind", "cancel", "shut up", "be quiet", "quiet"],
+        goodbyePhrases: ["goodbye", "good bye", "bye", "that's all", "thats all",
+                         "thanks claude", "thank you claude", "i'm done", "im done",
+                         "end conversation", "go to sleep"],
+        photoPhrases: ["take a picture", "take a photo", "take photo", "take picture",
+                       "capture photo", "snap a photo", "snap a picture", "take a snap"]
+    )
+
+    // MARK: - Command recognition
+
+    /// "stop" and friends — matched as a whole word (equal, or a leading/trailing token) so
+    /// "stop the timer" counts but "nonstop music" does not.
+    func isStop(_ text: String) -> Bool {
+        let lower = normalize(text)
+        return stopPhrases.contains { lower == $0 || lower.hasPrefix($0 + " ") || lower.hasSuffix(" " + $0) }
+    }
+
+    /// "goodbye" and friends — matched as a substring, since these end a conversation and users
+    /// pad them ("okay, thanks Claude, bye").
+    func isGoodbye(_ text: String) -> Bool {
+        let lower = normalize(text)
+        return goodbyePhrases.contains { lower.contains($0) }
+    }
+
+    /// "take a picture" and friends — substring match.
+    func isPhoto(_ text: String) -> Bool {
+        let lower = normalize(text)
+        return photoPhrases.contains { lower.contains($0) }
+    }
+
+    // MARK: - Persona wake-prefix
+
+    /// A persona and the phrases that activate it (its wake phrases + aliases).
+    struct PersonaPhrases {
+        let id: String
+        let phrases: [String]
+    }
+
+    /// Result of finding a persona wake-prefix in a transcript.
+    struct PersonaMatch: Equatable {
+        /// The matched persona's id.
+        let personaId: String
+        /// The remaining query with the wake phrase stripped, or the original text if stripping
+        /// left nothing usable.
+        let query: String
+    }
+
+    /// Detect a persona wake phrase anywhere in `text` (prefix or contained) and return the matched
+    /// persona plus the query with the phrase removed. Mirrors the Action-Button / push-to-talk
+    /// path: "Hey Claude, what's the weather" → (claude, "what's the weather").
+    func detectPersona(in text: String, personas: [PersonaPhrases]) -> PersonaMatch? {
+        let lower = normalize(text)
+        for persona in personas {
+            for phrase in persona.phrases {
+                guard lower.hasPrefix(phrase) || lower.contains(phrase) else { continue }
+                var query = text
+                if let range = lower.range(of: phrase) {
+                    query = String(text[range.upperBound...])
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .trimmingCharacters(in: CharacterSet(charactersIn: ","))
+                        .trimmingCharacters(in: .whitespaces)
+                }
+                if query.isEmpty { query = text }
+                return PersonaMatch(personaId: persona.id, query: query)
+            }
+        }
+        return nil
+    }
+
+    private func normalize(_ text: String) -> String {
+        text.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/OpenGlassesTests/VoiceCommandParserTests.swift
+++ b/OpenGlassesTests/VoiceCommandParserTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan BG P2 groundwork (docs/plans/BG-spine-refactor.md): the pure pre-LLM command recognition
+/// lifted out of `AppState.handleTranscription`. These are the first tests over the flow's decision
+/// logic — the state machine's side effects stay in AppState and are device-verified.
+final class VoiceCommandParserTests: XCTestCase {
+
+    private let parser = VoiceCommandParser.default
+
+    // MARK: - Stop (whole-word)
+
+    func testStopMatchesWholeWordAndLeadingToken() {
+        XCTAssertTrue(parser.isStop("stop"))
+        XCTAssertTrue(parser.isStop("Stop"))
+        XCTAssertTrue(parser.isStop("stop the timer"))
+        XCTAssertTrue(parser.isStop("cancel"))
+        XCTAssertTrue(parser.isStop("never mind"))
+    }
+
+    func testStopDoesNotMatchInsideAnotherWord() {
+        XCTAssertFalse(parser.isStop("nonstop music"), "'stop' inside a word must not trigger")
+        XCTAssertFalse(parser.isStop("what's the weather"))
+    }
+
+    // MARK: - Goodbye (substring)
+
+    func testGoodbyeMatchesPaddedPhrases() {
+        XCTAssertTrue(parser.isGoodbye("goodbye"))
+        XCTAssertTrue(parser.isGoodbye("okay, thanks Claude, bye"))
+        XCTAssertTrue(parser.isGoodbye("I'm done"))
+        XCTAssertTrue(parser.isGoodbye("go to sleep"))
+    }
+
+    func testGoodbyeDoesNotMatchUnrelated() {
+        XCTAssertFalse(parser.isGoodbye("what time is it"))
+    }
+
+    // MARK: - Photo
+
+    func testPhotoMatchesVariants() {
+        for phrase in ["take a picture", "take a photo", "snap a picture", "capture photo"] {
+            XCTAssertTrue(parser.isPhoto(phrase), phrase)
+        }
+        XCTAssertTrue(parser.isPhoto("hey, take a photo of this"))
+    }
+
+    func testPhotoDoesNotMatchUnrelated() {
+        XCTAssertFalse(parser.isPhoto("what do you see"))
+    }
+
+    // MARK: - Persona wake-prefix
+
+    private let personas = [
+        VoiceCommandParser.PersonaPhrases(id: "claude", phrases: ["hey claude", "claude"]),
+        VoiceCommandParser.PersonaPhrases(id: "chef", phrases: ["hey chef", "chef"]),
+    ]
+
+    func testDetectPersonaStripsPrefix() {
+        let match = parser.detectPersona(in: "Hey Claude, what's the weather", personas: personas)
+        XCTAssertEqual(match, .init(personaId: "claude", query: "what's the weather"))
+    }
+
+    func testDetectPersonaKeepsOriginalWhenPhraseIsWholeUtterance() {
+        // "Claude" alone leaves no query — fall back to the original text rather than empty.
+        let match = parser.detectPersona(in: "Claude", personas: personas)
+        XCTAssertEqual(match?.personaId, "claude")
+        XCTAssertEqual(match?.query, "Claude")
+    }
+
+    func testDetectPersonaPicksFirstMatchInOrder() {
+        let match = parser.detectPersona(in: "hey chef, what's for dinner", personas: personas)
+        XCTAssertEqual(match?.personaId, "chef")
+        XCTAssertEqual(match?.query, "what's for dinner")
+    }
+
+    func testDetectPersonaReturnsNilWhenNoneMatch() {
+        XCTAssertNil(parser.detectPersona(in: "what's the weather", personas: personas))
+    }
+
+    func testDefaultPhrasesArePresent() {
+        // Guard against an accidental empty phrase list silently disabling recognition.
+        XCTAssertFalse(VoiceCommandParser.default.stopPhrases.isEmpty)
+        XCTAssertFalse(VoiceCommandParser.default.goodbyePhrases.isEmpty)
+        XCTAssertFalse(VoiceCommandParser.default.photoPhrases.isEmpty)
+    }
+}

--- a/docs/plans/BG-spine-refactor.md
+++ b/docs/plans/BG-spine-refactor.md
@@ -1,6 +1,10 @@
 # Plan BG — Spine Refactor (phased): single-source tool prompts, flow engine, provider adapters, audio-engine merge
 
-**Status:** 📋 Planned (audit round 12, priority 6 — phased, one PR per phase)
+**Status:** 🚧 Phased, one PR per phase. **P1 shipped** (registry-generated tool prompts).
+**P2 groundwork shipped** — pure `VoiceCommandParser` (stop/goodbye/photo + persona-prefix
+stripping) extracted from `handleTranscription` with tests. Still open in P2: the full
+`ConversationFlowEngine` + `VoiceCommandHandler` chain, the resume-listening dedup, and the
+cancellable-turn fix — they restructure the live voice path and want device verification. P3–P5 planned.
 
 ## The problem
 The July 2026 audit's clearest structural signal: **whatever got extracted got tested; the three


### PR DESCRIPTION
First step of Plan BG Phase 2 (`docs/plans/BG-spine-refactor.md`): lift the pre-LLM voice-command recognition out of the ~370-line `AppState.handleTranscription` into a deterministic, headless-testable `VoiceCommandParser`.

## What moved
- Stop / goodbye / photo phrase matching (`isStop` / `isGoodbye` / `isPhoto`) — `AppState`'s three private methods now delegate.
- Persona wake-prefix detection + query stripping ("Hey Claude, what's the weather" → persona `claude`, query "what's the weather").

`AppState` keeps owning all side effects; this only decides *what* a transcript is. Behavior is unchanged.

## Why
It's the first test coverage over the conversation flow's decision logic (**11 tests**) — the audit's core finding was that the app's spine is untested. This is the safe, pure slice of Phase 2.

## Explicitly deferred (need device verification of the live voice path)
- The full `ConversationFlowEngine` + `VoiceCommandHandler` chain.
- Deduplicating the 8× resume-listening boilerplate.
- The cancellable-turn fix (`currentLLMTask` on the main LLM path so cancel/barge-in works on a normal text turn).

These restructure the live wake→LLM→TTS flow, so per the deterministic-core-first house style they're left for a device-verified follow-up.

## Verification
- `VoiceCommandParserTests`: 11/11 pass.
- Full suite: 1451/1452 (the one failure is the pre-existing `HUDPreviewSnapshotTests` GPU-warm-up flake — it fails only on a cold/freshly-erased simulator and passes warm; logs show `timed out while waiting for image provider` before the snapshot assertion; my change touches no rendering code).
- Release build: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)