### PR TITLE
BG P5: @UserDefaultsBacked property wrapper + first toggle cohort

### DIFF
--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -1414,13 +1414,9 @@ struct Config {
     }
 
     /// Whether to show all quick actions on the Voice tab, or only the top 4.
-    static var showAllQuickActions: Bool {
-        UserDefaults.standard.bool(forKey: "showAllQuickActions")
-    }
+    @UserDefaultsBacked("showAllQuickActions", default: false) static var showAllQuickActions: Bool
 
-    static func setShowAllQuickActions(_ show: Bool) {
-        UserDefaults.standard.set(show, forKey: "showAllQuickActions")
-    }
+    static func setShowAllQuickActions(_ show: Bool) { showAllQuickActions = show }
 
     // MARK: - OpenClaw Configuration
 
@@ -1962,13 +1958,9 @@ struct Config {
     // MARK: - Audio-Only Mode
 
     /// When enabled, disables video frame streaming to save battery. Voice still works.
-    static var audioOnlyMode: Bool {
-        UserDefaults.standard.bool(forKey: "audioOnlyMode")
-    }
+    @UserDefaultsBacked("audioOnlyMode", default: false) static var audioOnlyMode: Bool
 
-    static func setAudioOnlyMode(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: "audioOnlyMode")
-    }
+    static func setAudioOnlyMode(_ enabled: Bool) { audioOnlyMode = enabled }
 
     // MARK: - Glasses Display (in-lens HUD)
 
@@ -1987,13 +1979,9 @@ struct Config {
     /// When on, the assistant offers a spoken nudge after you state a durable fact or repeat a
     /// multi-step request ("say 'remember it'" / "save that as a skill"). Off by default. When
     /// Agent Mode is also on, those are auto-saved silently instead of nudged.
-    static var memoryNudgesEnabled: Bool {
-        UserDefaults.standard.bool(forKey: "memoryNudgesEnabled")
-    }
+    @UserDefaultsBacked("memoryNudgesEnabled", default: false) static var memoryNudgesEnabled: Bool
 
-    static func setMemoryNudgesEnabled(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: "memoryNudgesEnabled")
-    }
+    static func setMemoryNudgesEnabled(_ enabled: Bool) { memoryNudgesEnabled = enabled }
 
     // MARK: - Teleprompter
 
@@ -2302,38 +2290,26 @@ struct Config {
     /// and Siri speaks the answer hands-free (OpenGlasses normally stays running to
     /// listen for wake words). Users whose app gets killed and see "OpenGlasses is
     /// not running" can enable this for reliability at the cost of launching the app.
-    static var siriAskOpensApp: Bool {
-        UserDefaults.standard.bool(forKey: "siriAskOpensApp")
-    }
+    @UserDefaultsBacked("siriAskOpensApp", default: false) static var siriAskOpensApp: Bool
 
-    static func setSiriAskOpensApp(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: "siriAskOpensApp")
-    }
+    static func setSiriAskOpensApp(_ enabled: Bool) { siriAskOpensApp = enabled }
 
     // MARK: - Silent Mode
 
     /// When enabled, the wake word listener is off but the agent is still actionable
     /// via the watch, widget quick actions, Action Button, and manual mic tap.
     /// Scheduled agent tasks still run in the background.
-    static var silentMode: Bool {
-        UserDefaults.standard.bool(forKey: "silentMode")
-    }
+    @UserDefaultsBacked("silentMode", default: false) static var silentMode: Bool
 
-    static func setSilentMode(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: "silentMode")
-    }
+    static func setSilentMode(_ enabled: Bool) { silentMode = enabled }
 
     // MARK: - Glasses-Only Audio
 
     /// When true, agent TTS and notification sounds are silenced if glasses are not connected.
     /// When false (default), audio plays through the phone speaker even without glasses.
-    static var glassesOnlyAudio: Bool {
-        UserDefaults.standard.bool(forKey: "glassesOnlyAudio")
-    }
+    @UserDefaultsBacked("glassesOnlyAudio", default: false) static var glassesOnlyAudio: Bool
 
-    static func setGlassesOnlyAudio(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: "glassesOnlyAudio")
-    }
+    static func setGlassesOnlyAudio(_ enabled: Bool) { glassesOnlyAudio = enabled }
 
 // MARK: - Auto-Sleep
 
@@ -2440,23 +2416,15 @@ struct Config {
 
     /// Developer-only: run the local MCP glasses HTTP server (Plan E). Only effective when
     /// `agentModeEnabled` is also on.
-    static var mcpServerEnabled: Bool {
-        UserDefaults.standard.bool(forKey: "mcpServerEnabled")
-    }
+    @UserDefaultsBacked("mcpServerEnabled", default: false) static var mcpServerEnabled: Bool
 
-    static func setMCPServerEnabled(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: "mcpServerEnabled")
-    }
+    static func setMCPServerEnabled(_ enabled: Bool) { mcpServerEnabled = enabled }
 
     /// Master toggle for the Accessibility Tier (A1 Reading Accessibility). When off, the
     /// ReadingAccessibilityTool is not registered.
-    static var accessibilityModeEnabled: Bool {
-        UserDefaults.standard.bool(forKey: "accessibilityModeEnabled")
-    }
+    @UserDefaultsBacked("accessibilityModeEnabled", default: false) static var accessibilityModeEnabled: Bool
 
-    static func setAccessibilityModeEnabled(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: "accessibilityModeEnabled")
-    }
+    static func setAccessibilityModeEnabled(_ enabled: Bool) { accessibilityModeEnabled = enabled }
 
     /// Master toggle for the Field Assist feature. When off, no vaults are loaded
     /// and the FieldSessionTool is not registered.

--- a/OpenGlasses/Sources/Utils/UserDefaultsBacked.swift
+++ b/OpenGlasses/Sources/Utils/UserDefaultsBacked.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// A `UserDefaults`-backed value with an explicit default (Plan BG P5).
+///
+/// Replaces the repeated `static var x: Bool { UserDefaults.standard.bool(forKey: "x") }` getter +
+/// `setX(_:)` setter boilerplate that `Config` carries hundreds of times. For a `Bool` toggle the
+/// default is `false`, matching `UserDefaults.bool(forKey:)` for an absent key; the stored value is
+/// an `NSNumber`, so `object(forKey:) as? Bool` reads back exactly what the old getter did.
+///
+/// `Config` keeps its `setX(_:)` functions as thin façades over the wrapped property, so existing
+/// call sites (which use `Config.setX(v)`) are unchanged and any side effects in those setters are
+/// preserved.
+@propertyWrapper
+struct UserDefaultsBacked<Value> {
+    let key: String
+    let defaultValue: Value
+    let store: UserDefaults
+
+    init(_ key: String, default defaultValue: Value, store: UserDefaults = .standard) {
+        self.key = key
+        self.defaultValue = defaultValue
+        self.store = store
+    }
+
+    var wrappedValue: Value {
+        get { store.object(forKey: key) as? Value ?? defaultValue }
+        set { store.set(newValue, forKey: key) }
+    }
+}

--- a/OpenGlassesTests/ConfigDefaultsTests.swift
+++ b/OpenGlassesTests/ConfigDefaultsTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan BG P5 — pins the key, default, and round-trip for each `Config` toggle migrated to
+/// `@UserDefaultsBacked`. A wrong key or default in the wrapper is a *silent* behaviour change,
+/// so these guard the migration: each assertion ties the property to its exact UserDefaults key.
+final class ConfigDefaultsTests: XCTestCase {
+
+    private let keys = [
+        "silentMode", "glassesOnlyAudio", "audioOnlyMode", "memoryNudgesEnabled",
+        "showAllQuickActions", "siriAskOpensApp", "mcpServerEnabled", "accessibilityModeEnabled",
+    ]
+
+    override func setUp() {
+        super.setUp()
+        keys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
+    }
+
+    override func tearDown() {
+        keys.forEach { UserDefaults.standard.removeObject(forKey: $0) }
+        super.tearDown()
+    }
+
+    /// Absent key → `false`, matching the legacy `UserDefaults.bool(forKey:)` getter.
+    func testDefaultsAreFalse() {
+        XCTAssertFalse(Config.silentMode)
+        XCTAssertFalse(Config.glassesOnlyAudio)
+        XCTAssertFalse(Config.audioOnlyMode)
+        XCTAssertFalse(Config.memoryNudgesEnabled)
+        XCTAssertFalse(Config.showAllQuickActions)
+        XCTAssertFalse(Config.siriAskOpensApp)
+        XCTAssertFalse(Config.mcpServerEnabled)
+        XCTAssertFalse(Config.accessibilityModeEnabled)
+    }
+
+    /// Each `setX` façade writes the property, and it round-trips through the exact legacy key.
+    func testSettersRoundTripThroughTheCorrectKey() {
+        assertRoundTrip("silentMode", set: Config.setSilentMode, get: { Config.silentMode })
+        assertRoundTrip("glassesOnlyAudio", set: Config.setGlassesOnlyAudio, get: { Config.glassesOnlyAudio })
+        assertRoundTrip("audioOnlyMode", set: Config.setAudioOnlyMode, get: { Config.audioOnlyMode })
+        assertRoundTrip("memoryNudgesEnabled", set: Config.setMemoryNudgesEnabled, get: { Config.memoryNudgesEnabled })
+        assertRoundTrip("showAllQuickActions", set: Config.setShowAllQuickActions, get: { Config.showAllQuickActions })
+        assertRoundTrip("siriAskOpensApp", set: Config.setSiriAskOpensApp, get: { Config.siriAskOpensApp })
+        assertRoundTrip("mcpServerEnabled", set: Config.setMCPServerEnabled, get: { Config.mcpServerEnabled })
+        assertRoundTrip("accessibilityModeEnabled", set: Config.setAccessibilityModeEnabled, get: { Config.accessibilityModeEnabled })
+    }
+
+    /// A raw value written under the legacy key (as the old setter did) is read by the new property —
+    /// proves the wrapper's key is unchanged, so previously-persisted user settings survive.
+    func testLegacyPersistedValuesStillRead() {
+        UserDefaults.standard.set(true, forKey: "silentMode")
+        XCTAssertTrue(Config.silentMode)
+        UserDefaults.standard.set(true, forKey: "accessibilityModeEnabled")
+        XCTAssertTrue(Config.accessibilityModeEnabled)
+    }
+
+    private func assertRoundTrip(_ key: String, set: (Bool) -> Void, get: () -> Bool,
+                                 file: StaticString = #file, line: UInt = #line) {
+        set(true)
+        XCTAssertTrue(get(), "\(key) should read true after set(true)", file: file, line: line)
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: key), "\(key) must persist under its exact key", file: file, line: line)
+        set(false)
+        XCTAssertFalse(get(), "\(key) should read false after set(false)", file: file, line: line)
+    }
+}


### PR DESCRIPTION
**Plan BG, Phase 5 — introduces the `@UserDefaultsBacked` property wrapper** and migrates the first cohort of `Config` toggles onto it. Independent of the P2 stack; no behaviour change.

## What changed
New `Sources/Utils/UserDefaultsBacked.swift` — a small property wrapper that replaces `Config`'s repeated
```swift
static var x: Bool { UserDefaults.standard.bool(forKey: "x") }
static func setX(_ v: Bool) { UserDefaults.standard.set(v, forKey: "x") }
```
boilerplate with `@UserDefaultsBacked("x", default: false) static var x: Bool`.

Migrated 8 verified-pure `Bool` toggles: `silentMode`, `glassesOnlyAudio`, `audioOnlyMode`, `memoryNudgesEnabled`, `showAllQuickActions`, `siriAskOpensApp`, `mcpServerEnabled`, `accessibilityModeEnabled`.

**Call sites are unchanged**: each `setX(_:)` stays as a thin façade (`{ x = v }`) over the wrapped property, so every `Config.setX(v)` caller is untouched — and any setter with side effects (e.g. `setOfflineModeEnabled`, which also edits `disabledTools`) was deliberately **left out** of this cohort so its façade wouldn't need special handling. The stored key and `false` default are identical to the old getter, so previously-persisted user settings read back unchanged.

## Tests
`OpenGlassesTests/ConfigDefaultsTests.swift` pins, for each migrated toggle: the default (`false` when absent), the setter round-trip **through the exact legacy UserDefaults key**, and that a value persisted under the old key is still read. A wrong key or default in the wrapper — the only real risk here, since it'd be a *silent* behaviour change — fails CI.

## Gates
- `build-for-testing` ✅
- full suite ✅ — **1516 tests, 0 failures** (exit 0)
- Release build (`-configuration Release … CODE_SIGNING_ALLOWED=NO`) ✅

Establishes the P5 mechanism; the remaining simple toggles can fold onto it in follow-up increments (each pinned the same way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
