### PR TITLE
Add Tavily web search + make ServicesSettingsView self-contained

### DIFF
--- a/OpenGlasses/Sources/App/Views/ServicesSettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/ServicesSettingsView.swift
@@ -7,18 +7,19 @@ import UniformTypeIdentifiers
 struct ServicesSettingsView: View {
     @ObservedObject var appState: AppState
 
-    // Text-to-Speech
-    @Binding var elevenLabsKeyInput: String
-    @Binding var selectedVoice: String
-    @Binding var emotionAwareTTSEnabled: Bool
+    // Text-to-Speech — self-contained: seeded from Config, persisted on change.
+    @State private var elevenLabsKeyInput: String = Config.elevenLabsAPIKey
+    @State private var selectedVoice: String = Config.elevenLabsVoiceId
+    @State private var emotionAwareTTSEnabled: Bool = Config.emotionAwareTTSEnabled
 
     // Web Search
-    @Binding var perplexityKeyInput: String
+    @State private var perplexityKeyInput: String = Config.perplexityAPIKey
+    @State private var tavilyKeyInput: String = Config.tavilyAPIKey
 
     // Live Streaming
-    @Binding var broadcastPlatform: String
-    @Binding var broadcastRTMPURL: String
-    @Binding var broadcastStreamKey: String
+    @State private var broadcastPlatform: String = Config.broadcastPlatform
+    @State private var broadcastRTMPURL: String = Config.broadcastRTMPURL
+    @State private var broadcastStreamKey: String = Config.broadcastStreamKey
 
     // Camera
     @State private var cameraResolution: String = Config.cameraResolution
@@ -70,6 +71,11 @@ struct ServicesSettingsView: View {
             // MARK: Text-to-Speech
             Section {
                 SecretInputField(placeholder: "API Key", text: $elevenLabsKeyInput)
+                    .onChange(of: elevenLabsKeyInput) { _, newValue in
+                        Config.setElevenLabsAPIKey(newValue)
+                        // Reset quota cache in case the user added credits or changed key.
+                        appState.speechService.resetElevenLabsQuota()
+                    }
 
                 if elevenLabsKeyInput.isEmpty {
                     Link(destination: URL(string: "https://elevenlabs.io/app/settings/api-keys")!) {
@@ -128,6 +134,9 @@ struct ServicesSettingsView: View {
                     isOn: $emotionAwareTTSEnabled,
                     info: "Detects the emotional tone of responses (happy, calm, concerned, excited) and adjusts the voice to match. ElevenLabs voices change stability and style parameters; iOS voices adjust rate and pitch. Makes the assistant sound more natural and empathetic."
                 )
+                .onChange(of: emotionAwareTTSEnabled) { _, newValue in
+                    Config.setEmotionAwareTTSEnabled(newValue)
+                }
             } header: {
                 Text("Text-to-Speech")
             } footer: {
@@ -268,7 +277,10 @@ struct ServicesSettingsView: View {
 
             // MARK: Web Search
             Section {
-                SecretInputField(placeholder: "API Key", text: $perplexityKeyInput)
+                SecretInputField(placeholder: "Perplexity API Key", text: $perplexityKeyInput)
+                    .onChange(of: perplexityKeyInput) { _, newValue in
+                        Config.setPerplexityAPIKey(newValue)
+                    }
 
                 if perplexityKeyInput.isEmpty {
                     Link(destination: URL(string: "https://www.perplexity.ai/settings/api")!) {
@@ -281,13 +293,32 @@ struct ServicesSettingsView: View {
                         }
                     }
                 }
+
+                SecretInputField(placeholder: "Tavily API Key", text: $tavilyKeyInput)
+                    .onChange(of: tavilyKeyInput) { _, newValue in
+                        Config.setTavilyAPIKey(newValue)
+                    }
+
+                if tavilyKeyInput.isEmpty {
+                    Link(destination: URL(string: "https://app.tavily.com/home")!) {
+                        HStack {
+                            Label("Get API Key", systemImage: "arrow.up.right.square")
+                            Spacer()
+                            Text("tavily.com")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
             } header: {
                 Text("Web Search")
             } footer: {
-                if perplexityKeyInput.isEmpty {
-                    Text("Add a Perplexity API key for AI-powered search with cited sources. Without one, DuckDuckGo is used.")
+                if perplexityKeyInput.isEmpty && tavilyKeyInput.isEmpty {
+                    Text("Add a Perplexity or Tavily API key for AI-powered search with cited sources. Without one, DuckDuckGo is used.")
+                } else if !perplexityKeyInput.isEmpty {
+                    Text("Web searches use Perplexity AI with cited sources\(tavilyKeyInput.isEmpty ? "" : ", then Tavily").")
                 } else {
-                    Text("Web searches use Perplexity AI with cited sources.")
+                    Text("Web searches use Tavily with cited sources.")
                 }
             }
 
@@ -368,7 +399,9 @@ struct ServicesSettingsView: View {
                     Text("Custom RTMP").tag("custom")
                 }
                 .onChange(of: broadcastPlatform) { _, platform in
-                    // Pre-fill RTMP ingest URL for known platforms
+                    Config.setBroadcastPlatform(platform)
+                    // Pre-fill RTMP ingest URL for known platforms (persisted via the
+                    // RTMP URL field's own onChange below).
                     switch platform {
                     case "youtube": broadcastRTMPURL = "rtmp://a.rtmp.youtube.com/live2"
                     case "twitch": broadcastRTMPURL = "rtmp://live.twitch.tv/app"
@@ -381,8 +414,14 @@ struct ServicesSettingsView: View {
                 TextField("RTMP URL", text: $broadcastRTMPURL)
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
+                    .onChange(of: broadcastRTMPURL) { _, newValue in
+                        Config.setBroadcastRTMPURL(newValue)
+                    }
 
                 SecretInputField(placeholder: "Stream Key", text: $broadcastStreamKey)
+                    .onChange(of: broadcastStreamKey) { _, newValue in
+                        Config.setBroadcastStreamKey(newValue)
+                    }
             } header: {
                 Text("Live Streaming")
             } footer: {

--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -27,13 +27,8 @@ struct SettingsView: View {
     @State private var isTogglingEncryption = false
 
     // Service settings (owned here, bound to ServicesSettingsView)
-    @State private var elevenLabsKeyInput = Config.elevenLabsAPIKey
-    @State private var selectedVoice = Config.elevenLabsVoiceId
-    @State private var emotionAwareTTSEnabled = Config.emotionAwareTTSEnabled
-    @State private var perplexityKeyInput = Config.perplexityAPIKey
-    @State private var broadcastPlatform = Config.broadcastPlatform
-    @State private var broadcastRTMPURL = Config.broadcastRTMPURL
-    @State private var broadcastStreamKey = Config.broadcastStreamKey
+    // ElevenLabs / TTS voice, web-search keys, and live-streaming config are owned
+    // by ServicesSettingsView (self-contained, persists to Config on change).
 
     var body: some View {
         Form {
@@ -416,16 +411,7 @@ struct SettingsView: View {
 
             Section {
                 NavigationLink {
-                    ServicesSettingsView(
-                        appState: appState,
-                        elevenLabsKeyInput: $elevenLabsKeyInput,
-                        selectedVoice: $selectedVoice,
-                        emotionAwareTTSEnabled: $emotionAwareTTSEnabled,
-                        perplexityKeyInput: $perplexityKeyInput,
-                        broadcastPlatform: $broadcastPlatform,
-                        broadcastRTMPURL: $broadcastRTMPURL,
-                        broadcastStreamKey: $broadcastStreamKey
-                    )
+                    ServicesSettingsView(appState: appState)
                 } label: {
                     Label("Services & Integrations", systemImage: "square.grid.2x2")
                 }
@@ -695,26 +681,14 @@ struct SettingsView: View {
         }
         appState.llmService.refreshActiveModel()
 
-        Config.setElevenLabsAPIKey(elevenLabsKeyInput)
-        Config.setElevenLabsVoiceId(selectedVoice)
-        // Reset quota cache in case user added credits or changed key
-        appState.speechService.resetElevenLabsQuota()
-
-        Config.setPerplexityAPIKey(perplexityKeyInput)
         Config.setPrivacyFilterEnabled(privacyFilterEnabled)
         appState.privacyFilter.isEnabled = privacyFilterEnabled
         Config.setUseGlassesMicForWakeWord(useGlassesMicForWakeWord)
-
-        Config.setEmotionAwareTTSEnabled(emotionAwareTTSEnabled)
 
         Config.setIntentClassifierEnabled(intentClassifierEnabled)
         Config.setUserMemoryEnabled(userMemoryEnabled)
         Config.setMemoryNudgesEnabled(memoryNudgesEnabled)
         Config.setConversationPersistenceEnabled(conversationPersistenceEnabled)
-
-        Config.setBroadcastPlatform(broadcastPlatform)
-        Config.setBroadcastRTMPURL(broadcastRTMPURL)
-        Config.setBroadcastStreamKey(broadcastStreamKey)
 
         if appState.currentMode == .direct {
             Task {

--- a/OpenGlasses/Sources/Services/NativeTools/WebSearchTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/WebSearchTool.swift
@@ -1,10 +1,11 @@
 import Foundation
 
-/// Searches the web. Uses Perplexity AI when an API key is configured (grounded, cited answers).
-/// Falls back to DuckDuckGo Instant Answer API (no API key needed) otherwise.
+/// Searches the web. Prefers Perplexity AI, then Tavily, when an API key is configured
+/// (grounded, cited answers). Falls back to DuckDuckGo Instant Answer API (no API key
+/// needed) otherwise.
 struct WebSearchTool: NativeTool {
     let name = "web_search"
-    let description = "Search the web for information. Uses Perplexity AI (with citations) when configured, otherwise DuckDuckGo. Returns a brief summary."
+    let description = "Search the web for information. Uses Perplexity AI or Tavily (with citations) when configured, otherwise DuckDuckGo. Returns a brief summary."
     let parametersSchema: [String: Any] = [
         "type": "object",
         "properties": [
@@ -23,8 +24,15 @@ struct WebSearchTool: NativeTool {
 
         // Try Perplexity first if configured
         if Config.isPerplexityConfigured {
-            let result = await searchPerplexity(query: query)
-            if let result = result {
+            if let result = await searchPerplexity(query: query) {
+                return result
+            }
+            // Fall through on failure
+        }
+
+        // Then Tavily if configured
+        if Config.isTavilyConfigured {
+            if let result = await searchTavily(query: query) {
                 return result
             }
             // Fall through to DuckDuckGo on failure
@@ -85,6 +93,67 @@ struct WebSearchTool: NativeTool {
 
         } catch {
             print("🔍 Perplexity error: \(error.localizedDescription), falling back to DuckDuckGo")
+            return nil
+        }
+    }
+
+    // MARK: - Tavily Search
+
+    private func searchTavily(query: String) async -> String? {
+        guard let url = URL(string: "https://api.tavily.com/search") else { return nil }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(Config.tavilyAPIKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 15
+
+        let body: [String: Any] = [
+            "query": query,
+            "search_depth": "basic",
+            "include_answer": true,
+            "max_results": 5
+        ]
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 15
+        let session = URLSession(configuration: config)
+
+        do {
+            let (data, response) = try await session.data(for: request)
+
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                print("🔍 Tavily failed (HTTP \((response as? HTTPURLResponse)?.statusCode ?? 0)), falling back to DuckDuckGo")
+                return nil // Fall back to DuckDuckGo
+            }
+
+            guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+
+            let results = json["results"] as? [[String: Any]] ?? []
+
+            // Prefer Tavily's synthesized answer; otherwise stitch the top result snippets.
+            var summary = (json["answer"] as? String) ?? ""
+            if summary.isEmpty {
+                let snippets = results.prefix(3).compactMap { $0["content"] as? String }
+                summary = snippets.joined(separator: " ")
+            }
+            guard !summary.isEmpty else { return nil }
+
+            var result = summary
+            let urls = results.prefix(3).compactMap { $0["url"] as? String }
+            if !urls.isEmpty {
+                let sourceList = urls.enumerated().map { "[\($0.offset + 1)] \($0.element)" }
+                result += "\n\nSources: \(sourceList.joined(separator: ", "))"
+            }
+
+            return "Search result for \"\(query)\" (via Tavily): \(result)"
+
+        } catch {
+            print("🔍 Tavily error: \(error.localizedDescription), falling back to DuckDuckGo")
             return nil
         }
     }

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -1840,6 +1840,24 @@ struct Config {
         !perplexityAPIKey.isEmpty
     }
 
+    // MARK: - Tavily Search
+
+    /// Tavily API key. Stored in the Keychain (see `KeychainService`).
+    static var tavilyAPIKey: String {
+        if let key = KeychainService.string(for: "tavilyAPIKey"), !key.isEmpty {
+            return key
+        }
+        return ""
+    }
+
+    static func setTavilyAPIKey(_ key: String) {
+        KeychainService.setString(key, for: "tavilyAPIKey")
+    }
+
+    static var isTavilyConfigured: Bool {
+        !tavilyAPIKey.isEmpty
+    }
+
     // MARK: - Privacy Filter
 
     @UserDefaultsBacked("privacyFilterEnabled", default: false) static var privacyFilterEnabled: Bool


### PR DESCRIPTION
## Summary

Two related changes to the settings/services layer:

### 1. Tavily as an optional web-search provider
`WebSearchTool` now falls back **Perplexity → Tavily → DuckDuckGo**. Tavily is a Keychain-backed, optional provider:
- `POST https://api.tavily.com/search` with `include_answer: true`
- Prefers Tavily's synthesized answer; otherwise stitches the top result snippets
- Appends up to 3 source URLs in the existing "Sources:" format
- Any non-200/parse failure returns `nil` and cascades to DuckDuckGo — same shape as the Perplexity path

Key entry added to the Web Search section in `ServicesSettingsView` (paste-friendly `SecretInputField` + get-key link), stored in the Keychain via `Config.tavilyAPIKey` / `setTavilyAPIKey`.

### 2. `ServicesSettingsView` is now self-contained
Previously it took **8 `@Binding`s** threaded from the 1,188-line root `SettingsView`, which hoisted the state and persisted everything in one deferred `saveSettings()` on disappear. Now:
- The 8 fields (ElevenLabs key/voice/expressive-toggle, Perplexity/Tavily keys, broadcast platform/URL/key) are `@State` seeded from `Config`
- Each persists to `Config` **on change** via `.onChange` — matching the convention already used by `DiarizationSettingsView`, the Home Assistant rows, etc.
- The root `SettingsView` sheds those 8 `@State` decls and their `saveSettings()` writes

Net effect: adding a service field is now a **1-file** change instead of a 3-file ripple (declare state in root → pass binding → declare binding in leaf).

## Behavior / risk
- The leaf view is rebuilt on each navigation-in, so `@State` re-seeds from `Config` fresh — no stale values.
- Platform picker still pre-fills the RTMP URL; that mutation now persists via the URL field's own `.onChange`.
- ElevenLabs quota reset moved into the key's `.onChange` (fires on actual key edits, not every settings close).
- No data-loss path: fields are written to `Config` before the parent ever disappears.

## Test
`BUILD SUCCEEDED` — Xcode 27.0 / iOS 27.0 simulator, full app + Watch + Share Extension + Widget targets. No device needed for these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)