### PR TITLE
Cost-tracker accuracy: cache tokens, freshness guard, drift marker (BM P3)

### DIFF
--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -1151,15 +1151,24 @@ class LLMService: ObservableObject {
     /// Streaming turns accumulate their own counts via `StreamingUsageAccumulator` and
     /// enter through the already-parsed overload below.
     private func recordUsage(provider: LLMProvider, model: String, json: [String: Any]) {
-        guard let tokens = UsageTracker.parseTokens(provider: provider, json: json) else { return }
-        recordUsage(provider: provider, model: model, tokensIn: tokens.tokensIn, tokensOut: tokens.tokensOut)
+        guard let usage = UsageTracker.parseUsage(provider: provider, json: json) else { return }
+        // A usage block that carried none of the expected keys is shape drift, not a
+        // free turn — mark it so it isn't silently lost (Plan BM P3).
+        guard usage.recognized else {
+            Task { @MainActor in UsageTracker.shared.noteUntrackedTurn() }
+            return
+        }
+        recordUsage(provider: provider, model: model, tokensIn: usage.tokensIn, tokensOut: usage.tokensOut,
+                    cacheWriteTokens: usage.cacheWriteTokens, cacheReadTokens: usage.cacheReadTokens)
     }
 
     /// Record already-parsed token counts (the streaming paths accumulate their own).
-    private func recordUsage(provider: LLMProvider, model: String, tokensIn: Int, tokensOut: Int) {
-        guard tokensIn + tokensOut > 0 else { return }
+    private func recordUsage(provider: LLMProvider, model: String, tokensIn: Int, tokensOut: Int,
+                             cacheWriteTokens: Int = 0, cacheReadTokens: Int = 0) {
+        guard tokensIn + tokensOut + cacheWriteTokens + cacheReadTokens > 0 else { return }
         Task { @MainActor in
-            UsageTracker.shared.record(provider: provider, model: model, tokensIn: tokensIn, tokensOut: tokensOut)
+            UsageTracker.shared.record(provider: provider, model: model, tokensIn: tokensIn, tokensOut: tokensOut,
+                                       cacheWriteTokens: cacheWriteTokens, cacheReadTokens: cacheReadTokens)
         }
     }
 
@@ -1608,7 +1617,8 @@ class LLMService: ObservableObject {
             }
         }
 
-        recordUsage(provider: provider, model: model, tokensIn: usage.tokensIn, tokensOut: usage.tokensOut)
+        recordUsage(provider: provider, model: model, tokensIn: usage.tokensIn, tokensOut: usage.tokensOut,
+                    cacheWriteTokens: usage.cacheWriteTokens, cacheReadTokens: usage.cacheReadTokens)
 
         var message: [String: Any] = ["role": "assistant", "content": fullContent]
         if !toolAcc.isEmpty {
@@ -1681,7 +1691,8 @@ class LLMService: ObservableObject {
             blocks[idx] = b
         }
 
-        recordUsage(provider: .anthropic, model: model, tokensIn: usage.tokensIn, tokensOut: usage.tokensOut)
+        recordUsage(provider: .anthropic, model: model, tokensIn: usage.tokensIn, tokensOut: usage.tokensOut,
+                    cacheWriteTokens: usage.cacheWriteTokens, cacheReadTokens: usage.cacheReadTokens)
 
         let content = blocks.sorted { $0.key < $1.key }.map { $0.value }
         return (content, stopReason)

--- a/OpenGlasses/Sources/Services/Usage/ModelPricing.swift
+++ b/OpenGlasses/Sources/Services/Usage/ModelPricing.swift
@@ -6,6 +6,11 @@ import Foundation
 /// matched by longest model-id prefix so dated variants (`claude-opus-4-8`,
 /// `gpt-4o-2024-…`) resolve to their family. An unknown/unpriced model yields `nil`
 /// — the tracker reports tokens and omits the dollar figure rather than guessing.
+///
+/// NOTE — realtime voice: the OpenAI/Gemini realtime models bill audio input/output at
+/// **audio token rates**, which these text rates don't capture. For a realtime session
+/// the token *counts* are right but the dollar estimate is a text-rate approximation
+/// (an undercount) — treat realtime cost as indicative, not exact.
 enum ModelPricing {
 
     struct Rate: Equatable, Codable {
@@ -59,23 +64,50 @@ enum ModelPricing {
     /// taking precedence on key collision. Injectable for tests.
     static var overrides: [String: Rate] = [:]
 
+    /// Anthropic prompt-cache multipliers over the base **input** rate (5-minute TTL):
+    /// a cache *write* costs ≈1.25× input, a cache *read* ≈0.1×. Named (not inlined)
+    /// so the cost math isn't magic, and calibrated to Anthropic — the dominant cache
+    /// consumer post-BF `cache_control`. Other providers' read discounts differ; a read
+    /// billed at 0.1× is a safe floor (never overstates cost).
+    static let cacheWriteMultiplier = 1.25
+    static let cacheReadMultiplier = 0.10
+
     /// The rate for a model, or `nil` if neither overrides nor defaults price it.
-    /// Matches by longest lowercased-prefix so dated model ids resolve to a family.
+    /// Exact id wins; otherwise the longest key that is a prefix followed by a **dated
+    /// snapshot** suffix (`-20260101`, `-2024-08-06`, `@…`) resolves to its family. A
+    /// bare version bump like `claude-opus-4-9` is deliberately NOT absorbed by the
+    /// `claude-opus-4` family — it yields `nil` (report tokens, omit dollars) rather
+    /// than silently billing a future model at an older family's rate.
     static func rate(for model: String) -> Rate? {
         let id = model.lowercased()
         let table = defaults.merging(overrides) { _, override in override }
+        if let exact = table[id] { return exact }
         let match = table.keys
-            .filter { id.hasPrefix($0) }
+            .filter { id.hasPrefix($0) && isSnapshotSuffix(String(id.dropFirst($0.count))) }
             .max(by: { $0.count < $1.count })
         return match.flatMap { table[$0] }
     }
 
+    /// A remainder is a dated-snapshot suffix — a `-`/`@`/`:` boundary carrying a date
+    /// (≥6 digits, e.g. `20260101` or `2024-08-06`). Short version tails (`-9`, `-002`)
+    /// are not snapshots, so an unknown family-version bump stays unpriced.
+    private static func isSnapshotSuffix(_ remainder: String) -> Bool {
+        guard let first = remainder.first, first == "-" || first == "@" || first == ":" else { return false }
+        return remainder.filter(\.isNumber).count >= 6
+    }
+
     /// Estimated USD cost for a call, or `nil` if the model is unpriced. Zero tokens
     /// at a known rate is `0` (priced, just free), distinct from `nil` (unpriced).
-    static func estimate(model: String, tokensIn: Int, tokensOut: Int) -> Double? {
+    /// Cache-creation and cache-read tokens are Anthropic's separate input-side counts
+    /// (excluded from `tokensIn`), priced off the input rate via the multipliers above.
+    static func estimate(model: String, tokensIn: Int, tokensOut: Int,
+                         cacheWriteTokens: Int = 0, cacheReadTokens: Int = 0) -> Double? {
         guard let rate = rate(for: model) else { return nil }
+        let perToken = rate.inputPer1M / 1_000_000
         let input = Double(max(0, tokensIn)) / 1_000_000 * rate.inputPer1M
         let output = Double(max(0, tokensOut)) / 1_000_000 * rate.outputPer1M
-        return input + output
+        let cacheWrite = Double(max(0, cacheWriteTokens)) * perToken * cacheWriteMultiplier
+        let cacheRead = Double(max(0, cacheReadTokens)) * perToken * cacheReadMultiplier
+        return input + output + cacheWrite + cacheRead
     }
 }

--- a/OpenGlasses/Sources/Services/Usage/StreamingUsageAccumulator.swift
+++ b/OpenGlasses/Sources/Services/Usage/StreamingUsageAccumulator.swift
@@ -9,8 +9,12 @@ import Foundation
 struct StreamingUsageAccumulator {
     private(set) var tokensIn = 0
     private(set) var tokensOut = 0
+    /// Anthropic prompt-cache counts, reported once on `message_start` (OpenAI-compatible
+    /// servers put cached reads in the final chunk's `prompt_tokens_details`).
+    private(set) var cacheWriteTokens = 0
+    private(set) var cacheReadTokens = 0
 
-    var hasUsage: Bool { tokensIn + tokensOut > 0 }
+    var hasUsage: Bool { tokensIn + tokensOut + cacheWriteTokens + cacheReadTokens > 0 }
 
     /// Feed one decoded Anthropic stream event.
     mutating func consumeAnthropic(_ event: [String: Any]) {
@@ -19,6 +23,8 @@ struct StreamingUsageAccumulator {
             if let usage = (event["message"] as? [String: Any])?["usage"] as? [String: Any] {
                 tokensIn = max(tokensIn, Self.int(usage["input_tokens"]))
                 tokensOut = max(tokensOut, Self.int(usage["output_tokens"]))
+                cacheWriteTokens = max(cacheWriteTokens, Self.int(usage["cache_creation_input_tokens"]))
+                cacheReadTokens = max(cacheReadTokens, Self.int(usage["cache_read_input_tokens"]))
             }
         case "message_delta":
             // Output is cumulative across deltas — keep the largest seen.
@@ -36,6 +42,9 @@ struct StreamingUsageAccumulator {
         guard let usage = chunk["usage"] as? [String: Any] else { return }
         tokensIn = max(tokensIn, Self.int(usage["prompt_tokens"]))
         tokensOut = max(tokensOut, Self.int(usage["completion_tokens"]))
+        if let details = usage["prompt_tokens_details"] as? [String: Any] {
+            cacheReadTokens = max(cacheReadTokens, Self.int(details["cached_tokens"]))
+        }
     }
 
     private static func int(_ value: Any?) -> Int {

--- a/OpenGlasses/Sources/Services/Usage/UsageModels.swift
+++ b/OpenGlasses/Sources/Services/Usage/UsageModels.swift
@@ -9,6 +9,10 @@ struct UsageRecord: Equatable {
     let model: String
     let tokensIn: Int
     let tokensOut: Int
+    /// Anthropic prompt-cache counts (separate from `tokensIn`): tokens written to and
+    /// read from the cache. 0 on providers/turns without caching. Priced into `costUSD`.
+    let cacheWriteTokens: Int
+    let cacheReadTokens: Int
     /// Estimated USD, or `nil` when the model is unpriced (tokens still recorded).
     let costUSD: Double?
     let at: Date
@@ -19,6 +23,8 @@ struct UsageRecord: Equatable {
          model: String,
          tokensIn: Int,
          tokensOut: Int,
+         cacheWriteTokens: Int = 0,
+         cacheReadTokens: Int = 0,
          costUSD: Double?,
          at: Date) {
         self.id = id
@@ -27,6 +33,8 @@ struct UsageRecord: Equatable {
         self.model = model
         self.tokensIn = tokensIn
         self.tokensOut = tokensOut
+        self.cacheWriteTokens = cacheWriteTokens
+        self.cacheReadTokens = cacheReadTokens
         self.costUSD = costUSD
         self.at = at
     }

--- a/OpenGlasses/Sources/Services/Usage/UsageStore.swift
+++ b/OpenGlasses/Sources/Services/Usage/UsageStore.swift
@@ -31,6 +31,10 @@ final class UsageStore {
         )
         """)
         exec("CREATE INDEX IF NOT EXISTS idx_usage_at ON usage(at)")
+        // Cache-token columns added post-launch (Plan BM P3). ADD COLUMN is idempotent
+        // enough here — it errors on an existing column, which we ignore.
+        exec("ALTER TABLE usage ADD COLUMN cache_write_tokens INTEGER NOT NULL DEFAULT 0")
+        exec("ALTER TABLE usage ADD COLUMN cache_read_tokens INTEGER NOT NULL DEFAULT 0")
     }
 
     deinit {
@@ -41,8 +45,8 @@ final class UsageStore {
 
     /// Persist a usage record. `cost_usd` is stored NULL when the model was unpriced.
     func insert(_ record: UsageRecord) {
-        let sql = "INSERT OR REPLACE INTO usage (id, session_id, provider, model, tokens_in, tokens_out, cost_usd, at) " +
-                  "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        let sql = "INSERT OR REPLACE INTO usage (id, session_id, provider, model, tokens_in, tokens_out, cache_write_tokens, cache_read_tokens, cost_usd, at) " +
+                  "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
         defer { sqlite3_finalize(stmt) }
@@ -52,12 +56,14 @@ final class UsageStore {
         bindText(stmt, 4, record.model)
         sqlite3_bind_int(stmt, 5, Int32(record.tokensIn))
         sqlite3_bind_int(stmt, 6, Int32(record.tokensOut))
+        sqlite3_bind_int(stmt, 7, Int32(record.cacheWriteTokens))
+        sqlite3_bind_int(stmt, 8, Int32(record.cacheReadTokens))
         if let cost = record.costUSD {
-            sqlite3_bind_double(stmt, 7, cost)
+            sqlite3_bind_double(stmt, 9, cost)
         } else {
-            sqlite3_bind_null(stmt, 7)
+            sqlite3_bind_null(stmt, 9)
         }
-        sqlite3_bind_double(stmt, 8, record.at.timeIntervalSince1970)
+        sqlite3_bind_double(stmt, 10, record.at.timeIntervalSince1970)
         _ = sqlite3_step(stmt)
     }
 
@@ -70,7 +76,7 @@ final class UsageStore {
 
     /// All records with `at >= since`, newest first.
     func records(since: Date) -> [UsageRecord] {
-        query("SELECT id, session_id, provider, model, tokens_in, tokens_out, cost_usd, at FROM usage " +
+        query("SELECT id, session_id, provider, model, tokens_in, tokens_out, cache_write_tokens, cache_read_tokens, cost_usd, at FROM usage " +
               "WHERE at >= \(since.timeIntervalSince1970) ORDER BY at DESC")
     }
 
@@ -96,10 +102,14 @@ final class UsageStore {
             let model = String(cString: sqlite3_column_text(stmt, 3))
             let tokensIn = Int(sqlite3_column_int(stmt, 4))
             let tokensOut = Int(sqlite3_column_int(stmt, 5))
-            let cost: Double? = sqlite3_column_type(stmt, 6) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 6)
-            let at = Date(timeIntervalSince1970: sqlite3_column_double(stmt, 7))
+            let cacheWrite = Int(sqlite3_column_int(stmt, 6))
+            let cacheRead = Int(sqlite3_column_int(stmt, 7))
+            let cost: Double? = sqlite3_column_type(stmt, 8) == SQLITE_NULL ? nil : sqlite3_column_double(stmt, 8)
+            let at = Date(timeIntervalSince1970: sqlite3_column_double(stmt, 9))
             out.append(UsageRecord(id: id, sessionId: sessionId, provider: provider, model: model,
-                                   tokensIn: tokensIn, tokensOut: tokensOut, costUSD: cost, at: at))
+                                   tokensIn: tokensIn, tokensOut: tokensOut,
+                                   cacheWriteTokens: cacheWrite, cacheReadTokens: cacheRead,
+                                   costUSD: cost, at: at))
         }
         return out
     }

--- a/OpenGlasses/Sources/Services/Usage/UsageTracker.swift
+++ b/OpenGlasses/Sources/Services/Usage/UsageTracker.swift
@@ -21,43 +21,88 @@ final class UsageTracker: ObservableObject {
         self.store = store ?? UsageStore()
     }
 
+    /// Turns where a usage block was present but in an unrecognized shape (e.g. a
+    /// provider renamed its fields), so token counts came back 0 and the turn's cost
+    /// went untracked. A rising count is the signal to update the parser (Plan BM P3).
+    @Published private(set) var untrackedTurns = 0
+
     /// Start a new usage session (e.g. when the conversation is cleared).
     func startNewSession() { sessionId = UUID().uuidString }
 
-    /// Price and persist one API call's usage. No-op when both token counts are 0.
-    func record(provider: LLMProvider, model: String, tokensIn: Int, tokensOut: Int, at: Date = Date()) {
-        guard tokensIn + tokensOut > 0 else { return }
-        let cost = ModelPricing.estimate(model: model, tokensIn: tokensIn, tokensOut: tokensOut)
+    /// Price and persist one API call's usage, including Anthropic prompt-cache tokens.
+    /// No-op when every count is 0.
+    func record(provider: LLMProvider, model: String, tokensIn: Int, tokensOut: Int,
+                cacheWriteTokens: Int = 0, cacheReadTokens: Int = 0, at: Date = Date()) {
+        guard tokensIn + tokensOut + cacheWriteTokens + cacheReadTokens > 0 else { return }
+        let cost = ModelPricing.estimate(model: model, tokensIn: tokensIn, tokensOut: tokensOut,
+                                          cacheWriteTokens: cacheWriteTokens, cacheReadTokens: cacheReadTokens)
         store.insert(UsageRecord(sessionId: sessionId,
                                  provider: provider.rawValue,
                                  model: model,
                                  tokensIn: tokensIn,
                                  tokensOut: tokensOut,
+                                 cacheWriteTokens: cacheWriteTokens,
+                                 cacheReadTokens: cacheReadTokens,
                                  costUSD: cost,
                                  at: at))
     }
+
+    /// Record a usage block whose shape wasn't recognized — nothing to price, but we
+    /// count it so silent drift is visible rather than invisible.
+    func noteUntrackedTurn() { untrackedTurns += 1 }
 
     /// Rolled-up tokens + estimated cost over the last `days`.
     func rollup(days: Int, now: Date = Date()) -> UsageRollup.Result {
         store.rollup(days: days, now: now)
     }
 
-    /// Extract `(tokensIn, tokensOut)` from a provider's response JSON, or `nil` when
-    /// no usage block is present. Pure and `nonisolated` so `LLMService` can call it
-    /// on its own async context (the non-Sendable JSON never crosses an actor hop —
-    /// only the resulting ints do).
-    nonisolated static func parseTokens(provider: LLMProvider, json: [String: Any]) -> (tokensIn: Int, tokensOut: Int)? {
+    /// Parsed token usage for one call. `recognized` is false when a usage block was
+    /// present but carried none of the expected token keys (shape drift).
+    struct ParsedUsage: Equatable {
+        let tokensIn: Int
+        let tokensOut: Int
+        let cacheWriteTokens: Int
+        let cacheReadTokens: Int
+        let recognized: Bool
+    }
+
+    /// Extract token + cache usage from a provider's response JSON, or `nil` when no
+    /// usage block is present at all. Pure and `nonisolated` so `LLMService` can call
+    /// it on its own async context (the non-Sendable JSON never crosses an actor hop).
+    nonisolated static func parseUsage(provider: LLMProvider, json: [String: Any]) -> ParsedUsage? {
         switch provider {
         case .anthropic:
             guard let u = json["usage"] as? [String: Any] else { return nil }
-            return (intValue(u["input_tokens"]), intValue(u["output_tokens"]))
+            let recognized = u["input_tokens"] != nil || u["output_tokens"] != nil
+                || u["cache_creation_input_tokens"] != nil || u["cache_read_input_tokens"] != nil
+            return ParsedUsage(tokensIn: intValue(u["input_tokens"]),
+                               tokensOut: intValue(u["output_tokens"]),
+                               cacheWriteTokens: intValue(u["cache_creation_input_tokens"]),
+                               cacheReadTokens: intValue(u["cache_read_input_tokens"]),
+                               recognized: recognized)
         case .gemini:
             guard let u = json["usageMetadata"] as? [String: Any] else { return nil }
-            return (intValue(u["promptTokenCount"]), intValue(u["candidatesTokenCount"]))
+            let recognized = u["promptTokenCount"] != nil || u["candidatesTokenCount"] != nil
+            return ParsedUsage(tokensIn: intValue(u["promptTokenCount"]),
+                               tokensOut: intValue(u["candidatesTokenCount"]),
+                               cacheWriteTokens: 0,
+                               cacheReadTokens: intValue(u["cachedContentTokenCount"]),
+                               recognized: recognized)
         case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom, .local, .appleOnDevice:
             guard let u = json["usage"] as? [String: Any] else { return nil }
-            return (intValue(u["prompt_tokens"]), intValue(u["completion_tokens"]))
+            let recognized = u["prompt_tokens"] != nil || u["completion_tokens"] != nil
+            let cachedRead = (u["prompt_tokens_details"] as? [String: Any]).map { intValue($0["cached_tokens"]) } ?? 0
+            return ParsedUsage(tokensIn: intValue(u["prompt_tokens"]),
+                               tokensOut: intValue(u["completion_tokens"]),
+                               cacheWriteTokens: 0,
+                               cacheReadTokens: cachedRead,
+                               recognized: recognized)
         }
+    }
+
+    /// Back-compat convenience: just the `(tokensIn, tokensOut)` pair.
+    nonisolated static func parseTokens(provider: LLMProvider, json: [String: Any]) -> (tokensIn: Int, tokensOut: Int)? {
+        parseUsage(provider: provider, json: json).map { ($0.tokensIn, $0.tokensOut) }
     }
 
     private nonisolated static func intValue(_ value: Any?) -> Int {

--- a/OpenGlassesTests/StreamingUsageAccumulatorTests.swift
+++ b/OpenGlassesTests/StreamingUsageAccumulatorTests.swift
@@ -24,6 +24,17 @@ final class StreamingUsageAccumulatorTests: XCTestCase {
         XCTAssertEqual(acc.tokensOut, 20)
     }
 
+    func testAnthropicCacheTokensCapturedFromMessageStart() {
+        var acc = StreamingUsageAccumulator()
+        acc.consumeAnthropic(["type": "message_start",
+                              "message": ["usage": ["input_tokens": 42, "output_tokens": 1,
+                                                    "cache_creation_input_tokens": 100,
+                                                    "cache_read_input_tokens": 200]]])
+        XCTAssertEqual(acc.cacheWriteTokens, 100)
+        XCTAssertEqual(acc.cacheReadTokens, 200)
+        XCTAssertTrue(acc.hasUsage)
+    }
+
     func testAnthropicNoUsageEvents() {
         var acc = StreamingUsageAccumulator()
         acc.consumeAnthropic(["type": "content_block_start", "index": 0])
@@ -43,6 +54,13 @@ final class StreamingUsageAccumulatorTests: XCTestCase {
         acc.consumeOpenAI(["choices": [], "usage": ["prompt_tokens": 12, "completion_tokens": 8]])
         XCTAssertEqual(acc.tokensIn, 12)
         XCTAssertEqual(acc.tokensOut, 8)
+    }
+
+    func testOpenAICachedReadFromPromptTokenDetails() {
+        var acc = StreamingUsageAccumulator()
+        acc.consumeOpenAI(["choices": [], "usage": ["prompt_tokens": 12, "completion_tokens": 8,
+                                                    "prompt_tokens_details": ["cached_tokens": 4]]])
+        XCTAssertEqual(acc.cacheReadTokens, 4)
     }
 
     func testOpenAINoUsageWhenServerOmitsIt() {

--- a/OpenGlassesTests/UsageTrackerTests.swift
+++ b/OpenGlassesTests/UsageTrackerTests.swift
@@ -39,6 +39,80 @@ final class UsageTrackerTests: XCTestCase {
         XCTAssertEqual(ModelPricing.rate(for: "gpt-4o"), ModelPricing.Rate(99, 99))
     }
 
+    // MARK: - Plan BM P3: cache tokens, freshness guard, drift
+
+    func testCacheTokensAreIncludedInCost() throws {
+        // claude-sonnet-4 input = $3/1M. Cache write ≈1.25× input, read ≈0.1× input.
+        let cost = ModelPricing.estimate(model: "claude-sonnet-4", tokensIn: 0, tokensOut: 0,
+                                          cacheWriteTokens: 1_000_000, cacheReadTokens: 1_000_000)
+        XCTAssertEqual(try XCTUnwrap(cost), 3.0 * 1.25 + 3.0 * 0.10, accuracy: 1e-9)
+    }
+
+    func testUnknownVersionBumpIsUnpricedNotFamilyRate() {
+        // A future bare version bump must NOT inherit the older family's 3× rate.
+        XCTAssertNil(ModelPricing.rate(for: "claude-opus-4-9"))
+        XCTAssertNil(ModelPricing.estimate(model: "claude-opus-4-9", tokensIn: 1000, tokensOut: 1000))
+        // A genuine dated snapshot of a known model still resolves to its rate.
+        XCTAssertEqual(ModelPricing.rate(for: "claude-opus-4-8-20260101"), ModelPricing.Rate(5, 25))
+    }
+
+    func testParseUsageCapturesAnthropicCacheTokens() throws {
+        let json: [String: Any] = ["usage": ["input_tokens": 10, "output_tokens": 20,
+                                             "cache_creation_input_tokens": 100, "cache_read_input_tokens": 200]]
+        let u = try XCTUnwrap(UsageTracker.parseUsage(provider: .anthropic, json: json))
+        XCTAssertEqual(u.tokensIn, 10)
+        XCTAssertEqual(u.cacheWriteTokens, 100)
+        XCTAssertEqual(u.cacheReadTokens, 200)
+        XCTAssertTrue(u.recognized)
+    }
+
+    func testParseUsageCapturesOpenAICachedRead() throws {
+        let json: [String: Any] = ["usage": ["prompt_tokens": 5, "completion_tokens": 7,
+                                             "prompt_tokens_details": ["cached_tokens": 3]]]
+        let u = try XCTUnwrap(UsageTracker.parseUsage(provider: .openai, json: json))
+        XCTAssertEqual(u.cacheReadTokens, 3)
+        XCTAssertTrue(u.recognized)
+    }
+
+    func testParseUsageFlagsShapeDrift() throws {
+        // A usage block whose fields were renamed → recognized == false (drift), not nil.
+        let drift = try XCTUnwrap(UsageTracker.parseUsage(provider: .openai, json: ["usage": ["prompt_toks": 5]]))
+        XCTAssertFalse(drift.recognized)
+        XCTAssertEqual(drift.tokensIn, 0)
+        // No usage block at all → nil (nothing to track, not drift).
+        XCTAssertNil(UsageTracker.parseUsage(provider: .openai, json: ["choices": []]))
+    }
+
+    @MainActor
+    func testDriftCounterIncrements() {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("usage-drift-\(UUID().uuidString).sqlite")
+        defer { try? FileManager.default.removeItem(at: path) }
+        let tracker = UsageTracker(store: UsageStore(path: path))
+        XCTAssertEqual(tracker.untrackedTurns, 0)
+        tracker.noteUntrackedTurn()
+        tracker.noteUntrackedTurn()
+        XCTAssertEqual(tracker.untrackedTurns, 2)
+    }
+
+    @MainActor
+    func testRecordPersistsCacheTokensAndCacheInclusiveCost() throws {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("usage-cache-\(UUID().uuidString).sqlite")
+        defer { try? FileManager.default.removeItem(at: path) }
+        let now = Date(timeIntervalSinceReferenceDate: 70_000)
+        let store = UsageStore(path: path)
+        let tracker = UsageTracker(store: store)
+
+        tracker.record(provider: .anthropic, model: "claude-sonnet-4", tokensIn: 0, tokensOut: 0,
+                       cacheWriteTokens: 1_000_000, cacheReadTokens: 1_000_000, at: now)
+
+        let row = try XCTUnwrap(store.records(since: now.addingTimeInterval(-1)).first)
+        XCTAssertEqual(row.cacheWriteTokens, 1_000_000)
+        XCTAssertEqual(row.cacheReadTokens, 1_000_000)
+        XCTAssertEqual(try XCTUnwrap(row.costUSD), 3.0 * 1.25 + 3.0 * 0.10, accuracy: 1e-9)
+    }
+
     // MARK: - UsageRollup
 
     private func rec(_ model: String, _ tIn: Int, _ tOut: Int, _ cost: Double?, at: Date) -> UsageRecord {


### PR DESCRIPTION
## Plan BM P3 — Cost-tracker accuracy 🟠 Money

Three verified cost-tracking errors (Plan AU riders), all fixed.

### 1. Anthropic cache tokens were invisible
Capture read only `input_tokens` / `output_tokens`; Anthropic's `cache_creation_input_tokens` / `cache_read_input_tokens` were never parsed — and post-BF `cache_control` history makes those the **largest single error source**.
- `UsageTracker.parseUsage` captures cache tokens on the non-streaming path; `StreamingUsageAccumulator` captures them from `message_start` (plus OpenAI `prompt_tokens_details.cached_tokens` on both paths).
- Priced into cost via **table-driven multipliers** (`cacheWriteMultiplier = 1.25`, `cacheReadMultiplier = 0.10` × the input rate) — not magic numbers.
- Persisted: new `cache_write_tokens` / `cache_read_tokens` columns on `UsageStore` (idempotent `ALTER TABLE` migration) + fields on `UsageRecord`.

### 2. Longest-prefix pricing billed unknown models at the wrong family rate
`claude-opus-4-9` (a future model) silently matched the `claude-opus-4` family at **3×** the current rate. Matching now requires an **exact id** or a **dated-snapshot suffix** (`-20260101`, `-2024-08-06`, `@…` — ≥6 digits). A bare version bump is **unpriced** (report tokens, omit dollars) rather than guessed; genuine dated snapshots (`claude-opus-4-8-20260101`, `gpt-4o-2024-11-20`) still resolve to their family.

### 3. A renamed usage block was a silent no-op
`parseUsage` now distinguishes **no usage block** (`nil`) from **block present but unrecognized shape** (`recognized == false`). The latter increments `UsageTracker.untrackedTurns`, so provider field-renames surface as a rising counter instead of vanishing.

Also documents that **realtime voice bills at audio rates** — token counts are right, the dollar estimate is a text-rate approximation (undercount).

### Tests (`UsageTrackerTests`, `StreamingUsageAccumulatorTests`)
Cache-inclusive cost math; dated variant resolves while a bare bump → nil; cache-token parsing on both providers and both stream paths; drift flag + counter; store round-trips cache tokens and cache-inclusive cost. All pre-existing pricing/usage/realtime tests still pass (the freshness guard and cache changes are non-regressing).

### Verification
Built **and tested green** with Xcode-beta 27 (iOS 27 sim): 38/38 across the four usage/pricing test classes, `** TEST SUCCEEDED **`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)