### PR TITLE
Simple Mode: hide the owner-only Settings surface

### DIFF
--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -7,6 +7,7 @@ struct SettingsView: View {
     @AppStorage("accentColorName") private var accentColorName: String = "violet"
 
     // Model configs editing
+    @State private var simpleModeEnabled = Config.simpleModeEnabled
     @State private var modelConfigs: [ModelConfig] = Config.savedModels
     @State private var editingModel: ModelConfig? = nil
     @State private var showAddModel = false
@@ -105,6 +106,10 @@ struct SettingsView: View {
                 Text("Alternative ways to start the assistant without the wake word — for noisy, silent, or no-speech situations. All are off by default. The Volume Button trigger can interfere with normal volume control.")
             }
 
+            // Simple Mode hides the owner-only configuration surface (models, personas,
+            // behavior, tools, integrations, advanced) — the device keeps working exactly
+            // as configured; the sections below just stop being visible/editable.
+            if !simpleModeEnabled {
             // MARK: AI Models
             Section {
                 ForEach(modelConfigs) { model in
@@ -442,6 +447,8 @@ struct SettingsView: View {
                 Text("ElevenLabs voices, Perplexity search, broadcast targets, and live-streaming live under Services. Gateways are OpenClaw bridges to your devices (smart home, automations). MCP Servers expose external tool servers the AI can call.")
             }
 
+            }
+
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
             // MARK: — Glasses & Privacy
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -548,6 +555,7 @@ struct SettingsView: View {
                 Text("Theme, accent colour, and which languages the assistant speaks and understands.")
             }
 
+            if !simpleModeEnabled {
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
             // MARK: — Advanced
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -586,6 +594,18 @@ struct SettingsView: View {
                 Text("Advanced")
             } footer: {
                 Text("Diagnostic tools for power users — inspect the prompts being sent to the AI and watch live network requests. Useful for debugging or building your own integrations.")
+            }
+
+            }
+
+            // MARK: Simple Mode (always visible so the owner can leave it)
+            Section {
+                Toggle(isOn: $simpleModeEnabled) {
+                    Label("Simple Mode", systemImage: "dial.low")
+                }
+                .onChange(of: simpleModeEnabled) { _, v in Config.simpleModeEnabled = v }
+            } footer: {
+                Text("Hides model, persona, behavior, tool, integration, and advanced settings — for handing the device to someone who just needs it to work. Everything keeps running exactly as configured.")
             }
 
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -1406,6 +1406,13 @@ struct Config {
 
     static func setShowAllQuickActions(_ show: Bool) { showAllQuickActions = show }
 
+    // MARK: - Simple Mode
+
+    /// Hide the owner-only configuration surface in Settings (models, personas, behavior, tools,
+    /// integrations, advanced) — for handing the device to someone who just needs it to work.
+    /// Pure UI gating: nothing about routing or behavior changes. Default off.
+    @UserDefaultsBacked("simpleModeEnabled", default: false) static var simpleModeEnabled: Bool
+
     // MARK: - Uncertainty Web Search (Plan BI)
 
     /// Local backends (MLX, Apple Foundation) can't tool-call `web_search`; when on, a hedged or

--- a/OpenGlassesTests/SimpleModeTests.swift
+++ b/OpenGlassesTests/SimpleModeTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Simple Mode is pure Settings-surface gating for handing the device to a non-technical user.
+final class SimpleModeTests: XCTestCase {
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "simpleModeEnabled")
+        super.tearDown()
+    }
+
+    func testDefaultsOff() {
+        UserDefaults.standard.removeObject(forKey: "simpleModeEnabled")
+        XCTAssertFalse(Config.simpleModeEnabled, "the owner sees the full app out of the box")
+    }
+
+    func testTogglePersists() {
+        Config.simpleModeEnabled = true
+        XCTAssertTrue(Config.simpleModeEnabled)
+        Config.simpleModeEnabled = false
+        XCTAssertFalse(Config.simpleModeEnabled)
+    }
+}


### PR DESCRIPTION
A kiosk-style **Simple Mode** for handing the device to a non-technical user (the reseller / end-user scenario) — the owner configures everything, then flips one toggle to hide the machinery.

## What it does
`Config.simpleModeEnabled` (default **off**) gates the owner-only Settings sections behind `if !simpleModeEnabled`:
- **Hidden in Simple Mode:** AI Models, Personality, How It Behaves, Tools the AI Can Use, Connected Apps & Services, Advanced.
- **Always visible:** Voice, Hands-Free Triggers, Glasses & Privacy, Look & Feel, About — plus an always-visible **Simple Mode** toggle so the owner can always leave it.

## Scope
**Pure UI gating.** Nothing about routing, model selection, or behavior changes — the device keeps working exactly as configured; the sections just stop being visible/editable. This is deliberately *not* the fork's "phone as terminal / VPS-only intelligence" strategy — just a settings-surface reduction, the genuinely upstream-useful half.

## Tests
`SimpleModeTests`: default-off (owner sees the full app out of the box) + toggle persistence.

## Gates
build-for-testing ✅ · full suite **1605 / 0** ✅ · Release ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)