### PR TITLE
Health-check rubric: fix medical-safety false negatives (BM P4)

### DIFF
--- a/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift
+++ b/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveSessionManager.swift
@@ -487,6 +487,11 @@ class GeminiLiveSessionManager: ObservableObject {
                 if !descriptions.isEmpty {
                     toolSection += "\n\n" + SystemPromptBuilder.toolLines(descriptions)
                 }
+                // Plan BM P4: domains the model must route through a tool, never self-answer.
+                let routingRules = SystemPromptBuilder.routingRules(toolNames: names)
+                if !routingRules.isEmpty {
+                    toolSection += "\n\nMANDATORY ROUTING:\n" + routingRules
+                }
 
                 // Inject user-defined custom tool descriptions
                 let customTools = Config.customTools.filter { Config.isToolEnabled($0.name) }

--- a/OpenGlasses/Sources/Services/HealthSafety/HealthSafetyAdvisor.swift
+++ b/OpenGlasses/Sources/Services/HealthSafety/HealthSafetyAdvisor.swift
@@ -44,16 +44,21 @@ final class HealthSafetyAdvisor {
             for: query, medicationsText: medsText, conditionsText: conditionsText, allergiesText: allergiesText)
 
         let hits: [InteractionRubric.Hit]
+        let recognized: Bool
         switch query.kind {
         case .canITake:
-            hits = rubric.check(SubstanceCatalog.substance(from: query.matchText), against: context)
+            let substance = SubstanceCatalog.substance(from: query.matchText)
+            hits = rubric.check(substance, against: context)
+            recognized = substance.isClassified
         case .canIEat:
-            hits = rubric.checkFood(SubstanceCatalog.foodTags(in: query.matchText), against: context)
+            let tags = SubstanceCatalog.foodTags(in: query.matchText)
+            hits = rubric.checkFood(tags, against: context)
+            recognized = !tags.isEmpty
         }
 
         let advisory = await llmAdvisory(for: query, context: context, hasAuthoritative: HealthSafetyResponseBuilder.hasAuthoritativeWarning(hits))
         let citations = citationFiles(medsText: medsText, conditionsText: conditionsText, allergiesText: allergiesText)
-        return HealthSafetyResponseBuilder.compose(subject: query.subject, hits: hits, llmAdvisory: advisory, citations: citations)
+        return HealthSafetyResponseBuilder.compose(subject: query.subject, hits: hits, subjectRecognized: recognized, llmAdvisory: advisory, citations: citations)
     }
 
     // MARK: - LLM long tail (grounded, stateless)

--- a/OpenGlasses/Sources/Services/HealthSafety/HealthSafetyResponseBuilder.swift
+++ b/OpenGlasses/Sources/Services/HealthSafety/HealthSafetyResponseBuilder.swift
@@ -14,10 +14,14 @@ enum HealthSafetyResponseBuilder {
     /// - Parameters:
     ///   - subject: what was asked about ("ibuprofen").
     ///   - hits: deterministic rubric hits (any order; sorted here).
+    ///   - subjectRecognized: whether the catalog classified the subject at all — an
+    ///     unrecognised name with no hits must never receive the authoritative
+    ///     "no interactions found" absence claim.
     ///   - llmAdvisory: the grounded model answer for the long tail, or nil when unavailable.
     ///   - citations: vault sources used (e.g. ["medications", "conditions"]).
     static func compose(subject: String,
                         hits: [InteractionRubric.Hit],
+                        subjectRecognized: Bool = true,
                         llmAdvisory: String?,
                         citations: [String]) -> String {
         var parts: [String] = []
@@ -40,7 +44,11 @@ enum HealthSafetyResponseBuilder {
         }
 
         if sorted.isEmpty {
-            parts.append("No high-severity interactions found in your vault for \(subject).")
+            if subjectRecognized {
+                parts.append("No high-severity interactions found in your vault for \(subject).")
+            } else {
+                parts.append("I don't recognise \(subject) in my interaction table, so I can't rule out interactions — check it with your pharmacist or doctor.")
+            }
         }
 
         if let advisory = llmAdvisory?.trimmingCharacters(in: .whitespacesAndNewlines), !advisory.isEmpty {

--- a/OpenGlasses/Sources/Services/HealthSafety/InteractionRubric.swift
+++ b/OpenGlasses/Sources/Services/HealthSafety/InteractionRubric.swift
@@ -29,8 +29,10 @@ struct InteractionRubric {
                             severity: .high, basis: "recorded allergy"))
         }
 
-        // NSAID + anticoagulant → major bleeding risk.
-        if substance.classes.contains(.nsaid), userClasses.contains(.anticoagulant) {
+        // NSAID + anticoagulant → major bleeding risk. Fires on the drug class OR the
+        // condition tag ("on blood thinners" in conditions.md with no recognised drug name).
+        if substance.classes.contains(.nsaid),
+           userClasses.contains(.anticoagulant) || context.conditions.contains(.anticoagulated) {
             hits.append(Hit(reason: "You take a blood thinner; an NSAID markedly raises bleeding risk.",
                             severity: .high, basis: "NSAID + anticoagulant → GI/bleeding risk"))
         }
@@ -38,6 +40,12 @@ struct InteractionRubric {
         if substance.classes.contains(.nsaid), context.conditions.contains(.pepticUlcer) {
             hits.append(Hit(reason: "You have a peptic ulcer history; NSAIDs can cause GI bleeding.",
                             severity: .high, basis: "NSAID + peptic ulcer"))
+        }
+        // NSAID + asthma → caution (aspirin-exacerbated respiratory disease: NSAIDs can
+        // trigger severe bronchospasm in a subset of people with asthma).
+        if substance.classes.contains(.nsaid), context.conditions.contains(.asthma) {
+            hits.append(Hit(reason: "You have asthma; NSAIDs can trigger severe breathing problems in some people with asthma.",
+                            severity: .caution, basis: "NSAID + asthma (aspirin-exacerbated respiratory disease)"))
         }
         // NSAID + kidney disease → caution.
         if substance.classes.contains(.nsaid), context.conditions.contains(.kidneyDisease) {

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -229,6 +229,11 @@ class LLMService: ObservableObject {
                 if !nativeToolDescriptions.isEmpty {
                     toolSection += "\n\n" + SystemPromptBuilder.toolLines(nativeToolDescriptions)
                 }
+                // Plan BM P4: domains the model must route through a tool, never self-answer.
+                let routingRules = SystemPromptBuilder.routingRules(toolNames: nativeToolNames)
+                if !routingRules.isEmpty {
+                    toolSection += "\n\nMANDATORY ROUTING:\n" + routingRules
+                }
 
                 // Inject user-defined custom tool descriptions
                 let customTools = Config.customTools.filter { Config.isToolEnabled($0.name) }

--- a/OpenGlasses/Sources/Services/SystemPromptBuilder.swift
+++ b/OpenGlasses/Sources/Services/SystemPromptBuilder.swift
@@ -18,6 +18,22 @@ enum SystemPromptBuilder {
             .joined(separator: "\n")
     }
 
+    /// Mandatory-routing rules for tools whose domain must never be answered from the model's
+    /// own weights (Plan BM P4). Returns an empty string when none of the gated tools are
+    /// enabled, so the block only appears alongside the tool it mandates.
+    static func routingRules(toolNames: [String]) -> String {
+        var rules: [String] = []
+        if toolNames.contains("health_check") {
+            rules.append("""
+            - Health safety is NOT answerable from your own knowledge: for ANY question about whether a \
+            medication, supplement, or food is safe for the user ("can I take…", "can I eat…", drug or \
+            food interactions), you MUST call health_check and base your answer on its result — it checks \
+            the user's own medications, conditions, and allergies, which you cannot see.
+            """)
+        }
+        return rules.map(flatten).joined(separator: "\n")
+    }
+
     /// Collapse a multi-line tool description into one line so it reads as a single bullet.
     private static func flatten(_ description: String) -> String {
         description

--- a/OpenGlassesTests/HealthSafetyTests.swift
+++ b/OpenGlassesTests/HealthSafetyTests.swift
@@ -199,4 +199,85 @@ final class HealthSafetyTests: XCTestCase {
         let hits = InteractionRubric().check(SubstanceCatalog.substance(from: "vitamin d"), against: context(meds: [.statin]))
         XCTAssertTrue(hits.isEmpty)
     }
+
+    // MARK: - Rubric false negatives (BM P4)
+
+    func testConditionOnlyAnticoagulationPlusNSAIDIsHigh() {
+        // "On blood thinners" in conditions.md with no recognised drug name must still
+        // fire the flagship NSAID/anticoagulant rule.
+        let hits = InteractionRubric().check(
+            SubstanceCatalog.substance(from: "ibuprofen"),
+            against: context(meds: [], conditions: [.anticoagulated]))
+        XCTAssertTrue(hits.contains { $0.severity == .high && $0.basis.contains("anticoagulant") })
+    }
+
+    func testConditionOnlyAnticoagulationGroundsFromVaultText() {
+        // End-to-end through grounding: the condition text alone produces the high hit.
+        let g = VaultGrounding()
+        let ctx = g.relevantEntries(
+            for: HealthSafetyQuery(kind: .canITake, subject: "ibuprofen"),
+            medicationsText: "", conditionsText: "- On blood thinners since 2023", allergiesText: "")
+        XCTAssertTrue(ctx.conditions.contains(.anticoagulated))
+        let hits = InteractionRubric().check(SubstanceCatalog.substance(from: "ibuprofen"), against: ctx)
+        XCTAssertTrue(hits.contains { $0.severity == .high })
+    }
+
+    func testAnticoagulantMedAndConditionYieldSingleBleedingHit() {
+        // Both the drug class and the condition tag present → one hit, not two.
+        let hits = InteractionRubric().check(
+            SubstanceCatalog.substance(from: "naproxen"),
+            against: context(meds: [.anticoagulant], conditions: [.anticoagulated]))
+        XCTAssertEqual(hits.filter { $0.basis.contains("anticoagulant") }.count, 1)
+    }
+
+    func testNSAIDPlusAsthmaIsCaution() {
+        let hits = InteractionRubric().check(
+            SubstanceCatalog.substance(from: "aspirin"),
+            against: context(meds: [], conditions: [.asthma]))
+        XCTAssertTrue(hits.contains { $0.severity == .caution && $0.basis.contains("asthma") })
+    }
+
+    func testNonNSAIDWithAsthmaHasNoHit() {
+        let hits = InteractionRubric().check(
+            SubstanceCatalog.substance(from: "sertraline"),
+            against: context(meds: [], conditions: [.asthma]))
+        XCTAssertTrue(hits.isEmpty)
+    }
+
+    // MARK: - Unrecognised substances must not get an absence claim (BM P4)
+
+    func testUnrecognizedSubstanceIsNotClassified() {
+        XCTAssertFalse(SubstanceCatalog.substance(from: "Zorbifen XR").isClassified)
+        XCTAssertTrue(SubstanceCatalog.substance(from: "ibuprofen").isClassified)
+    }
+
+    func testUnrecognizedSubjectGetsHonestUncertaintyNotAbsenceClaim() {
+        let out = HealthSafetyResponseBuilder.compose(
+            subject: "Zorbifen XR", hits: [], subjectRecognized: false,
+            llmAdvisory: nil, citations: ["medications"])
+        XCTAssertTrue(out.contains("don't recognise"))
+        XCTAssertFalse(out.contains("No high-severity interactions"))
+        XCTAssertTrue(out.contains(HealthSafetyResponseBuilder.disclaimer))
+    }
+
+    func testUnrecognizedSubjectWithAllergyHitStillWarns() {
+        // An allergy match fires on the raw name even for an unclassified substance —
+        // the warning must win over the "don't recognise" path.
+        let hit = InteractionRubric().check(
+            SubstanceCatalog.substance(from: "penicillin"),
+            against: context(meds: [], allergies: ["penicillin"]))
+        let out = HealthSafetyResponseBuilder.compose(
+            subject: "penicillin", hits: hit, subjectRecognized: false,
+            llmAdvisory: nil, citations: [])
+        XCTAssertTrue(out.contains("Not recommended"))
+        XCTAssertFalse(out.contains("don't recognise"))
+    }
+
+    func testRecognizedSubjectWithNoHitsKeepsAbsenceClaim() {
+        let out = HealthSafetyResponseBuilder.compose(
+            subject: "atorvastatin", hits: [], subjectRecognized: true,
+            llmAdvisory: nil, citations: ["medications"])
+        XCTAssertTrue(out.contains("No high-severity interactions"))
+        XCTAssertFalse(out.contains("don't recognise"))
+    }
 }

--- a/OpenGlassesTests/SystemPromptBuilderTests.swift
+++ b/OpenGlassesTests/SystemPromptBuilderTests.swift
@@ -44,6 +44,27 @@ final class SystemPromptBuilderTests: XCTestCase {
         }
     }
 
+    // MARK: - Mandatory routing rules (BM P4)
+
+    func testHealthCheckRoutingRulePresentWhenToolEnabled() {
+        let rules = SystemPromptBuilder.routingRules(toolNames: ["get_weather", "health_check"])
+        XCTAssertTrue(rules.contains("health_check"))
+        XCTAssertTrue(rules.contains("MUST"))
+        XCTAssertFalse(rules.contains("\n  "), "rule must be flattened to a single bullet line")
+    }
+
+    func testNoRoutingRulesWithoutGatedTools() {
+        XCTAssertEqual(SystemPromptBuilder.routingRules(toolNames: ["get_weather", "calculate"]), "")
+        XCTAssertEqual(SystemPromptBuilder.routingRules(toolNames: []), "")
+    }
+
+    func testRegistryToolSetTriggersHealthRoutingRule() {
+        // The real registry registers health_check, so the generated prompt carries the rule.
+        let registry = NativeToolRegistry(locationService: LocationService())
+        let rules = SystemPromptBuilder.routingRules(toolNames: registry.toolNames)
+        XCTAssertTrue(rules.contains("health_check"))
+    }
+
     func testDescriptionsComeFromTheToolItself() {
         let registry = NativeToolRegistry(locationService: LocationService())
         // Sample a stable, always-registered tool and confirm the generated line matches its own


### PR DESCRIPTION
Plan BM P4 — the Plan AB health advisor's rubric had four verified false-negative surfaces where a dangerous combination produced a reassuring answer.

## The bugs (file:line evidence in the plan's P4 section)

1. **Condition-only anticoagulation missed.** `.anticoagulated` is parsed from the vault (`SubstanceCatalog.swift:109` — "blood thinner"/"anticoagulat…") but `check()` keyed the flagship NSAID/anticoagulant high-severity rule on the drug class only (`InteractionRubric.swift:33`). "On blood thinners" in conditions.md with no recognized drug name → no warning for ibuprofen.
2. **Asthma never consulted.** `.asthma` was parsed but no rule used it — NSAID + aspirin-exacerbated respiratory disease is textbook curated-tier.
3. **Unrecognized substances got an authoritative absence claim.** `Substance.isClassified` was never used, so an unknown brand name yielded the same "No high-severity interactions found in your vault" as a genuinely-checked drug.
4. **Direct-mode bypass.** Nothing forced health questions through `health_check`, so in Direct mode the LLM could answer "can I take X?" from its own weights — no rubric, no vault grounding, no disclaimer.

## The fixes

- NSAID/anticoagulant rule fires on the drug class **or** the `.anticoagulated` condition tag (one hit when both are present).
- New NSAID + asthma **caution** rule (caution, not high — most people with asthma tolerate NSAIDs; the AERD subset does not).
- `HealthSafetyResponseBuilder.compose(subjectRecognized:)` — unrecognized subject with no hits now answers "I don't recognise X in my interaction table, so I can't rule out interactions — check it with your pharmacist or doctor." Allergy hits (which match on the raw name) still take precedence; the disclaimer path is untouched (`compose()` appends it unconditionally).
- `SystemPromptBuilder.routingRules(toolNames:)` emits a MANDATORY ROUTING block when `health_check` is enabled, requiring health/medication/food-safety questions to route through the tool; injected in both Direct mode (`LLMService`) and Gemini Live.

## Tests

12 new headless tests, all pure-core (no `.shared`, no vault store needed):
- condition-only anticoagulation → high (rubric-level and end-to-end through `VaultGrounding` from raw conditions text)
- med + condition both present → exactly one bleeding hit
- asthma + NSAID → caution; non-NSAID + asthma → no hit
- unrecognized substance → honest uncertainty, no absence claim, disclaimer intact; allergy hit wins over "don't recognise"; recognized subject keeps the absence claim
- routing rule present with `health_check` (incl. via the real registry), absent without

Full suite green: **1660 tests, 0 failures** (iOS 27 sim, Xcode 27 beta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)