### PR TITLE
FaceRecognitionService: fix lifecycle leak + run Vision off the main thread

### DIFF
--- a/OpenGlasses/Sources/Services/FaceRecognitionService.swift
+++ b/OpenGlasses/Sources/Services/FaceRecognitionService.swift
@@ -62,18 +62,20 @@ class FaceRecognitionService: ObservableObject {
         isActive = true
         frameCount = 0
 
-        // Subscribe to camera frames via callback
-        let previousCallback = cameraService.onVideoFrame
-        cameraService.onVideoFrame = { [weak self] (image: UIImage) in
-            previousCallback?(image)
-            guard let self = self else { return }
-            Task { @MainActor in
-                self.frameCount += 1
-                if self.frameCount % self.currentProcessEveryN == 0 && !self.processingFrame {
-                    self.processFrame(image)
+        // Subscribe to the shared frame publisher with a stored cancellable (Plan: face-rec
+        // lifecycle). The old code chained `cameraService.onVideoFrame`, which `stop()` never
+        // detached — so recognition kept running after stop, and every start() stacked another
+        // closure. A publisher subscription cancels cleanly and can't stack.
+        frameSubscription = cameraService.framePublisher
+            .sink { [weak self] image in
+                Task { @MainActor in
+                    guard let self, self.isActive else { return }
+                    self.frameCount += 1
+                    if self.frameCount % self.currentProcessEveryN == 0 && !self.processingFrame {
+                        self.processFrame(image)
+                    }
                 }
             }
-        }
 
         print("👤 Face recognition started")
     }
@@ -163,12 +165,14 @@ class FaceRecognitionService: ObservableObject {
     // MARK: - Frame Processing
 
     private func processFrame(_ image: UIImage) {
-        guard let cgImage = image.cgImage, !knownFaces.isEmpty else { return }
+        guard isActive, let cgImage = image.cgImage, !knownFaces.isEmpty else { return }
         processingFrame = true
 
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self = self else { return }
             do {
+                // `detectFaceprints` is nonisolated, so this Vision work runs off the main actor
+                // (the old code left it main-isolated, so the detached task hopped straight back).
                 let faceprints = try await self.detectFaceprints(in: cgImage)
 
                 await MainActor.run {
@@ -201,7 +205,7 @@ class FaceRecognitionService: ObservableObject {
 
     // MARK: - Vision Framework
 
-    private func detectFaceprints(in cgImage: CGImage) async throws -> [[Float]] {
+    private nonisolated func detectFaceprints(in cgImage: CGImage) async throws -> [[Float]] {
         // Step 1: Detect face rectangles
         let faceRequest = VNDetectFaceRectanglesRequest()
         let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
@@ -240,7 +244,7 @@ class FaceRecognitionService: ObservableObject {
         return faceprints
     }
 
-    private func cropFace(from cgImage: CGImage, boundingBox: CGRect) -> CGImage? {
+    private nonisolated func cropFace(from cgImage: CGImage, boundingBox: CGRect) -> CGImage? {
         let width = CGFloat(cgImage.width)
         let height = CGFloat(cgImage.height)
 
@@ -258,38 +262,7 @@ class FaceRecognitionService: ObservableObject {
     // MARK: - Matching
 
     private func findMatch(for faceprint: [Float]) -> Int? {
-        var bestMatch: Int?
-        var bestDistance: Float = Float.greatestFiniteMagnitude
-
-        for (idx, known) in knownFaces.enumerated() {
-            guard known.faceprint.count == faceprint.count else { continue }
-            let distance = cosineSimilarity(a: faceprint, b: known.faceprint)
-            if distance > matchThreshold && (bestMatch == nil || distance > (1.0 - bestDistance)) {
-                // Higher cosine similarity = better match
-                bestMatch = idx
-                bestDistance = 1.0 - distance
-            }
-        }
-
-        return bestMatch
-    }
-
-    private func cosineSimilarity(a: [Float], b: [Float]) -> Float {
-        guard a.count == b.count, !a.isEmpty else { return 0 }
-
-        var dotProduct: Float = 0
-        var magnitudeA: Float = 0
-        var magnitudeB: Float = 0
-
-        for i in 0..<a.count {
-            dotProduct += a[i] * b[i]
-            magnitudeA += a[i] * a[i]
-            magnitudeB += b[i] * b[i]
-        }
-
-        let magnitude = sqrt(magnitudeA) * sqrt(magnitudeB)
-        guard magnitude > 0 else { return 0 }
-        return dotProduct / magnitude
+        FaceMatcher.bestMatch(for: faceprint, among: knownFaces.map(\.faceprint), threshold: matchThreshold)
     }
 
     // MARK: - Persistence

--- a/OpenGlasses/Sources/Services/Vision/FaceMatcher.swift
+++ b/OpenGlasses/Sources/Services/Vision/FaceMatcher.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Pure face-embedding matching math for `FaceRecognitionService` — cosine similarity plus
+/// best-match-above-threshold selection. Kept separate so the recognition decision is
+/// headless-testable without a camera or the Vision framework.
+enum FaceMatcher {
+
+    /// Cosine similarity of two equal-length vectors (0 for mismatched/empty inputs).
+    static func cosineSimilarity(_ a: [Float], _ b: [Float]) -> Float {
+        guard a.count == b.count, !a.isEmpty else { return 0 }
+        var dot: Float = 0, magA: Float = 0, magB: Float = 0
+        for i in 0..<a.count {
+            dot += a[i] * b[i]
+            magA += a[i] * a[i]
+            magB += b[i] * b[i]
+        }
+        let mag = sqrt(magA) * sqrt(magB)
+        return mag > 0 ? dot / mag : 0
+    }
+
+    /// Index of the candidate with the highest cosine similarity to `faceprint` that also clears
+    /// `threshold`, or nil if none qualify. Candidates whose length differs are skipped.
+    static func bestMatch(for faceprint: [Float], among candidates: [[Float]], threshold: Float) -> Int? {
+        var bestIndex: Int?
+        var bestSimilarity = threshold   // must strictly exceed the threshold to match
+        for (idx, candidate) in candidates.enumerated() {
+            guard candidate.count == faceprint.count else { continue }
+            let similarity = cosineSimilarity(faceprint, candidate)
+            if similarity > bestSimilarity {
+                bestSimilarity = similarity
+                bestIndex = idx
+            }
+        }
+        return bestIndex
+    }
+}

--- a/OpenGlassesTests/FaceMatcherTests.swift
+++ b/OpenGlassesTests/FaceMatcherTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests for the pure face-embedding matching math extracted from `FaceRecognitionService`.
+final class FaceMatcherTests: XCTestCase {
+
+    func testCosineSimilarityIdenticalVectors() {
+        let v: [Float] = [1, 2, 3, 4]
+        XCTAssertEqual(FaceMatcher.cosineSimilarity(v, v), 1.0, accuracy: 1e-5)
+    }
+
+    func testCosineSimilarityOrthogonal() {
+        XCTAssertEqual(FaceMatcher.cosineSimilarity([1, 0], [0, 1]), 0.0, accuracy: 1e-6)
+    }
+
+    func testCosineSimilarityMismatchedOrEmpty() {
+        XCTAssertEqual(FaceMatcher.cosineSimilarity([1, 2, 3], [1, 2]), 0)
+        XCTAssertEqual(FaceMatcher.cosineSimilarity([], []), 0)
+        XCTAssertEqual(FaceMatcher.cosineSimilarity([0, 0], [0, 0]), 0, "zero-magnitude → 0, no NaN")
+    }
+
+    func testBestMatchPicksHighestAboveThreshold() {
+        let probe: [Float] = [1, 0, 0]
+        let candidates: [[Float]] = [
+            [0.9, 0.1, 0],   // high similarity
+            [0.5, 0.5, 0],   // lower
+            [1, 0, 0],       // exact
+        ]
+        // Exact match (index 2) is the highest similarity.
+        XCTAssertEqual(FaceMatcher.bestMatch(for: probe, among: candidates, threshold: 0.6), 2)
+    }
+
+    func testBestMatchReturnsNilWhenNoneClearThreshold() {
+        let probe: [Float] = [1, 0, 0]
+        let candidates: [[Float]] = [[0, 1, 0], [0, 0, 1]]   // orthogonal → similarity 0
+        XCTAssertNil(FaceMatcher.bestMatch(for: probe, among: candidates, threshold: 0.6))
+    }
+
+    func testBestMatchSkipsLengthMismatches() {
+        let probe: [Float] = [1, 0, 0]
+        let candidates: [[Float]] = [[1, 0], [1, 0, 0]]   // first is wrong length → skipped
+        XCTAssertEqual(FaceMatcher.bestMatch(for: probe, among: candidates, threshold: 0.6), 1)
+    }
+
+    func testBestMatchThresholdIsStrict() {
+        let probe: [Float] = [1, 0]
+        let candidates: [[Float]] = [[1, 0]]   // similarity exactly 1.0
+        XCTAssertNil(FaceMatcher.bestMatch(for: probe, among: candidates, threshold: 1.0),
+                     "a candidate must strictly exceed the threshold")
+        XCTAssertEqual(FaceMatcher.bestMatch(for: probe, among: candidates, threshold: 0.99), 0)
+    }
+
+    func testBestMatchEmptyCandidates() {
+        XCTAssertNil(FaceMatcher.bestMatch(for: [1, 0, 0], among: [], threshold: 0.6))
+    }
+}


### PR DESCRIPTION
First item from the audit's "self-contained perf/concurrency" bucket — the one that's an actual bug.

## The bugs (concurrency audit, HIGH)
1. **Lifecycle leak / stacking.** `start()` chained `cameraService.onVideoFrame`, capturing the previous callback, but `stop()` only cancelled an `AnyCancellable` that was **never assigned**. So face detection kept running after `stop()`, and every `start()`/`stop()`/`start()` cycle stacked another closure — K cycles meant K live Vision passes per frame. Toggling the feature a few times then streaming to Gemini Live would visibly stutter.
2. **Vision on the main thread.** `detectFaceprints`/`cropFace` were main-actor-isolated, so the `Task.detached` in `processFrame` hopped straight back to the main actor and ran `VNDetectFaceRectangles` + per-face feature-print extraction (100 ms+) on main.

## The fix
- Subscribe to the shared `framePublisher` with a **stored cancellable** that `stop()` actually cancels — no callback chaining, can't stack. The frame handler guards on `isActive`, and `processFrame` re-checks it.
- Mark `detectFaceprints`/`cropFace` **`nonisolated`** so the detached task genuinely runs off the main actor.
- Extract the matching math into a pure, tested **`FaceMatcher`** (cosine similarity + best-match-above-threshold); `findMatch` delegates to it.

## Verification
- `FaceMatcherTests`: 8/8 pass.
- Full suite: **1486/1486, 0 failures** (cold sim).
- Release build: green.

## Bucket A remaining (future PRs)
PrivacyFilter per-frame `CIContext`, BroadcastService pixel-buffer pool, WebRTC frame-encode waste + session leak, realtime JSON/base64 on the main actor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)