### PR TITLE
BG P2: introduce ConversationFlowEngine + VoiceCommandHandler chain

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2298,6 +2298,61 @@ class AppState: ObservableObject, AppStateProtocol {
         }
     }
 
+    /// The ordered pre-LLM voice-command chain (Plan BG P2). Each handler checks the transcript and,
+    /// if it applies, drives its mode and resumes listening, reporting that it consumed the turn so
+    /// the flow stops before the LLM. Order is preserved exactly from the original if-ladder:
+    /// teleprompter → HUD task → launcher select → launcher open → intent-ignore filter.
+    private func preLLMHandlers() -> [VoiceCommandHandler] {
+        [
+            // Teleprompter (Phase 2): while a session is running it owns the display, so
+            // "next/back/pause/resume/restart/faster/slower/stop" drive the prompter rather than
+            // the LLM. Checked first since it's a focused, full-screen mode.
+            VoiceCommandHandler(label: "teleprompter") { [weak self] text in
+                guard let self, self.teleprompterService.isActive,
+                      self.teleprompterService.handleVoiceCommand(text) else { return false }
+                print("📜 Teleprompter command handled: \(text)")
+                await self.resumeListeningOrReturnToWakeWord()
+                return true
+            },
+            // HUD task control (Display Phase 3 / Plan X): while a Now/Next card is on the glasses,
+            // "next/done/skip/back" drive the task instead of the LLM. Before intent classification
+            // so these short commands aren't filtered.
+            VoiceCommandHandler(label: "hud-task") { [weak self] text in
+                guard let self, await self.hudRouter.handleVoiceCommand(text) else { return false }
+                print("🎯 HUD task command handled: \(text)")
+                await self.resumeListeningOrReturnToWakeWord()
+                return true
+            },
+            // HUD launcher voice nav (Display Phase 4 / Plan Y): while a menu is open, a spoken item
+            // label (or "back"/"close") selects it. Before the open command so saying a leaf name
+            // inside the menu navigates instead of re-opening the root.
+            VoiceCommandHandler(label: "hud-launcher-select") { [weak self] text in
+                guard let self, self.hudLauncher.handleVoiceSelection(text) else { return false }
+                print("🎛 HUD launcher voice selection: \(text)")
+                await self.resumeListeningOrReturnToWakeWord()
+                return true
+            },
+            // HUD launcher (Display Phase 4 / Plan Y): "menu" opens the band-navigable launcher.
+            VoiceCommandHandler(label: "hud-launcher-open") { [weak self] text in
+                guard let self, HUDLauncher.isOpenCommand(text), self.hudLauncher.hasContent else { return false }
+                print("🎛 HUD launcher opened")
+                self.hudLauncher.open()
+                await self.resumeListeningOrReturnToWakeWord()
+                return true
+            },
+            // Intent classification — filter bystander/filler speech.
+            VoiceCommandHandler(label: "intent-ignore") { [weak self] text in
+                guard let self, self.intentClassifier.isEnabled,
+                      !self.isPhotoCommand(text), !self.isStopCommand(text), !self.isGoodbyeCommand(text)
+                else { return false }
+                guard await self.intentClassifier.classify(transcript: text) == .ignore else { return false }
+                print("🚫 Intent classifier: IGNORE — not responding")
+                await self.resumeListeningOrReturnToWakeWord()
+                return true
+            },
+        ]
+    }
+
     /// Reuse an already-available live frame for vision-capable models without trying to
     /// start the camera. This avoids re-triggering fragile Meta camera permission flows.
     private func currentVisionFrameDataIfAvailable() -> Data? {
@@ -2394,53 +2449,16 @@ class AppState: ObservableObject, AppStateProtocol {
         speechService.playEndListeningTone()
         print("📝 Transcription: \(text)")
 
-        // Teleprompter (Phase 2): while a session is running it owns the display, so
-        // "next/back/pause/resume/restart/faster/slower/stop" drive the prompter rather than
-        // the LLM. Checked first since it's a focused, full-screen mode.
-        if teleprompterService.isActive, teleprompterService.handleVoiceCommand(text) {
-            print("📜 Teleprompter command handled: \(text)")
-            await resumeListeningOrReturnToWakeWord()
-            return
-        }
-
-        // HUD task control (Display Phase 3 / Plan X): while a Now/Next card is on the
-        // glasses, "next/done/skip/back" drive the task instead of going to the LLM.
-        // Checked before intent classification so these short commands aren't filtered.
-        if await hudRouter.handleVoiceCommand(text) {
-            print("🎯 HUD task command handled: \(text)")
-            await resumeListeningOrReturnToWakeWord()
-            return
-        }
-
-        // HUD launcher voice nav (Display Phase 4 / Plan Y): while a menu is open, a spoken
-        // item label (or "back"/"close") selects it. Checked before the open command so
-        // saying a leaf name inside the menu navigates instead of re-opening the root.
-        if hudLauncher.handleVoiceSelection(text) {
-            print("🎛 HUD launcher voice selection: \(text)")
-            await resumeListeningOrReturnToWakeWord()
-            return
-        }
-
-        // HUD launcher (Display Phase 4 / Plan Y): "menu" opens the band-navigable launcher.
-        if HUDLauncher.isOpenCommand(text), hudLauncher.hasContent {
-            print("🎛 HUD launcher opened")
-            hudLauncher.open()
-            await resumeListeningOrReturnToWakeWord()
+        // Pre-LLM voice-command chain (Plan BG P2): teleprompter, HUD task card, HUD launcher
+        // selection/open, and the intent-ignore filter each get first crack at the transcript. The
+        // first one that consumes it drives its own mode and short-circuits before the LLM. Order
+        // matters and is preserved from the original if-ladder (see `preLLMHandlers`).
+        if await ConversationFlowEngine(handlers: preLLMHandlers()).route(text) != nil {
             return
         }
 
         // Will be updated below if persona detected in text
         var query = text
-
-        // Intent classification — filter bystander/filler speech
-        if intentClassifier.isEnabled && !isPhotoCommand(text) && !isStopCommand(text) && !isGoodbyeCommand(text) {
-            let intent = await intentClassifier.classify(transcript: text)
-            if intent == .ignore {
-                print("🚫 Intent classifier: IGNORE — not responding")
-                await resumeListeningOrReturnToWakeWord()
-                return
-            }
-        }
 
         // Check for persona names in the transcription (for Action Button / push-to-talk mode)
         // e.g. "Hey Claude, what's the weather" → activate Claude persona, strip prefix.

--- a/OpenGlasses/Sources/Services/Flow/ConversationFlowEngine.swift
+++ b/OpenGlasses/Sources/Services/Flow/ConversationFlowEngine.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// One pre-LLM voice-command handler in the ordered chain (Plan BG P2).
+///
+/// A handler inspects the transcript and, if it applies, performs its side effect (drive the
+/// teleprompter, a HUD card, the launcher, filter bystander speech, …) and reports that it consumed
+/// the turn. Consuming the turn stops the flow before the LLM is ever called. Handlers capture the
+/// live `AppState` in their closure, so the engine needs no wide protocol seam over it.
+struct VoiceCommandHandler {
+    /// Short identifier for logging / tests (e.g. "teleprompter", "intent-ignore").
+    let label: String
+    /// Inspect `text`; return `true` if this handler consumed the turn (flow stops), else `false`.
+    let handle: (_ text: String) async -> Bool
+}
+
+/// Runs the ordered pre-LLM voice-command chain: the first handler that consumes the transcript
+/// wins, and no later handler runs. If none consume it, the transcript falls through to the LLM.
+///
+/// This is the deterministic core of the conversation flow's routing decision — pure orchestration
+/// over injected handlers, so it is unit-testable with mock handlers even though the real handlers
+/// drive device-only services.
+struct ConversationFlowEngine {
+    let handlers: [VoiceCommandHandler]
+
+    /// Route `text` through the chain. Returns the `label` of the handler that consumed the turn,
+    /// or `nil` if none did (the caller then proceeds to the LLM path).
+    func route(_ text: String) async -> String? {
+        for handler in handlers {
+            if await handler.handle(text) {
+                return handler.label
+            }
+        }
+        return nil
+    }
+}

--- a/OpenGlassesTests/ConversationFlowEngineTests.swift
+++ b/OpenGlassesTests/ConversationFlowEngineTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan BG P2 — the pure routing core of the conversation flow: an ordered `VoiceCommandHandler`
+/// chain where the first handler to consume the transcript wins and short-circuits the rest.
+final class ConversationFlowEngineTests: XCTestCase {
+
+    /// Records which handlers ran, in order, so we can assert short-circuiting.
+    private func recordingHandler(_ label: String, consumes: Bool, into log: Box<[String]>) -> VoiceCommandHandler {
+        VoiceCommandHandler(label: label) { _ in
+            log.value.append(label)
+            return consumes
+        }
+    }
+
+    func testFirstConsumingHandlerWinsAndShortCircuits() async {
+        let ran = Box<[String]>([])
+        let engine = ConversationFlowEngine(handlers: [
+            recordingHandler("a", consumes: false, into: ran),
+            recordingHandler("b", consumes: true, into: ran),
+            recordingHandler("c", consumes: true, into: ran),   // must never run
+        ])
+        let consumed = await engine.route("hello")
+        XCTAssertEqual(consumed, "b")
+        XCTAssertEqual(ran.value, ["a", "b"], "handlers run in order; nothing after the winner runs")
+    }
+
+    func testNoHandlerConsumesReturnsNil() async {
+        let ran = Box<[String]>([])
+        let engine = ConversationFlowEngine(handlers: [
+            recordingHandler("a", consumes: false, into: ran),
+            recordingHandler("b", consumes: false, into: ran),
+        ])
+        let consumed = await engine.route("weather?")
+        XCTAssertNil(consumed, "nothing consumed → caller proceeds to the LLM")
+        XCTAssertEqual(ran.value, ["a", "b"], "every handler is offered the transcript")
+    }
+
+    func testEmptyChainReturnsNil() async {
+        let consumed = await ConversationFlowEngine(handlers: []).route("anything")
+        XCTAssertNil(consumed)
+    }
+
+    func testFirstHandlerCanWinImmediately() async {
+        let ran = Box<[String]>([])
+        let engine = ConversationFlowEngine(handlers: [
+            recordingHandler("first", consumes: true, into: ran),
+            recordingHandler("second", consumes: true, into: ran),
+        ])
+        let consumed = await engine.route("next")
+        XCTAssertEqual(consumed, "first")
+        XCTAssertEqual(ran.value, ["first"], "the rest of the chain is skipped")
+    }
+
+    func testHandlerReceivesTheTranscript() async {
+        var seen: String?
+        let engine = ConversationFlowEngine(handlers: [
+            VoiceCommandHandler(label: "capture") { text in seen = text; return true }
+        ])
+        _ = await engine.route("open the menu")
+        XCTAssertEqual(seen, "open the menu")
+    }
+}


### PR DESCRIPTION
**Plan BG, Phase 2 — introduces the `ConversationFlowEngine`.** This lands P2's named abstraction (an ordered `[VoiceCommandHandler]` chain + a testable engine) and migrates the pre-LLM handler ladder onto it, giving the conversation-flow spine its first unit tests. Faithful code-motion — no behaviour change.

## Why this shape (and not a wholesale move)
An inventory of the flow methods showed the full extraction would need a ~40-member protocol over `AppState` plus 19 injected services — a huge, error-prone seam to move blind (this is the untested, device-only voice loop, which I can't verify on-glasses here). That's the opposite of the house style. The plan's actual design — handlers as an ordered chain — is extractable *safely*: each handler is a closure that captures `AppState` (so no wide protocol), and the engine is a pure iterator that's unit-testable with mocks.

## What changed
New `Sources/Services/Flow/ConversationFlowEngine.swift`:
- **`VoiceCommandHandler`** — `{ label, handle: (String) async -> Bool }`. A handler inspects the transcript, and if it applies, drives its mode + resumes listening and reports it consumed the turn.
- **`ConversationFlowEngine.route(_:)`** — runs the chain in order; the first handler to consume wins and short-circuits the rest; returns the winner's label or `nil` (→ proceed to the LLM).

`AppState.handleTranscription` now builds the chain via `preLLMHandlers()` and replaces the five copy-pasted `if X { … return }` blocks (teleprompter → HUD task → HUD launcher select → launcher open → intent-ignore) with one `if await ConversationFlowEngine(handlers: preLLMHandlers()).route(text) != nil { return }`. Each handler body is the **verbatim** logic from the old ladder (same order, same checks, same `resumeListeningOrReturnToWakeWord()` side effect), just relocated into the chain.

The interleaved persona-detection + conversation-store step and the post-store handlers (stop / goodbye / photo) and the normal-LLM turn are left inline for now — they'll fold onto the chain in follow-up increments, each independently gated.

## Tests
`OpenGlassesTests/ConversationFlowEngineTests.swift` (5 tests): in-order execution, first-consumer-wins short-circuit, no-consumer → nil (→ LLM), empty chain, and transcript pass-through. The spine's routing decision now has real regression coverage for the first time.

## Gates
- `build-for-testing` ✅
- full suite ✅ — **1518 tests, 0 failures** (xcodebuild exit 0)
- Release build (`-configuration Release … CODE_SIGNING_ALLOWED=NO`) ✅

Device-sensitive (live voice loop). The engine + its tests are headless; the handler bodies are unchanged logic, so behaviour is preserved by construction — but the on-glasses path isn't re-verified on hardware here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
