### PR TITLE
Locale-aware speech recognition (was hardcoded en-US everywhere)

### DIFF
--- a/OpenGlasses/Sources/Services/AmbientCaptionService.swift
+++ b/OpenGlasses/Sources/Services/AmbientCaptionService.swift
@@ -57,7 +57,7 @@ class AmbientCaptionService: ObservableObject {
     private var lastFinalizedText = ""
 
     init() {
-        recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+        recognizer = SFSpeechRecognizer(locale: SpeechLocaleResolver.current)
     }
 
     // MARK: - Public API

--- a/OpenGlasses/Sources/Services/MemoryRewindService.swift
+++ b/OpenGlasses/Sources/Services/MemoryRewindService.swift
@@ -29,7 +29,7 @@ class MemoryRewindService: ObservableObject {
     /// Reference to wake word service for audio tap
     weak var wakeWordService: WakeWordService?
 
-    private let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+    private let recognizer = SFSpeechRecognizer(locale: SpeechLocaleResolver.current)
 
     // MARK: - Public API
 

--- a/OpenGlasses/Sources/Services/Teleprompter/TeleprompterService.swift
+++ b/OpenGlasses/Sources/Services/Teleprompter/TeleprompterService.swift
@@ -73,7 +73,7 @@ final class TeleprompterService: ObservableObject {
     private var geometry = TeleprompterPaginator.Geometry(maxLines: 3, maxChars: 32)
 
     // Live recognition (device-pending shell).
-    private let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+    private let recognizer = SFSpeechRecognizer(locale: SpeechLocaleResolver.current)
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
     private var recognitionTask: SFSpeechRecognitionTask?
     static let recognitionConsumerID = "teleprompter"

--- a/OpenGlasses/Sources/Services/TranscriptionService.swift
+++ b/OpenGlasses/Sources/Services/TranscriptionService.swift
@@ -39,7 +39,7 @@ class TranscriptionService: ObservableObject {
     private var captureSampleRate: Double = 16000
 
     init() {
-        speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+        speechRecognizer = SFSpeechRecognizer(locale: SpeechLocaleResolver.current)
     }
 
     func startRecording() {

--- a/OpenGlasses/Sources/Services/WakeWordService.swift
+++ b/OpenGlasses/Sources/Services/WakeWordService.swift
@@ -101,7 +101,7 @@ class WakeWordService: NSObject, ObservableObject {
 
     override init() {
         super.init()
-        speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+        speechRecognizer = SFSpeechRecognizer(locale: SpeechLocaleResolver.current)
     }
 
     /// Force reconfigure audio session (e.g. when mic source changes)

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -1406,6 +1406,16 @@ struct Config {
 
     static func setShowAllQuickActions(_ show: Bool) { showAllQuickActions = show }
 
+    // MARK: - Speech Recognition Locale
+
+    /// Which locale the speech features (wake word, transcription, captions, rewind, teleprompter)
+    /// recognize in. `"auto"` follows the device's preferred language; an explicit identifier
+    /// (e.g. `"de-DE"`) pins it. Resolved against what `SFSpeechRecognizer` actually supports —
+    /// see `SpeechLocaleResolver`. Default `"auto"` (was hardcoded en-US everywhere).
+    @UserDefaultsBacked("speechRecognitionLocale", default: "auto") static var speechRecognitionLocale: String
+
+    static func setSpeechRecognitionLocale(_ id: String) { speechRecognitionLocale = id }
+
     // MARK: - Simple Mode
 
     /// Hide the owner-only configuration surface in Settings (models, personas, behavior, tools,

--- a/OpenGlasses/Sources/Utils/SpeechLocaleResolver.swift
+++ b/OpenGlasses/Sources/Utils/SpeechLocaleResolver.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Speech
+
+/// Resolves which `SFSpeechRecognizer` locale the speech features use — wake word,
+/// transcription, ambient captions, memory rewind, teleprompter. Previously all of them
+/// hardcoded en-US, so non-English wake phrases and dictation quietly under-performed.
+///
+/// `"auto"` (the default) follows the device's preferred languages, constrained to what
+/// `SFSpeechRecognizer` actually supports on this OS; an explicit identifier pins it (with
+/// same-language region fallback, e.g. fr-CA → fr-FR when only fr-FR is supported). en-US is
+/// the last-resort fallback — exactly the old behavior for English-device users.
+enum SpeechLocaleResolver {
+
+    static let automatic = "auto"
+
+    /// Pure resolution: preference + device languages + supported identifiers → identifier.
+    /// Matching is case- and separator-insensitive; the returned value is always one of
+    /// `supported` (or "en-US" when nothing matches).
+    static func resolve(preference: String, deviceLanguages: [String], supported: [String]) -> String {
+        // lowercased-canonical → original supported identifier (first wins per key)
+        var exact: [String: String] = [:]
+        var byLanguage: [String: [String]] = [:]
+        for identifier in supported.sorted() {
+            let key = canonical(identifier)
+            if exact[key] == nil { exact[key] = identifier }
+            byLanguage[languageCode(of: identifier), default: []].append(identifier)
+        }
+
+        func bestMatch(_ candidate: String) -> String? {
+            if let hit = exact[canonical(candidate)] { return hit }
+            return byLanguage[languageCode(of: candidate)]?.first
+        }
+
+        if preference != automatic, let match = bestMatch(preference) { return match }
+        for language in deviceLanguages {
+            if let match = bestMatch(language) { return match }
+        }
+        return "en-US"
+    }
+
+    /// The live resolution the speech services use when creating a recognizer.
+    static var current: Locale {
+        let supported = SFSpeechRecognizer.supportedLocales().map(\.identifier)
+        let identifier = resolve(
+            preference: Config.speechRecognitionLocale,
+            deviceLanguages: Locale.preferredLanguages,
+            supported: supported
+        )
+        return Locale(identifier: identifier)
+    }
+
+    // MARK: - Private
+
+    private static func canonical(_ identifier: String) -> String {
+        identifier.replacingOccurrences(of: "_", with: "-").lowercased()
+    }
+
+    private static func languageCode(of identifier: String) -> String {
+        canonical(identifier).components(separatedBy: "-").first ?? identifier
+    }
+}

--- a/OpenGlassesTests/SpeechLocaleResolverTests.swift
+++ b/OpenGlassesTests/SpeechLocaleResolverTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Locale resolution for all speech features (wake word, transcription, captions, rewind,
+/// teleprompter). Language-agnostic by design — no per-language special cases.
+final class SpeechLocaleResolverTests: XCTestCase {
+
+    private let supported = ["en-US", "en-GB", "fr-FR", "de-DE", "pt-BR", "ja-JP"]
+
+    private func resolve(_ preference: String, device: [String] = ["en-US"]) -> String {
+        SpeechLocaleResolver.resolve(preference: preference, deviceLanguages: device, supported: supported)
+    }
+
+    // MARK: - Explicit preference
+
+    func testExactMatchWins() {
+        XCTAssertEqual(resolve("de-DE"), "de-DE")
+        XCTAssertEqual(resolve("pt-BR", device: ["en-US"]), "pt-BR")
+    }
+
+    func testMatchingIsCaseAndSeparatorInsensitive() {
+        XCTAssertEqual(resolve("DE_de"), "de-DE")
+        XCTAssertEqual(resolve("pt_br"), "pt-BR")
+    }
+
+    func testSameLanguageRegionFallback() {
+        // fr-CA isn't supported; any supported French beats falling back to English.
+        XCTAssertEqual(resolve("fr-CA"), "fr-FR")
+    }
+
+    func testUnsupportedPreferenceFallsBackToDeviceThenEnglish() {
+        XCTAssertEqual(resolve("xx-XX", device: ["de-DE"]), "de-DE")
+        XCTAssertEqual(resolve("xx-XX", device: ["yy-YY"]), "en-US")
+    }
+
+    // MARK: - Automatic
+
+    func testAutoFollowsFirstSupportedDeviceLanguage() {
+        XCTAssertEqual(resolve(SpeechLocaleResolver.automatic, device: ["ja-JP", "en-US"]), "ja-JP")
+        XCTAssertEqual(resolve(SpeechLocaleResolver.automatic, device: ["nl-NL", "de-DE"]), "de-DE",
+                       "unsupported first language → next preferred one")
+    }
+
+    func testAutoRegionFallbackForDeviceLanguage() {
+        XCTAssertEqual(resolve(SpeechLocaleResolver.automatic, device: ["pt-PT"]), "pt-BR",
+                       "same-language region beats English")
+    }
+
+    func testAutoWithNothingSupportedIsEnglishUS() {
+        XCTAssertEqual(resolve(SpeechLocaleResolver.automatic, device: ["zz-ZZ"]), "en-US",
+                       "the old hardcoded behavior is the floor")
+    }
+
+    func testResolutionAlwaysReturnsASupportedIdentifierOrEnUS() {
+        for pref in ["auto", "de-DE", "fr-CA", "xx"] {
+            let out = resolve(pref, device: ["it-IT"])
+            XCTAssertTrue(supported.contains(out) || out == "en-US", "\(pref) → \(out)")
+        }
+    }
+
+    // MARK: - Config default
+
+    func testPreferenceDefaultsToAutomatic() {
+        UserDefaults.standard.removeObject(forKey: "speechRecognitionLocale")
+        XCTAssertEqual(Config.speechRecognitionLocale, SpeechLocaleResolver.automatic)
+    }
+}


### PR DESCRIPTION
The last of the fork-inspired features — and generalized to be language-agnostic (not pt-BR-specific).

## The problem
Five services created their `SFSpeechRecognizer` with a hardcoded `en-US` locale — wake word, transcription, ambient captions, memory rewind, teleprompter. On a non-English device (or with a non-English wake phrase) recognition quietly under-performed.

## Change
- **`SpeechLocaleResolver`** (pure, headless-tested): resolves a preference + the device's preferred languages against what `SFSpeechRecognizer.supportedLocales()` actually offers. `"auto"` (default) follows the device language; an explicit identifier pins it; **same-language region fallback** (`fr-CA` → `fr-FR` when only `fr-FR` is supported); `en-US` as the last resort — i.e. **exactly the old behavior for English devices**, better for everyone else. Case/separator-insensitive matching (`de_DE` ≡ `de-DE`).
- **`Config.speechRecognitionLocale`** (default `"auto"`).
- All 5 recognizer sites → `SpeechLocaleResolver.current`.

No per-language special-casing. Cloud transcription (Deepgram, etc.) is untouched — this is the on-device Speech framework path only.

## Tests
`SpeechLocaleResolverTests` (9): exact/case/separator matching, same-language region fallback, unsupported-preference → device → en-US chain, `auto` following device languages, always returns a supported id or en-US, and the Config default.

## Gates
build-for-testing ✅ · full suite **1618 / 0** ✅ · Release ✅ (one sim runner-hang flake mid-run, cleared by erase+retry — not a code issue)

## Device-verified / follow-up
The resolution logic is fully covered headlessly; actual non-English recognition accuracy needs a device. A Settings picker to override `"auto"` is an easy follow-up — the Config flag and resolver already support an explicit identifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)