### PR TITLE
Registration: wait longer for Meta AI approval + actionable status

### DIFF
--- a/OpenGlasses/Sources/Services/GlassesConnectionService.swift
+++ b/OpenGlasses/Sources/Services/GlassesConnectionService.swift
@@ -60,19 +60,20 @@ class GlassesConnectionService: ObservableObject {
         do {
             try await Wearables.shared.startRegistration()
 
-            // Poll registration state — can take up to ~10s on fresh install
+            // Poll registration state. `startRegistration()` returns before the user approves the
+            // app in the Meta AI companion app, and that approval has been seen to take ~25s — so
+            // wait that long (RegistrationFlow policy) and, throughout, show an actionable "approve
+            // in Meta AI" status instead of giving up early with a cryptic internal state number.
             var stateAfter = Wearables.shared.registrationState
-            let deadline = ContinuousClock.now + .seconds(10)
-            while stateAfter.rawValue < 3, ContinuousClock.now < deadline {
-                connectionStatus = "Registering… (state \(stateAfter.rawValue))"
+            let deadline = ContinuousClock.now + .seconds(RegistrationFlow.approvalDeadlineSeconds)
+            while !RegistrationFlow.isRegistered(stateRaw: stateAfter.rawValue), ContinuousClock.now < deadline {
+                connectionStatus = RegistrationFlow.status(stateRaw: stateAfter.rawValue)
                 try? await Task.sleep(nanoseconds: 500_000_000)
                 stateAfter = Wearables.shared.registrationState
             }
 
             print("✅ startRegistration() succeeded, state: \(stateAfter)")
-            connectionStatus = stateAfter.rawValue >= 3
-                ? "Waiting for device..."
-                : "Complete authorization in Meta AI app"
+            connectionStatus = RegistrationFlow.status(stateRaw: stateAfter.rawValue)
         } catch {
             print("❌ startRegistration() failed: \(error)")
             connectionStatus = "Connection failed: \(error.localizedDescription)"

--- a/OpenGlasses/Sources/Services/RegistrationFlow.swift
+++ b/OpenGlasses/Sources/Services/RegistrationFlow.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Pure policy for the Meta registration wait — the setup step that most often blocks users
+/// (the DAT permission gate is *the* onboarding blocker).
+///
+/// `Wearables.startRegistration()` returns *before* the user has approved the app inside the Meta
+/// AI companion app; `registrationState` only reaches the camera/mic-capable value once they do,
+/// and that approval has been observed to take ~25 s. The old 10 s deadline gave up while the user
+/// was still tapping through Meta AI, leaving a "connected but nothing works" state — and the
+/// status shown was a raw internal state number, not something the user could act on.
+enum RegistrationFlow {
+    /// How long to keep polling for the Meta AI approval before giving up (still with guidance).
+    static let approvalDeadlineSeconds: Int64 = 25
+    /// `registrationState` raw value at which camera/mic capabilities become available.
+    static let registeredStateRawValue = 3
+
+    static func isRegistered(stateRaw: Int) -> Bool { stateRaw >= registeredStateRawValue }
+
+    /// User-facing connection status — tells the user what to *do*, never an internal state number.
+    static func status(stateRaw: Int) -> String {
+        isRegistered(stateRaw: stateRaw)
+            ? "Waiting for device…"
+            : "Approve OpenGlasses in the Meta AI app to continue…"
+    }
+}

--- a/OpenGlassesTests/RegistrationFlowTests.swift
+++ b/OpenGlassesTests/RegistrationFlowTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import OpenGlasses
+
+/// The Meta-registration wait policy: the registered threshold, actionable status text, and a
+/// deadline long enough for the real Meta AI approval round-trip.
+final class RegistrationFlowTests: XCTestCase {
+
+    func testRegisteredThreshold() {
+        XCTAssertFalse(RegistrationFlow.isRegistered(stateRaw: 0))
+        XCTAssertFalse(RegistrationFlow.isRegistered(stateRaw: 2))
+        XCTAssertTrue(RegistrationFlow.isRegistered(stateRaw: 3))
+        XCTAssertTrue(RegistrationFlow.isRegistered(stateRaw: 4))
+    }
+
+    func testStatusTellsTheUserWhatToDoWhileWaiting() {
+        let waiting = RegistrationFlow.status(stateRaw: 2)
+        XCTAssertTrue(waiting.contains("Meta AI"), "the blocked state is fixed in the Meta AI app — say so")
+        XCTAssertFalse(waiting.contains("state"), "never surface a raw internal state number")
+        XCTAssertFalse(waiting.contains(where: \.isNumber), "no digits in the user-facing status")
+    }
+
+    func testStatusOnceRegistered() {
+        XCTAssertEqual(RegistrationFlow.status(stateRaw: 3), "Waiting for device…")
+        XCTAssertEqual(RegistrationFlow.status(stateRaw: 4), "Waiting for device…")
+    }
+
+    func testDeadlineCoversTheObservedApprovalLatency() {
+        XCTAssertGreaterThanOrEqual(RegistrationFlow.approvalDeadlineSeconds, 25,
+            "Meta AI approval has been observed to take ~25s; the old 10s deadline gave up too early")
+    }
+}


### PR DESCRIPTION
Improves the onboarding step that blocks users most — the Meta DAT permission gate.

## The problem
`Wearables.startRegistration()` returns *before* the user approves the app in the Meta AI companion app; `registrationState` only reaches the camera/mic-capable value (3) once they do, and that approval has been observed to take **~25 s**. The poll gave up after **10 s**, and during the wait showed a raw internal state number (`Registering… (state 2)`) the user can't act on — leaving a "connected but nothing works" state.

## Change
- **`RegistrationFlow`** (pure, headless-tested): the registered threshold (3), a **25 s** approval deadline, and actionable status text — `Approve OpenGlasses in the Meta AI app to continue…` until registered, then `Waiting for device…`. Never a state number.
- **`GlassesConnectionService.connect()`** polls against the policy's deadline and shows its status throughout and at the end.

Camera permission is deliberately **unchanged** — `CameraService` already requests it on first stream, so this adds no duplicate prompt.

## Tests
`RegistrationFlowTests`: threshold, actionable status (mentions "Meta AI", contains no digits), registered status, and the deadline ≥ 25 s.

## Gates
build-for-testing ✅ · full suite **1609 / 0** ✅ · Release ✅

## Device-verified
The pure policy is covered headlessly; the live registration round-trip (the actual ~25 s Meta AI approval and state transitions) needs Ray-Ban hardware + the Meta AI app to confirm the longer wait and status read correctly on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)