### PR TITLE
Setup traps + paste-friendly key entry: plist example, Watch companion ID, last SecureFields

### DIFF
--- a/Config/Info/Info.personal.plist.example
+++ b/Config/Info/Info.personal.plist.example
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+<!--
+  WARNING: project.local.yml points INFOPLIST_FILE at Info.personal.plist, which REPLACES the
+  app's entire Info.plist. Your real Info.personal.plist must therefore contain ALL standard
+  keys (CFBundle*, usage descriptions, background modes, ...) PLUS the MWDAT dict below —
+  an MWDAT-only file builds but fails at runtime/processing ("missing bundle identifier").
+
+  Don't hand-copy this example. Run `./Scripts/setup-local-dev.sh`, which seeds the file from
+  the full OpenGlasses/Info.plist; then merge in the MWDAT dict shown here.
+-->
 <dict>
 	<key>MWDAT</key>
 	<dict>

--- a/OpenGlasses/Sources/App/Views/MedicalExportSettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/MedicalExportSettingsView.swift
@@ -67,7 +67,7 @@ struct MedicalExportSettingsView: View {
                         Text("Bearer Token")
                             .font(.caption)
                             .foregroundStyle(.secondary)
-                        SecureField("Pre-obtained OAuth token", text: $fhirConfig.bearerToken)
+                        SecretInputField(placeholder: "Pre-obtained OAuth token", text: $fhirConfig.bearerToken)
                     }
 
                     VStack(alignment: .leading, spacing: 4) {

--- a/OpenGlasses/Sources/App/Views/OnboardingView.swift
+++ b/OpenGlasses/Sources/App/Views/OnboardingView.swift
@@ -265,10 +265,7 @@ struct OnboardingView: View {
                             .foregroundStyle(.white.opacity(0.5))
 
                         HStack {
-                            SecureField("sk-...", text: $apiKey)
-                                .font(.system(.body, design: .monospaced))
-                                .autocorrectionDisabled()
-                                .textInputAutocapitalization(.never)
+                            SecretInputField(placeholder: "sk-...", text: $apiKey)
                                 .foregroundStyle(.white)
                                 .onChange(of: apiKey) { _, _ in
                                     validationError = nil
@@ -464,10 +461,7 @@ struct OnboardingView: View {
                             .foregroundStyle(.white)
                     }
 
-                    SecureField("ElevenLabs API Key", text: $elevenLabsKey)
-                        .font(.system(.body, design: .monospaced))
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
+                    SecretInputField(placeholder: "ElevenLabs API Key", text: $elevenLabsKey)
                         .foregroundStyle(.white)
                         .padding(14)
                         .contentShape(Rectangle())
@@ -505,10 +499,7 @@ struct OnboardingView: View {
                             .foregroundStyle(.white)
                     }
 
-                    SecureField("Perplexity API Key", text: $perplexityKey)
-                        .font(.system(.body, design: .monospaced))
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
+                    SecretInputField(placeholder: "Perplexity API Key", text: $perplexityKey)
                         .foregroundStyle(.white)
                         .padding(14)
                         .contentShape(Rectangle())

--- a/OpenGlassesWatch/Info.plist
+++ b/OpenGlassesWatch/Info.plist
@@ -25,7 +25,9 @@
 	<key>WKApplication</key>
 	<true/>
 	<key>WKCompanionAppBundleIdentifier</key>
-	<string>com.openglasses.app</string>
+	<!-- Substituted from project.watch.yml so a rebrand via project.local.yml propagates;
+	     a hardcoded value here breaks Watch install with InvalidCompanionAppBundleIdentifier. -->
+	<string>$(WK_COMPANION_APP_BUNDLE_IDENTIFIER)</string>
 	<key>WKRunsIndependentlyOfCompanionApp</key>
 	<true/>
 </dict>

--- a/project.local.yml.example
+++ b/project.local.yml.example
@@ -7,6 +7,11 @@ targets:
       base:
         CODE_SIGN_ENTITLEMENTS: Config/Entitlements/Personal/OpenGlasses.entitlements
         DEVELOPMENT_TEAM: YOUR_APPLE_TEAM_ID
+        # NOTE: this REPLACES the app's entire Info.plist — Info.personal.plist must be a
+        # full plist (all CFBundle*/usage keys) plus the MWDAT dict, not MWDAT-only.
+        # `./Scripts/setup-local-dev.sh` seeds it correctly from OpenGlasses/Info.plist.
+        # If you also change PRODUCT_BUNDLE_IDENTIFIER (rebrand), override
+        # WK_COMPANION_APP_BUNDLE_IDENTIFIER on the OpenGlassesWatch target to match.
         INFOPLIST_FILE: Config/Info/Info.personal.plist
 
   GlassesActivityWidget:

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -15,6 +15,10 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp
+        # Substituted into OpenGlassesWatch/Info.plist (WKCompanionAppBundleIdentifier).
+        # Must equal the iOS app's PRODUCT_BUNDLE_IDENTIFIER — override BOTH in
+        # project.local.yml when rebranding, or Watch install fails.
+        WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2.2.0"
         CURRENT_PROJECT_VERSION: "11"
         SWIFT_VERSION: "5.9"


### PR DESCRIPTION
Three small fixes for setup traps that bit a downstream fork and would bite any rebrand or manual setup:

1. **`Info.personal.plist.example` warning** — `project.local.yml` points `INFOPLIST_FILE` at `Info.personal.plist`, which *replaces* the app's whole Info.plist; an MWDAT-only copy (what the example looked like it wanted) builds but fails AppIntents processing with "missing bundle identifier". The example (and `project.local.yml.example`) now say so loudly and point at `setup-local-dev.sh`, which seeds the file correctly.
2. **Watch companion bundle ID substitution** — `OpenGlassesWatch/Info.plist` hardcoded `com.openglasses.app`; any `PRODUCT_BUNDLE_IDENTIFIER` rebrand broke Watch install with `InvalidCompanionAppBundleIdentifier`. It now substitutes `$(WK_COMPANION_APP_BUNDLE_IDENTIFIER)` defined in `project.watch.yml` (overridable in `project.local.yml`, documented in the example). **Verified** by building the `OpenGlassesWatch` scheme and reading the processed plist — note the iOS-scheme gates reuse a cached Watch product and never rebuild it, so this needed its own build to prove.
3. **Last four SecureFields → `SecretInputField`** — OnboardingView (Claude/ElevenLabs/Perplexity keys) and MedicalExportSettingsView (OAuth token), finishing the #180 sweep. Onboarding was the worst place left to fight iOS paste.

## Gates
build-for-testing ✅ · full suite **1590 / 0 failures** ✅ · Release ✅ · explicit `OpenGlassesWatch` scheme build with substituted plist verified ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)