### PR TITLE
BG P2 complete: post-store command chain, cancellable typed turns, wake-start sequence

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2252,25 +2252,18 @@ class AppState: ObservableObject, AppStateProtocol {
     func handleWakeWordDetected(manual: Bool = false) async {
         print("🎤 \(manual ? "Tap-to-talk" : "Wake word") detected! Starting conversation...")
         manuallyTriggered = manual
-        inConversation = true
-
-        // Ensure audio session + engine are alive BEFORE marking ourselves as listening.
-        // Tap-to-talk calls stopListening() first (engine = nil), and startListening()
-        // bails on `guard !isListening`, so setting isListening early would leave the shared
-        // engine dead and force TranscriptionService onto a fragile fallback engine.
-        wakeWordService.configureAudioSession()
-        try? await wakeWordService.ensureAudioEngineRunning()
-        isListening = true
-
-        // Snapshot what's playing before pausing it
-        nowPlayingAtStart = NowPlayingSnapshot.current()
-
-        // Pause podcasts/music so the user can speak clearly (skips if call in progress)
-        wakeWordService.pauseOtherAudio()
-
-        speechService.playAcknowledgmentTone()
-        transcriptionService.startRecording()
-        updateLiveActivity()
+        // The engine-before-listening ordering lives (tested) in ConversationStartSequence.
+        await ConversationStartSequence.run(.init(
+            beginConversation: { [self] in inConversation = true },
+            configureAudioSession: { [self] in wakeWordService.configureAudioSession() },
+            ensureAudioEngineRunning: { [self] in try await wakeWordService.ensureAudioEngineRunning() },
+            markListening: { [self] in isListening = true },
+            snapshotNowPlaying: { [self] in nowPlayingAtStart = NowPlayingSnapshot.current() },
+            pauseOtherAudio: { [self] in wakeWordService.pauseOtherAudio() },
+            playAcknowledgmentTone: { [self] in speechService.playAcknowledgmentTone() },
+            startRecording: { [self] in transcriptionService.startRecording() },
+            updateLiveActivity: { [self] in updateLiveActivity() }
+        ))
     }
 
     // MARK: - Voice Commands
@@ -2348,6 +2341,102 @@ class AppState: ObservableObject, AppStateProtocol {
                 guard await self.intentClassifier.classify(transcript: text) == .ignore else { return false }
                 print("🚫 Intent classifier: IGNORE — not responding")
                 await self.resumeListeningOrReturnToWakeWord()
+                return true
+            },
+        ]
+    }
+
+    /// The post-store voice-command chain (Plan BG P2): stop, goodbye, and photo. These run after
+    /// the user's turn is persisted to the conversation store and after persona detection, so the
+    /// photo handler prompts the LLM with the persona-stripped `query` while command matching uses
+    /// the raw transcript. Same first-consumer-wins contract as `preLLMHandlers`.
+    private func postStoreHandlers(query: String) -> [VoiceCommandHandler] {
+        [
+            // "stop" — interrupt TTS, stay in conversation
+            VoiceCommandHandler(label: "stop") { [weak self] text in
+                guard let self, self.isStopCommand(text) else { return false }
+                print("🛑 Voice command: stop")
+                self.speechService.stopSpeaking()
+                if self.inConversation { print("💬 Stopped — listening for next question...") }
+                await self.resumeListeningOrReturnToWakeWord()
+                return true
+            },
+            // "goodbye" — end conversation, back to wake word
+            VoiceCommandHandler(label: "goodbye") { [weak self] text in
+                guard let self, self.isGoodbyeCommand(text) else { return false }
+                print("👋 Voice command: goodbye")
+                self.speechService.stopSpeaking()
+                self.inConversation = false
+                self.lastResponse = "Goodbye!"
+                await self.speechService.speak("Goodbye!")
+                await self.returnToWakeWord()
+                return true
+            },
+            // "take a picture" — capture photo from glasses camera, describe via the vision LLM
+            VoiceCommandHandler(label: "photo") { [weak self] text in
+                guard let self, self.isPhotoCommand(text) else { return false }
+                print("📸 Voice command: take a picture")
+                self.isProcessing = true
+                // Start capture immediately — play the shutter tone, no spoken "taking a picture"
+                self.speechService.playAcknowledgmentTone()
+                self.speechService.startThinkingSound()
+
+                self.currentLLMTask = Task {
+                    await ConversationTurnRunner.run(.init(
+                        send: {
+                            // Capture and send to LLM concurrently — no extra round-trip speech
+                            let photoData = try await self.cameraService.capturePhoto()
+                            try Task.checkCancellation()
+                            // Restore audio for wake word after camera capture (camera reconfigures for Bluetooth)
+                            self.cameraService.restoreAudioForWakeWord()
+                            self.cameraService.saveToPhotoLibrary(photoData)
+                            print("📸 Photo captured, sending to LLM with prompt: \(query)")
+
+                            return try await self.llmService.sendMessage(
+                                query,
+                                locationContext: self.locationService.locationContext,
+                                imageData: photoData,
+                                memoryContext: Config.userMemoryEnabled ? self.userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? query : nil) : nil
+                            )
+                        },
+                        postProcess: { rawResponse in
+                            Config.userMemoryEnabled ? self.userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse
+                        },
+                        accept: { response in
+                            self.lastResponse = response
+                            if Config.conversationPersistenceEnabled {
+                                self.conversationStore.appendMessage(role: "assistant", content: response)
+                            }
+                            print("🤖 \(self.llmService.activeModelName) (vision): \(response)")
+
+                            // If an audio or video recording is active, inject the description
+                            // into the caption history so the meeting assistant has visual context.
+                            if self.audioRecorder.isRecording || self.videoRecorder.isRecording {
+                                self.ambientCaptions.insertVisualNote(response)
+                            }
+                        },
+                        speak: { response in
+                            // Start wake word listener during TTS so user can say "stop"
+                            self.startStopListener()
+                            await self.speechService.speak(response)
+                            self.stopStopListener()
+                        },
+                        onCancelled: {
+                            print("🛑 Photo/LLM task cancelled")
+                        },
+                        onError: { error in
+                            self.cameraService.restoreAudioForWakeWord()
+                            print("📸 Photo capture failed: \(error)")
+                            self.lastResponse = "Photo failed: \(error.localizedDescription)"
+                            await self.speechService.speak("Sorry, I couldn't take a photo or process the image. \(error.localizedDescription)")
+                        },
+                        finish: {
+                            self.isProcessing = false
+                            self.speechService.stopThinkingSound()
+                            await self.resumeListeningOrReturnToWakeWord(ensureEngine: true)
+                        }
+                    ))
+                }
                 return true
             },
         ]
@@ -2487,90 +2576,11 @@ class AppState: ObservableObject, AppStateProtocol {
             conversationStore.appendMessage(role: "user", content: text)
         }
 
-        // Voice command: "stop" — interrupt TTS, stay in conversation
-        if isStopCommand(text) {
-            print("🛑 Voice command: stop")
-            speechService.stopSpeaking()
-            if inConversation { print("💬 Stopped — listening for next question...") }
-            await resumeListeningOrReturnToWakeWord()
-            return
-        }
-
-        // Voice command: "goodbye" — end conversation, back to wake word
-        if isGoodbyeCommand(text) {
-            print("👋 Voice command: goodbye")
-            speechService.stopSpeaking()
-            inConversation = false
-            lastResponse = "Goodbye!"
-            await speechService.speak("Goodbye!")
-            await returnToWakeWord()
-            return
-        }
-
-        // Voice command: "take a picture" — capture photo from glasses camera
-        if isPhotoCommand(text) {
-            print("📸 Voice command: take a picture")
-            isProcessing = true
-            // Start capture immediately — play the shutter tone, no spoken "taking a picture"
-            speechService.playAcknowledgmentTone()
-            speechService.startThinkingSound()
-
-            currentLLMTask = Task {
-                await ConversationTurnRunner.run(.init(
-                    send: { [self] in
-                        // Capture and send to LLM concurrently — no extra round-trip speech
-                        let photoData = try await cameraService.capturePhoto()
-                        try Task.checkCancellation()
-                        // Restore audio for wake word after camera capture (camera reconfigures for Bluetooth)
-                        cameraService.restoreAudioForWakeWord()
-                        cameraService.saveToPhotoLibrary(photoData)
-                        print("📸 Photo captured, sending to LLM with prompt: \(query)")
-
-                        return try await llmService.sendMessage(
-                            query,
-                            locationContext: locationService.locationContext,
-                            imageData: photoData,
-                            memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? query : nil) : nil
-                        )
-                    },
-                    postProcess: { [self] rawResponse in
-                        Config.userMemoryEnabled ? userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse
-                    },
-                    accept: { [self] response in
-                        lastResponse = response
-                        if Config.conversationPersistenceEnabled {
-                            conversationStore.appendMessage(role: "assistant", content: response)
-                        }
-                        print("🤖 \(llmService.activeModelName) (vision): \(response)")
-
-                        // If an audio or video recording is active, inject the description
-                        // into the caption history so the meeting assistant has visual context.
-                        if audioRecorder.isRecording || videoRecorder.isRecording {
-                            ambientCaptions.insertVisualNote(response)
-                        }
-                    },
-                    speak: { [self] response in
-                        // Start wake word listener during TTS so user can say "stop"
-                        startStopListener()
-                        await speechService.speak(response)
-                        stopStopListener()
-                    },
-                    onCancelled: {
-                        print("🛑 Photo/LLM task cancelled")
-                    },
-                    onError: { [self] error in
-                        cameraService.restoreAudioForWakeWord()
-                        print("📸 Photo capture failed: \(error)")
-                        lastResponse = "Photo failed: \(error.localizedDescription)"
-                        await speechService.speak("Sorry, I couldn't take a photo or process the image. \(error.localizedDescription)")
-                    },
-                    finish: { [self] in
-                        isProcessing = false
-                        speechService.stopThinkingSound()
-                        await resumeListeningOrReturnToWakeWord(ensureEngine: true)
-                    }
-                ))
-            }
+        // Post-store voice-command chain (Plan BG P2): stop, goodbye, photo. Runs after the user
+        // turn is persisted (so "stop"/"goodbye" still appear in the thread) and after persona
+        // detection (the photo prompt uses the persona-stripped `query`). The first consumer
+        // short-circuits before the LLM; order is preserved from the original if-ladder.
+        if await ConversationFlowEngine(handlers: postStoreHandlers(query: query)).route(text) != nil {
             return
         }
 
@@ -2769,56 +2779,74 @@ class AppState: ObservableObject, AppStateProtocol {
         let streamThreadId = conversationStore.activeThreadId
         if let streamThreadId { streamingTurn = StreamingTurn(threadId: streamThreadId, text: "") }
 
-        do {
-            // Use provided image, or fall back to smart camera if no image attached
-            let image: Data?
-            if let imageData {
-                image = imageData
-            } else {
-                image = await smartCameraImageData(for: query)
-            }
-            let rawResponse = try await llmService.sendMessage(
-                query,
-                locationContext: locationService.locationContext,
-                imageData: image,
-                memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? query : nil) : nil,
-                playbookContext: playbookStore.playbookContext(),
-                shortcutsContext: ShortcutsCatalog.shared.promptBlock(),
-                onToken: { [weak self] chunk in
-                    guard let self, let id = streamThreadId else { return }
-                    if self.streamingTurn?.threadId == id { self.streamingTurn?.text += chunk }
+        // Typed turns run the same skeleton as voice turns, tracked in `currentLLMTask` so
+        // barge-in / cancel stops a typed turn too (Plan BG P2: every turn is cancellable).
+        // Awaited so callers (Siri intent, askUnderPersona) still see the turn complete.
+        let turn = Task {
+            await ConversationTurnRunner.run(.init(
+                send: { [self] in
+                    // Use provided image, or fall back to smart camera if no image attached
+                    let image: Data?
+                    if let imageData {
+                        image = imageData
+                    } else {
+                        image = await smartCameraImageData(for: query)
+                    }
+                    return try await llmService.sendMessage(
+                        query,
+                        locationContext: locationService.locationContext,
+                        imageData: image,
+                        memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? query : nil) : nil,
+                        playbookContext: playbookStore.playbookContext(),
+                        shortcutsContext: ShortcutsCatalog.shared.promptBlock(),
+                        onToken: { [weak self] chunk in
+                            guard let self, let id = streamThreadId else { return }
+                            if self.streamingTurn?.threadId == id { self.streamingTurn?.text += chunk }
+                        }
+                    )
+                },
+                postProcess: { [self] rawResponse in
+                    Config.userMemoryEnabled ? userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse
+                },
+                accept: { [self] response in
+                    lastResponse = response
+                    streamingTurn = nil  // clear before persisting so the live bubble doesn't duplicate the saved message
+
+                    if Config.conversationPersistenceEnabled {
+                        conversationStore.appendMessage(role: "assistant", content: response)
+                    }
+
+                    // Memory loop (Phase 3): spot a durable fact or a repeated multi-step request and
+                    // offer to remember it (or silently save it in Agent Mode).
+                    MemoryLoopService.shared.observeTurn(userText: query, assistantText: response,
+                                                         toolNames: nativeToolRouter.takeTurnToolNames())
+                },
+                speak: { [self] response in
+                    // Speak the response (user can still say "stop")
+                    guard speakResponse else { return }
+                    startStopListener()
+                    await speechService.speak(response)
+                    stopStopListener()
+                },
+                onCancelled: { [self] in
+                    streamingTurn = nil
+                    print("🛑 Text turn cancelled")
+                },
+                onError: { [self] error in
+                    streamingTurn = nil
+                    errorMessage = "Failed to get response: \(error.localizedDescription)"
+                    if speakResponse {
+                        await speechService.speak("Sorry, I encountered an error.")
+                    }
+                },
+                finish: { [self] in
+                    isProcessing = false
+                    speechService.stopThinkingSound()
                 }
-            )
-
-            let response = Config.userMemoryEnabled ? userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse
-            lastResponse = response
-            streamingTurn = nil  // clear before persisting so the live bubble doesn't duplicate the saved message
-
-            if Config.conversationPersistenceEnabled {
-                conversationStore.appendMessage(role: "assistant", content: response)
-            }
-
-            // Memory loop (Phase 3): spot a durable fact or a repeated multi-step request and
-            // offer to remember it (or silently save it in Agent Mode).
-            MemoryLoopService.shared.observeTurn(userText: query, assistantText: response,
-                                                 toolNames: nativeToolRouter.takeTurnToolNames())
-
-            // Speak the response (user can still say "stop")
-            if speakResponse {
-                startStopListener()
-                await speechService.speak(response)
-                stopStopListener()
-            }
-        } catch {
-            streamingTurn = nil
-            errorMessage = "Failed to get response: \(error.localizedDescription)"
-            if speakResponse {
-                await speechService.speak("Sorry, I encountered an error.")
-            }
+            ))
         }
-
-        isProcessing = false
-        speechService.stopThinkingSound()
+        currentLLMTask = turn
+        await turn.value
     }
 
     /// Run a one-shot query under a specific persona, then restore the prior

--- a/OpenGlasses/Sources/Services/Flow/ConversationStartSequence.swift
+++ b/OpenGlasses/Sources/Services/Flow/ConversationStartSequence.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// The wake-word / tap-to-talk conversation-start choreography (Plan BG P2): mark the conversation
+/// active, bring the audio session + engine up, only then mark ourselves listening, snapshot and
+/// pause other audio, acknowledge, start recording, refresh the Live Activity.
+///
+/// The ordering is load-bearing and has bitten before: the audio session + engine must be alive
+/// BEFORE `markListening`. Tap-to-talk calls `stopListening()` first (engine = nil), and
+/// `startListening()` bails on `guard !isListening`, so marking listening early leaves the shared
+/// engine dead and forces `TranscriptionService` onto a fragile fallback engine. The stages are
+/// injected as `@MainActor` closures capturing the live `AppState` (same seam pattern as
+/// `ConversationTurnRunner`), so unit tests lock the order with recorder closures.
+enum ConversationStartSequence {
+
+    struct Deps {
+        /// Mark the conversation active (`inConversation = true`).
+        let beginConversation: @MainActor () -> Void
+        /// Configure the shared audio session for recording.
+        let configureAudioSession: @MainActor () -> Void
+        /// Bring the shared audio engine up. Failure must not abort the start — the
+        /// transcription path has its own fallback engine.
+        let ensureAudioEngineRunning: @MainActor () async throws -> Void
+        /// Mark ourselves listening (`isListening = true`) — only after the engine is up.
+        let markListening: @MainActor () -> Void
+        /// Snapshot what's playing before pausing it.
+        let snapshotNowPlaying: @MainActor () -> Void
+        /// Pause podcasts/music so the user can speak clearly (skips if call in progress).
+        let pauseOtherAudio: @MainActor () -> Void
+        /// Play the acknowledgment tone.
+        let playAcknowledgmentTone: @MainActor () -> Void
+        /// Start transcribing the user's turn.
+        let startRecording: @MainActor () -> Void
+        /// Push the new state to the Live Activity.
+        let updateLiveActivity: @MainActor () -> Void
+    }
+
+    @MainActor
+    static func run(_ deps: Deps) async {
+        deps.beginConversation()
+        // Audio session + engine BEFORE marking ourselves as listening (see type comment).
+        deps.configureAudioSession()
+        try? await deps.ensureAudioEngineRunning()
+        deps.markListening()
+        deps.snapshotNowPlaying()
+        deps.pauseOtherAudio()
+        deps.playAcknowledgmentTone()
+        deps.startRecording()
+        deps.updateLiveActivity()
+    }
+}

--- a/OpenGlassesTests/ConversationStartSequenceTests.swift
+++ b/OpenGlassesTests/ConversationStartSequenceTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan BG P2 — the wake-word / tap-to-talk conversation-start choreography. The load-bearing
+/// invariant these tests lock: the audio session + engine come up BEFORE we mark ourselves
+/// listening (marking early left the shared engine dead on tap-to-talk and forced
+/// TranscriptionService onto its fragile fallback engine).
+@MainActor
+final class ConversationStartSequenceTests: XCTestCase {
+
+    private struct EngineError: Error {}
+
+    private func recordingDeps(into log: Box<[String]>, engineFails: Bool = false) -> ConversationStartSequence.Deps {
+        ConversationStartSequence.Deps(
+            beginConversation: { log.value.append("beginConversation") },
+            configureAudioSession: { log.value.append("configureAudioSession") },
+            ensureAudioEngineRunning: {
+                log.value.append("ensureAudioEngineRunning")
+                if engineFails { throw EngineError() }
+            },
+            markListening: { log.value.append("markListening") },
+            snapshotNowPlaying: { log.value.append("snapshotNowPlaying") },
+            pauseOtherAudio: { log.value.append("pauseOtherAudio") },
+            playAcknowledgmentTone: { log.value.append("playAcknowledgmentTone") },
+            startRecording: { log.value.append("startRecording") },
+            updateLiveActivity: { log.value.append("updateLiveActivity") }
+        )
+    }
+
+    private static let expectedOrder = [
+        "beginConversation",
+        "configureAudioSession",
+        "ensureAudioEngineRunning",
+        "markListening",
+        "snapshotNowPlaying",
+        "pauseOtherAudio",
+        "playAcknowledgmentTone",
+        "startRecording",
+        "updateLiveActivity",
+    ]
+
+    func testRunsStagesInExactOrder() async {
+        let log = Box<[String]>([])
+        await ConversationStartSequence.run(recordingDeps(into: log))
+        XCTAssertEqual(log.value, Self.expectedOrder)
+    }
+
+    /// The regression this seam exists to lock: the audio session + engine are brought up
+    /// strictly before `markListening` (and the now-playing snapshot happens before the pause).
+    func testEngineIsEnsuredBeforeListeningIsMarked() async {
+        let log = Box<[String]>([])
+        await ConversationStartSequence.run(recordingDeps(into: log))
+        let engineAt = log.value.firstIndex(of: "ensureAudioEngineRunning")
+        let listeningAt = log.value.firstIndex(of: "markListening")
+        let snapshotAt = log.value.firstIndex(of: "snapshotNowPlaying")
+        let pauseAt = log.value.firstIndex(of: "pauseOtherAudio")
+        XCTAssertNotNil(engineAt)
+        XCTAssertNotNil(listeningAt)
+        XCTAssertLessThan(engineAt!, listeningAt!, "engine must be alive before we mark ourselves listening")
+        XCTAssertLessThan(snapshotAt!, pauseAt!, "snapshot what's playing before pausing it")
+    }
+
+    /// An engine failure must not abort the start — transcription has its own fallback engine,
+    /// so the sequence still marks listening and starts recording.
+    func testEngineFailureStillCompletesTheSequence() async {
+        let log = Box<[String]>([])
+        await ConversationStartSequence.run(recordingDeps(into: log, engineFails: true))
+        XCTAssertEqual(log.value, Self.expectedOrder,
+                       "a throwing engine bring-up is swallowed; every later stage still runs")
+    }
+}

--- a/docs/plans/BG-spine-refactor.md
+++ b/docs/plans/BG-spine-refactor.md
@@ -3,13 +3,13 @@
 **Status:** 🚧 Phased, one PR per phase. **P1 shipped** (registry-generated tool prompts).
 **P3 shipped** (one tool-loop driver). **P4 shipped** (merged realtime audio engine).
 **P5 shipped incrementally** (`@UserDefaultsBacked` cohorts, model types → `Models/`, NotesTool rename).
-**P2 shipped incrementally:** pure `VoiceCommandParser`; `ConversationFlowEngine` +
-`VoiceCommandHandler` pre-LLM chain; `resumeListeningOrReturnToWakeWord` dedup; cancellable
-turns; pure `ModelRoutingPolicy`; `ConversationTurnRunner` (the LLM-turn skeleton — send →
-post-process → cancel-check → accept → speak → always-finish — behind testable closure seams,
-adopted by the photo and normal turns). Still open in P2 (small follow-ups): fold the inline
-stop/goodbye/photo ifs into a post-store handler chain; adopt the turn runner in
-`sendTextMessage`; extract the wake-detected start sequence behind a seam. All P2 changes to the
+**P2 complete:** pure `VoiceCommandParser`; `ConversationFlowEngine` + `VoiceCommandHandler`
+chains (pre-LLM: teleprompter/HUD task/launcher/intent-ignore; post-store: stop/goodbye/photo);
+`resumeListeningOrReturnToWakeWord` dedup; pure `ModelRoutingPolicy`; `ConversationTurnRunner`
+(the LLM-turn skeleton — send → post-process → cancel-check → accept → speak → always-finish —
+behind testable closure seams, adopted by the photo, normal, and typed turns, all tracked in
+`currentLLMTask` so barge-in/stop/cancel stops any turn); `ConversationStartSequence` (the
+wake-detected choreography, locking the engine-before-listening ordering). All P2 changes to the
 live voice path still want an on-glasses smoke test.
 
 ## The problem


### PR DESCRIPTION
## What

The whole remaining Plan BG P2 in one PR (follows #177's `ConversationTurnRunner`). Three pieces:

### 1. `postStoreHandlers(query:)` — the second `VoiceCommandHandler` chain
The inline stop/goodbye/photo if-blocks in `handleTranscription` become an ordered chain run through `ConversationFlowEngine`, after the user turn is persisted (so "stop"/"goodbye" still land in the thread) and after persona detection (the photo prompt uses the persona-stripped `query`). Order preserved from the if-ladder: stop → goodbye → photo. The photo handler keeps its tracked `ConversationTurnRunner` task unchanged. With this, **every voice command — pre-LLM and post-store — routes through the same tested engine.**

### 2. `sendTextMessage` adopts the turn runner, tracked and cancellable
Typed turns now run the same skeleton as voice turns, inside a tracked `currentLLMTask` (awaited, so Siri intents and `askUnderPersona` still see the turn complete). This lands the plan's "**every turn runs inside a tracked, cancellable task**": barge-in and cancel now stop a typed turn too, and a cancelled typed turn clears the streaming bubble instead of speaking a stale reply or an apology.

### 3. `ConversationStartSequence` — the wake-detected choreography
`handleWakeWordDetected`'s body moves behind `@MainActor` closure seams. Tests lock the load-bearing ordering: **audio session + engine come up BEFORE `isListening` is marked** (the past tap-to-talk dead-engine bug, now a regression test), snapshot-before-pause, and an engine bring-up failure still completing the start.

## Semantic deltas (called out)

- Typed turns are cancellable (plan-named fix).
- A typed turn no longer aborts if its *caller's* task is cancelled mid-flight — it runs in its own tracked task (previously URLSession cancellation surfaced as an error + spoken apology).
- A cancelled typed turn is silent (`streamingTurn` cleared, no error message) instead of speaking "Sorry, I encountered an error."

Everything else is faithful code motion — the moved bodies are the previous inline code.

## Tests

`ConversationStartSequenceTests` (3): exact stage order; engine-before-listening + snapshot-before-pause invariants; engine failure still completes the sequence. Chain mechanics and turn-skeleton ordering remain covered by `ConversationFlowEngineTests` and `ConversationTurnRunnerTests`.

## Gates

- build-for-testing ✅
- full suite: **1538 tests, 0 failures** ✅
- Release build (`-configuration Release`, `CODE_SIGNING_ALLOWED=NO`) ✅

## ⚠️ Device verification

This completes the restructuring of the live wake→transcribe→LLM→speak→resume path, which cannot be exercised here. **Please smoke-test on glasses before relying on it**: wake word + tap-to-talk start, "stop"/"goodbye", photo command, a typed Chat message (and one via Siri), barge-in during both a voice and a typed reply, and an error turn (e.g. airplane mode).

With this, Plan BG P2 — and the BG plan overall — is complete (plan doc status updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)