### PR TITLE
Clean up compiler warnings (weak-self, Combine import, Swift 6 isolation)

### DIFF
--- a/OpenGlasses/Sources/App/CarPlaySceneDelegate.swift
+++ b/OpenGlasses/Sources/App/CarPlaySceneDelegate.swift
@@ -254,7 +254,8 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
     /// Rebuild the conversations tab with current data from the main actor.
     func refreshConversationsTab() {
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
+            guard let self else { return }
             guard let store = AppStateProvider.shared?.conversationStore else { return }
             let threads = store.threads.sorted { $0.updatedAt > $1.updatedAt }.prefix(11)
 
@@ -301,7 +302,8 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
     /// Rebuild the playbooks tab with current data from the main actor.
     func refreshPlaybooksTab() {
-        Task { @MainActor in
+        Task { @MainActor [weak self] in
+            guard let self else { return }
             guard let store = AppStateProvider.shared?.playbookStore else { return }
             let playbooks = store.playbooks
             let activeId = store.activeSession?.playbookId

--- a/OpenGlasses/Sources/App/Views/Chat/ChatThreadView.swift
+++ b/OpenGlasses/Sources/App/Views/Chat/ChatThreadView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 import PDFKit
 import UniformTypeIdentifiers
 

--- a/OpenGlasses/Sources/Services/ASR/ASRModelDownloader.swift
+++ b/OpenGlasses/Sources/Services/ASR/ASRModelDownloader.swift
@@ -96,7 +96,9 @@ final class ASRModelDownloader: ObservableObject {
 
     /// Fetches each required file directly from HuggingFace (the files are unpacked, so no tree
     /// enumeration). Progress is per-file completed fraction.
-    static let liveInstaller: Installer = { bundle, destination, progress in
+    // nonisolated: a pure closure literal (no main-actor state at definition) so it can be the
+    // default argument of the nonisolated init below.
+    nonisolated static let liveInstaller: Installer = { bundle, destination, progress in
         let files = bundle.requiredFiles
         for (index, name) in files.enumerated() {
             let url = bundle.huggingFaceResolveURL(for: name)
@@ -107,6 +109,9 @@ final class ASRModelDownloader: ObservableObject {
             let dest = destination.appendingPathComponent(name)
             try? FileManager.default.removeItem(at: dest)
             try FileManager.default.moveItem(at: tempURL, to: dest)
+            // NB: the `await` is required — calling the @MainActor `progress` closure from this
+            // nonisolated context is an actor hop. (The "no async operations" warning is a known
+            // diagnostic quirk that disagrees with the type system; removing await fails to build.)
             await progress(Double(index + 1) / Double(max(files.count, 1)))
         }
     }

--- a/OpenGlasses/Sources/Services/Display/ProcedureHUDTaskSource.swift
+++ b/OpenGlasses/Sources/Services/Display/ProcedureHUDTaskSource.swift
@@ -21,8 +21,11 @@ extension FieldSessionService: ProcedureHosting {}
 final class ProcedureHUDTaskSource: HUDTaskSource {
     private let host: ProcedureHosting
 
-    init(host: ProcedureHosting = FieldSessionService.shared) {
-        self.host = host
+    // Default resolved in the body (not the signature): `FieldSessionService.shared` is
+    // main-actor-isolated, and a default argument is evaluated in the caller's (possibly
+    // nonisolated) context, which Swift 6 rejects.
+    init(host: ProcedureHosting? = nil) {
+        self.host = host ?? FieldSessionService.shared
     }
 
     var changes: AnyPublisher<Void, Never> {

--- a/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift
+++ b/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift
@@ -264,8 +264,11 @@ class GeminiLiveSessionManager: ObservableObject {
                 guard let self else { return }
                 Task { @MainActor in
                     for call in toolCall.functionCalls {
-                        self.toolCallRouter?.handleToolCall(call) { [weak self] response in
-                            self?.geminiService.sendToolResponse(response)
+                        // `self` is already strongly held by the enclosing handler (guard let self
+                        // above) for the duration of this response, so a redundant inner [weak self]
+                        // only tripped the ownership-mismatch warning.
+                        self.toolCallRouter?.handleToolCall(call) { response in
+                            self.geminiService.sendToolResponse(response)
                         }
                     }
                 }

--- a/OpenGlasses/Sources/Services/MemoryRewindService.swift
+++ b/OpenGlasses/Sources/Services/MemoryRewindService.swift
@@ -23,7 +23,8 @@ class MemoryRewindService: ObservableObject {
     /// Periodically refreshes the published duration off the audio hot path.
     private var durationTimer: Timer?
 
-    private static func bytesPerMinute(at rate: Double) -> Int { Int(rate) * 2 * 60 }
+    // Pure (no main-actor state) — nonisolated so the ingest-queue paths can call it.
+    private nonisolated static func bytesPerMinute(at rate: Double) -> Int { Int(rate) * 2 * 60 }
 
     /// Reference to wake word service for audio tap
     weak var wakeWordService: WakeWordService?
@@ -71,7 +72,9 @@ class MemoryRewindService: ObservableObject {
         print("⏪ Memory rewind stopped")
     }
 
-    private func refreshDuration() {
+    // nonisolated: only touches ingest-queue state and hops to @MainActor for the UI update,
+    // so it's safe to call from the nonisolated duration timer.
+    private nonisolated func refreshDuration() {
         ingestQueue.async { [weak self] in
             guard let self, let ring = self.ring else { return }
             let minutes = Double(ring.count) / Double(Self.bytesPerMinute(at: self.bufferSampleRate))

--- a/OpenGlasses/Sources/Services/Offline/OfflineQueue.swift
+++ b/OpenGlasses/Sources/Services/Offline/OfflineQueue.swift
@@ -52,7 +52,7 @@ final class OfflineQueue {
         bindText(stmt, 2, op.kind.rawValue)
         bindText(stmt, 3, op.sessionId)
         op.payload.withUnsafeBytes { raw in
-            sqlite3_bind_blob(stmt, 4, raw.baseAddress, Int32(op.payload.count), Self.transient)
+            _ = sqlite3_bind_blob(stmt, 4, raw.baseAddress, Int32(op.payload.count), Self.transient)
         }
         sqlite3_bind_double(stmt, 5, op.createdAt.timeIntervalSince1970)
         sqlite3_bind_int(stmt, 6, Int32(op.attempts))

--- a/OpenGlasses/Sources/Services/Skills/SkillEvolutionService.swift
+++ b/OpenGlasses/Sources/Services/Skills/SkillEvolutionService.swift
@@ -41,7 +41,9 @@ final class SkillEvolutionService: ObservableObject {
     var rateThreshold = 6.0          // failures/hour for the burst path
     var window: TimeInterval = 1800  // 30 min
 
-    init(store: EvolvedSkillStore = .shared) { self.store = store }
+    // Default resolved in the body: `.shared` is main-actor-isolated and can't be a default
+    // argument (evaluated in the caller's possibly-nonisolated context) under Swift 6.
+    init(store: EvolvedSkillStore? = nil) { self.store = store ?? .shared }
 
     /// Record an unsatisfactory turn. No-op unless Agent Mode is on (the whole feature is gated).
     func record(_ sample: FailureSample) {

--- a/OpenGlasses/Sources/Services/TextToSpeechService.swift
+++ b/OpenGlasses/Sources/Services/TextToSpeechService.swift
@@ -765,8 +765,8 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
 
             // Soft ambient breath every 2 seconds
             thinkingPlayer?.play()
-            thinkingTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
-                Task { @MainActor [weak self] in
+            thinkingTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+                Task { @MainActor in
                     self?.thinkingPlayer?.currentTime = 0
                     self?.thinkingPlayer?.play()
                 }


### PR DESCRIPTION
Cleans up pre-existing compiler warnings surfaced by a build (none from recent feature work). Fixed the clearly-safe, headless-verifiable ones; deferred two device-unverifiable areas.

## Fixed (9 files)
- **ChatThreadView** — add `import Combine` (`Timer.publish(...).autoconnect()` used a transitively-imported type).
- **OfflineQueue** — discard the unused `sqlite3_bind_blob` result inside `withUnsafeBytes`.
- **MemoryRewindService** — `nonisolated` on the pure `bytesPerMinute` and the ingest-queue-only `refreshDuration` (no main-actor state) → clears 4 "main-actor call from nonisolated" warnings.
- **ASRModelDownloader** — `nonisolated static let liveInstaller` so it's a valid default arg; this *also* clears the redundant-`await` warning (isolation is now unambiguous, so the required actor-hop `await` is no longer misflagged).
- **ProcedureHUDTaskSource / SkillEvolutionService** — resolve the main-actor `.shared` default inside the init body (Swift 6 evaluates default args in the caller's possibly-nonisolated context).
- **CarPlaySceneDelegate / TextToSpeechService / GeminiLiveSessionManager** — fix "weak ownership differs from strong outer" mismatches: make the outer capture explicitly `[weak self]` (CarPlay Tasks, TTS timer) or drop a redundant inner `[weak self]` where the enclosing scope already guarantees `self` (Gemini tool-response callback).

## Deferred (called out, not silently skipped)
- **LocalServerScanner** (2 warnings) — mutable-capture + non-Sendable conversion in experimental `NWBrowser` Bonjour code; the concurrency-safe restructure changes device behavior I can't verify headlessly.
- **KokoroSynthesizer** (1) — `SherpaOnnxOfflineTtsGenerate` deprecation; the `WithConfig` swap is a vendored-C-API change needing on-device TTS verification.

These are warnings under Swift 5.9 (the "error in Swift 6 language mode" ones are future-proofing), so deferring is safe.

## Gates
build-for-testing ✅ · full suite **1603 / 0** ✅ · Release ✅
(One sim runner-hang flake mid-run, cleared by a `simctl erase` + retry — not a code failure.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)