### PR TITLE
Gateway handshake v4: Ed25519 device identity, capability advert, device.event push

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -384,6 +384,15 @@ class AppState: ObservableObject, AppStateProtocol {
     @Published var isConnected: Bool = false {
         didSet {
             speechService.glassesConnected = isConnected
+            // Tell the gateway-side agent the glasses attached/detached (device.event push,
+            // Plan BH follow-up). Consent-gated like the remote observe class; the client
+            // itself no-ops unless the socket is authenticated.
+            if oldValue != isConnected, Config.agentModeEnabled, Config.remoteInvokeObserveEnabled {
+                openClawEventClient.sendDeviceEvent(type: "glasses", payload: [
+                    "connected": isConnected,
+                    "battery": glassesService.batteryLevel ?? -1,
+                ])
+            }
             // Clean up hardware-facing interfaces when glasses disconnect.
             // The agent and in-flight LLM requests keep running — results
             // can appear in notifications or be read when the app is opened.

--- a/OpenGlasses/Sources/Services/OpenClaw/OpenClawConnectParams.swift
+++ b/OpenGlasses/Sources/Services/OpenClaw/OpenClawConnectParams.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Pure builder for the `connect` request params both gateway sockets send (the chat socket in
+/// `OpenClawBridge` and the event/invoke socket in `OpenClawEventClient`). One builder so the
+/// two handshakes can't drift — critical because the device-identity signature covers the
+/// clientId/mode/role/scopes carried in the frame, and a mismatch means zero scopes.
+///
+/// Protocol notes:
+/// - `minProtocol 3, maxProtocol 4` — v3 gateways keep working; v4 gateways can use the
+///   device-identity and capability fields.
+/// - `deviceCapabilities` advertises the remote-invoke command surface up front so the
+///   gateway-side agent knows what it can ask for without a round-trip (Plan BH commands).
+/// - `device` (present only when the gateway issued a `connect.challenge` nonce) is the signed
+///   Ed25519 identity block — remote gateways may grant zero scopes without it.
+enum OpenClawConnectParams {
+
+    static let role = "operator"
+    static let scopes = ["operator.read", "operator.write"]
+    static let clientMode = "node"
+
+    static func build(
+        clientId: String,
+        displayName: String,
+        version: String,
+        token: String,
+        challengeNonce: String?,
+        pairedDeviceId: String? = nil,
+        localeIdentifier: String = Locale.current.identifier,
+        identity: OpenClawDeviceIdentity.Identity? = nil,
+        signedAtMs: Int? = nil
+    ) -> [String: Any] {
+        var client: [String: Any] = [
+            "id": clientId,
+            "displayName": displayName,
+            "version": version,
+            "platform": "ios",
+            "mode": clientMode,
+        ]
+        if let pairedDeviceId, !pairedDeviceId.isEmpty {
+            client["deviceId"] = pairedDeviceId
+        }
+
+        var params: [String: Any] = [
+            "minProtocol": 3,
+            "maxProtocol": 4,
+            "role": role,
+            "scopes": scopes,
+            "client": client,
+            "deviceCapabilities": RemoteGlassesCommand.allCanonicalActions,
+            "locale": localeIdentifier,
+            "auth": ["token": token],
+        ]
+
+        if let nonce = challengeNonce, !nonce.isEmpty {
+            let signingIdentity = identity ?? OpenClawDeviceIdentity.loadOrCreate()
+            let timestamp = signedAtMs ?? Int(Date().timeIntervalSince1970 * 1000)
+            if let device = OpenClawDeviceIdentity.connectDevice(
+                identity: signingIdentity,
+                token: token,
+                nonce: nonce,
+                clientId: clientId,
+                clientMode: clientMode,
+                role: role,
+                scopes: scopes,
+                signedAtMs: timestamp
+            ) {
+                params["device"] = device
+            }
+        }
+        return params
+    }
+}

--- a/OpenGlasses/Sources/Services/OpenClaw/OpenClawDeviceIdentity.swift
+++ b/OpenGlasses/Sources/Services/OpenClaw/OpenClawDeviceIdentity.swift
@@ -1,0 +1,151 @@
+import CryptoKit
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Ed25519 device identity for OpenClaw gateway handshakes (protocol v3/v4).
+///
+/// Remote gateways grant scopes based on a signed device identity presented with the `connect`
+/// request: the client signs the gateway's `connect.challenge` nonce (plus the connect metadata)
+/// with a per-device Ed25519 key. A token-only connect still authenticates but can be granted
+/// zero scopes on newer gateways, leaving the socket deaf for chat/invoke. The private key is
+/// generated once and kept in the Keychain; the device id is the SHA-256 of the public key.
+enum OpenClawDeviceIdentity {
+
+    private static let privateKeyKeychainKey = "openClawDeviceEd25519PrivateKey"
+
+    struct Identity {
+        let deviceId: String
+        let publicKeyBase64URL: String
+        let privateKey: Curve25519.Signing.PrivateKey
+
+        init(privateKey: Curve25519.Signing.PrivateKey) {
+            let rawPublic = privateKey.publicKey.rawRepresentation
+            self.privateKey = privateKey
+            self.deviceId = OpenClawDeviceIdentity.sha256Hex(rawPublic)
+            self.publicKeyBase64URL = OpenClawDeviceIdentity.base64URLEncode(rawPublic)
+        }
+    }
+
+    /// Load the stored device key, or mint and persist a new one.
+    static func loadOrCreate() -> Identity {
+        if let stored = KeychainService.data(for: privateKeyKeychainKey),
+           stored.count == 32,
+           let privateKey = try? Curve25519.Signing.PrivateKey(rawRepresentation: stored) {
+            return Identity(privateKey: privateKey)
+        }
+        let privateKey = Curve25519.Signing.PrivateKey()
+        _ = KeychainService.setData(privateKey.rawRepresentation, for: privateKeyKeychainKey)
+        return Identity(privateKey: privateKey)
+    }
+
+    /// Build the `device` object for a `connect` request. `clientId`/`clientMode`/`role`/`scopes`
+    /// MUST match what the connect frame itself carries — the gateway verifies the signature over
+    /// exactly these values.
+    ///
+    /// The identity/time-injected form is deterministic for tests; the convenience overload uses
+    /// the stored identity and the current clock.
+    static func connectDevice(
+        identity: Identity,
+        token: String,
+        nonce: String,
+        clientId: String,
+        clientMode: String,
+        role: String,
+        scopes: [String],
+        signedAtMs: Int
+    ) -> [String: Any]? {
+        let payload = signedPayloadV3(
+            deviceId: identity.deviceId,
+            clientId: clientId,
+            clientMode: clientMode,
+            role: role,
+            scopes: scopes,
+            signedAtMs: signedAtMs,
+            token: token,
+            nonce: nonce
+        )
+        guard let signature = try? identity.privateKey.signature(for: Data(payload.utf8)) else {
+            return nil
+        }
+        return [
+            "id": identity.deviceId,
+            "publicKey": identity.publicKeyBase64URL,
+            "signature": base64URLEncode(signature),
+            "signedAt": signedAtMs,
+            "nonce": nonce,
+        ]
+    }
+
+    static func connectDevice(
+        token: String,
+        nonce: String,
+        clientId: String,
+        clientMode: String,
+        role: String,
+        scopes: [String]
+    ) -> [String: Any]? {
+        connectDevice(
+            identity: loadOrCreate(),
+            token: token,
+            nonce: nonce,
+            clientId: clientId,
+            clientMode: clientMode,
+            role: role,
+            scopes: scopes,
+            signedAtMs: Int(Date().timeIntervalSince1970 * 1000)
+        )
+    }
+
+    /// The exact string the signature covers (gateway "v3" payload format) — exposed for tests.
+    static func signedPayloadV3(
+        deviceId: String,
+        clientId: String,
+        clientMode: String,
+        role: String,
+        scopes: [String],
+        signedAtMs: Int,
+        token: String,
+        nonce: String
+    ) -> String {
+        [
+            "v3",
+            deviceId,
+            clientId,
+            clientMode,
+            role,
+            scopes.joined(separator: ","),
+            String(signedAtMs),
+            token,
+            nonce,
+            normalizeMetadata("ios"),
+            normalizeMetadata(deviceFamilyLabel()),
+        ].joined(separator: "|")
+    }
+
+    // MARK: - Helpers
+
+    private static func normalizeMetadata(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private static func deviceFamilyLabel() -> String {
+        #if canImport(UIKit)
+        return UIDevice.current.userInterfaceIdiom == .pad ? "ipad" : "iphone"
+        #else
+        return "iphone"
+        #endif
+    }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func base64URLEncode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/OpenGlasses/Sources/Services/OpenClaw/RemoteInvoke/RemoteGlassesCommand.swift
+++ b/OpenGlasses/Sources/Services/OpenClaw/RemoteInvoke/RemoteGlassesCommand.swift
@@ -56,6 +56,22 @@ extension RemoteGlassesCommand {
         }
     }
 
+    /// Every canonical wire name — advertised to the gateway at connect time
+    /// (`OpenClawConnectParams.deviceCapabilities`) so the agent knows the command surface
+    /// without a round-trip. Tests assert each entry round-trips through the parser.
+    static let allCanonicalActions: [String] = [
+        "capture_photo",
+        "start_audio_recording", "stop_audio_recording",
+        "start_video", "stop_video",
+        "start_translation", "stop_translation",
+        "start_transcription", "stop_transcription",
+        "speak",
+        "display_show", "display_clear",
+        "device_status", "device_capabilities",
+        "add_note", "get_transcript",
+        "stop_all",
+    ]
+
     /// Canonical wire name, used in audit entries and replies.
     var canonicalAction: String {
         switch self {

--- a/OpenGlasses/Sources/Services/OpenClawBridge.swift
+++ b/OpenGlasses/Sources/Services/OpenClawBridge.swift
@@ -313,30 +313,31 @@ class OpenClawBridge: ObservableObject {
         webSocketTask = wsSession?.webSocketTask(with: request)
         webSocketTask?.resume()
 
-        // Wait for connect.challenge
+        // Wait for connect.challenge and pull its nonce — signing it into the device-identity
+        // block is what earns real scopes on remote gateways (token-only can be zero-scoped).
         let challengeMsg = try await receiveMessage()
         NSLog("[OpenClaw] WS received: %@", String(challengeMsg.prefix(100)))
+        var challengeNonce: String?
+        if let data = challengeMsg.data(using: .utf8),
+           let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let payload = json["payload"] as? [String: Any] {
+            challengeNonce = payload["nonce"] as? String
+        }
 
-        // Send connect handshake — register as "node" with device capabilities
+        // Send connect handshake — register as "node" via the shared params builder (protocol
+        // v3/v4, role/scopes, capability advertisement, signed device identity when challenged).
         let connectId = UUID().uuidString
         let connectMsg: [String: Any] = [
             "type": "req",
             "id": connectId,
             "method": "connect",
-            "params": [
-                "minProtocol": 3,
-                "maxProtocol": 3,
-                "client": [
-                    "id": "gateway-client",
-                    "displayName": "OpenGlasses",
-                    "version": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0",
-                    "platform": "ios",
-                    "mode": "node"
-                ] as [String: Any],
-                "auth": [
-                    "token": token
-                ]
-            ] as [String: Any]
+            "params": OpenClawConnectParams.build(
+                clientId: "gateway-client",
+                displayName: "OpenGlasses",
+                version: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0",
+                token: token,
+                challengeNonce: challengeNonce
+            )
         ]
 
         let connectData = try JSONSerialization.data(withJSONObject: connectMsg)

--- a/OpenGlasses/Sources/Services/OpenClawEventClient.swift
+++ b/OpenGlasses/Sources/Services/OpenClawEventClient.swift
@@ -19,6 +19,9 @@ class OpenClawEventClient {
     private let maxReconnectDelay: TimeInterval = 30
     /// The gateway resolved for the current connection — its credential drives the handshake.
     private var currentGateway: GatewayConfig?
+    /// Nonce from the gateway's `connect.challenge` — signed into the device-identity block so
+    /// remote gateways grant real scopes (token-only connects can be granted zero scopes).
+    private var challengeNonce: String?
 
     func connect() {
         guard Config.isOpenClawConfigured else {
@@ -31,8 +34,10 @@ class OpenClawEventClient {
     }
 
     func disconnect() {
+        sendDeviceEvent(type: "connection", payload: ["status": "disconnected"])
         shouldReconnect = false
         isConnected = false
+        challengeNonce = nil
         webSocketTask?.cancel(with: .normalClosure, reason: nil)
         webSocketTask = nil
         session?.invalidateAndCancel()
@@ -202,6 +207,25 @@ class OpenClawEventClient {
         }
     }
 
+    /// Fire-and-forget `device.event` push (Plan BH follow-up): tell the gateway-side agent
+    /// something changed on the device without being asked — connection state, glasses
+    /// attach/detach, battery. The request/reply invoke path stays unchanged; this is the
+    /// outbound half of the bidirectional terminal. No-op unless the socket is authenticated.
+    func sendDeviceEvent(type: String, payload: [String: Any]) {
+        guard isConnected else { return }
+        var body: [String: Any] = [
+            "type": type,
+            "timestamp": Int(Date().timeIntervalSince1970),
+        ]
+        if !payload.isEmpty { body["data"] = payload }
+        sendFrame([
+            "type": "event",
+            "event": "device.event",
+            "payload": body,
+        ])
+        NSLog("[OpenClawWS] Sent device.event type=%@", type)
+    }
+
     /// Map a connect `res` to a pairing outcome: persist a freshly-issued device token, update
     /// connection state, and surface the status. Pure interpretation lives in
     /// `PairingResponseInterpreter`; this applies its side effects.
@@ -218,6 +242,7 @@ class OpenClawEventClient {
             isConnected = true
             reconnectDelay = 2
             NSLog("[OpenClawWS] Connected and authenticated")
+            sendDeviceEvent(type: "connection", payload: ["status": "connected"])
         case .waitingApproval:
             NSLog("[OpenClawWS] Device pairing pending — awaiting approval on the gateway")
         case .error(let msg):
@@ -234,6 +259,7 @@ class OpenClawEventClient {
 
         switch event {
         case "connect.challenge":
+            challengeNonce = payload["nonce"] as? String
             sendConnectHandshake()
         case "device.paired":
             if let outcome = PairingResponseInterpreter.interpretPairedEvent(payload),
@@ -269,27 +295,20 @@ class OpenClawEventClient {
             token = Config.openClawGatewayToken
         }
 
-        var client: [String: Any] = [
-            "id": "gateway-client",
-            "displayName": "OpenGlasses",
-            "version": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0",
-            "platform": "ios",
-            "mode": "node"
-        ]
-        if !deviceId.isEmpty { client["deviceId"] = deviceId }
-
+        // Shared builder (protocol v3/v4): role/scopes, capability advertisement, and — when the
+        // gateway issued a challenge nonce — the signed Ed25519 device-identity block.
         let connectMsg: [String: Any] = [
             "type": "req",
             "id": UUID().uuidString,
             "method": "connect",
-            "params": [
-                "minProtocol": 3,
-                "maxProtocol": 3,
-                "client": client,
-                "auth": [
-                    "token": token
-                ]
-            ] as [String: Any]
+            "params": OpenClawConnectParams.build(
+                clientId: "gateway-client",
+                displayName: "OpenGlasses",
+                version: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0",
+                token: token,
+                challengeNonce: challengeNonce,
+                pairedDeviceId: deviceId.isEmpty ? nil : deviceId
+            )
         ]
 
         guard let data = try? JSONSerialization.data(withJSONObject: connectMsg),

--- a/OpenGlassesTests/OpenClawConnectParamsTests.swift
+++ b/OpenGlassesTests/OpenClawConnectParamsTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+import CryptoKit
+@testable import OpenGlasses
+
+/// The shared connect-params builder both gateway sockets use — one builder so the handshakes
+/// can't drift from what the device-identity signature covers.
+final class OpenClawConnectParamsTests: XCTestCase {
+
+    private func build(nonce: String? = nil, pairedDeviceId: String? = nil,
+                       identity: OpenClawDeviceIdentity.Identity? = nil) -> [String: Any] {
+        OpenClawConnectParams.build(
+            clientId: "gateway-client",
+            displayName: "OpenGlasses",
+            version: "1.0",
+            token: "tok",
+            challengeNonce: nonce,
+            pairedDeviceId: pairedDeviceId,
+            localeIdentifier: "en_US",
+            identity: identity,
+            signedAtMs: 42_000
+        )
+    }
+
+    func testBaseParamsCarryProtocolRoleScopesAndCapabilities() {
+        let params = build()
+        XCTAssertEqual(params["minProtocol"] as? Int, 3, "v3 gateways must keep working")
+        XCTAssertEqual(params["maxProtocol"] as? Int, 4)
+        XCTAssertEqual(params["role"] as? String, "operator")
+        XCTAssertEqual(params["scopes"] as? [String], ["operator.read", "operator.write"])
+        XCTAssertEqual(params["deviceCapabilities"] as? [String], RemoteGlassesCommand.allCanonicalActions,
+                       "the agent learns the invokable command surface at connect time")
+        XCTAssertEqual(params["locale"] as? String, "en_US")
+        XCTAssertEqual((params["auth"] as? [String: String])?["token"], "tok")
+        let client = params["client"] as? [String: Any]
+        XCTAssertEqual(client?["id"] as? String, "gateway-client")
+        XCTAssertEqual(client?["mode"] as? String, "node")
+        XCTAssertNil(client?["deviceId"], "no paired device id → none advertised")
+    }
+
+    func testNoNonceMeansNoDeviceBlock() {
+        XCTAssertNil(build()["device"], "unchallenged connects stay token-only (v3 behavior)")
+    }
+
+    func testPairedDeviceIdIsCarriedOnTheClient() {
+        let client = build(pairedDeviceId: "paired-123")["client"] as? [String: Any]
+        XCTAssertEqual(client?["deviceId"] as? String, "paired-123")
+    }
+
+    func testChallengedConnectCarriesAVerifiableDeviceIdentity() throws {
+        let identity = OpenClawDeviceIdentity.Identity(privateKey: Curve25519.Signing.PrivateKey())
+        let params = build(nonce: "n0nce", identity: identity)
+        let device = try XCTUnwrap(params["device"] as? [String: Any])
+        XCTAssertEqual(device["id"] as? String, identity.deviceId)
+        XCTAssertEqual(device["nonce"] as? String, "n0nce")
+
+        // The signature must cover the SAME clientId/mode/role/scopes the frame carries —
+        // this is the no-drift property the shared builder exists for.
+        let payload = OpenClawDeviceIdentity.signedPayloadV3(
+            deviceId: identity.deviceId,
+            clientId: (params["client"] as? [String: Any])?["id"] as? String ?? "",
+            clientMode: (params["client"] as? [String: Any])?["mode"] as? String ?? "",
+            role: params["role"] as? String ?? "",
+            scopes: params["scopes"] as? [String] ?? [],
+            signedAtMs: device["signedAt"] as? Int ?? 0,
+            token: "tok",
+            nonce: "n0nce")
+        var b64 = try XCTUnwrap(device["signature"] as? String)
+            .replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        while b64.count % 4 != 0 { b64 += "=" }
+        let signature = try XCTUnwrap(Data(base64Encoded: b64))
+        XCTAssertTrue(identity.privateKey.publicKey.isValidSignature(signature, for: Data(payload.utf8)))
+    }
+
+    func testEveryAdvertisedCapabilityRoundTripsThroughTheParser() {
+        XCTAssertEqual(RemoteGlassesCommand.allCanonicalActions.count, 17)
+        for action in RemoteGlassesCommand.allCanonicalActions {
+            let frame: [String: Any] = [
+                "type": "req", "id": "x", "method": "node.invoke",
+                "params": ["action": action, "text": "t", "source": "de", "target": "en"] as [String: Any],
+            ]
+            guard case .command(let command)? = RemoteCommandParser.parse(frame)?.outcome else {
+                return XCTFail("advertised capability '\(action)' is not parseable")
+            }
+            XCTAssertEqual(command.canonicalAction, action,
+                           "advertised name must be the canonical name the parser produces")
+        }
+    }
+}

--- a/OpenGlassesTests/OpenClawDeviceIdentityTests.swift
+++ b/OpenGlassesTests/OpenClawDeviceIdentityTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import CryptoKit
+@testable import OpenGlasses
+
+/// Gateway device identity (BH follow-up): the signed Ed25519 block that earns real scopes on
+/// remote gateways. Fresh keys throughout — no keychain dependence.
+final class OpenClawDeviceIdentityTests: XCTestCase {
+
+    private func freshIdentity() -> OpenClawDeviceIdentity.Identity {
+        OpenClawDeviceIdentity.Identity(privateKey: Curve25519.Signing.PrivateKey())
+    }
+
+    private func base64URLDecode(_ s: String) -> Data? {
+        var b64 = s.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        while b64.count % 4 != 0 { b64 += "=" }
+        return Data(base64Encoded: b64)
+    }
+
+    func testDeviceIdIsSHA256HexOfPublicKey() {
+        let identity = freshIdentity()
+        let expected = SHA256.hash(data: identity.privateKey.publicKey.rawRepresentation)
+            .map { String(format: "%02x", $0) }.joined()
+        XCTAssertEqual(identity.deviceId, expected)
+        XCTAssertEqual(identity.deviceId.count, 64)
+    }
+
+    func testPublicKeyIsBase64URLWithoutPadding() {
+        let identity = freshIdentity()
+        XCTAssertFalse(identity.publicKeyBase64URL.contains("+"))
+        XCTAssertFalse(identity.publicKeyBase64URL.contains("/"))
+        XCTAssertFalse(identity.publicKeyBase64URL.contains("="))
+        XCTAssertEqual(base64URLDecode(identity.publicKeyBase64URL),
+                       identity.privateKey.publicKey.rawRepresentation)
+    }
+
+    func testSignedPayloadV3FieldOrder() {
+        let payload = OpenClawDeviceIdentity.signedPayloadV3(
+            deviceId: "dev", clientId: "gateway-client", clientMode: "node",
+            role: "operator", scopes: ["operator.read", "operator.write"],
+            signedAtMs: 1_234, token: "tok", nonce: "n0nce")
+        let fields = payload.components(separatedBy: "|")
+        XCTAssertEqual(Array(fields[0...8]),
+                       ["v3", "dev", "gateway-client", "node", "operator",
+                        "operator.read,operator.write", "1234", "tok", "n0nce"])
+        XCTAssertEqual(fields[9], "ios")
+        XCTAssertTrue(["iphone", "ipad"].contains(fields[10]))
+        XCTAssertEqual(fields.count, 11)
+    }
+
+    func testConnectDeviceSignatureVerifiesOverTheV3Payload() throws {
+        let identity = freshIdentity()
+        let block = try XCTUnwrap(OpenClawDeviceIdentity.connectDevice(
+            identity: identity, token: "tok", nonce: "n0nce",
+            clientId: "gateway-client", clientMode: "node",
+            role: "operator", scopes: ["operator.read", "operator.write"],
+            signedAtMs: 99_000))
+
+        XCTAssertEqual(block["id"] as? String, identity.deviceId)
+        XCTAssertEqual(block["publicKey"] as? String, identity.publicKeyBase64URL)
+        XCTAssertEqual(block["signedAt"] as? Int, 99_000)
+        XCTAssertEqual(block["nonce"] as? String, "n0nce")
+
+        let payload = OpenClawDeviceIdentity.signedPayloadV3(
+            deviceId: identity.deviceId, clientId: "gateway-client", clientMode: "node",
+            role: "operator", scopes: ["operator.read", "operator.write"],
+            signedAtMs: 99_000, token: "tok", nonce: "n0nce")
+        let signature = try XCTUnwrap(base64URLDecode(try XCTUnwrap(block["signature"] as? String)))
+        XCTAssertTrue(identity.privateKey.publicKey.isValidSignature(signature, for: Data(payload.utf8)),
+                      "the gateway must be able to verify the signature over exactly the v3 payload")
+        // And it must NOT verify over a payload with different connect metadata (no drift).
+        let tampered = payload.replacingOccurrences(of: "node", with: "ui")
+        XCTAssertFalse(identity.privateKey.publicKey.isValidSignature(signature, for: Data(tampered.utf8)))
+    }
+}

--- a/docs/plans/BH-gateway-remote-invoke.md
+++ b/docs/plans/BH-gateway-remote-invoke.md
@@ -9,7 +9,7 @@ audit ring) wired into `OpenClawEventClient` (`type:"req"` frames answered on th
 socket). Settings: per-class toggles + activity log in Gateway settings. Hardening riders:
 reconnect jitter, `LLMImagePreparer.isDegenerate` frame guard, `SecretInputField` (paste + reveal)
 swapped into 12 token/key forms. Token-in-URL hygiene was already fixed (handshake auth +
-`LogRedaction`). Deferred: live end-to-end against a real gateway (device/backend-pending).
+`LogRedaction`). Follow-up shipped: signed Ed25519 device identity on both gateway handshakes (`OpenClawDeviceIdentity` + shared `OpenClawConnectParams`, protocol v3/v4 — remote gateways can zero-scope token-only connects), capability advertisement at connect time, and `device.event` push (connection + glasses attach/detach, observe-consent-gated). Deferred: live end-to-end against a real gateway (device/backend-pending).
 
 ## The problem
 The gateway link is one-directional in practice: the phone initiates every exchange


### PR DESCRIPTION
## Why

Remote OpenClaw gateways grant scopes based on a **signed device identity** presented at connect; a token-only connect can authenticate but be granted **zero scopes** — a socket that looks connected but is deaf for `chat.send` and remote invoke. Upstream answered `connect.challenge` by re-presenting the bare token at protocol 3. This PR completes the handshake and adds the outbound event half of the bidirectional terminal.

## What

- **`OpenClawDeviceIdentity`** — per-device Ed25519 key (Keychain-persisted), `deviceId = sha256(publicKey)`, signs the gateway's v3 payload (`v3|deviceId|clientId|mode|role|scopes|signedAt|token|nonce|platform|family`), base64url encoding. Deterministic, time-injected form for tests; signature verified in tests against the exact payload.
- **`OpenClawConnectParams`** — one pure params builder used by **both** sockets (`OpenClawBridge` chat + `OpenClawEventClient` events/invoke). The signature covers the frame's `clientId/mode/role/scopes`, so a drift between what's signed and what's sent = zero scopes; a single builder makes drift impossible, and a test asserts the signature verifies over values read back out of the built frame. Negotiates `minProtocol 3 / maxProtocol 4` — v3 gateways see no behavior change (no nonce → no device block, tested).
- **Capability advertisement** — connect params carry `deviceCapabilities` = the 17 canonical Plan BH remote-invoke actions, so the gateway-side agent knows the command surface without a round-trip. Test: every advertised name round-trips through `RemoteCommandParser` to itself.
- **`device.event` push** — fire-and-forget client→gateway events on the event socket: connection up/down from the client lifecycle, and **glasses attach/detach (+ battery)** from `AppState`'s `isConnected` transition. Consent-gated on `agentModeEnabled` + the Plan BH **observe** toggle; the client no-ops unless the socket is authenticated.

## Gates

- build-for-testing ✅ · full suite **1599 tests, 0 failures** (9 new) ✅ · Release ✅

## ⚠️ Needs live-gateway verification

The client-side contract is covered headlessly, but two things only a real gateway can confirm: that the signed identity is accepted and real scopes are granted (check the connect `res`), and that `device.event` frames are ingested rather than logged as unknown. Worth one connect against your gateway before relying on remote invoke over a tunnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)