### PR TITLE
Realtime: parse JSON + decode audio off the main actor (audit M2)

### DIFF
--- a/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveService.swift
+++ b/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveService.swift
@@ -376,15 +376,18 @@ class GeminiLiveService: ObservableObject {
                 guard let task = self.webSocketTask else { break }
                 do {
                     let message = try await task.receive()
+                    let text: String?
                     switch message {
-                    case .string(let text):
-                        await self.handleMessage(text)
-                    case .data(let data):
-                        if let text = String(data: data, encoding: .utf8) {
-                            await self.handleMessage(text)
-                        }
-                    @unknown default:
-                        break
+                    case .string(let t): text = t
+                    case .data(let d): text = String(data: d, encoding: .utf8)
+                    @unknown default: text = nil
+                    }
+                    guard let text else { continue }
+                    // Parse JSON + decode audio base64 OFF the main actor (`parse` is nonisolated
+                    // async), then apply state/callbacks on main — the old code did both on main for
+                    // every message, at 10-25 msgs/sec while the model speaks.
+                    if let parsed = await Self.parse(text) {
+                        self.handleMessage(parsed)
                     }
                 } catch {
                     if !Task.isCancelled {
@@ -403,11 +406,40 @@ class GeminiLiveService: ObservableObject {
         }
     }
 
-    private func handleMessage(_ text: String) async {
+    /// A message parsed off the main actor: the decoded JSON plus any audio chunks already
+    /// base64-decoded off-main. `@unchecked Sendable` is safe here because it's a single-owner
+    /// handoff — built on a background executor, consumed once on the main actor, never mutated
+    /// or shared concurrently.
+    private struct ParsedGeminiMessage: @unchecked Sendable {
+        let json: [String: Any]
+        let audioChunks: [Data]
+    }
+
+    /// Parse the raw text and pre-decode audio, entirely off the main actor.
+    private nonisolated static func parse(_ text: String) async -> ParsedGeminiMessage? {
         guard let data = text.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return
+            return nil
         }
+        var chunks: [Data] = []
+        if let serverContent = json["serverContent"] as? [String: Any],
+           let modelTurn = serverContent["modelTurn"] as? [String: Any],
+           let parts = modelTurn["parts"] as? [[String: Any]] {
+            for part in parts {
+                if let inlineData = part["inlineData"] as? [String: Any],
+                   let mimeType = inlineData["mimeType"] as? String,
+                   mimeType.hasPrefix("audio/pcm"),
+                   let base64Data = inlineData["data"] as? String,
+                   let audioData = Data(base64Encoded: base64Data) {
+                    chunks.append(audioData)
+                }
+            }
+        }
+        return ParsedGeminiMessage(json: json, audioChunks: chunks)
+    }
+
+    private func handleMessage(_ parsed: ParsedGeminiMessage) {
+        let json = parsed.json
 
         // Token usage (cumulative) → record the delta for the cost tracker (Plan AU).
         if let cumulative = RealtimeUsage.geminiCumulative(json) {
@@ -460,26 +492,25 @@ class GeminiLiveService: ObservableObject {
                 return
             }
 
-            // Model audio/text output
+            // Model audio output — chunks were base64-decoded off the main actor in `parse`.
+            for audioData in parsed.audioChunks {
+                if !isModelSpeaking {
+                    isModelSpeaking = true
+                    // Log response latency
+                    if let speechEnd = lastUserSpeechEnd, !responseLatencyLogged {
+                        let latency = Date().timeIntervalSince(speechEnd)
+                        NSLog("[Latency] %.0fms (user speech end -> first audio)", latency * 1000)
+                        responseLatencyLogged = true
+                    }
+                }
+                onAudioReceived?(audioData)
+            }
+
+            // Model text output (logged)
             if let modelTurn = serverContent["modelTurn"] as? [String: Any],
                let parts = modelTurn["parts"] as? [[String: Any]] {
-                for part in parts {
-                    if let inlineData = part["inlineData"] as? [String: Any],
-                       let mimeType = inlineData["mimeType"] as? String,
-                       mimeType.hasPrefix("audio/pcm"),
-                       let base64Data = inlineData["data"] as? String,
-                       let audioData = Data(base64Encoded: base64Data) {
-                        if !isModelSpeaking {
-                            isModelSpeaking = true
-                            // Log response latency
-                            if let speechEnd = lastUserSpeechEnd, !responseLatencyLogged {
-                                let latency = Date().timeIntervalSince(speechEnd)
-                                NSLog("[Latency] %.0fms (user speech end -> first audio)", latency * 1000)
-                                responseLatencyLogged = true
-                            }
-                        }
-                        onAudioReceived?(audioData)
-                    } else if let text = part["text"] as? String {
+                for part in parts where part["inlineData"] == nil {
+                    if let text = part["text"] as? String {
                         NSLog("[Gemini] %@", text)
                     }
                 }

--- a/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeService.swift
+++ b/OpenGlasses/Sources/Services/OpenAIRealtime/OpenAIRealtimeService.swift
@@ -343,15 +343,17 @@ class OpenAIRealtimeService: ObservableObject {
                 guard let task = self.webSocketTask else { break }
                 do {
                     let message = try await task.receive()
+                    let text: String?
                     switch message {
-                    case .string(let text):
-                        await self.handleMessage(text)
-                    case .data(let data):
-                        if let text = String(data: data, encoding: .utf8) {
-                            await self.handleMessage(text)
-                        }
-                    @unknown default:
-                        break
+                    case .string(let t): text = t
+                    case .data(let d): text = String(data: d, encoding: .utf8)
+                    @unknown default: text = nil
+                    }
+                    guard let text else { continue }
+                    // Parse JSON + decode the audio delta OFF the main actor, then apply on main —
+                    // response.audio.delta arrives many times/sec while the model speaks.
+                    if let parsed = await Self.parse(text) {
+                        self.handleMessage(parsed)
                     }
                 } catch {
                     if !Task.isCancelled {
@@ -370,12 +372,30 @@ class OpenAIRealtimeService: ObservableObject {
         }
     }
 
-    private func handleMessage(_ text: String) async {
+    /// A message parsed off the main actor: decoded JSON plus the pre-decoded audio delta.
+    /// `@unchecked Sendable` is safe — single-owner handoff, built off-main and consumed once on main.
+    private struct ParsedOpenAIMessage: @unchecked Sendable {
+        let json: [String: Any]
+        let type: String
+        let audioDelta: Data?
+    }
+
+    private nonisolated static func parse(_ text: String) async -> ParsedOpenAIMessage? {
         guard let data = text.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let type = json["type"] as? String else {
-            return
+            return nil
         }
+        var audioDelta: Data?
+        if type == "response.audio.delta", let delta = json["delta"] as? String {
+            audioDelta = Data(base64Encoded: delta)
+        }
+        return ParsedOpenAIMessage(json: json, type: type, audioDelta: audioDelta)
+    }
+
+    private func handleMessage(_ parsed: ParsedOpenAIMessage) {
+        let json = parsed.json
+        let type = parsed.type
 
         switch type {
         case "session.created":
@@ -389,9 +409,8 @@ class OpenAIRealtimeService: ObservableObject {
             resolveConnect(success: true)
 
         case "response.audio.delta":
-            // Model audio chunk
-            if let delta = json["delta"] as? String,
-               let audioData = Data(base64Encoded: delta) {
+            // Model audio chunk — base64-decoded off the main actor in `parse`.
+            if let audioData = parsed.audioDelta {
                 if !isModelSpeaking {
                     isModelSpeaking = true
                     if let speechEnd = lastUserSpeechEnd, !responseLatencyLogged {


### PR DESCRIPTION
The last remaining item from the round-12 audit — the one I'd deferred as more invasive.

## The problem (concurrency audit, M2)
Both realtime receive loops (`GeminiLiveService.startReceiving` / `OpenAIRealtimeService.startReceiving`) create their `Task` inside a `@MainActor` method, so it inherits main-actor isolation. Every server message was therefore `JSONSerialization`-parsed and its audio base64-decoded **on the main thread** — 10–25 messages/sec while the model is speaking, contending with SwiftUI and the audio-playback callbacks.

## The fix
Each service now:
- parses the message and pre-decodes its audio in a `nonisolated static func parse(...) async` — which runs **off** the main actor;
- hands the result to the main actor in a single-owner `@unchecked Sendable` box (safe: built off-main, consumed exactly once on main, never shared or mutated concurrently);
- keeps every existing state mutation + callback on the main actor, now reading the pre-parsed JSON and pre-decoded audio.

Behavior is unchanged — only the JSON parse and base64 decode moved off-main. The branch logic, ordering, latency logging, usage recording, and callbacks are identical.

## Verification
- Full suite: **1489/1489, 0 failures** (cold sim) — the realtime session-manager tests confirm no behavioral regression.
- Release build: green.

The threading win itself is only observable on-device (fewer main-thread stalls during long spoken responses), so that part is device-pending by house style.

## Audit status
This closes the bucket-A / concurrency items from the audit. Remaining audit work is the security mediums (gateway token in `ws://` URL + logs, data-protection classes on sensitive files, WebRTC room-code entropy) and the larger BG spine refactors (P3 provider adapters, P4 audio-manager merge, P5 Config split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)