### PR TITLE
HIPAA diarization runtime guard — stop cloud audio the instant HIPAA flips (BM P0)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -695,6 +695,11 @@ class AppState: ObservableObject, AppStateProtocol {
         // Wire Tier 1 services
         ambientCaptions.wakeWordService = wakeWordService
         ambientCaptions.glassesDisplay = glassesDisplay
+        // Toggling HIPAA mid-session must tear down any live cloud diarization at once (Plan BM
+        // P0): reconfigure ambient captions onto the on-device path the moment the flag flips.
+        hipaaService.onModeChanged = { [weak ambientCaptions] in
+            ambientCaptions?.reconfigureForModeChange()
+        }
         // Teleprompter (Phase 2): shared audio engine for live recognition + the in-lens HUD.
         teleprompterService.wakeWordService = wakeWordService
         teleprompterService.glassesDisplay = glassesDisplay

--- a/OpenGlasses/Sources/App/Views/DiarizationSettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/DiarizationSettingsView.swift
@@ -51,7 +51,15 @@ struct DiarizationSettingsView: View {
             } header: {
                 Text("Deepgram")
             } footer: {
-                Text("Stored in the Keychain. Raw audio is sent to Deepgram for transcription — only enable this if that's acceptable.")
+                Text("""
+                Raw audio is streamed to Deepgram's cloud for transcription — including the voices \
+                of anyone nearby, not just you. Many places (two-party-consent jurisdictions) \
+                require everyone's consent before their speech is recorded, and Deepgram may retain \
+                or use audio under its own terms. Unlike the on-device visual bystander filter, \
+                there is no audio equivalent — nearby speech is sent as captured. The key is stored \
+                in the Keychain; only enable this where recording bystanders is lawful and \
+                acceptable.
+                """)
             }
 
             Section {

--- a/OpenGlasses/Sources/App/Views/HIPAASettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/HIPAASettingsView.swift
@@ -460,8 +460,7 @@ struct HIPAASettingsView: View {
         .navigationTitle("Medical Compliance")
         .alert("Enable Medical Compliance?", isPresented: $showConfirmEnable) {
             Button("Enable") {
-                Config.hipaaMode = true
-                hipaaService.log(action: "COMPLIANCE_ENABLED", detail: "Medical compliance mode enabled")
+                hipaaService.setMode(true)
             }
             Button("Cancel", role: .cancel) {
                 complianceEnabled = false
@@ -471,8 +470,7 @@ struct HIPAASettingsView: View {
         }
         .alert("Disable Medical Compliance?", isPresented: $showConfirmDisable) {
             Button("Disable", role: .destructive) {
-                hipaaService.log(action: "COMPLIANCE_DISABLED", detail: "Medical compliance mode disabled")
-                Config.hipaaMode = false
+                hipaaService.setMode(false)
             }
             Button("Cancel", role: .cancel) {
                 complianceEnabled = true

--- a/OpenGlasses/Sources/Services/AmbientCaptionService.swift
+++ b/OpenGlasses/Sources/Services/AmbientCaptionService.swift
@@ -104,6 +104,18 @@ class AmbientCaptionService: ObservableObject {
         print("🎙️ Ambient captions resumed (presence)")
     }
 
+    /// Re-pick the transcription backend after a mode/config change (e.g. HIPAA toggled). If a
+    /// session is live, tear it down and restart on the now-correct path: under HIPAA the cloud
+    /// diarizer is gone and the on-device `SFSpeechRecognizer` takes over, so any Deepgram socket
+    /// closes deterministically instead of waiting for the next audio buffer. No-op when inactive
+    /// or presence-suspended (the suspend path already picks the right backend on resume).
+    func reconfigureForModeChange() {
+        guard isActive, !presenceSuspended else { return }
+        stopRecognitionSession()
+        startRecognitionSession()
+        print("🎙️ Ambient captions reconfigured (mode change)")
+    }
+
     func clearHistory() {
         captionHistory.removeAll()
     }

--- a/OpenGlasses/Sources/Services/Diarization/DeepgramSTTService.swift
+++ b/OpenGlasses/Sources/Services/Diarization/DeepgramSTTService.swift
@@ -19,6 +19,13 @@ final class DeepgramSTTService: ObservableObject, DiarizationProvider {
     var onSegment: ((DiarizedSegment) -> Void)?
     @Published private(set) var state: ConnectionState = .idle
 
+    /// Runtime gate for cloud egress. Defaults to the live `Config.isDiarizationConfigured`
+    /// (opt-in + key + **not** HIPAA); injectable so tests can drive the invariant without the
+    /// Keychain. Checked on `start()` *and* every `sendAudio` so a mid-session HIPAA flip (or a
+    /// revoked opt-in) stops audio leaving the device immediately — the start-time gate alone
+    /// would let a live stream keep flowing.
+    var isConfigured: () -> Bool = { Config.isDiarizationConfigured }
+
     private var wantsConnection = false
     private var webSocketTask: URLSessionWebSocketTask?
     private var session: URLSession?
@@ -28,8 +35,8 @@ final class DeepgramSTTService: ObservableObject, DiarizationProvider {
     /// Arm the provider. The socket opens on the first `sendAudio` so it can use the buffer's
     /// real sample rate.
     func start() {
-        guard !Config.deepgramAPIKey.isEmpty else {
-            state = .error("Deepgram not configured")
+        guard isConfigured() else {
+            state = .error("Diarization not available")
             return
         }
         wantsConnection = true
@@ -47,6 +54,13 @@ final class DeepgramSTTService: ObservableObject, DiarizationProvider {
     }
 
     func sendAudio(_ buffer: AVAudioPCMBuffer) {
+        // Runtime invariant: the moment diarization stops being configured (HIPAA flipped on, or
+        // opt-in revoked) mid-session, stop egressing audio and tear the socket down. The next
+        // captured buffer closes the stream even if nothing else told us to stop.
+        guard isConfigured() else {
+            if wantsConnection || webSocketTask != nil { stop() }
+            return
+        }
         if wantsConnection, webSocketTask == nil {
             connect(sampleRate: Int(buffer.format.sampleRate.rounded()))
         }

--- a/OpenGlasses/Sources/Services/HIPAAComplianceService.swift
+++ b/OpenGlasses/Sources/Services/HIPAAComplianceService.swift
@@ -31,10 +31,25 @@ class HIPAAComplianceService: ObservableObject {
     private let auditLogURL: URL
     private let maxAuditEntries = 1000
 
+    /// Invoked right after `hipaaMode` is toggled so live services (cloud diarization, ambient
+    /// captions) can tear down/restart deterministically rather than waiting for a natural
+    /// restart. Wired by AppState; nil in tests and headless contexts.
+    var onModeChanged: (() -> Void)?
+
     init() {
         let docsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         auditLogURL = docsDir.appendingPathComponent("hipaa_audit_log.json")
         loadAuditLog()
+    }
+
+    /// Single entry point for toggling compliance mode: writes the flag, audit-logs the change,
+    /// and fires `onModeChanged` so dependent live sessions reconfigure at once. Callers must use
+    /// this rather than setting `Config.hipaaMode` directly, so the teardown never gets skipped.
+    func setMode(_ enabled: Bool) {
+        Config.hipaaMode = enabled
+        log(action: enabled ? "COMPLIANCE_ENABLED" : "COMPLIANCE_DISABLED",
+            detail: enabled ? "Medical compliance mode enabled" : "Medical compliance mode disabled")
+        onModeChanged?()
     }
 
     // MARK: - File Protection

--- a/OpenGlassesTests/HIPAADiarizationGuardTests.swift
+++ b/OpenGlassesTests/HIPAADiarizationGuardTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import AVFoundation
+@testable import OpenGlasses
+
+/// Plan BM P0 — cloud diarization must stop egressing audio the moment HIPAA flips on, not just
+/// at session start. Fresh service instances with an injected `isConfigured` seam (never the
+/// Keychain-backed `Config.isDiarizationConfigured`, which can't be driven headless).
+@MainActor
+final class HIPAADiarizationGuardTests: XCTestCase {
+
+    private func makeBuffer() -> AVAudioPCMBuffer {
+        let format = AVAudioFormat(standardFormatWithSampleRate: 16000, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 160)!
+        buffer.frameLength = 160
+        return buffer
+    }
+
+    // MARK: - Start-time gate
+
+    func testStartRefusesWhenNotConfigured() {
+        let svc = DeepgramSTTService()
+        svc.isConfigured = { false }   // e.g. HIPAA mode on
+        svc.start()
+        XCTAssertEqual(svc.state, .error("Diarization not available"))
+    }
+
+    func testStartArmsWhenConfigured() {
+        let svc = DeepgramSTTService()
+        svc.isConfigured = { true }
+        svc.start()
+        XCTAssertEqual(svc.state, .connecting)
+    }
+
+    // MARK: - Runtime invariant: a mid-session HIPAA flip stops audio
+
+    func testSendAudioTearsDownWhenConfigRevokedMidSession() {
+        let svc = DeepgramSTTService()
+        var configured = true
+        svc.isConfigured = { configured }
+        svc.start()
+        XCTAssertEqual(svc.state, .connecting)
+
+        // HIPAA flips on while the stream is live — the next captured buffer must close it.
+        configured = false
+        svc.sendAudio(makeBuffer())
+        XCTAssertEqual(svc.state, .idle, "revoking config mid-session tears the socket down")
+    }
+
+    func testSendAudioIsInertWhenNeverArmed() {
+        let svc = DeepgramSTTService()
+        svc.isConfigured = { false }
+        svc.sendAudio(makeBuffer())   // no start(); must not crash or leave a dangling state
+        XCTAssertEqual(svc.state, .idle)
+    }
+
+    // MARK: - Toggle plumbing
+
+    func testSetModeWritesFlagAndFiresCallback() {
+        let svc = HIPAAComplianceService()
+        let original = Config.hipaaMode
+        defer { Config.hipaaMode = original }
+
+        var fired = 0
+        svc.onModeChanged = { fired += 1 }
+
+        svc.setMode(true)
+        XCTAssertTrue(Config.hipaaMode)
+        XCTAssertEqual(fired, 1)
+
+        svc.setMode(false)
+        XCTAssertFalse(Config.hipaaMode)
+        XCTAssertEqual(fired, 2)
+    }
+
+    func testReconfigureForModeChangeIsNoOpWhenInactive() {
+        let captions = AmbientCaptionService()
+        captions.reconfigureForModeChange()   // nothing running — must stay inactive
+        XCTAssertFalse(captions.isActive)
+    }
+}

--- a/OpenGlassesTests/ProjectScopingTests.swift
+++ b/OpenGlassesTests/ProjectScopingTests.swift
@@ -172,21 +172,23 @@ final class ProjectScopingTests: XCTestCase {
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let memory = SemanticMemoryStore(directory: dir)
         memory.activePersonaId = "projA"
-        _ = memory.remember("launch plan", value: "quokka launch codenamed thunderbird")
+        // Assert on "quokka" — a token in the stored VALUE only, never in the query, so the
+        // empty-result message (which echoes the query) can't produce a false positive.
+        _ = memory.remember("launch plan", value: "the launch is codenamed quokka")
         memory.activePersonaId = nil
 
         var globalBrain = BrainTool()
         globalBrain.memoryStore = memory
         globalBrain.activeNamespace = { "global" }
-        let globalAnswer = try await globalBrain.execute(args: ["action": "query", "question": "thunderbird launch"])
-        XCTAssertFalse(globalAnswer.contains("thunderbird"),
+        let globalAnswer = try await globalBrain.execute(args: ["action": "query", "question": "launch"])
+        XCTAssertFalse(globalAnswer.contains("quokka"),
                        "a global brain ask must not see projA's remembered fact")
 
         var projectBrain = BrainTool()
         projectBrain.memoryStore = memory
         projectBrain.activeNamespace = { "projA" }
-        let projectAnswer = try await projectBrain.execute(args: ["action": "query", "question": "thunderbird launch"])
-        XCTAssertTrue(projectAnswer.contains("thunderbird"),
+        let projectAnswer = try await projectBrain.execute(args: ["action": "query", "question": "launch"])
+        XCTAssertTrue(projectAnswer.contains("quokka"),
                       "inside projA the same fact is visible")
     }
 
@@ -198,20 +200,22 @@ final class ProjectScopingTests: XCTestCase {
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let memory = SemanticMemoryStore(directory: dir)
         memory.activePersonaId = "projA"
-        _ = memory.remember("mascot", value: "the projA mascot is a narwhal")
+        // "quokka" lives only in the stored value, not the query — so the no-results message
+        // (which echoes the query) can't trip the absence assertion.
+        _ = memory.remember("mascot", value: "the flagship mascot is a quokka")
         memory.activePersonaId = nil
 
         var globalSearch = MemorySearchTool()
         globalSearch.memoryStore = memory
         globalSearch.activeNamespace = { "global" }
-        let globalResult = try await globalSearch.execute(args: ["query": "narwhal mascot"])
-        XCTAssertFalse(globalResult.contains("narwhal"),
+        let globalResult = try await globalSearch.execute(args: ["query": "mascot"])
+        XCTAssertFalse(globalResult.contains("quokka"),
                        "memory_search in a global chat must not surface projA's memory")
 
         var projectSearch = MemorySearchTool()
         projectSearch.memoryStore = memory
         projectSearch.activeNamespace = { "projA" }
-        let projectResult = try await projectSearch.execute(args: ["query": "narwhal mascot"])
-        XCTAssertTrue(projectResult.contains("narwhal"), "inside projA the memory is searchable")
+        let projectResult = try await projectSearch.execute(args: ["query": "mascot"])
+        XCTAssertTrue(projectResult.contains("quokka"), "inside projA the memory is searchable")
     }
 }


### PR DESCRIPTION
## Plan BM P0 — HIPAA diarization runtime guard 🔴 Privacy

**The bug.** "HIPAA hard-disables diarization" was a *start-time* gate, not a runtime invariant. `Config.isDiarizationConfigured` (which includes `!hipaaMode`) was checked only when a caption session started; `DeepgramSTTService.sendAudio` never re-checked and nothing tore a live session down. So enabling HIPAA mid-session left a running Deepgram stream flowing — bystanders' room audio kept going to the cloud until captions happened to restart.

### Fix — enforce it at the service layer
- **`DeepgramSTTService`** gains an injectable `isConfigured` gate (defaults to `Config.isDiarizationConfigured`). `start()` refuses when unconfigured; the **next `sendAudio`** after a mid-session HIPAA flip (or a revoked opt-in) tears the socket down, so audio stops leaving the device immediately — the start-time gate alone couldn't do this.
- **`HIPAAComplianceService.setMode(_:)`** is now the single toggle entry point: writes the flag, audit-logs, and fires `onModeChanged`. `AppState` wires that to **`AmbientCaptionService.reconfigureForModeChange()`** so a live caption session deterministically drops to the on-device `SFSpeechRecognizer` path the instant the flag flips (belt-and-braces with the service-layer guard).
- **`HIPAASettingsView`** routes both enable/disable alert actions through `setMode`.
- **Bystander-consent copy:** the diarization disclosure now covers nearby voices, two-party-consent jurisdictions, Deepgram retention/training terms, and the "visual bystander filter has no audio analogue" asymmetry.

### Tests (`HIPAADiarizationGuardTests`) — injected seams, never Keychain/`.shared`
- `start()` refuses under HIPAA; arms when configured.
- `sendAudio` tears the socket down when config is revoked mid-session; inert when never armed.
- `setMode` writes the flag and fires the callback; `reconfigureForModeChange` is a no-op when inactive.

### Also in this PR (test-only)
Two Plan **P8** `ProjectScopingTests` asserted the *absence* of a word that the tool's empty-result message echoes back from the query — false negatives that only surfaced on the first real device-runtime test run. Fixed to assert on a value-only token (`quokka`) instead. **The P8 production scoping was correct; only the assertions were wrong.** (Heads-up: these were red on `main` until this fix.)

### Verification
Built **and tested green** locally with Xcode-beta 27 (iOS 27 simulator): all 6 P0 tests pass; the full `ProjectScopingTests` class passes; `** TEST SUCCEEDED **`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)