### PR TITLE
Local model: lean prompt on the active-model path too (not just agent)

### DIFF
--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -174,6 +174,17 @@ class LLMService: ObservableObject {
     /// Build the full system prompt, optionally including location, tools, memory, and vision context.
     /// When `promptSections` is provided (from the ConversationClassifier), irrelevant sections are
     /// stripped to reduce token count. When nil, all sections are included (backward compatible).
+    /// The lean system prompt for an on-device model: persona/behavior + location + memory, but
+    /// NOT the ~100 native-tool descriptions (~8k tokens) that OOM a 2B model on a phone, and none
+    /// of the heavy optional contexts (playbook/shortcuts/OpenClaw). `sendLocal` appends its own
+    /// reduced tool block, so the model still has usable tools. Used by every on-device path
+    /// (active-model `sendMessage` and fast-tier `sendViaLocalAgent`) so they can't diverge.
+    static func leanOnDevicePrompt(locationContext: String?, memoryContext: String?, hasImage: Bool, turn: String) async -> String {
+        await buildSystemPrompt(
+            locationContext: locationContext, includeTools: false, includeOpenClaw: false,
+            hasImage: hasImage, memoryContext: memoryContext, turn: turn)
+    }
+
     private static func buildSystemPrompt(locationContext: String?, includeTools: Bool, includeOpenClaw: Bool, hasImage: Bool, nativeToolNames: [String] = [], nativeToolDescriptions: [(name: String, description: String)] = [], gatewayToolNames: [String] = [], memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil, turn: String? = nil) async -> String {
         // Agent personality mode: soul.md + skills.md + memory.md replace the standard prompt
         var prompt: String
@@ -418,13 +429,27 @@ class LLMService: ObservableObject {
         }
 
         let provider = modelConfig.llmProvider
+        let isOnDevice = (provider == .local || provider == .appleOnDevice)
         let hasNativeTools = nativeToolRouter != nil
         let includeOpenClaw = Config.isOpenClawConfigured && openClawBridge != nil
         let includeTools = hasNativeTools || includeOpenClaw
-        let nativeToolNames = nativeToolRouter?.registry.toolNames ?? []
-        let nativeToolDescriptions = nativeToolRouter?.registry.toolDescriptions(for: nativeToolNames) ?? []
-        let gatewayToolNames = openClawBridge?.availableToolNames ?? []
-        let fullPrompt = await Self.buildSystemPrompt(locationContext: locationContext, includeTools: includeTools, includeOpenClaw: includeOpenClaw, hasImage: imageData != nil, nativeToolNames: nativeToolNames, nativeToolDescriptions: nativeToolDescriptions, gatewayToolNames: gatewayToolNames, memoryContext: memoryContext, agentContext: agentContext, playbookContext: playbookContext, nowPlayingContext: nowPlayingContext, shortcutsContext: shortcutsContext, promptSections: promptSections, turn: text)
+        let nativeToolNames = nativeToolRouter?.registry.toolNames ?? []   // used by the agent-plan block too
+
+        // On-device models get a LEAN prompt regardless of how they were reached (active model or
+        // agent). The full ~100-tool prompt is ~8k tokens and OOM-kills a 2B model on a phone;
+        // `sendLocal` appends its own reduced tool block, so the model still has usable tools.
+        // Cloud providers get the full tool-laden prompt. (`sendLocal` keeps `includeTools` so it
+        // still adds the reduced set — only the PROMPT drops the ~100-tool dump.)
+        let fullPrompt: String
+        if isOnDevice {
+            fullPrompt = await Self.leanOnDevicePrompt(
+                locationContext: locationContext, memoryContext: memoryContext,
+                hasImage: imageData != nil, turn: text)
+        } else {
+            let nativeToolDescriptions = nativeToolRouter?.registry.toolDescriptions(for: nativeToolNames) ?? []
+            let gatewayToolNames = openClawBridge?.availableToolNames ?? []
+            fullPrompt = await Self.buildSystemPrompt(locationContext: locationContext, includeTools: includeTools, includeOpenClaw: includeOpenClaw, hasImage: imageData != nil, nativeToolNames: nativeToolNames, nativeToolDescriptions: nativeToolDescriptions, gatewayToolNames: gatewayToolNames, memoryContext: memoryContext, agentContext: agentContext, playbookContext: playbookContext, nowPlayingContext: nowPlayingContext, shortcutsContext: shortcutsContext, promptSections: promptSections, turn: text)
+        }
 
         var toolsLabel = ""
         if hasNativeTools { toolsLabel += " [NativeTools]" }
@@ -2050,21 +2075,14 @@ class LLMService: ObservableObject {
             return try await sendCloud(text, systemPrompt: fullPrompt, config: cloudConfig, includeTools: hasNativeTools)
         }
 
-        // On-device agent: build a LEAN prompt — `includeTools: false` omits the ~100 native-tool
-        // descriptions (~8k tokens) that OOM-crash a 2B model on a phone. `sendLocal` appends its
-        // own reduced ~12-tool block, so the model still has usable tools. This is the difference
-        // between an ~8k-token prompt (Jetsam kill) and a few hundred tokens.
+        // On-device agent: build a LEAN prompt (shared with the active-model path) — omits the
+        // ~100 native-tool descriptions (~8k tokens) that OOM-crash a 2B model on a phone.
+        // `sendLocal` appends its own reduced ~12-tool block, so the model still has usable tools.
         guard let localService = localLLMService else {
             throw LLMError.missingAPIKey("Local LLM service not initialized")
         }
-        let leanPrompt = await Self.buildSystemPrompt(
-            locationContext: locationContext,
-            includeTools: false,
-            includeOpenClaw: false,
-            hasImage: false,
-            memoryContext: memoryContext,
-            turn: text
-        )
+        let leanPrompt = await Self.leanOnDevicePrompt(
+            locationContext: locationContext, memoryContext: memoryContext, hasImage: false, turn: text)
         if !localService.isModelLoaded || localService.loadedModelId != agentModelId {
             try await localService.loadModel(agentModelId)
         }


### PR DESCRIPTION
Follow-up to #184. On-device confirmation of #184 showed the local model **still** got an 8241-token prompt and hit the new guard (`Prompt is too long … 8241 tokens; limit 4096`).

## Why #184 missed it
#184 gave the on-device model a lean prompt only via `sendViaLocalAgent` (the fast-tier *agent* route). But when gemma-4 is the user's **active model**, turns go through `sendMessage` → `sendLocal` with the full ~100-tool system prompt (~8k tokens). That path still built the fat prompt. The good news: #184's guard did its job — a clean "switch to a cloud model" error instead of the earlier Jetsam/OOM crash.

## Fix
Extract the lean-prompt build into a shared `LLMService.leanOnDevicePrompt(...)` and use it for **both** on-device routes so they can't diverge again:
- `sendMessage` now branches on `isOnDevice` (`.local` / `.appleOnDevice`) → lean prompt (persona/location/memory only; no ~100-tool dump, no playbook/shortcuts/OpenClaw).
- `sendViaLocalAgent` refactored to call the same helper.
- `sendLocal` still receives `includeTools` and appends its own reduced ~12-tool block, so the model keeps usable tools — only the *prompt* drops the dump.

## Gates
build-for-testing ✅ · full suite **1603 / 0** ✅ · Release ✅

## ⚠️ On-device verification
Confirm the log's `tokenIDs.shape` now drops well under 4096 for a normal question and the local model returns an answer. The token-count reduction can't be measured headlessly (no MLX in the sim); the guard from #184 remains the backstop if any path still overshoots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)