### PR TITLE
Memory Rewind: ring buffer + off-main-actor bulk conversion

### DIFF
--- a/OpenGlasses/Sources/Services/Memory/RewindRingBuffer.swift
+++ b/OpenGlasses/Sources/Services/Memory/RewindRingBuffer.swift
@@ -1,0 +1,87 @@
+import Foundation
+import os.lock
+
+/// Fixed-capacity byte ring buffer for Memory Rewind's rolling audio window.
+///
+/// The old `MemoryRewindService` accumulated PCM into one growing `Data` and, once full, called
+/// `removeFirst(excess)` on every audio callback — an O(n) memmove of the whole (up to ~58 MB)
+/// buffer ~10–15×/sec. This ring overwrites the oldest bytes in place, so an append is O(bytes
+/// appended) regardless of window size. Lock-guarded so the audio-render thread can write while the
+/// main actor reads a snapshot for transcription.
+final class RewindRingBuffer: @unchecked Sendable {
+
+    private let lock = OSAllocatedUnfairLock()
+    private var storage: [UInt8]
+    /// Index where the next byte will be written.
+    private var writeIndex = 0
+    /// Number of valid bytes currently held (≤ capacity).
+    private var filled = 0
+
+    let capacity: Int
+
+    init(capacity: Int) {
+        self.capacity = max(0, capacity)
+        storage = [UInt8](repeating: 0, count: self.capacity)
+    }
+
+    /// Bytes currently buffered.
+    var count: Int { lock.withLock { filled } }
+
+    /// Append bytes, overwriting the oldest once full. Safe to call from the audio thread.
+    func append(_ data: Data) {
+        guard capacity > 0, !data.isEmpty else { return }
+        lock.withLock {
+            data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) in
+                let src = raw.bindMemory(to: UInt8.self)
+                // If the incoming chunk is larger than the whole ring, keep only its tail.
+                let start = src.count > capacity ? src.count - capacity : 0
+                storage.withUnsafeMutableBufferPointer { dst in
+                    var i = start
+                    while i < src.count {
+                        let chunk = min(src.count - i, capacity - writeIndex)
+                        dst.baseAddress!.advanced(by: writeIndex)
+                            .update(from: src.baseAddress!.advanced(by: i), count: chunk)
+                        writeIndex = (writeIndex + chunk) % capacity
+                        i += chunk
+                    }
+                }
+                filled = min(filled + (src.count - start), capacity)
+            }
+        }
+    }
+
+    /// Return the most recent `maxBytes` bytes in chronological order (oldest → newest). Passing a
+    /// value ≥ `count` returns the whole buffer. Safe to call from the main actor.
+    func snapshotSuffix(_ maxBytes: Int) -> Data {
+        lock.withLock {
+            let n = min(max(0, maxBytes), filled)
+            guard n > 0 else { return Data() }
+            var out = [UInt8](repeating: 0, count: n)
+            // The newest byte is at (writeIndex - 1); the oldest of our n bytes is n back from there.
+            let startLogical = filled - n                 // 0 = oldest valid byte
+            let oldestPhysical = (writeIndex - filled + capacity * 2) % capacity
+            let readStart = (oldestPhysical + startLogical) % capacity
+            out.withUnsafeMutableBufferPointer { dst in
+                storage.withUnsafeBufferPointer { src in
+                    var i = 0
+                    var pos = readStart
+                    while i < n {
+                        let chunk = min(n - i, capacity - pos)
+                        dst.baseAddress!.advanced(by: i)
+                            .update(from: src.baseAddress!.advanced(by: pos), count: chunk)
+                        pos = (pos + chunk) % capacity
+                        i += chunk
+                    }
+                }
+            }
+            return Data(out)
+        }
+    }
+
+    func reset() {
+        lock.withLock {
+            writeIndex = 0
+            filled = 0
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/MemoryRewindService.swift
+++ b/OpenGlasses/Sources/Services/MemoryRewindService.swift
@@ -13,14 +13,17 @@ class MemoryRewindService: ObservableObject {
     /// How many minutes of audio to keep (configurable)
     var maxBufferMinutes: Double = 10.0
 
-    /// Audio buffer — stores raw PCM samples
-    private var audioBuffer: Data = Data()
-    private var bufferSampleRate: Double = 16000
+    /// All rolling-buffer state is confined to `ingestQueue` — the audio thread writes and the main
+    /// actor reads only by hopping here, so the lazily-sized ring is never accessed concurrently.
+    private let ingestQueue = DispatchQueue(label: "memory.rewind.ingest", qos: .utility)
+    private nonisolated(unsafe) var ring: RewindRingBuffer?      // ingestQueue only
+    private nonisolated(unsafe) var bufferSampleRate: Double = 16000   // ingestQueue only
+    private nonisolated(unsafe) var ringMaxMinutes: Double = 10        // ingestQueue only
     private var bufferStartTime: Date?
+    /// Periodically refreshes the published duration off the audio hot path.
+    private var durationTimer: Timer?
 
-    /// Bytes per minute at 16kHz mono 16-bit = 16000 * 2 * 60 = 1,920,000
-    private var bytesPerMinute: Int { Int(bufferSampleRate) * 2 * 60 }
-    private var maxBufferBytes: Int { Int(maxBufferMinutes) * bytesPerMinute }
+    private static func bytesPerMinute(at rate: Double) -> Int { Int(rate) * 2 * 60 }
 
     /// Reference to wake word service for audio tap
     weak var wakeWordService: WakeWordService?
@@ -32,14 +35,23 @@ class MemoryRewindService: ObservableObject {
     func start() {
         guard !isActive else { return }
         isActive = true
-        audioBuffer = Data()
         bufferStartTime = Date()
 
-        // Hook into the audio buffer stream (named consumer)
+        let maxMinutes = maxBufferMinutes
+        ingestQueue.async { [weak self] in
+            self?.ring = nil                 // (re)created on the first buffer, sized to its rate
+            self?.ringMaxMinutes = maxMinutes
+        }
+
+        // Ingest directly on the audio thread — no per-buffer main-actor hop. Conversion is bulk
+        // (PCMConverter) and the ring append is O(bytes appended); the published duration is
+        // refreshed on a 1s timer instead of once per buffer.
         wakeWordService?.addAudioBufferConsumer(id: "memory_rewind") { [weak self] buffer in
-            Task { @MainActor in
-                self?.appendAudioBuffer(buffer)
-            }
+            self?.ingest(buffer)
+        }
+
+        durationTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.refreshDuration()
         }
 
         print("⏪ Memory rewind started (keeping \(Int(maxBufferMinutes)) min)")
@@ -48,10 +60,23 @@ class MemoryRewindService: ObservableObject {
     func stop() {
         isActive = false
         wakeWordService?.removeAudioBufferConsumer(id: "memory_rewind")
-        audioBuffer = Data()
+        durationTimer?.invalidate()
+        durationTimer = nil
+        ingestQueue.async { [weak self] in
+            self?.ring?.reset()
+            self?.ring = nil
+        }
         bufferStartTime = nil
         bufferDurationMinutes = 0
         print("⏪ Memory rewind stopped")
+    }
+
+    private func refreshDuration() {
+        ingestQueue.async { [weak self] in
+            guard let self, let ring = self.ring else { return }
+            let minutes = Double(ring.count) / Double(Self.bytesPerMinute(at: self.bufferSampleRate))
+            Task { @MainActor in self.bufferDurationMinutes = minutes }
+        }
     }
 
     /// Transcribe the last N minutes (or all buffered audio) and return text
@@ -60,24 +85,30 @@ class MemoryRewindService: ObservableObject {
             return "Memory rewind is not active. Enable it in settings first."
         }
 
-        guard !audioBuffer.isEmpty else {
+        let minutesToTranscribe = min(lastMinutes, max(bufferDurationMinutes, 0))
+
+        // Read the most recent window off the ingest queue (where the ring lives).
+        let (recentAudio, rate): (Data, Double) = await withCheckedContinuation { continuation in
+            ingestQueue.async { [weak self] in
+                guard let self, let ring = self.ring else {
+                    continuation.resume(returning: (Data(), 16000))
+                    return
+                }
+                let bytesPerMin = Self.bytesPerMinute(at: self.bufferSampleRate)
+                // `minutesToTranscribe` is 0 when the fraction is < 1 min; fall back to the whole ring.
+                let requested = minutesToTranscribe >= 1 ? Int(minutesToTranscribe) * bytesPerMin : ring.count
+                continuation.resume(returning: (ring.snapshotSuffix(requested), self.bufferSampleRate))
+            }
+        }
+
+        guard !recentAudio.isEmpty else {
             return "No audio buffered yet. Keep it running for a bit."
         }
-
-        let minutesToTranscribe = min(lastMinutes, bufferDurationMinutes)
-        let bytesToUse = min(Int(minutesToTranscribe) * bytesPerMinute, audioBuffer.count)
-
-        guard bytesToUse > 0 else {
-            return "Not enough audio buffered."
-        }
-
-        // Take the most recent N bytes
-        let recentAudio = audioBuffer.suffix(bytesToUse)
 
         print("⏪ Rewinding \(String(format: "%.1f", minutesToTranscribe)) min (\(recentAudio.count) bytes)...")
 
         // Convert raw PCM data to a WAV file for speech recognition
-        let wavData = createWAV(from: recentAudio, sampleRate: bufferSampleRate)
+        let wavData = createWAV(from: recentAudio, sampleRate: rate)
 
         do {
             let transcript = try await transcribeAudio(wavData)
@@ -92,33 +123,20 @@ class MemoryRewindService: ObservableObject {
 
     // MARK: - Audio Buffer Management
 
-    private func appendAudioBuffer(_ buffer: AVAudioPCMBuffer) {
-        // Convert to 16-bit PCM data
-        guard let channelData = buffer.floatChannelData else { return }
-        let frameCount = Int(buffer.frameLength)
-        let sampleRate = buffer.format.sampleRate
-        bufferSampleRate = sampleRate
-
-        // Convert float samples to Int16
-        var pcmData = Data(capacity: frameCount * 2)
-        for i in 0..<frameCount {
-            let sample = channelData[0][i]
-            let clamped = max(-1.0, min(1.0, sample))
-            var int16Sample = Int16(clamped * Float(Int16.max))
-            pcmData.append(Data(bytes: &int16Sample, count: 2))
-        }
-
-        audioBuffer.append(pcmData)
-
-        // Trim to max size
-        if audioBuffer.count > maxBufferBytes {
-            let excess = audioBuffer.count - maxBufferBytes
-            audioBuffer.removeFirst(excess)
-        }
-
-        // Update duration
-        Task { @MainActor in
-            bufferDurationMinutes = Double(audioBuffer.count) / Double(bytesPerMinute)
+    /// Called on the audio-render thread. Bulk-converts float32 → linear16 (one allocation) and
+    /// appends into the ring on `ingestQueue`; the whole-buffer memmove of the old design is gone.
+    private nonisolated func ingest(_ buffer: AVAudioPCMBuffer) {
+        let rate = buffer.format.sampleRate
+        let pcm = PCMConverter.linear16Mono(from: buffer)
+        guard !pcm.isEmpty else { return }
+        ingestQueue.async { [weak self] in
+            guard let self else { return }
+            self.bufferSampleRate = rate
+            if self.ring == nil {
+                let capacity = max(1, Int(self.ringMaxMinutes * Double(Self.bytesPerMinute(at: rate))))
+                self.ring = RewindRingBuffer(capacity: capacity)
+            }
+            self.ring?.append(pcm)
         }
     }
 

--- a/OpenGlassesTests/HUDPreviewSnapshotTests.swift
+++ b/OpenGlassesTests/HUDPreviewSnapshotTests.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @MainActor
 final class HUDPreviewSnapshotTests: XCTestCase {
 
-    func testTaskCardRendersVisibleContent() throws {
+    func testTaskCardRendersVisibleContent() async throws {
         let screen = HUDScreen(
             title: "Torque bolts",
             lines: [HUDLine("45 Nm, 2 passes", emphasis: .secondary),
@@ -18,14 +18,29 @@ final class HUDPreviewSnapshotTests: XCTestCase {
             items: [HUDItem(id: "done", label: "Done", icon: .success, style: .primary) {},
                     HUDItem(id: "back", label: "Back", style: .outline) {}]
         )
-        let renderer = ImageRenderer(content: HUDPreviewView(screen: screen).frame(width: 320, height: 240))
-        renderer.scale = 2
-        let image = try XCTUnwrap(renderer.uiImage, "ImageRenderer produced no image")
 
-        XCTAssertGreaterThan(image.size.width, 0)
-        XCTAssertGreaterThan(image.size.height, 0)
-        XCTAssertTrue(Self.brightFraction(image) > 0.002,
-                      "the preview should render visible text/buttons over the dark panel")
+        // On a cold GPU (e.g. a freshly-erased simulator) the first ImageRenderer pass can time out
+        // building the Metal pipeline and return a blank image, failing the brightness check
+        // spuriously. Render until visible content appears, letting the pipeline warm up between
+        // attempts. On a warm renderer this passes on the first attempt with no delay.
+        var image: UIImage?
+        var fraction = 0.0
+        for attempt in 0..<12 {
+            let renderer = ImageRenderer(content: HUDPreviewView(screen: screen).frame(width: 320, height: 240))
+            renderer.scale = 2
+            if let rendered = renderer.uiImage {
+                image = rendered
+                fraction = Self.brightFraction(rendered)
+                if fraction > 0.002 { break }
+            }
+            if attempt < 11 { try await Task.sleep(nanoseconds: 400_000_000) }
+        }
+
+        let finalImage = try XCTUnwrap(image, "ImageRenderer produced no image")
+        XCTAssertGreaterThan(finalImage.size.width, 0)
+        XCTAssertGreaterThan(finalImage.size.height, 0)
+        XCTAssertTrue(fraction > 0.002,
+                      "the preview should render visible text/buttons over the dark panel (after warm-up)")
     }
 
     /// Fraction of pixels noticeably brighter than the near-black panel.

--- a/OpenGlassesTests/RewindRingBufferTests.swift
+++ b/OpenGlassesTests/RewindRingBufferTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for the Memory Rewind rolling window (RewindRingBuffer): the fixed-capacity ring that
+/// replaced the O(n)-per-append `Data.removeFirst` design.
+final class RewindRingBufferTests: XCTestCase {
+
+    private func bytes(_ values: [UInt8]) -> Data { Data(values) }
+
+    func testAppendAndSnapshotUnderCapacity() {
+        let ring = RewindRingBuffer(capacity: 10)
+        ring.append(bytes([1, 2, 3]))
+        XCTAssertEqual(ring.count, 3)
+        XCTAssertEqual(Array(ring.snapshotSuffix(10)), [1, 2, 3])
+        XCTAssertEqual(Array(ring.snapshotSuffix(2)), [2, 3], "suffix returns the newest bytes")
+    }
+
+    func testOverwritesOldestWhenFull() {
+        let ring = RewindRingBuffer(capacity: 4)
+        ring.append(bytes([1, 2, 3, 4]))
+        ring.append(bytes([5, 6]))          // pushes out 1, 2
+        XCTAssertEqual(ring.count, 4)
+        XCTAssertEqual(Array(ring.snapshotSuffix(4)), [3, 4, 5, 6])
+    }
+
+    func testAppendSpanningWrapPreservesOrder() {
+        let ring = RewindRingBuffer(capacity: 5)
+        ring.append(bytes([1, 2, 3]))
+        ring.append(bytes([4, 5, 6, 7]))    // wraps; keeps last 5: 3,4,5,6,7
+        XCTAssertEqual(Array(ring.snapshotSuffix(5)), [3, 4, 5, 6, 7])
+        XCTAssertEqual(Array(ring.snapshotSuffix(2)), [6, 7])
+    }
+
+    func testChunkLargerThanCapacityKeepsTail() {
+        let ring = RewindRingBuffer(capacity: 3)
+        ring.append(bytes([1, 2, 3, 4, 5, 6, 7]))
+        XCTAssertEqual(ring.count, 3)
+        XCTAssertEqual(Array(ring.snapshotSuffix(3)), [5, 6, 7])
+    }
+
+    func testSnapshotMoreThanHeldReturnsAll() {
+        let ring = RewindRingBuffer(capacity: 8)
+        ring.append(bytes([9, 8, 7]))
+        XCTAssertEqual(Array(ring.snapshotSuffix(100)), [9, 8, 7])
+    }
+
+    func testResetClears() {
+        let ring = RewindRingBuffer(capacity: 4)
+        ring.append(bytes([1, 2, 3]))
+        ring.reset()
+        XCTAssertEqual(ring.count, 0)
+        XCTAssertTrue(ring.snapshotSuffix(4).isEmpty)
+    }
+
+    func testZeroCapacityIsSafe() {
+        let ring = RewindRingBuffer(capacity: 0)
+        ring.append(bytes([1, 2, 3]))
+        XCTAssertEqual(ring.count, 0)
+        XCTAssertTrue(ring.snapshotSuffix(1).isEmpty)
+    }
+
+    func testManyWrapsStayConsistent() {
+        // Continuously overwrite; the snapshot must always be the last `capacity` bytes appended.
+        let ring = RewindRingBuffer(capacity: 6)
+        var expected: [UInt8] = []
+        for i in 0..<200 {
+            let b = UInt8(i % 256)
+            ring.append(bytes([b]))
+            expected.append(b)
+            if expected.count > 6 { expected.removeFirst(expected.count - 6) }
+        }
+        XCTAssertEqual(Array(ring.snapshotSuffix(6)), expected)
+    }
+
+    func testConcurrentAppendsDoNotCrash() {
+        // The ring is written from the audio thread and read from the main actor — exercise both
+        // under contention (TSAN regression guard).
+        let ring = RewindRingBuffer(capacity: 1024)
+        let writeExp = expectation(description: "writes")
+        let readExp = expectation(description: "reads")
+        DispatchQueue.global().async {
+            for i in 0..<5000 { ring.append(Data([UInt8(i % 256)])) }
+            writeExp.fulfill()
+        }
+        DispatchQueue.global().async {
+            for _ in 0..<5000 { _ = ring.snapshotSuffix(128) }
+            readExp.fulfill()
+        }
+        wait(for: [writeExp, readExp], timeout: 10)
+        XCTAssertEqual(ring.count, 1024)
+    }
+}


### PR DESCRIPTION
Fixes the HIGH concurrency/performance finding from the round-12 audit: `MemoryRewindService`'s rolling audio buffer was doing per-sample allocation, an O(n) memmove, and a per-buffer main-actor hop on every audio callback while rewind is enabled.

## The problem (every audio callback, ~10–15×/sec while active)
- Allocated a fresh 2-byte `Data` **per sample** (~48k heap allocs/sec).
- Once full, `audioBuffer.removeFirst(excess)` — an O(n) memmove of the whole (up to ~58 MB) `Data`.
- Hopped to the `@MainActor` per buffer just to update the published duration.
- Ran the whole conversion on the main actor.

## The fix
- **`RewindRingBuffer`** — a fixed-capacity, lock-guarded byte ring; appends overwrite the oldest in place (O(bytes appended), no memmove). Sized lazily to the tap's real sample rate. **9 tests** including a concurrent read/write stress test.
- Conversion now uses the existing `PCMConverter.linear16Mono` (one bulk `Int16` allocation) instead of the per-sample loop.
- Ingest runs on a dedicated serial queue **off the main actor**; the published `bufferDurationMinutes` is refreshed on a 1 s timer, not per buffer.
- `rewind()` reads the recent window via that queue. Also fixes the sub-minute truncation bug (a request < 1 min fell to 0 bytes; now falls back to the whole ring).

## Also folded in
- **`HUDPreviewSnapshotTests` cold-GPU flake fix** (retry the render until the Metal pipeline is warm). This fix was written for #158 but landed on that branch *after* it was merged, so it never reached main — and it was blocking clean cold-sim runs here. Retries up to 12×400ms; passes instantly when warm.

## Verification
- `RewindRingBufferTests`: 9/9 pass (incl. concurrent stress).
- Full suite: **1478/1478 pass, 0 failures** (cold-sim HUD flake now fixed).
- Release build: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)