### PR TITLE
Scope brain/memory/teleprompter retrieval to the active project (BM P8)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -794,8 +794,11 @@ class AppState: ObservableObject, AppStateProtocol {
         nativeToolRegistry.register(translationTool)
 
         // Teleprompter tool (Phase 2): registered after the lazy service is available. The
-        // document store enables prompting from a saved knowledge-base doc (Document-RAG source).
-        nativeToolRegistry.register(TeleprompterTool(service: teleprompterService, documentStore: documentStore))
+        // document store enables prompting from a saved knowledge-base doc (Document-RAG source),
+        // scoped to the active project + global so it can't read another project's doc (Plan BM P8).
+        var teleprompterTool = TeleprompterTool(service: teleprompterService, documentStore: documentStore)
+        teleprompterTool.activeNamespace = { memoryForNamespace.activePersonaId ?? "global" }
+        nativeToolRegistry.register(teleprompterTool)
 
         // Wire translation output to TTS
         liveTranslation.onTranslation = { [weak self] translation in

--- a/OpenGlasses/Sources/Services/NativeTools/BrainTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/BrainTool.swift
@@ -41,8 +41,22 @@ struct BrainTool: NativeTool {
 
     var memoryStore: SemanticMemoryStore?
     var documentStore: DocumentStore?
+    /// Resolves the active project's namespace (Plan AN). Defaults to "global" when unset or no
+    /// project is active. Retrieval is scoped through this so an unscoped/global chat never sees a
+    /// project's documents or another persona's memory (the inverse of projects-see-global).
+    var activeNamespace: (() -> String)?
 
     private static let maxResultChars = 2200
+
+    /// The active project's namespace for this call.
+    private func currentNamespace() -> String { activeNamespace?() ?? "global" }
+
+    /// Namespaces a scoped query may read: shared "global" plus the active project (projects see
+    /// global; global never sees a project). Deduped when already global.
+    private func scopedNamespaces() -> [String] {
+        let ns = currentNamespace()
+        return ns == "global" ? ["global"] : ["global", ns]
+    }
 
     func execute(args: [String: Any]) async throws -> String {
         let action = (args["action"] as? String ?? "query").lowercased()
@@ -148,7 +162,7 @@ struct BrainTool: NativeTool {
         case "status", "stats":
             let stats = brain.stats
             let memoryCount = memoryStore != nil ? "available" : "disabled"
-            let docCount = documentStore?.list().count ?? 0
+            let docCount = documentStore?.documentCount(namespace: currentNamespace()) ?? 0
             return "Brain: \(stats.entities) entities, \(stats.edges) relationships, \(stats.encounters) encounters, \(stats.openNeeds) open follow-ups. " +
                    "Semantic memory \(memoryCount); \(docCount) documents; \(SocialContextStore.shared.allPeople().count) people with notes."
 
@@ -176,15 +190,17 @@ struct BrainTool: NativeTool {
             sections.append("RELATIONSHIPS & ENCOUNTERS:\n" + graphLines.joined(separator: "\n"))
         }
 
-        // Semantic memory (embedding search over remembered facts).
-        let memoryHits = memoryStore?.semanticSearch(query: question, limit: 4) ?? []
+        // Semantic memory (embedding search over remembered facts). Scoped to global + the active
+        // project so an unscoped chat never surfaces another persona's remembered facts.
+        let memoryHits = memoryStore?.semanticSearch(query: question, limit: 4, namespaces: scopedNamespaces()) ?? []
         if memoryHits.isEmpty { gaps.append("remembered facts") } else {
             let lines = memoryHits.map { "- \($0.keyName): \($0.value) [memory, \(shortDate($0.createdAt))]" }
             sections.append("REMEMBERED FACTS:\n" + lines.joined(separator: "\n"))
         }
 
-        // Documents (embedding search over ingested document chunks).
-        let passages = documentStore?.query(question, limit: 3) ?? []
+        // Documents (embedding search over ingested document chunks). Scoped to the active project
+        // namespace like DocumentRAGTool, so a global chat never retrieves a project's documents.
+        let passages = documentStore?.query(question, limit: 3, namespace: currentNamespace()) ?? []
         if passages.isEmpty { gaps.append("documents") } else {
             let lines = passages.map { passage -> String in
                 let locator = passage.page.map { ", p.\($0)" } ?? ""
@@ -271,7 +287,7 @@ struct BrainTool: NativeTool {
             sections.append("OPEN FOLLOW-UPS:\n" + openNeeds.map { "- \($0.text)" }.joined(separator: "\n"))
         }
 
-        let memoryHits = memoryStore?.semanticSearch(query: person, limit: 3) ?? []
+        let memoryHits = memoryStore?.semanticSearch(query: person, limit: 3, namespaces: scopedNamespaces()) ?? []
         if !memoryHits.isEmpty {
             sections.append("FROM MEMORY:\n" + memoryHits.map { "- \($0.keyName): \($0.value)" }.joined(separator: "\n"))
         }

--- a/OpenGlasses/Sources/Services/NativeTools/MemorySearchTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/MemorySearchTool.swift
@@ -29,6 +29,15 @@ struct MemorySearchTool: NativeTool {
     ]
 
     weak var memoryStore: SemanticMemoryStore?
+    /// Resolves the active project's namespace (Plan AN). Defaults to "global". Search is scoped
+    /// through this so a global chat never surfaces another persona's memory (Plan BM P8).
+    var activeNamespace: (() -> String)?
+
+    /// Namespaces a scoped search may read: shared "global" plus the active project.
+    private func scopedNamespaces() -> [String] {
+        let ns = activeNamespace?() ?? "global"
+        return ns == "global" ? ["global"] : ["global", ns]
+    }
 
     func execute(args: [String: Any]) async throws -> String {
         guard let store = memoryStore else {
@@ -41,7 +50,8 @@ struct MemorySearchTool: NativeTool {
         let limit = min(args["limit"] as? Int ?? 5, 15)
         let topicFilter = args["topic"] as? String
 
-        var results = await MainActor.run { store.semanticSearch(query: query, limit: limit) }
+        let namespaces = scopedNamespaces()
+        var results = await MainActor.run { store.semanticSearch(query: query, limit: limit, namespaces: namespaces) }
 
         if let topic = topicFilter {
             results = results.filter { $0.topic == topic }

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
@@ -191,12 +191,14 @@ final class NativeToolRegistry {
         var brainTool = BrainTool()
         brainTool.memoryStore = semanticMemory
         brainTool.documentStore = documentStore
+        brainTool.activeNamespace = activeNamespace   // Project scoping (Plan AN / BM P8)
         register(brainTool)
 
         // Semantic memory tools — only available when memory is enabled
         if let memory = semanticMemory {
             var searchTool = MemorySearchTool()
             searchTool.memoryStore = memory
+            searchTool.activeNamespace = activeNamespace   // Project scoping (Plan AN / BM P8)
             register(searchTool)
             var diaryTool = AgentDiaryTool()
             diaryTool.memoryStore = memory

--- a/OpenGlasses/Sources/Services/NativeTools/TeleprompterTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/TeleprompterTool.swift
@@ -8,6 +8,16 @@ struct TeleprompterTool: NativeTool {
     let service: TeleprompterService
     /// Optional source for starting from a saved knowledge-base document (Document-RAG adapter).
     var documentStore: DocumentStore?
+    /// Resolves the active project's namespace (Plan AN). Defaults to "global" when unset or no
+    /// project is active. Document lookup is scoped through this so one chat can never read another
+    /// project's document by name.
+    var activeNamespace: (() -> String)?
+
+    /// Namespaces a document lookup may read: the active project plus shared "global".
+    private func scopedNamespaces() -> [String] {
+        let ns = activeNamespace?() ?? "global"
+        return ns == "global" ? ["global"] : ["global", ns]
+    }
 
     let name = "teleprompter"
     let description = """
@@ -74,7 +84,8 @@ struct TeleprompterTool: NativeTool {
             }
             if let documentName, !documentName.isEmpty {
                 guard let store = documentStore else { return "Documents aren't available right now." }
-                guard let doc = store.document(named: documentName), let raw = store.fullText(documentId: doc.id) else {
+                guard let doc = store.document(named: documentName, namespaces: scopedNamespaces()),
+                      let raw = store.fullText(documentId: doc.id) else {
                     return "I couldn't find a saved document named \"\(documentName)\"."
                 }
                 let parsed = TeleprompterScript.parse(title: doc.name,

--- a/OpenGlasses/Sources/Services/RAG/DocumentStore.swift
+++ b/OpenGlasses/Sources/Services/RAG/DocumentStore.swift
@@ -153,6 +153,18 @@ final class DocumentStore: ObservableObject {
             ?? documents.first { $0.name.lowercased().contains(needle) }
     }
 
+    /// Resolve a document by name, restricted to an allowed set of namespaces (project scope,
+    /// Plan AN). Callers that reach documents by name — e.g. the teleprompter — must pass
+    /// `{active project, "global"}` so a chat can never read another project's document text.
+    func document(named name: String, namespaces: [String]) -> DocumentRef? {
+        let needle = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !needle.isEmpty else { return nil }
+        let allowed = Set(namespaces)
+        let scoped = documents.filter { allowed.contains($0.namespace) }
+        return scoped.first { $0.name.lowercased() == needle }
+            ?? scoped.first { $0.name.lowercased().contains(needle) }
+    }
+
     /// Reconstruct a document's continuous text from its (overlapping) chunks, in order.
     /// Used by sources that need the whole document, e.g. the teleprompter.
     func fullText(documentId: String) -> String? {

--- a/OpenGlasses/Sources/Services/SemanticMemoryStore.swift
+++ b/OpenGlasses/Sources/Services/SemanticMemoryStore.swift
@@ -219,10 +219,22 @@ class SemanticMemoryStore: ObservableObject {
     // MARK: - Semantic Search (new)
 
     /// Search memories by meaning. Falls back to keyword scoring if no embedding model.
+    /// `namespace: nil` searches EVERY namespace — including other personas' scoped memory —
+    /// so callers at a chat boundary must pass an explicit scope (see the `namespaces:` overload).
     func semanticSearch(query: String, limit: Int = 5, namespace: String? = nil) -> [SearchResult] {
+        scoreSearch(query: query, limit: limit, rows: fetchAllMemories(namespace: namespace))
+    }
+
+    /// Search memories restricted to an explicit set of namespaces (project scope, Plan AN).
+    /// A scoped chat passes `["global", activePersonaId]` so it sees shared memory plus its own
+    /// persona, but never another persona's remembered facts.
+    func semanticSearch(query: String, limit: Int = 5, namespaces: [String]) -> [SearchResult] {
+        scoreSearch(query: query, limit: limit, rows: fetchAllMemories(namespaces: namespaces))
+    }
+
+    private func scoreSearch(query: String, limit: Int, rows: [MemoryEntry]) -> [SearchResult] {
         let queryVec = embed(query)
         let current = embedder.version
-        let rows = fetchAllMemories(namespace: namespace)
 
         let scored: [(MemoryEntry, Float)] = rows.map { row in
             if let qv = queryVec, let stored = fetchEmbedding(key: row.keyName, namespace: row.namespace) {
@@ -513,6 +525,37 @@ class SemanticMemoryStore: ObservableObject {
         defer { sqlite3_finalize(stmt) }
         if let ns = namespace {
             sqlite3_bind_text(stmt, 1, ns, -1, SQLITE_TRANSIENT)
+        }
+        let now = Date().timeIntervalSince1970
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            let expiresAt = sqlite3_column_type(stmt, 6) != SQLITE_NULL ? sqlite3_column_double(stmt, 6) : nil
+            if let exp = expiresAt, exp < now { continue }  // skip expired
+            entries.append(MemoryEntry(
+                id: String(cString: sqlite3_column_text(stmt, 0)),
+                keyName: String(cString: sqlite3_column_text(stmt, 1)),
+                value: String(cString: sqlite3_column_text(stmt, 2)),
+                topic: String(cString: sqlite3_column_text(stmt, 3)),
+                namespace: String(cString: sqlite3_column_text(stmt, 4)),
+                createdAt: Date(timeIntervalSince1970: sqlite3_column_double(stmt, 5)),
+                expiresAt: expiresAt.map { Date(timeIntervalSince1970: $0) }
+            ))
+        }
+        return entries
+    }
+
+    /// Fetch memories across an explicit set of namespaces (deduped). An empty set matches nothing,
+    /// which is the safe default — never fall through to "all namespaces" here.
+    private func fetchAllMemories(namespaces: [String]) -> [MemoryEntry] {
+        let unique = Array(Set(namespaces))
+        guard !unique.isEmpty else { return [] }
+        var entries: [MemoryEntry] = []
+        var stmt: OpaquePointer?
+        let placeholders = unique.map { _ in "?" }.joined(separator: ", ")
+        let sql = "SELECT id, key_name, value, topic, namespace, created_at, expires_at FROM memories WHERE namespace IN (\(placeholders))"
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return entries }
+        defer { sqlite3_finalize(stmt) }
+        for (i, ns) in unique.enumerated() {
+            sqlite3_bind_text(stmt, Int32(i + 1), ns, -1, SQLITE_TRANSIENT)
         }
         let now = Date().timeIntervalSince1970
         while sqlite3_step(stmt) == SQLITE_ROW {

--- a/OpenGlassesTests/ProjectScopingTests.swift
+++ b/OpenGlassesTests/ProjectScopingTests.swift
@@ -116,4 +116,102 @@ final class ProjectScopingTests: XCTestCase {
         let projB = store.query("how do I reset the thermostat", limit: 3, namespace: "projB")
         XCTAssertTrue(projB.isEmpty, "An empty namespace returns no passages")
     }
+
+    // MARK: - Cross-store isolation (Plan BM P8): global never sees project docs
+
+    /// The teleprompter reaches a document by name; that lookup must not cross into another
+    /// project's namespace. Deterministic (name resolution only — no embedder needed).
+    @MainActor
+    func testDocumentByNameHonoursNamespaceScope() async throws {
+        let store = makeStore()
+        _ = await store.ingest(name: "Keynote", text: body, namespace: "projA")
+
+        // A global (or projB) chat cannot resolve projA's document by name…
+        XCTAssertNil(store.document(named: "Keynote", namespaces: ["global"]))
+        XCTAssertNil(store.document(named: "Keynote", namespaces: ["global", "projB"]))
+        // …but its own project (plus shared global) can.
+        XCTAssertEqual(store.document(named: "Keynote", namespaces: ["global", "projA"])?.name, "Keynote")
+    }
+
+    /// Semantic memory search restricted to an explicit namespace set must never return a memory
+    /// from a namespace outside that set (persona isolation). Keyword fallback ⇒ no embedder needed.
+    @MainActor
+    func testMemorySearchNeverCrossesPersonas() {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let memory = SemanticMemoryStore(directory: dir)
+
+        memory.activePersonaId = nil
+        _ = memory.remember("shared fact", value: "the office coffee is excellent")
+        memory.activePersonaId = "personaA"
+        _ = memory.remember("alpha fact", value: "alpha widget schematic")
+        memory.activePersonaId = "personaB"
+        _ = memory.remember("beta fact", value: "beta gadget blueprint")
+        memory.activePersonaId = nil
+
+        // personaA's scope (global + personaA) sees global + its own, never personaB.
+        let scoped = memory.semanticSearch(query: "gadget blueprint coffee widget", limit: 10,
+                                           namespaces: ["global", "personaA"])
+        let values = scoped.map(\.value)
+        XCTAssertTrue(values.contains("the office coffee is excellent"), "projects see global memory")
+        XCTAssertTrue(values.contains("alpha widget schematic"), "a persona sees its own memory")
+        XCTAssertFalse(values.contains("beta gadget blueprint"), "must not cross into another persona")
+
+        // personaB's scope reaches personaB's memory — proving isolation, not disappearance.
+        let bScope = memory.semanticSearch(query: "gadget blueprint", limit: 10,
+                                           namespaces: ["global", "personaB"])
+        XCTAssertTrue(bScope.map(\.value).contains("beta gadget blueprint"))
+    }
+
+    /// End-to-end through BrainTool: an unscoped/global `brain ask` must not surface a project's
+    /// remembered fact, while the same ask inside that project does. Guards the tool wiring, not
+    /// just the store seam. Keyword fallback ⇒ deterministic without an embedder.
+    @MainActor
+    func testBrainAskMemoryIsProjectScoped() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let memory = SemanticMemoryStore(directory: dir)
+        memory.activePersonaId = "projA"
+        _ = memory.remember("launch plan", value: "quokka launch codenamed thunderbird")
+        memory.activePersonaId = nil
+
+        var globalBrain = BrainTool()
+        globalBrain.memoryStore = memory
+        globalBrain.activeNamespace = { "global" }
+        let globalAnswer = try await globalBrain.execute(args: ["action": "query", "question": "thunderbird launch"])
+        XCTAssertFalse(globalAnswer.contains("thunderbird"),
+                       "a global brain ask must not see projA's remembered fact")
+
+        var projectBrain = BrainTool()
+        projectBrain.memoryStore = memory
+        projectBrain.activeNamespace = { "projA" }
+        let projectAnswer = try await projectBrain.execute(args: ["action": "query", "question": "thunderbird launch"])
+        XCTAssertTrue(projectAnswer.contains("thunderbird"),
+                      "inside projA the same fact is visible")
+    }
+
+    /// The standalone `memory_search` tool must honour the same project scope as `brain` — a
+    /// global chat can't read another persona's memory through it.
+    @MainActor
+    func testMemorySearchToolIsProjectScoped() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let memory = SemanticMemoryStore(directory: dir)
+        memory.activePersonaId = "projA"
+        _ = memory.remember("mascot", value: "the projA mascot is a narwhal")
+        memory.activePersonaId = nil
+
+        var globalSearch = MemorySearchTool()
+        globalSearch.memoryStore = memory
+        globalSearch.activeNamespace = { "global" }
+        let globalResult = try await globalSearch.execute(args: ["query": "narwhal mascot"])
+        XCTAssertFalse(globalResult.contains("narwhal"),
+                       "memory_search in a global chat must not surface projA's memory")
+
+        var projectSearch = MemorySearchTool()
+        projectSearch.memoryStore = memory
+        projectSearch.activeNamespace = { "projA" }
+        let projectResult = try await projectSearch.execute(args: ["query": "narwhal mascot"])
+        XCTAssertTrue(projectResult.contains("narwhal"), "inside projA the memory is searchable")
+    }
 }


### PR DESCRIPTION
## Plan BM P8 — *Global never sees project docs*

The Projects boundary (Plan AN) was leaking: retrieval tools passed `namespace: nil`, which the stores interpret as **every namespace**. So an unscoped/global chat could retrieve and quote another project's documents, and memory search crossed persona-scoped namespaces.

### Fix — enforce `GLOBAL NEVER SEES PROJECT DOCS`
Thread the active-namespace closure (the same one `DocumentRAGTool` already uses) through every place retrieval crosses the boundary:

- **DocumentStore** — new `document(named:namespaces:)`: resolve a doc by name only within an allowed namespace set.
- **SemanticMemoryStore** — new `semanticSearch(query:limit:namespaces:)` + multi-namespace fetch; the legacy `namespace: nil` path is documented as spanning every persona so callers at a chat boundary must pass an explicit scope.
- **BrainTool** — documents scoped to the active namespace (parity with `DocumentRAGTool`); memory search, dossier, and `status` counts scoped to `["global", activeProject]` (projects see global; global never sees a project).
- **TeleprompterTool** — name lookup goes through the scoped resolver.
- **MemorySearchTool** — same-class leak found while auditing (unscoped `semanticSearch` across all personas); scoped identically and folded in.
- Closures wired at construction (registry + app).

### Tests (`ProjectScopingTests`) — fresh stores, temp dirs, never `.shared`
- A scoped doc is invisible to a global name lookup, visible inside its project.
- Memory search never crosses personas (store seam + end-to-end through `brain` and `memory_search`).
- Deterministic via keyword fallback (no embedder); the embedder-dependent doc-query test keeps its `XCTSkipUnless` gate.

### Verification note
Could not run `xcodebuild` locally: the only installed simulator runtime is iOS 27.0 (beta), which Xcode 26.5 marks ineligible for all destinations, and the device target needs iOS 26.5 (not installed). Changes verified by call-site audit + signature review; CI runs the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)