### PR TITLE
Security mediums: redact gateway token, protect sensitive files, harden room code

### DIFF
--- a/OpenGlasses/Sources/Services/ConversationStore.swift
+++ b/OpenGlasses/Sources/Services/ConversationStore.swift
@@ -413,7 +413,7 @@ class ConversationStore: ObservableObject {
             if FileManager.default.fileExists(atPath: storageURL.path),
                encryption.isFileEncrypted(at: storageURL) {
                 let plaintext = try await encryption.decryptFile(at: storageURL)
-                try plaintext.write(to: storageURL, options: .atomic)
+                try plaintext.write(to: storageURL, options: [.atomic, .completeFileProtection])
             }
             await encryption.deleteKey()
             Config.setConversationEncryptionEnabled(false)
@@ -479,13 +479,15 @@ class ConversationStore: ObservableObject {
                         let encrypted = try await enc.encrypt(data)
                         var output = Data("OGENC1".utf8)
                         output.append(encrypted)
-                        try output.write(to: url, options: .atomic)
+                        try output.write(to: url, options: [.atomic, .completeFileProtection])
                     } catch {
                         NSLog("[ConversationStore] Encrypted save failed: %@", error.localizedDescription)
                     }
                 }
             } else {
-                try data.write(to: storageURL, options: .atomic)
+                // Conversation history can hold sensitive content — encrypt at rest even when
+                // the optional biometric encryption layer is off.
+                try data.write(to: storageURL, options: [.atomic, .completeFileProtection])
             }
         } catch {
             NSLog("[ConversationStore] Save failed: %@", error.localizedDescription)

--- a/OpenGlasses/Sources/Services/FaceRecognitionService.swift
+++ b/OpenGlasses/Sources/Services/FaceRecognitionService.swift
@@ -270,7 +270,8 @@ class FaceRecognitionService: ObservableObject {
     private func saveFaces() {
         do {
             let data = try JSONEncoder().encode(knownFaces)
-            try data.write(to: storageURL, options: .atomic)
+            // Face embeddings are biometric data — encrypt at rest (accessible only while unlocked).
+            try data.write(to: storageURL, options: [.atomic, .completeFileProtection])
         } catch {
             print("👤 Failed to save faces: \(error)")
         }

--- a/OpenGlasses/Sources/Services/MemoryRewindService.swift
+++ b/OpenGlasses/Sources/Services/MemoryRewindService.swift
@@ -149,7 +149,9 @@ class MemoryRewindService: ObservableObject {
 
         // Write to temp file (SFSpeechURLRecognitionRequest needs a file URL)
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("rewind_\(UUID().uuidString).wav")
-        try wavData.write(to: tempURL)
+        // Rolling-buffer audio is sensitive — encrypt the on-disk temp file at rest. It is
+        // deleted as soon as recognition finishes (see `defer`).
+        try wavData.write(to: tempURL, options: [.atomic, .completeFileProtection])
         defer { try? FileManager.default.removeItem(at: tempURL) }
 
         let request = SFSpeechURLRecognitionRequest(url: tempURL)

--- a/OpenGlasses/Sources/Services/OpenClawBridge.swift
+++ b/OpenGlasses/Sources/Services/OpenClawBridge.swift
@@ -296,11 +296,13 @@ class OpenClawBridge: ObservableObject {
             .replacingOccurrences(of: "http://", with: "ws://")
         let token = activeToken
 
-        guard let url = URL(string: "\(wsURL)/ws?token=\(token)") else {
+        // Token is presented in the `connect` handshake below, not in the URL query string —
+        // this keeps the credential out of device, proxy, and server access logs.
+        guard let url = URL(string: "\(wsURL)/ws") else {
             throw NSError(domain: "OpenClaw", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid WebSocket URL"])
         }
 
-        NSLog("[OpenClaw] WS connecting to %@", url.absoluteString)
+        NSLog("[OpenClaw] WS connecting to %@", LogRedaction.redact(url.absoluteString))
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 30
         wsSession = URLSession(configuration: config)
@@ -339,7 +341,7 @@ class OpenClawBridge: ObservableObject {
 
         let connectData = try JSONSerialization.data(withJSONObject: connectMsg)
         let connectJSON = String(data: connectData, encoding: .utf8)!
-        NSLog("[OpenClawWS] Sending connect: %@", String(connectJSON.prefix(500)))
+        NSLog("[OpenClawWS] Sending connect: %@", LogRedaction.redact(String(connectJSON.prefix(500))))
         try await webSocketTask!.send(.string(connectJSON))
 
         // Wait for connect response

--- a/OpenGlasses/Sources/Services/OpenClawEventClient.swift
+++ b/OpenGlasses/Sources/Services/OpenClawEventClient.swift
@@ -74,7 +74,7 @@ class OpenClawEventClient {
         webSocketTask = session?.webSocketTask(with: url)
         webSocketTask?.resume()
 
-        NSLog("[OpenClawWS] Connecting to %@ (gateway: %@)", url.absoluteString, gateway.name)
+        NSLog("[OpenClawWS] Connecting to %@ (gateway: %@)", LogRedaction.redact(url.absoluteString), gateway.name)
         startReceiving()
     }
 
@@ -118,19 +118,22 @@ class OpenClawEventClient {
         }
     }
 
+    // The gateway token is presented in the `connect` handshake (see `sendConnectHandshake`),
+    // never in the URL — keeping it out of the query string prevents it leaking into device,
+    // proxy, and server access logs.
     private static func tunnelWebSocketURL(for gateway: GatewayConfig) -> String {
         let base = gateway.tunnelHost
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
             .replacingOccurrences(of: "https://", with: "wss://")
             .replacingOccurrences(of: "http://", with: "ws://")
-        return "\(base)/ws?token=\(gateway.token)"
+        return "\(base)/ws"
     }
 
     private static func lanWebSocketURL(for gateway: GatewayConfig) -> String {
         let host = gateway.lanHost
             .replacingOccurrences(of: "http://", with: "")
             .replacingOccurrences(of: "https://", with: "")
-        return "ws://\(host):\(gateway.port)/ws?token=\(gateway.token)"
+        return "ws://\(host):\(gateway.port)/ws"
     }
 
     private func startReceiving() {
@@ -188,7 +191,7 @@ class OpenClawEventClient {
         case .waitingApproval:
             NSLog("[OpenClawWS] Device pairing pending — awaiting approval on the gateway")
         case .error(let msg):
-            NSLog("[OpenClawWS] Connect failed: %@ (full response: %@)", msg, rawText)
+            NSLog("[OpenClawWS] Connect failed: %@ (full response: %@)", msg, LogRedaction.redact(rawText))
         case .disconnected, .connecting:
             break
         }

--- a/OpenGlasses/Sources/Services/WebRTCStreamingService.swift
+++ b/OpenGlasses/Sources/Services/WebRTCStreamingService.swift
@@ -269,8 +269,9 @@ class WebRTCStreamingService: ObservableObject {
     }
 
     private func generateRoomId() -> String {
-        // 6-character alphanumeric room code
-        let chars = "abcdefghijklmnopqrstuvwxyz0123456789"
-        return String((0..<6).map { _ in chars.randomElement()! })
+        // A viewer who knows the room code can watch the live stream, so the code must be
+        // unguessable rather than a short slug: 128 bits of cryptographic randomness,
+        // URL-safe base64. Replaces the old 6-char alphanumeric code (~31 bits, brute-forceable).
+        return SecureToken.urlSafe(byteCount: 16)
     }
 }

--- a/OpenGlasses/Sources/Utils/LogRedaction.swift
+++ b/OpenGlasses/Sources/Utils/LogRedaction.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Redacts sensitive credentials from strings before they reach the log.
+///
+/// Gateway tokens historically travelled in the WebSocket URL query string and inside the
+/// `connect` handshake JSON, both of which were logged verbatim via `NSLog`. This masks the
+/// token value while leaving the surrounding text intact, so logs stay useful for debugging
+/// without spilling a bearer credential to the device console / sysdiagnose.
+enum LogRedaction {
+    static let mask = "***"
+
+    /// Mask the value of any `token=…` query parameter *and* any `"token": "…"` JSON field.
+    static func redact(_ text: String) -> String {
+        redactJSONToken(redactQueryToken(text))
+    }
+
+    /// `…?token=SECRET&x=1` → `…?token=***&x=1` (case-insensitive on the key).
+    static func redactQueryToken(_ text: String) -> String {
+        replace(in: text, pattern: #"(?i)([?&]token=)[^&\s"']+"#, with: "$1\(mask)")
+    }
+
+    /// `"token":"SECRET"` (any surrounding whitespace) → `"token":"***"`.
+    static func redactJSONToken(_ text: String) -> String {
+        replace(in: text, pattern: #"("token"\s*:\s*")[^"]*(")"#, with: "$1\(mask)$2")
+    }
+
+    private static func replace(in text: String, pattern: String, with template: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return text }
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.stringByReplacingMatches(in: text, range: range, withTemplate: template)
+    }
+}

--- a/OpenGlasses/Sources/Utils/SecureToken.swift
+++ b/OpenGlasses/Sources/Utils/SecureToken.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Cryptographically-random, URL-safe identifiers for things that must be unguessable —
+/// e.g. a WebRTC room code that, on its own, grants a viewer access to the live stream.
+enum SecureToken {
+    /// A URL-safe token carrying `byteCount` bytes of cryptographic randomness.
+    /// 16 bytes → 128 bits of entropy, encoded as 22 URL-safe base64 characters.
+    static func urlSafe(byteCount: Int = 16) -> String {
+        let count = max(1, byteCount)
+        var bytes = [UInt8](repeating: 0, count: count)
+        let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+        if status != errSecSuccess {
+            // Extremely unlikely; fall back to the system RNG (still non-deterministic).
+            var rng = SystemRandomNumberGenerator()
+            for i in bytes.indices { bytes[i] = UInt8.random(in: .min ... .max, using: &rng) }
+        }
+        return urlSafeString(from: bytes)
+    }
+
+    /// Pure: encode bytes as unpadded URL-safe base64 (`+` → `-`, `/` → `_`, no `=` padding).
+    static func urlSafeString(from bytes: [UInt8]) -> String {
+        Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/OpenGlassesTests/SecurityMediumsTests.swift
+++ b/OpenGlassesTests/SecurityMediumsTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Pure-logic coverage for the audit "security mediums" bundle:
+/// gateway-token log redaction and cryptographically-random room tokens.
+final class SecurityMediumsTests: XCTestCase {
+
+    // MARK: - LogRedaction
+
+    func testRedactsTokenInWebSocketURLQuery() {
+        let url = "wss://gw.example.com/ws?token=super-secret-abc123"
+        let redacted = LogRedaction.redact(url)
+        XCTAssertFalse(redacted.contains("super-secret-abc123"))
+        XCTAssertTrue(redacted.contains("token=\(LogRedaction.mask)"))
+        XCTAssertTrue(redacted.hasPrefix("wss://gw.example.com/ws?token="))
+    }
+
+    func testRedactsTokenButKeepsOtherQueryParams() {
+        let url = "ws://host:8080/ws?token=abc123&room=foo"
+        let redacted = LogRedaction.redact(url)
+        XCTAssertFalse(redacted.contains("abc123"))
+        XCTAssertTrue(redacted.contains("token=\(LogRedaction.mask)"))
+        XCTAssertTrue(redacted.contains("&room=foo"))
+    }
+
+    func testRedactsTokenInJSONHandshake() {
+        let json = #"{"type":"req","params":{"auth":{"token":"deviceToken-xyz-789"}}}"#
+        let redacted = LogRedaction.redact(json)
+        XCTAssertFalse(redacted.contains("deviceToken-xyz-789"))
+        XCTAssertTrue(redacted.contains(#""token":"\#(LogRedaction.mask)""#))
+    }
+
+    func testRedactsTokenInJSONWithWhitespace() {
+        let json = #"{ "token" : "spaced-secret" }"#
+        let redacted = LogRedaction.redact(json)
+        XCTAssertFalse(redacted.contains("spaced-secret"))
+    }
+
+    func testLeavesTextWithoutTokenUnchanged() {
+        let text = "Connecting to wss://gw.example.com/ws (gateway: Home)"
+        XCTAssertEqual(LogRedaction.redact(text), text)
+    }
+
+    func testRedactionIsCaseInsensitiveOnQueryKey() {
+        let redacted = LogRedaction.redact("wss://h/ws?TOKEN=Secret1")
+        XCTAssertFalse(redacted.contains("Secret1"))
+    }
+
+    // MARK: - SecureToken
+
+    func testURLSafeStringMatchesKnownVector() {
+        // base64("hello") = "aGVsbG8=" → url-safe, unpadded = "aGVsbG8"
+        let bytes = Array("hello".utf8)
+        XCTAssertEqual(SecureToken.urlSafeString(from: bytes), "aGVsbG8")
+    }
+
+    func testURLSafeStringUsesURLSafeAlphabetWithoutPadding() {
+        // 0xFB 0xFF 0xBF → standard base64 "+/+/" style bytes to force + and / substitution.
+        let encoded = SecureToken.urlSafeString(from: [0xFB, 0xFF, 0xBF])
+        XCTAssertFalse(encoded.contains("+"))
+        XCTAssertFalse(encoded.contains("/"))
+        XCTAssertFalse(encoded.contains("="))
+    }
+
+    func testURLSafeTokenHasExpectedEntropyLength() {
+        // 16 bytes → 22 unpadded base64 chars.
+        XCTAssertEqual(SecureToken.urlSafe(byteCount: 16).count, 22)
+    }
+
+    func testURLSafeTokensAreUnique() {
+        let tokens = Set((0..<200).map { _ in SecureToken.urlSafe() })
+        XCTAssertEqual(tokens.count, 200, "Room tokens must not collide")
+    }
+
+    func testURLSafeTokenIsUnguessablyLong() {
+        // The old room code was 6 chars; the new one carries far more entropy.
+        XCTAssertGreaterThan(SecureToken.urlSafe().count, 6)
+    }
+}


### PR DESCRIPTION
Bundles the audit's remaining **security-medium** findings into one PR. No behaviour change for users; three quiet hardening fixes plus two tested pure helpers.

## Fixes

**1. Gateway token no longer travels in the WebSocket URL / logs**
The OpenClaw gateway token was placed in the `ws://…/ws?token=<token>` query string and then `NSLog`'d verbatim (URL logs, and the `connect` handshake JSON which embeds `auth.token`). Query-string credentials leak into device consoles, sysdiagnoses, and any proxy/server access log.
- Dropped `?token=…` from all three WS URL builders (`OpenClawEventClient` tunnel/LAN, `OpenClawBridge.ensureWebSocket`). The token is already presented in the `connect` handshake, so auth is unchanged on the wire.
- Routed the remaining token-bearing logs through a new `LogRedaction` helper (masks `token=…` query values and `"token":"…"` JSON fields), as defence-in-depth.

**2. Sensitive local files get `FileProtectionType.complete`**
Added `.completeFileProtection` (encrypted at rest, readable only while the device is unlocked) to the writes for:
- `known_faces.json` — biometric face embeddings
- `conversations.json` — all three write paths (plaintext, encrypted, decrypt-on-disable)
- the MemoryRewind rolling-buffer temp WAV (already deleted immediately after recognition)

Mirrors the existing `HIPAAComplianceService` pattern, but applied unconditionally rather than only in HIPAA mode. Writes that fail while backgrounded-and-locked degrade gracefully via existing `catch`/retry-on-next-save paths.

**3. WebRTC room code is now cryptographically random**
`generateRoomId` produced a 6-char alphanumeric slug (~31 bits) that alone grants a viewer stream access. Replaced with a 128-bit URL-safe token via the new `SecureToken` helper.

## New tested helpers (deterministic core, house style)
- `LogRedaction` — pure token masking for logs
- `SecureToken` — cryptographically-random URL-safe tokens + a pure base64url encoder
- `SecurityMediumsTests` — 11 tests (redaction cases, known base64url vectors, entropy length, uniqueness)

## Gates
- `build-for-testing` ✅
- full suite ✅ — **1500 tests, 0 failures**
- Release build (`-configuration Release … CODE_SIGNING_ALLOWED=NO`) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
