### PR TITLE
xAI (Grok) provider + Sign in with Claude (OAuth)

### DIFF
--- a/OpenGlasses/Sources/App/Views/ModelFormView.swift
+++ b/OpenGlasses/Sources/App/Views/ModelFormView.swift
@@ -28,6 +28,12 @@ struct ModelFormView: View {
     @State private var discoveredServers: [LocalServerScanner.DiscoveredServer] = []
     @State private var scanMessage: String?
 
+    // "Sign in with Claude" OAuth state (Anthropic only)
+    @ObservedObject private var claudeOAuth = ClaudeOAuthService.shared
+    @State private var showOAuthCodeField = false
+    @State private var oauthCode = ""
+    @State private var isExchangingOAuthCode = false
+
     var body: some View {
         Section {
             TextField("e.g. Claude Sonnet, GPT-4o", text: $name)
@@ -100,7 +106,11 @@ struct ModelFormView: View {
         } else {
             // MARK: Cloud API key section
             Section {
-                SecureField(selectedProvider == .custom ? "API Key (optional for local servers)" : "API Key", text: $apiKey)
+                if selectedProvider == .anthropic {
+                    claudeSignInRows
+                }
+
+                SecureField(anthropicKeyPlaceholder, text: $apiKey)
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
                     .onChange(of: apiKey) { _, _ in resetModelList() }
@@ -158,7 +168,7 @@ struct ModelFormView: View {
                         }
                     }
                 }
-                .disabled((apiKey.isEmpty && selectedProvider != .custom) || isFetchingModels)
+                .disabled((apiKey.isEmpty && selectedProvider != .custom && !anthropicOAuthReady) || isFetchingModels)
 
                 if let error = fetchError {
                     Label(error, systemImage: "xmark.circle")
@@ -328,10 +338,97 @@ struct ModelFormView: View {
         case .zai: return "Z.ai subscription — OpenAI-compatible API"
         case .qwen: return "Coding Plan subscription — coding-intl.dashscope.aliyuncs.com"
         case .minimax: return "MiniMax subscription — platform.minimaxi.com"
+        case .xai: return "Get your API key at console.x.ai"
         case .openrouter: return "500+ models with one API key — openrouter.ai/keys"
         case .custom: return "Any OpenAI-compatible endpoint — a cloud API or a self-hosted Ollama / llama.cpp / LM Studio / vLLM / LocalAI server. For a local server, set the Base URL to e.g. http://your-mac.local:11434/v1 and leave the API Key blank. Use the host's .local name or a Tailscale address — a raw 192.168.x.x IP over http may be blocked by App Transport Security."
         case .local: return "On-device inference — no internet needed"
         case .appleOnDevice: return "Apple Intelligence — built-in, no download, no API key"
+        }
+    }
+
+    // MARK: - Sign in with Claude (OAuth)
+
+    /// True when the Anthropic provider can authenticate without a pasted key.
+    private var anthropicOAuthReady: Bool {
+        selectedProvider == .anthropic && claudeOAuth.isConnected
+    }
+
+    private var anthropicKeyPlaceholder: String {
+        switch selectedProvider {
+        case .custom: return "API Key (optional for local servers)"
+        case .anthropic: return claudeOAuth.isConnected ? "API Key (optional — account connected)" : "API Key"
+        default: return "API Key"
+        }
+    }
+
+    @ViewBuilder
+    private var claudeSignInRows: some View {
+        if claudeOAuth.isConnected {
+            HStack {
+                Image(systemName: "checkmark.seal.fill")
+                    .foregroundStyle(.green)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Claude account connected")
+                    Text("Requests use your Claude subscription unless an API key is set below.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Sign out", role: .destructive) {
+                    claudeOAuth.signOut()
+                }
+                .buttonStyle(.borderless)
+            }
+        } else {
+            Button {
+                if let url = claudeOAuth.beginSignIn() {
+                    UIApplication.shared.open(url)
+                    showOAuthCodeField = true
+                }
+            } label: {
+                Label("Sign in with Claude", systemImage: "person.crop.circle.badge.checkmark")
+            }
+
+            if showOAuthCodeField {
+                TextField("Paste authorization code", text: $oauthCode)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .font(.footnote.monospaced())
+
+                Button {
+                    Task {
+                        isExchangingOAuthCode = true
+                        let ok = await claudeOAuth.completeSignIn(pastedCode: oauthCode)
+                        isExchangingOAuthCode = false
+                        if ok {
+                            oauthCode = ""
+                            showOAuthCodeField = false
+                            resetModelList()
+                        }
+                    }
+                } label: {
+                    HStack {
+                        if isExchangingOAuthCode {
+                            ProgressView().scaleEffect(0.8)
+                            Text("Connecting…")
+                        } else {
+                            Image(systemName: "link")
+                            Text("Connect")
+                        }
+                    }
+                }
+                .disabled(oauthCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isExchangingOAuthCode)
+
+                Text("Sign in in the browser, copy the code shown on the callback page, then paste it here.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let error = claudeOAuth.lastError {
+                Label(error, systemImage: "xmark.circle")
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
         }
     }
 

--- a/OpenGlasses/Sources/App/Views/OnboardingView.swift
+++ b/OpenGlasses/Sources/App/Views/OnboardingView.swift
@@ -1173,6 +1173,7 @@ struct OnboardingView: View {
         case .openrouter: urlString = "https://openrouter.ai/keys"
         case .qwen: urlString = "https://dashscope.console.aliyun.com/apiKey"
         case .zai: urlString = "https://open.bigmodel.cn/usercenter/apikeys"
+        case .xai: urlString = "https://console.x.ai"
         default: urlString = ""
         }
         if let url = URL(string: urlString) {
@@ -1189,6 +1190,7 @@ struct OnboardingView: View {
         case .openrouter: return "Get a key at openrouter.ai"
         case .qwen: return "Get a key at dashscope.console.aliyun.com"
         case .zai: return "Get a key at open.bigmodel.cn"
+        case .xai: return "Get a key at console.x.ai"
         default: return "Get an access key"
         }
     }

--- a/OpenGlasses/Sources/Services/ClaudeOAuthService.swift
+++ b/OpenGlasses/Sources/Services/ClaudeOAuthService.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Network/persistence edge for the "Sign in with Claude" OAuth flow. The protocol logic
+/// (PKCE, URLs, request bodies, expiry) is pure in `ClaudeOAuth`; this service performs the
+/// token exchange/refresh over the network and keeps credentials in the keychain.
+@MainActor
+final class ClaudeOAuthService: ObservableObject {
+    static let shared = ClaudeOAuthService()
+
+    /// Whether a Claude account is currently connected (credentials on file).
+    @Published private(set) var isConnected: Bool = false
+    @Published private(set) var lastError: String?
+
+    private static let keychainKey = "claudeOAuthCredentials"
+
+    /// PKCE verifier + state for the sign-in currently in progress (nil between attempts).
+    private var pendingVerifier: String?
+    private var pendingState: String?
+
+    private var credentials: ClaudeOAuth.Credentials? {
+        didSet { isConnected = credentials != nil }
+    }
+
+    init() {
+        if let data = KeychainService.data(for: Self.keychainKey),
+           let stored = try? JSONDecoder().decode(ClaudeOAuth.Credentials.self, from: data) {
+            credentials = stored
+            isConnected = true
+        }
+    }
+
+    // MARK: - Sign-in flow
+
+    /// Start a sign-in attempt: mint a fresh PKCE verifier/state and return the browser URL.
+    func beginSignIn() -> URL? {
+        let verifier = ClaudeOAuth.makeVerifier()
+        let state = ClaudeOAuth.makeVerifier()
+        pendingVerifier = verifier
+        pendingState = state
+        lastError = nil
+        return ClaudeOAuth.authorizeURL(verifier: verifier, state: state)
+    }
+
+    /// Complete sign-in with the code the user pasted from the callback page.
+    /// Returns true on success.
+    @discardableResult
+    func completeSignIn(pastedCode: String) async -> Bool {
+        guard let verifier = pendingVerifier else {
+            lastError = "Sign-in wasn't started — tap Sign in with Claude first."
+            return false
+        }
+        guard let parsed = ClaudeOAuth.parseAuthorizationInput(pastedCode) else {
+            lastError = "That doesn't look like an authorization code."
+            return false
+        }
+        let request = ClaudeOAuth.tokenExchangeRequest(
+            code: parsed.code,
+            state: parsed.state ?? pendingState,
+            verifier: verifier
+        )
+        do {
+            let response = try await performTokenRequest(request)
+            store(ClaudeOAuth.Credentials(response: response))
+            pendingVerifier = nil
+            pendingState = nil
+            lastError = nil
+            return true
+        } catch {
+            lastError = "Sign-in failed: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    /// Disconnect the Claude account and wipe stored tokens.
+    func signOut() {
+        credentials = nil
+        _ = KeychainService.delete(Self.keychainKey)
+        pendingVerifier = nil
+        pendingState = nil
+        lastError = nil
+    }
+
+    // MARK: - Token access
+
+    /// The current access token, refreshed first if it's at/near expiry.
+    /// Returns nil when no account is connected or the refresh fails.
+    func validAccessToken() async -> String? {
+        guard var current = credentials else { return nil }
+        guard current.needsRefresh() else { return current.accessToken }
+        guard let refreshToken = current.refreshToken else {
+            // Expired with no refresh token — the stored credential is dead.
+            return nil
+        }
+        do {
+            let response = try await performTokenRequest(ClaudeOAuth.refreshRequest(refreshToken: refreshToken))
+            current = ClaudeOAuth.Credentials(response: response, previousRefreshToken: refreshToken)
+            store(current)
+            return current.accessToken
+        } catch {
+            NSLog("[ClaudeOAuth] Token refresh failed: %@", error.localizedDescription)
+            lastError = "Claude sign-in expired — please sign in again."
+            return nil
+        }
+    }
+
+    // MARK: - Internals
+
+    private func store(_ newCredentials: ClaudeOAuth.Credentials) {
+        credentials = newCredentials
+        if let data = try? JSONEncoder().encode(newCredentials) {
+            _ = KeychainService.setData(data, for: Self.keychainKey)
+        }
+    }
+
+    private func performTokenRequest(_ request: URLRequest) async throws -> ClaudeOAuth.TokenResponse {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw NSError(domain: "ClaudeOAuth", code: status, userInfo: [
+                NSLocalizedDescriptionKey: "Token endpoint returned HTTP \(status)"
+            ])
+        }
+        return try JSONDecoder().decode(ClaudeOAuth.TokenResponse.self, from: data)
+    }
+}

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -12,6 +12,7 @@ enum LLMProvider: String, CaseIterable {
     case zai = "zai"
     case qwen = "qwen"
     case minimax = "minimax"
+    case xai = "xai"
     case openrouter = "openrouter"
     case custom = "custom"
     case local = "local"
@@ -26,6 +27,7 @@ enum LLMProvider: String, CaseIterable {
         case .zai: return "Z.ai (Subscription)"
         case .qwen: return "Qwen (Subscription)"
         case .minimax: return "MiniMax (Subscription)"
+        case .xai: return "xAI (Grok)"
         case .openrouter: return "OpenRouter (500+ models)"
         case .custom: return "Custom (OpenAI-compatible)"
         case .local: return "Local (On-Device MLX)"
@@ -41,6 +43,7 @@ enum LLMProvider: String, CaseIterable {
         case .gemini: return URL(string: "https://aistudio.google.com/apikey")
         case .groq: return URL(string: "https://console.groq.com/keys")
         case .minimax: return URL(string: "https://platform.minimaxi.com")
+        case .xai: return URL(string: "https://console.x.ai")
         case .openrouter: return URL(string: "https://openrouter.ai/keys")
         case .qwen: return URL(string: "https://dashscope.console.aliyun.com/apiKey")
         case .zai, .custom, .local, .appleOnDevice: return nil
@@ -51,7 +54,7 @@ enum LLMProvider: String, CaseIterable {
     var isOpenAICompatible: Bool {
         switch self {
         case .anthropic, .gemini, .local, .appleOnDevice: return false
-        case .openai, .groq, .zai, .qwen, .minimax, .openrouter, .custom: return true
+        case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom: return true
         }
     }
 
@@ -65,6 +68,7 @@ enum LLMProvider: String, CaseIterable {
         case .zai: return "https://api.z.ai/api/coding/paas/v4/chat/completions"
         case .qwen: return "https://coding-intl.dashscope.aliyuncs.com/v1/chat/completions"
         case .minimax: return "https://api.minimax.io/v1/chat/completions"
+        case .xai: return "https://api.x.ai/v1/chat/completions"
         case .openrouter: return "https://openrouter.ai/api/v1/chat/completions"
         case .custom: return "https://api.openai.com/v1/chat/completions"
         case .local: return ""
@@ -75,13 +79,14 @@ enum LLMProvider: String, CaseIterable {
     /// Default model for the provider
     var defaultModel: String {
         switch self {
-        case .anthropic: return "claude-sonnet-4-20250514"
+        case .anthropic: return "claude-sonnet-5"
         case .openai: return "gpt-4o"
         case .gemini: return "gemini-2.0-flash"
         case .groq: return "llama-3.3-70b-versatile"
         case .zai: return "glm-4.5"
         case .qwen: return "qwen3.5-plus"
         case .minimax: return "MiniMax-M2.7"
+        case .xai: return "grok-4"
         case .openrouter: return "anthropic/claude-sonnet-4"
         case .custom: return "gpt-4o"
         case .local: return "mlx-community/gemma-4-e2b-it-4bit"
@@ -431,7 +436,7 @@ class LLMService: ObservableObject {
             rawResponse = try await sendLocal(text, systemPrompt: fullPrompt, config: modelConfig, includeTools: includeTools, imageData: imageData, onToken: onToken)
         case .appleOnDevice:
             rawResponse = try await sendAppleOnDevice(text, systemPrompt: fullPrompt)
-        case .openai, .groq, .zai, .qwen, .minimax, .openrouter, .custom:
+        case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom:
             rawResponse = try await sendOpenAICompatible(text, systemPrompt: fullPrompt, config: modelConfig, includeTools: includeTools, imageData: imageData, onToken: onToken)
         }
 
@@ -511,7 +516,7 @@ class LLMService: ObservableObject {
             return try await sendLocal(text, systemPrompt: system, config: config, includeTools: false, imageData: nil)
         case .appleOnDevice:
             return try await sendAppleOnDevice(text, systemPrompt: system)
-        case .openai, .groq, .zai, .qwen, .minimax, .openrouter, .custom:
+        case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom:
             return try await sendOpenAICompatible(text, systemPrompt: system, config: config, includeTools: false, imageData: nil)
         }
     }
@@ -701,8 +706,7 @@ class LLMService: ObservableObject {
                 var request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
                 request.httpMethod = "POST"
                 request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-                request.setValue(modelConfig.apiKey, forHTTPHeaderField: "x-api-key")
-                request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+                AnthropicAuth.apply(credential: await AnthropicAuth.resolveCredential(apiKey: modelConfig.apiKey), to: &request)
                 request.timeoutInterval = 15
                 let body: [String: Any] = [
                     "model": modelConfig.model,
@@ -718,7 +722,7 @@ class LLMService: ObservableObject {
                       let text = content.first?["text"] as? String else { return nil }
                 return text
 
-            case .openai, .groq, .zai, .qwen, .minimax, .openrouter, .custom:
+            case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom:
                 var baseURL = modelConfig.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !baseURL.hasSuffix("/chat/completions") {
                     baseURL += baseURL.hasSuffix("/") ? "chat/completions" : "/chat/completions"
@@ -792,8 +796,7 @@ class LLMService: ObservableObject {
                 var request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
                 request.httpMethod = "POST"
                 request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-                request.setValue(modelConfig.apiKey, forHTTPHeaderField: "x-api-key")
-                request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+                AnthropicAuth.apply(credential: await AnthropicAuth.resolveCredential(apiKey: modelConfig.apiKey), to: &request)
                 request.timeoutInterval = 20
                 let body: [String: Any] = [
                     "model": modelConfig.model,
@@ -812,7 +815,7 @@ class LLMService: ObservableObject {
                       let text = content.first?["text"] as? String else { return nil }
                 return text
 
-            case .openai, .groq, .zai, .qwen, .minimax, .openrouter, .custom:
+            case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom:
                 var baseURL = modelConfig.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !baseURL.hasSuffix("/chat/completions") {
                     baseURL += baseURL.hasSuffix("/") ? "chat/completions" : "/chat/completions"
@@ -897,8 +900,7 @@ class LLMService: ObservableObject {
                 var request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
                 request.httpMethod = "POST"
                 request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-                request.setValue(modelConfig.apiKey, forHTTPHeaderField: "x-api-key")
-                request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+                AnthropicAuth.apply(credential: await AnthropicAuth.resolveCredential(apiKey: modelConfig.apiKey), to: &request)
                 request.timeoutInterval = 30
                 let body: [String: Any] = [
                     "model": modelConfig.model,
@@ -916,7 +918,7 @@ class LLMService: ObservableObject {
                 guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
                 return StructuredVisionParser.anthropic(data, toolName: toolName)
 
-            case .openai, .groq, .zai, .qwen, .minimax, .openrouter, .custom:
+            case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom:
                 var baseURL = modelConfig.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !baseURL.hasSuffix("/chat/completions") {
                     baseURL += baseURL.hasSuffix("/") ? "chat/completions" : "/chat/completions"
@@ -997,8 +999,7 @@ class LLMService: ObservableObject {
                 var request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
                 request.httpMethod = "POST"
                 request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-                request.setValue(modelConfig.apiKey, forHTTPHeaderField: "x-api-key")
-                request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+                AnthropicAuth.apply(credential: await AnthropicAuth.resolveCredential(apiKey: modelConfig.apiKey), to: &request)
                 request.timeoutInterval = 45
                 let body: [String: Any] = [
                     "model": modelConfig.model,
@@ -1013,7 +1014,7 @@ class LLMService: ObservableObject {
                 guard let http = response as? HTTPURLResponse, http.statusCode == 200 else { return nil }
                 return StructuredVisionParser.anthropic(data, toolName: toolName)
 
-            case .openai, .groq, .zai, .qwen, .minimax, .openrouter, .custom:
+            case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom:
                 var baseURL = modelConfig.baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
                 if !baseURL.hasSuffix("/chat/completions") {
                     baseURL += baseURL.hasSuffix("/") ? "chat/completions" : "/chat/completions"
@@ -1093,7 +1094,7 @@ class LLMService: ObservableObject {
             return try await sendGemini(text, systemPrompt: systemPrompt, config: config, includeTools: includeTools, imageData: nil)
         case .local, .appleOnDevice:
             throw LLMError.missingAPIKey("Local providers cannot be used as cloud agent")
-        case .openai, .groq, .zai, .qwen, .minimax, .openrouter, .custom:
+        case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom:
             return try await sendOpenAICompatible(text, systemPrompt: systemPrompt, config: config, includeTools: includeTools, imageData: nil)
         }
     }
@@ -1118,9 +1119,10 @@ class LLMService: ObservableObject {
     }
 
     private func sendAnthropic(_ text: String, systemPrompt: String, config: ModelConfig, includeTools: Bool, imageData: Data?, onToken: ((String) -> Void)? = nil) async throws -> String {
-        let apiKey = config.apiKey
+        // An explicit API key wins; otherwise fall back to a connected Claude account (OAuth).
+        let apiKey = await AnthropicAuth.resolveCredential(apiKey: config.apiKey)
         guard !apiKey.isEmpty else {
-            throw LLMError.missingAPIKey("Anthropic API key not configured")
+            throw LLMError.missingAPIKey("Anthropic API key not configured — add a key or sign in with Claude")
         }
 
         // Add user message to history
@@ -1150,8 +1152,7 @@ class LLMService: ObservableObject {
             var request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
-            request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+            AnthropicAuth.apply(credential: apiKey, to: &request)  // already resolved above
 
             // Turn hygiene (Plan BF): drop stale images that would otherwise re-upload every turn,
             // and repair any dangling tool_use so a single interrupted tool call can't 400 the whole

--- a/OpenGlasses/Sources/Services/ModelFetcher.swift
+++ b/OpenGlasses/Sources/Services/ModelFetcher.swift
@@ -59,7 +59,7 @@ enum ModelFetcher {
     static func fetchModels(provider: LLMProvider, apiKey: String, baseURL: String) async -> [RemoteModel] {
         // Local OpenAI-compatible servers (Ollama, llama.cpp, LM Studio, vLLM…) usually
         // need no API key, so let the custom provider list models without one.
-        guard !apiKey.isEmpty || provider == .custom else { return [] }
+        guard !apiKey.isEmpty || provider == .custom || provider == .anthropic else { return [] }
 
         switch provider {
         case .anthropic:
@@ -70,7 +70,7 @@ enum ModelFetcher {
             return await fetchQwen(apiKey: apiKey, baseURL: baseURL)
         case .minimax:
             return await fetchMiniMax(apiKey: apiKey, baseURL: baseURL)
-        case .openai, .groq, .zai, .openrouter, .custom:
+        case .openai, .groq, .zai, .xai, .openrouter, .custom:
             return await fetchOpenAICompatible(apiKey: apiKey, baseURL: baseURL)
         case .local, .appleOnDevice:
             return []  // Local/Apple models are managed separately
@@ -235,10 +235,11 @@ enum ModelFetcher {
 
     private static func fetchAnthropic(apiKey: String) async -> [RemoteModel] {
         guard let url = URL(string: "https://api.anthropic.com/v1/models") else { return [] }
+        let credential = await AnthropicAuth.resolveCredential(apiKey: apiKey)
+        guard !credential.isEmpty else { return [] }
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
-        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
-        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        AnthropicAuth.apply(credential: credential, to: &request)
         request.timeoutInterval = 30
 
         do {

--- a/OpenGlasses/Sources/Services/Usage/ModelPricing.swift
+++ b/OpenGlasses/Sources/Services/Usage/ModelPricing.swift
@@ -22,7 +22,12 @@ enum ModelPricing {
     /// list prices at time of writing; override from Settings when they change.
     static let defaults: [String: Rate] = [
         // Anthropic
+        "claude-fable-5": Rate(10, 50),
+        "claude-opus-4-8": Rate(5, 25),
+        "claude-opus-4-7": Rate(5, 25),
+        "claude-opus-4-6": Rate(5, 25),
         "claude-opus-4": Rate(15, 75),
+        "claude-sonnet-5": Rate(3, 15),
         "claude-sonnet-4": Rate(3, 15),
         "claude-haiku-4": Rate(1, 5),
         "claude-3-5-sonnet": Rate(3, 15),
@@ -38,6 +43,11 @@ enum ModelPricing {
         "gpt-4": Rate(30, 60),
         "o4-mini": Rate(1.10, 4.40),
         "o3-mini": Rate(1.10, 4.40),
+        // xAI
+        "grok-4-fast": Rate(0.20, 0.50),
+        "grok-4": Rate(3, 15),
+        "grok-3-mini": Rate(0.30, 0.50),
+        "grok-3": Rate(3, 15),
         // Google
         "gemini-2.0-flash": Rate(0.10, 0.40),
         "gemini-1.5-flash": Rate(0.075, 0.30),

--- a/OpenGlasses/Sources/Services/Usage/UsageTracker.swift
+++ b/OpenGlasses/Sources/Services/Usage/UsageTracker.swift
@@ -54,7 +54,7 @@ final class UsageTracker: ObservableObject {
         case .gemini:
             guard let u = json["usageMetadata"] as? [String: Any] else { return nil }
             return (intValue(u["promptTokenCount"]), intValue(u["candidatesTokenCount"]))
-        case .openai, .groq, .zai, .qwen, .minimax, .openrouter, .custom, .local, .appleOnDevice:
+        case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom, .local, .appleOnDevice:
             guard let u = json["usage"] as? [String: Any] else { return nil }
             return (intValue(u["prompt_tokens"]), intValue(u["completion_tokens"]))
         }

--- a/OpenGlasses/Sources/Utils/ClaudeOAuth.swift
+++ b/OpenGlasses/Sources/Utils/ClaudeOAuth.swift
@@ -1,0 +1,186 @@
+import Foundation
+import CryptoKit
+
+/// Pure core for the Anthropic "Sign in with Claude" OAuth flow (Plan-style deterministic core —
+/// no I/O, fully unit-testable). The network/persistence edge lives in `ClaudeOAuthService`.
+///
+/// Flow (authorization code + PKCE, same protocol the official `ant auth login` CLI uses):
+/// 1. Build an authorize URL with a fresh PKCE verifier and open it in the browser.
+/// 2. The user signs in with their claude.ai account; the callback page displays an
+///    authorization code (`code#state`) which they copy and paste back into the app.
+/// 3. Exchange the code for an access token (`sk-ant-oat…`) + refresh token at the token endpoint.
+/// 4. API calls authenticate with `Authorization: Bearer` + the `oauth-2025-04-20` beta header
+///    instead of `x-api-key`.
+enum ClaudeOAuth {
+
+    // MARK: - Protocol constants
+
+    /// Anthropic's public OAuth client (the one issued for CLI/desktop sign-in).
+    static let clientID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+    static let authorizeEndpoint = "https://claude.ai/oauth/authorize"
+    static let tokenEndpoint = "https://console.anthropic.com/v1/oauth/token"
+    /// Redirect target registered for the public client — a page that displays the code to paste.
+    static let redirectURI = "https://console.anthropic.com/oauth/code/callback"
+    static let scopes = "org:create_api_key user:profile user:inference"
+    /// Beta header required when authenticating `/v1/messages` (and friends) with an OAuth token.
+    static let oauthBetaHeader = "oauth-2025-04-20"
+
+    /// OAuth access tokens are distinguishable from API keys by prefix
+    /// (`sk-ant-oat…` vs `sk-ant-api…`).
+    static func isOAuthToken(_ credential: String) -> Bool {
+        credential.hasPrefix("sk-ant-oat")
+    }
+
+    // MARK: - PKCE
+
+    /// Base64url (no padding) — the encoding PKCE uses for both verifier and challenge.
+    static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// Derive a code verifier from random bytes (injectable so tests are deterministic).
+    static func verifier(from randomBytes: Data) -> String {
+        base64URL(randomBytes)
+    }
+
+    /// Generate a fresh random verifier (32 random bytes → 43-char base64url string).
+    static func makeVerifier() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return verifier(from: Data(bytes))
+    }
+
+    /// S256 code challenge for a verifier (RFC 7636).
+    static func challenge(for verifier: String) -> String {
+        base64URL(Data(SHA256.hash(data: Data(verifier.utf8))))
+    }
+
+    // MARK: - Authorize URL
+
+    /// Build the browser authorize URL. `state` doubles as CSRF token; the token exchange
+    /// sends it back alongside the code.
+    static func authorizeURL(verifier: String, state: String) -> URL? {
+        var components = URLComponents(string: authorizeEndpoint)
+        components?.queryItems = [
+            URLQueryItem(name: "code", value: "true"),
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "scope", value: scopes),
+            URLQueryItem(name: "code_challenge", value: challenge(for: verifier)),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "state", value: state),
+        ]
+        return components?.url
+    }
+
+    // MARK: - Pasted-code parsing
+
+    /// The callback page shows the authorization code as `code#state`. Accept that, a bare
+    /// code, or a full callback URL the user pasted; trim whitespace either way.
+    static func parseAuthorizationInput(_ input: String) -> (code: String, state: String?)? {
+        var text = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+        // Full callback URL pasted: pull code/state from the query.
+        if text.hasPrefix("http"), let components = URLComponents(string: text) {
+            let code = components.queryItems?.first(where: { $0.name == "code" })?.value
+            let state = components.queryItems?.first(where: { $0.name == "state" })?.value
+            if let code, !code.isEmpty { return (code, state) }
+            if let fragment = components.fragment { text = fragment } else { return nil }
+        }
+        let parts = text.split(separator: "#", maxSplits: 1).map(String.init)
+        guard let code = parts.first, !code.isEmpty else { return nil }
+        return (code, parts.count > 1 ? parts[1] : nil)
+    }
+
+    // MARK: - Token requests
+
+    static func tokenExchangeRequest(code: String, state: String?, verifier: String) -> URLRequest {
+        var body: [String: Any] = [
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": clientID,
+            "redirect_uri": redirectURI,
+            "code_verifier": verifier,
+        ]
+        if let state { body["state"] = state }
+        return jsonPOST(body: body)
+    }
+
+    static func refreshRequest(refreshToken: String) -> URLRequest {
+        jsonPOST(body: [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": clientID,
+        ])
+    }
+
+    private static func jsonPOST(body: [String: Any]) -> URLRequest {
+        var request = URLRequest(url: URL(string: tokenEndpoint)!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        request.timeoutInterval = 30
+        return request
+    }
+
+    // MARK: - Token response / credentials
+
+    struct TokenResponse: Decodable {
+        let accessToken: String
+        let refreshToken: String?
+        let expiresIn: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case accessToken = "access_token"
+            case refreshToken = "refresh_token"
+            case expiresIn = "expires_in"
+        }
+    }
+
+    struct Credentials: Codable, Equatable {
+        var accessToken: String
+        var refreshToken: String?
+        var expiresAt: Date?
+
+        init(response: TokenResponse, now: Date = Date(), previousRefreshToken: String? = nil) {
+            accessToken = response.accessToken
+            // A refresh response may omit the refresh token — keep the old one.
+            refreshToken = response.refreshToken ?? previousRefreshToken
+            expiresAt = response.expiresIn.map { now.addingTimeInterval($0) }
+        }
+
+        /// Refresh ahead of expiry so an in-flight request doesn't race the deadline.
+        func needsRefresh(now: Date = Date(), leeway: TimeInterval = 300) -> Bool {
+            guard let expiresAt else { return false }
+            return now.addingTimeInterval(leeway) >= expiresAt
+        }
+    }
+}
+
+/// Applies Anthropic authentication to a request: OAuth access tokens (`sk-ant-oat…`) go on
+/// `Authorization: Bearer` with the OAuth beta header; anything else is a regular API key on
+/// `x-api-key`. Pure — credential resolution (refresh, keychain) happens in `ClaudeOAuthService`.
+enum AnthropicAuth {
+    static func apply(credential: String, to request: inout URLRequest) {
+        if ClaudeOAuth.isOAuthToken(credential) {
+            request.setValue("Bearer \(credential)", forHTTPHeaderField: "Authorization")
+            request.setValue(ClaudeOAuth.oauthBetaHeader, forHTTPHeaderField: "anthropic-beta")
+        } else {
+            request.setValue(credential, forHTTPHeaderField: "x-api-key")
+        }
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+    }
+
+    /// Resolve the credential for an Anthropic request: an explicit API key on the model config
+    /// wins; otherwise a connected Claude account's (refreshed) OAuth access token.
+    @MainActor
+    static func resolveCredential(apiKey: String) async -> String {
+        let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        return await ClaudeOAuthService.shared.validAccessToken() ?? ""
+    }
+}

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -248,6 +248,10 @@ struct ModelConfig: Codable, Identifiable, Equatable {
             // Qwen3.5-plus and qwen-vl models support vision
             let lowerModel = model.lowercased()
             return lowerModel.contains("vl") || lowerModel.contains("plus") || lowerModel.contains("max") || lowerModel.contains("omni")
+        case .xai:
+            // Grok 4 family is multimodal; earlier Grok text models are not
+            let lowerModel = model.lowercased()
+            return lowerModel.contains("grok-4") || lowerModel.contains("vision")
         case .openrouter:
             // OpenRouter supports vision for many models
             let lowerModel = model.lowercased()
@@ -553,7 +557,7 @@ struct Config {
     }
 
     /// Claude model to use
-    static let claudeModel = "claude-sonnet-4-20250514"
+    static let claudeModel = "claude-sonnet-5"
 
     /// Max tokens for LLM response
     static let maxTokens = 500

--- a/OpenGlassesTests/ClaudeOAuthTests.swift
+++ b/OpenGlassesTests/ClaudeOAuthTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Pure-logic coverage for the "Sign in with Claude" OAuth core: PKCE derivation,
+/// authorize-URL construction, pasted-code parsing, token-response decoding, expiry
+/// logic, and the OAuth-vs-API-key header split. The network/persistence edge
+/// (`ClaudeOAuthService`) is deliberately untested — the protocol logic is the bug surface.
+final class ClaudeOAuthTests: XCTestCase {
+
+    // MARK: - PKCE
+
+    func testChallengeMatchesRFC7636Vector() {
+        // Appendix B of RFC 7636 — the canonical S256 test vector.
+        XCTAssertEqual(
+            ClaudeOAuth.challenge(for: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        )
+    }
+
+    func testVerifierIsBase64URLWithoutPadding() {
+        // 32 bytes → 43 chars, no '+', '/', or '='.
+        let verifier = ClaudeOAuth.verifier(from: Data(repeating: 0xFB, count: 32))
+        XCTAssertEqual(verifier.count, 43)
+        XCTAssertFalse(verifier.contains("+"))
+        XCTAssertFalse(verifier.contains("/"))
+        XCTAssertFalse(verifier.contains("="))
+    }
+
+    func testMakeVerifierIsRandomAndWellFormed() {
+        let a = ClaudeOAuth.makeVerifier()
+        let b = ClaudeOAuth.makeVerifier()
+        XCTAssertNotEqual(a, b)
+        XCTAssertEqual(a.count, 43)
+    }
+
+    // MARK: - Authorize URL
+
+    func testAuthorizeURLCarriesPKCEAndIdentity() throws {
+        let url = try XCTUnwrap(ClaudeOAuth.authorizeURL(verifier: "test-verifier", state: "test-state"))
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let params = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+
+        XCTAssertEqual(components.host, "claude.ai")
+        XCTAssertEqual(params["client_id"], ClaudeOAuth.clientID)
+        XCTAssertEqual(params["response_type"], "code")
+        XCTAssertEqual(params["code_challenge_method"], "S256")
+        XCTAssertEqual(params["code_challenge"], ClaudeOAuth.challenge(for: "test-verifier"))
+        XCTAssertEqual(params["state"], "test-state")
+        XCTAssertEqual(params["redirect_uri"], ClaudeOAuth.redirectURI)
+        XCTAssertEqual(params["scope"], ClaudeOAuth.scopes)
+    }
+
+    // MARK: - Pasted-code parsing
+
+    func testParseCodeHashState() throws {
+        let parsed = try XCTUnwrap(ClaudeOAuth.parseAuthorizationInput("abc123#state456"))
+        XCTAssertEqual(parsed.code, "abc123")
+        XCTAssertEqual(parsed.state, "state456")
+    }
+
+    func testParseBareCodeAndWhitespace() throws {
+        let parsed = try XCTUnwrap(ClaudeOAuth.parseAuthorizationInput("  abc123 \n"))
+        XCTAssertEqual(parsed.code, "abc123")
+        XCTAssertNil(parsed.state)
+    }
+
+    func testParsePastedCallbackURL() throws {
+        let parsed = try XCTUnwrap(ClaudeOAuth.parseAuthorizationInput(
+            "https://console.anthropic.com/oauth/code/callback?code=abc123&state=xyz"
+        ))
+        XCTAssertEqual(parsed.code, "abc123")
+        XCTAssertEqual(parsed.state, "xyz")
+    }
+
+    func testParseRejectsEmptyInput() {
+        XCTAssertNil(ClaudeOAuth.parseAuthorizationInput("   "))
+        XCTAssertNil(ClaudeOAuth.parseAuthorizationInput(""))
+    }
+
+    // MARK: - Token requests
+
+    func testTokenExchangeRequestBody() throws {
+        let request = ClaudeOAuth.tokenExchangeRequest(code: "the-code", state: "the-state", verifier: "the-verifier")
+        XCTAssertEqual(request.url?.absoluteString, ClaudeOAuth.tokenEndpoint)
+        XCTAssertEqual(request.httpMethod, "POST")
+        let body = try XCTUnwrap(try JSONSerialization.jsonObject(with: XCTUnwrap(request.httpBody)) as? [String: Any])
+        XCTAssertEqual(body["grant_type"] as? String, "authorization_code")
+        XCTAssertEqual(body["code"] as? String, "the-code")
+        XCTAssertEqual(body["state"] as? String, "the-state")
+        XCTAssertEqual(body["code_verifier"] as? String, "the-verifier")
+        XCTAssertEqual(body["client_id"] as? String, ClaudeOAuth.clientID)
+    }
+
+    func testRefreshRequestBody() throws {
+        let request = ClaudeOAuth.refreshRequest(refreshToken: "sk-ant-ort01-xyz")
+        let body = try XCTUnwrap(try JSONSerialization.jsonObject(with: XCTUnwrap(request.httpBody)) as? [String: Any])
+        XCTAssertEqual(body["grant_type"] as? String, "refresh_token")
+        XCTAssertEqual(body["refresh_token"] as? String, "sk-ant-ort01-xyz")
+    }
+
+    // MARK: - Token response / credentials
+
+    func testTokenResponseDecodingAndExpiry() throws {
+        let json = #"{"access_token":"sk-ant-oat01-abc","refresh_token":"sk-ant-ort01-def","expires_in":3600}"#
+        let response = try JSONDecoder().decode(ClaudeOAuth.TokenResponse.self, from: Data(json.utf8))
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let credentials = ClaudeOAuth.Credentials(response: response, now: now)
+
+        XCTAssertEqual(credentials.accessToken, "sk-ant-oat01-abc")
+        XCTAssertEqual(credentials.refreshToken, "sk-ant-ort01-def")
+        XCTAssertEqual(credentials.expiresAt, now.addingTimeInterval(3600))
+        // Fresh token: no refresh needed…
+        XCTAssertFalse(credentials.needsRefresh(now: now))
+        // …but within the 5-minute leeway of expiry it is.
+        XCTAssertTrue(credentials.needsRefresh(now: now.addingTimeInterval(3600 - 200)))
+        XCTAssertTrue(credentials.needsRefresh(now: now.addingTimeInterval(4000)))
+    }
+
+    func testRefreshResponseKeepsPreviousRefreshToken() throws {
+        let json = #"{"access_token":"sk-ant-oat01-new","expires_in":3600}"#
+        let response = try JSONDecoder().decode(ClaudeOAuth.TokenResponse.self, from: Data(json.utf8))
+        let credentials = ClaudeOAuth.Credentials(response: response, previousRefreshToken: "sk-ant-ort01-old")
+        XCTAssertEqual(credentials.refreshToken, "sk-ant-ort01-old")
+    }
+
+    func testCredentialsWithoutExpiryNeverNeedRefresh() throws {
+        let json = #"{"access_token":"sk-ant-oat01-abc"}"#
+        let response = try JSONDecoder().decode(ClaudeOAuth.TokenResponse.self, from: Data(json.utf8))
+        let credentials = ClaudeOAuth.Credentials(response: response)
+        XCTAssertFalse(credentials.needsRefresh(now: .distantFuture))
+    }
+
+    // MARK: - Header application
+
+    func testOAuthTokenGetsBearerAndBetaHeader() {
+        var request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
+        AnthropicAuth.apply(credential: "sk-ant-oat01-abc", to: &request)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sk-ant-oat01-abc")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "anthropic-beta"), "oauth-2025-04-20")
+        XCTAssertNil(request.value(forHTTPHeaderField: "x-api-key"))
+        XCTAssertEqual(request.value(forHTTPHeaderField: "anthropic-version"), "2023-06-01")
+    }
+
+    func testAPIKeyGetsXAPIKeyHeader() {
+        var request = URLRequest(url: URL(string: "https://api.anthropic.com/v1/messages")!)
+        AnthropicAuth.apply(credential: "sk-ant-api03-abc", to: &request)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "x-api-key"), "sk-ant-api03-abc")
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertNil(request.value(forHTTPHeaderField: "anthropic-beta"))
+        XCTAssertEqual(request.value(forHTTPHeaderField: "anthropic-version"), "2023-06-01")
+    }
+
+    func testIsOAuthTokenClassification() {
+        XCTAssertTrue(ClaudeOAuth.isOAuthToken("sk-ant-oat01-abc"))
+        XCTAssertFalse(ClaudeOAuth.isOAuthToken("sk-ant-api03-abc"))
+        XCTAssertFalse(ClaudeOAuth.isOAuthToken(""))
+    }
+}

--- a/OpenGlassesTests/ModelFetcherTests.swift
+++ b/OpenGlassesTests/ModelFetcherTests.swift
@@ -47,6 +47,20 @@ final class ModelFetcherTests: XCTestCase {
         )
     }
 
+    // MARK: - xAI provider defaults
+
+    func testXAIProviderDefaults() {
+        let config = ModelConfig.defaultConfig(for: .xai)
+        XCTAssertEqual(config.baseURL, "https://api.x.ai/v1/chat/completions")
+        XCTAssertEqual(config.model, "grok-4")
+        XCTAssertTrue(LLMProvider.xai.isOpenAICompatible)
+        XCTAssertTrue(LLMProvider.xai.requiresAPIKey)
+        XCTAssertEqual(
+            ModelFetcher.modelsEndpoint(from: LLMProvider.xai.defaultBaseURL),
+            "https://api.x.ai/v1/models"
+        )
+    }
+
     // MARK: - ModelConfig.inferredSupportsVision
 
     private func inferredVision(_ provider: LLMProvider, _ model: String, baseURL: String = "") -> Bool {
@@ -87,6 +101,10 @@ final class ModelFetcherTests: XCTestCase {
 
     func testInferredVisionOpenRouterHeuristic() {
         XCTAssertTrue(inferredVision(.openrouter, "anthropic/claude-3.5-sonnet"))
+        // xAI: Grok 4 family is multimodal, earlier text models are not
+        XCTAssertTrue(inferredVision(.xai, "grok-4"))
+        XCTAssertTrue(inferredVision(.xai, "grok-4-fast"))
+        XCTAssertFalse(inferredVision(.xai, "grok-3-mini"))
         XCTAssertTrue(inferredVision(.openrouter, "meta-llama/llava-13b"))
         XCTAssertFalse(inferredVision(.openrouter, "mistralai/mistral-7b"))
     }

--- a/OpenGlassesTests/UsageTrackerTests.swift
+++ b/OpenGlassesTests/UsageTrackerTests.swift
@@ -17,8 +17,10 @@ final class UsageTrackerTests: XCTestCase {
         XCTAssertEqual(mini, ModelPricing.Rate(0.15, 0.60))
         let full = ModelPricing.rate(for: "gpt-4o-2024-11-20")
         XCTAssertEqual(full, ModelPricing.Rate(2.50, 10))
-        // Opus dated id resolves to the opus family.
-        XCTAssertEqual(ModelPricing.rate(for: "claude-opus-4-8"), ModelPricing.Rate(15, 75))
+        // Current-gen Opus has its own (longer) prefix entry at current pricing…
+        XCTAssertEqual(ModelPricing.rate(for: "claude-opus-4-8"), ModelPricing.Rate(5, 25))
+        // …while older dated Opus ids still fall back to the opus family rate.
+        XCTAssertEqual(ModelPricing.rate(for: "claude-opus-4-1-20250805"), ModelPricing.Rate(15, 75))
     }
 
     func testUnknownModelIsNil() {

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Assign models to **Fast**, **Balanced**, and **Best** tiers, then let OpenGlasse
 
 ## Enterprise
 
-Commercial features for teams and regulated industries. These are licensed separately from the open-source core — see [License](#license) or contact Skunkworks NZ.
+Commercial features for teams and regulated industries. These are licensed separately from the open-source core — see [License](#license) or contact Skunkworks NZ at [g@skunkworks.kiwi](mailto:g@skunkworks.kiwi).
 
 ### Field Assist — Guided Field Service
 
@@ -512,7 +512,7 @@ Key areas for contribution:
 
 ## License
 
-Business Source License 1.1 — free for non-commercial use. Commercial use requires a separate license from Skunk0 / Skunkworks NZ. Converts to Apache 2.0 on March 24, 2030. See LICENSE file for details.
+Business Source License 1.1 — free for non-commercial use. Commercial use requires a separate license from Skunk0 / Skunkworks NZ — contact [g@skunkworks.kiwi](mailto:g@skunkworks.kiwi). Converts to Apache 2.0 on March 24, 2030. See LICENSE file for details.
 
 ## Credits
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -435,7 +435,7 @@ open OpenGlasses.xcodeproj
 
 ## 许可证
 
-BSL 1.1（Business Source License 1.1）——非商业用途免费。商业用途需从 Skunk0 / Skunkworks NZ 获取单独许可。2030 年 3 月 24 日转换为 Apache 2.0。详见 LICENSE 文件。
+BSL 1.1（Business Source License 1.1）——非商业用途免费。商业用途需从 Skunk0 / Skunkworks NZ 获取单独许可（联系 [g@skunkworks.kiwi](mailto:g@skunkworks.kiwi)）。2030 年 3 月 24 日转换为 Apache 2.0。详见 LICENSE 文件。
 
 ## 致谢
 


### PR DESCRIPTION
## Summary

Two additions to the Direct-mode model stack:

### xAI (Grok) provider
- New `LLMProvider.xai` case wired through every provider switch: display name, console URL, OpenAI-compatible request path (`https://api.x.ai/v1/chat/completions`), default model `grok-4`, model listing via `/v1/models`, usage-token parsing, and vision inference (Grok 4 family is multimodal; earlier Grok text models are not).
- Grok pricing added to `ModelPricing` (`grok-4`, `grok-4-fast`, `grok-3`, `grok-3-mini`).

### Sign in with Claude (OAuth)
- `ClaudeOAuth` (Utils): pure, fully unit-tested protocol core — PKCE (RFC 7636 S256), authorize-URL construction, pasted-code parsing (`code#state`, bare code, or full callback URL), token exchange/refresh request builders, token-response decoding, expiry-with-leeway logic.
- `ClaudeOAuthService` (Services): the network/persistence edge — token exchange + refresh over URLSession, credentials in the keychain.
- `AnthropicAuth`: one auth seam for every Anthropic request. OAuth access tokens (`sk-ant-oat…`) go on `Authorization: Bearer` with the `oauth-2025-04-20` beta header; API keys keep `x-api-key`. An explicit key on the model config always wins; otherwise a connected Claude account's (auto-refreshed) token is used. All five request sites in `LLMService` plus `ModelFetcher.fetchAnthropic` now route through it.
- `ModelFormView`: "Sign in with Claude" for the Anthropic provider — opens the browser sign-in, user pastes the authorization code back, connected state with sign-out. The API key field remains as an alternative and as an override.

### Related fix
- The Anthropic default model was `claude-sonnet-4-20250514`, which is deprecated; new configs now default to `claude-sonnet-5`, and the stale Claude pricing rows were refreshed (Opus 4.x $5/$25, Sonnet 5 $3/$15, Haiku 4.5 $1/$5, Fable 5 $10/$50) — longest-prefix matching keeps older dated models on their original rates.

## Tests
- New `ClaudeOAuthTests` (15 cases): RFC 7636 PKCE vector, verifier shape, authorize-URL params, code parsing variants, token request bodies, response decoding, refresh-token retention, expiry leeway, header split, token classification.
- `ModelFetcherTests`: xAI provider defaults + vision inference cases.

## Notes
- The OAuth flow is the standard Anthropic authorization-code + PKCE flow (the same protocol `ant auth login` uses), with the paste-the-code callback page since the public client's redirect is web-based.
- Full suite + Release build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
