### PR TITLE
Capture-flow schema safety: versioning, rejection reports, typed audit record (BM P2)

### DIFF
--- a/OpenGlasses/Sources/App/Views/SyncStatusView.swift
+++ b/OpenGlasses/Sources/App/Views/SyncStatusView.swift
@@ -66,10 +66,11 @@ struct SyncStatusView: View {
 
     private func label(for kind: OpKind) -> String {
         switch kind {
-        case .logEntry:     return "Log entry"
-        case .photoUpload:  return "Photo upload"
-        case .llmGrounding: return "Deferred question"
-        case .auditExport:  return "Audit export"
+        case .logEntry:      return "Log entry"
+        case .photoUpload:   return "Photo upload"
+        case .llmGrounding:  return "Deferred question"
+        case .auditExport:   return "Audit export"
+        case .captureRecord: return "Capture record"
         }
     }
 

--- a/OpenGlasses/Sources/Services/CaptureFlow/CaptureFlow.swift
+++ b/OpenGlasses/Sources/Services/CaptureFlow/CaptureFlow.swift
@@ -79,23 +79,32 @@ struct FlowPrecondition: Codable, Equatable {
 /// A declarative, typed capture template loaded from `vault/flows/*.json` (Plan U) — the field
 /// analogue of an action-form. One flow can run across asset types it `appliesTo`.
 struct CaptureFlow: Codable, Identifiable, Equatable {
+    /// Newest flow-JSON schema this build understands. Files declaring a higher `schema_version`
+    /// are rejected at load with a report instead of silently vanishing (BM P2); files without
+    /// the field are treated as version 1.
+    static let currentSchemaVersion = 1
+
     let id: String
     let title: String
     let appliesTo: [String]
     let steps: [FlowStep]
     let preconditions: [FlowPrecondition]
+    let schemaVersion: Int
 
     enum CodingKeys: String, CodingKey {
         case id, title, steps, preconditions
         case appliesTo = "applies_to"
+        case schemaVersion = "schema_version"
     }
 
-    init(id: String, title: String, appliesTo: [String] = [], steps: [FlowStep], preconditions: [FlowPrecondition] = []) {
+    init(id: String, title: String, appliesTo: [String] = [], steps: [FlowStep],
+         preconditions: [FlowPrecondition] = [], schemaVersion: Int = CaptureFlow.currentSchemaVersion) {
         self.id = id
         self.title = title
         self.appliesTo = appliesTo
         self.steps = steps
         self.preconditions = preconditions
+        self.schemaVersion = schemaVersion
     }
 
     init(from decoder: Decoder) throws {
@@ -105,6 +114,7 @@ struct CaptureFlow: Codable, Identifiable, Equatable {
         appliesTo = try c.decodeIfPresent([String].self, forKey: .appliesTo) ?? []
         steps = try c.decode([FlowStep].self, forKey: .steps)
         preconditions = try c.decodeIfPresent([FlowPrecondition].self, forKey: .preconditions) ?? []
+        schemaVersion = try c.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 1
     }
 
     /// Field names this flow captures — used by `FieldResolver` for cross-pack binding.

--- a/OpenGlasses/Sources/Services/CaptureFlow/CaptureFlowLibrary.swift
+++ b/OpenGlasses/Sources/Services/CaptureFlow/CaptureFlowLibrary.swift
@@ -6,18 +6,23 @@ import Foundation
 struct CaptureFlowLibrary {
     let vaultId: String
     private let flows: [CaptureFlow]
+    /// "filename: reason" for each flow file that failed to load (BM P2) — surfaced by the
+    /// `capture_flow` tool's `list` action so a typo'd overlay never silently vanishes.
+    let rejected: [String]
 
     /// Build from a vault store. Returns an empty library if the vault has no `flows/` content.
     init(store: VaultStore) {
         vaultId = store.manifest.id
-        flows = Self.load(bundleDir: store.bundleRoot?.appendingPathComponent("flows", isDirectory: true),
-                          overlayDir: store.overlayRoot.appendingPathComponent("flows", isDirectory: true))
+        (flows, rejected) = Self.loadStrict(
+            bundleDir: store.bundleRoot?.appendingPathComponent("flows", isDirectory: true),
+            overlayDir: store.overlayRoot.appendingPathComponent("flows", isDirectory: true))
     }
 
     /// Test / explicit init.
     init(vaultId: String, flows: [CaptureFlow]) {
         self.vaultId = vaultId
         self.flows = flows
+        self.rejected = []
     }
 
     var all: [CaptureFlow] { flows }
@@ -32,11 +37,34 @@ struct CaptureFlowLibrary {
 
     /// Decode a single flow from JSON data (nil on malformed input).
     static func decode(_ data: Data) -> CaptureFlow? {
-        try? JSONDecoder().decode(CaptureFlow.self, from: data)
+        decodeReporting(data).flow
+    }
+
+    /// Decode a single flow, returning a human-readable rejection reason on failure — the
+    /// `MCPCatalog.loadStrict` pattern (BM P2). A file declaring a `schema_version` newer than
+    /// `CaptureFlow.currentSchemaVersion` is rejected without attempting a full decode, so a
+    /// v2 flow reads as "too new", not as a pile of decoding errors.
+    static func decodeReporting(_ data: Data) -> (flow: CaptureFlow?, rejection: String?) {
+        let decoder = JSONDecoder()
+        if let probe = try? decoder.decode(VersionProbe.self, from: data),
+           let version = probe.schemaVersion, version > CaptureFlow.currentSchemaVersion {
+            return (nil, "schema_version \(version) is newer than this app supports (\(CaptureFlow.currentSchemaVersion))")
+        }
+        do {
+            return (try decoder.decode(CaptureFlow.self, from: data), nil)
+        } catch {
+            return (nil, rejectionReason(from: error))
+        }
     }
 
     /// Load every `*.json` flow from a directory (overlay wins over bundle by filename).
     static func load(bundleDir: URL?, overlayDir: URL?) -> [CaptureFlow] {
+        loadStrict(bundleDir: bundleDir, overlayDir: overlayDir).flows
+    }
+
+    /// As `load`, additionally reporting every file that failed ("filename: reason") instead of
+    /// silently dropping it.
+    static func loadStrict(bundleDir: URL?, overlayDir: URL?) -> (flows: [CaptureFlow], rejected: [String]) {
         var byFilename: [String: URL] = [:]
         if let bundleDir {
             for url in jsonFiles(in: bundleDir) { byFilename[url.lastPathComponent] = url }
@@ -44,11 +72,49 @@ struct CaptureFlowLibrary {
         if let overlayDir {
             for url in jsonFiles(in: overlayDir) { byFilename[url.lastPathComponent] = url }
         }
-        let loaded = byFilename.values.compactMap { url -> CaptureFlow? in
-            guard let data = try? Data(contentsOf: url) else { return nil }
-            return decode(data)
+        var flows: [CaptureFlow] = []
+        var rejected: [String] = []
+        for (filename, url) in byFilename.sorted(by: { $0.key < $1.key }) {
+            guard let data = try? Data(contentsOf: url) else {
+                rejected.append("\(filename): unreadable")
+                continue
+            }
+            let (flow, rejection) = decodeReporting(data)
+            if let flow {
+                flows.append(flow)
+            } else {
+                rejected.append("\(filename): \(rejection ?? "not valid flow JSON")")
+            }
         }
-        return loaded.sorted { $0.id < $1.id }
+        return (flows.sorted { $0.id < $1.id }, rejected)
+    }
+
+    private struct VersionProbe: Decodable {
+        let schemaVersion: Int?
+        enum CodingKeys: String, CodingKey { case schemaVersion = "schema_version" }
+    }
+
+    private static func rejectionReason(from error: Error) -> String {
+        switch error {
+        case DecodingError.dataCorrupted(let ctx),
+             DecodingError.typeMismatch(_, let ctx),
+             DecodingError.valueNotFound(_, let ctx):
+            return readable(ctx)
+        case DecodingError.keyNotFound(let key, let ctx):
+            let path = pathString(ctx.codingPath)
+            return "missing required field '\(key.stringValue)'\(path.isEmpty ? "" : " at \(path)")"
+        default:
+            return "not valid flow JSON"
+        }
+    }
+
+    private static func readable(_ ctx: DecodingError.Context) -> String {
+        let path = pathString(ctx.codingPath)
+        return path.isEmpty ? ctx.debugDescription : "\(path): \(ctx.debugDescription)"
+    }
+
+    private static func pathString(_ codingPath: [CodingKey]) -> String {
+        codingPath.map { $0.intValue.map { "[\($0)]" } ?? $0.stringValue }.joined(separator: ".")
     }
 
     private static func jsonFiles(in dir: URL) -> [URL] {

--- a/OpenGlasses/Sources/Services/CaptureFlow/CaptureFlowService.swift
+++ b/OpenGlasses/Sources/Services/CaptureFlow/CaptureFlowService.swift
@@ -39,6 +39,10 @@ final class CaptureFlowService: ObservableObject {
 
     func availableFlows() -> [String] { library()?.summaries() ?? [] }
 
+    /// "filename: reason" for flow files that failed to load (BM P2) — surfaced on `list` so a
+    /// hand-edited overlay with a typo or a too-new schema never just vanishes.
+    func flowLoadIssues() -> [String] { library()?.rejected ?? [] }
+
     func start(flowId: String, assetId: String?) throws -> String {
         guard FieldSessionService.shared.activeSession != nil, let lib = library() else {
             throw CaptureFlowError.noSession
@@ -123,7 +127,10 @@ final class CaptureFlowService: ObservableObject {
     }
 
     private func persist(_ record: CaptureRecord) {
-        guard let data = try? JSONEncoder().encode(record) else { return }
-        offlineQueue?.enqueue(QueuedOp(kind: .logEntry, sessionId: record.sessionId, payload: data))
+        if let data = try? JSONEncoder().encode(record) {
+            offlineQueue?.enqueue(QueuedOp(kind: .captureRecord, sessionId: record.sessionId, payload: data))
+        }
+        // Also into the session's append-only audit log, so the export folds it in (BM P2).
+        FieldSessionService.shared.logCaptureRecord(record)
     }
 }

--- a/OpenGlasses/Sources/Services/CaptureFlow/CaptureRecord.swift
+++ b/OpenGlasses/Sources/Services/CaptureFlow/CaptureRecord.swift
@@ -86,3 +86,23 @@ struct CaptureRecord: Codable, Equatable {
         fields.first { $0.field == field }?.value
     }
 }
+
+extension CaptureRecord {
+    /// The append-only audit-log event for a finished record — `SessionExporter` folds these into
+    /// the consolidated export (closing Plan U's "audit-ready record" promise, BM P2). Values are
+    /// rendered via `display` so the export stays human-readable; the full typed record lives in
+    /// the offline queue as a `.captureRecord` op.
+    var auditEvent: SessionLogger.Event {
+        var payload: [String: AnyCodable] = [
+            "flow_id": AnyCodable(flowId),
+            "fields": AnyCodable(fields.map { [
+                "field": $0.field,
+                "value": $0.value.display,
+                "method": $0.provenance.method,
+            ] }),
+        ]
+        if let assetId { payload["asset_id"] = AnyCodable(assetId) }
+        return SessionLogger.Event(
+            timestamp: finishedAt ?? startedAt, kind: .captureRecordSaved, text: flowId, payload: payload)
+    }
+}

--- a/OpenGlasses/Sources/Services/FieldAssist/FieldSessionService.swift
+++ b/OpenGlasses/Sources/Services/FieldAssist/FieldSessionService.swift
@@ -203,6 +203,12 @@ final class FieldSessionService: ObservableObject {
         logger?.appendAssistantMessage(text, citations: citations)
     }
 
+    /// Append a finished capture-flow record to the audit log so `SessionExporter` folds it into
+    /// the consolidated export (no-op if no session).
+    func logCaptureRecord(_ record: CaptureRecord) {
+        logger?.append(record.auditEvent)
+    }
+
     /// Append a HECA safety-assessment event to the active session's audit log (no-op if no session).
     func logSafetyAssessment(summary: String, score: Double?) {
         logger?.append(SessionLogger.Event(

--- a/OpenGlasses/Sources/Services/FieldAssist/SessionExport.swift
+++ b/OpenGlasses/Sources/Services/FieldAssist/SessionExport.swift
@@ -19,6 +19,7 @@ struct SessionExport: Codable, Equatable {
     let transcript: [TranscriptEntry]
     let photos: [PhotoRef]
     let proceduresRun: [ProcedureRun]
+    let captures: [CaptureRun]
     let citations: [Citation]
     let escalations: [EscalationEntry]
 
@@ -45,6 +46,26 @@ struct SessionExport: Codable, Equatable {
         let outcome: String?   // nil if the procedure was left in progress
     }
 
+    /// A finished capture-flow record (Plan U) reconstructed from its `capture_record` audit event.
+    struct CaptureRun: Codable, Equatable {
+        let timestamp: Date
+        let flowId: String
+        let assetId: String?
+        let fields: [Field]
+
+        struct Field: Codable, Equatable {
+            let field: String
+            let value: String    // human-readable rendering (`CaptureValue.display`)
+            let method: String   // provenance — "voice" | "voice_number" | "enum" | "photo" | "barcode" | "ocr"
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case timestamp, fields
+            case flowId = "flow_id"
+            case assetId = "asset_id"
+        }
+    }
+
     struct Citation: Codable, Equatable {
         let timestamp: Date
         let source: String
@@ -67,6 +88,6 @@ struct SessionExport: Codable, Equatable {
         case billableMinutes = "billable_minutes"
         case location, transcript, photos
         case proceduresRun = "procedures_run"
-        case citations, escalations
+        case captures, citations, escalations
     }
 }

--- a/OpenGlasses/Sources/Services/FieldAssist/SessionExporter.swift
+++ b/OpenGlasses/Sources/Services/FieldAssist/SessionExporter.swift
@@ -54,6 +54,7 @@ enum SessionExporter {
 
         var transcript: [SessionExport.TranscriptEntry] = []
         var photos: [SessionExport.PhotoRef] = []
+        var captures: [SessionExport.CaptureRun] = []
         var citations: [SessionExport.Citation] = []
         var escalations: [SessionExport.EscalationEntry] = []
 
@@ -89,6 +90,18 @@ enum SessionExporter {
                 }
             case .escalationRequested:
                 escalations.append(.init(timestamp: event.timestamp, reason: event.text ?? "Escalation requested"))
+            case .captureRecordSaved:
+                if let flowId = event.payload?["flow_id"]?.value as? String {
+                    let fields = (event.payload?["fields"]?.value as? [Any] ?? []).compactMap { raw -> SessionExport.CaptureRun.Field? in
+                        guard let dict = raw as? [String: Any], let field = dict["field"] as? String else { return nil }
+                        return .init(field: field,
+                                     value: dict["value"] as? String ?? "",
+                                     method: dict["method"] as? String ?? "")
+                    }
+                    captures.append(.init(timestamp: event.timestamp, flowId: flowId,
+                                          assetId: event.payload?["asset_id"]?.value as? String,
+                                          fields: fields))
+                }
             case .procedureStarted:
                 if let id = event.payload?["procedure_id"]?.value as? String {
                     if procStepIds[id] == nil { procStepIds[id] = []; procOrder.append(id) }
@@ -126,6 +139,7 @@ enum SessionExporter {
             transcript: transcript,
             photos: photos,
             proceduresRun: proceduresRun,
+            captures: captures,
             citations: citations,
             escalations: escalations
         )
@@ -172,6 +186,17 @@ enum SessionExporter {
                 for run in document.proceduresRun {
                     let outcome = run.outcome ?? "in progress"
                     layout.body("• \(run.procedureId) — \(run.stepsCompleted) step(s), outcome: \(outcome)")
+                }
+            }
+
+            if !document.captures.isEmpty {
+                layout.section("Captured Records")
+                for capture in document.captures {
+                    let asset = capture.assetId.map { " (\($0))" } ?? ""
+                    layout.body("• \(capture.flowId)\(asset) — \(capture.fields.count) field(s)")
+                    for field in capture.fields {
+                        layout.body("    \(field.field): \(field.value) [\(field.method)]")
+                    }
                 }
             }
 

--- a/OpenGlasses/Sources/Services/FieldAssist/SessionLogger.swift
+++ b/OpenGlasses/Sources/Services/FieldAssist/SessionLogger.swift
@@ -55,6 +55,7 @@ final class SessionLogger {
             case escalationResolved = "escalation_resolved"
             case citation = "citation"
             case safetyAssessment = "safety_assessment"
+            case captureRecordSaved = "capture_record"
             case error = "error"
         }
     }

--- a/OpenGlasses/Sources/Services/NativeTools/CaptureFlowTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/CaptureFlowTool.swift
@@ -51,9 +51,15 @@ final class CaptureFlowTool: NativeTool {
         switch action {
         case "list":
             let flows = service.availableFlows()
-            return flows.isEmpty
+            var out = flows.isEmpty
                 ? "No capture flows are available in the active vault."
                 : "Available capture flows:\n" + flows.map { "• \($0)" }.joined(separator: "\n")
+            let issues = service.flowLoadIssues()
+            if !issues.isEmpty {
+                out += "\n⚠️ \(issues.count) flow file\(issues.count == 1 ? "" : "s") couldn't be loaded:\n"
+                    + issues.map { "• \($0)" }.joined(separator: "\n")
+            }
+            return out
 
         case "start":
             guard let id = (args["flow_id"] as? String), !id.isEmpty else {

--- a/OpenGlasses/Sources/Services/Offline/QueuedOp.swift
+++ b/OpenGlasses/Sources/Services/Offline/QueuedOp.swift
@@ -2,10 +2,11 @@ import Foundation
 
 /// What a queued operation does when it eventually reaches the network (Plan T).
 enum OpKind: String, Codable {
-    case logEntry      // a structured step/observation — durable locally, sync-only
-    case photoUpload   // a captured photo on disk → upload when online
-    case llmGrounding  // a question asked offline → answer when back online
-    case auditExport   // generate / upload the session audit export
+    case logEntry       // a structured step/observation — durable locally, sync-only
+    case photoUpload    // a captured photo on disk → upload when online
+    case llmGrounding   // a question asked offline → answer when back online
+    case auditExport    // generate / upload the session audit export
+    case captureRecord  // a finished capture-flow record (Plan U) — typed so a networked sink can route it
 }
 
 /// Where an operation is in its lifecycle.

--- a/OpenGlassesTests/CaptureFlowTests.swift
+++ b/OpenGlassesTests/CaptureFlowTests.swift
@@ -154,6 +154,93 @@ final class CaptureFlowTests: XCTestCase {
         XCTAssertTrue(FieldResolver.canRun(universal, vaultId: "anything"))
     }
 
+    // MARK: - Schema version + rejection reporting (BM P2)
+
+    func testSchemaVersionRoundTripsAndDefaultsToOne() throws {
+        let flow = sampleFlow()
+        XCTAssertEqual(flow.schemaVersion, 1)
+        let data = try JSONEncoder().encode(flow)
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(json.contains("\"schema_version\":1"))
+        XCTAssertEqual(try JSONDecoder().decode(CaptureFlow.self, from: data), flow)
+
+        // Legacy JSON with no schema_version decodes as version 1.
+        let legacy = """
+        { "id": "f", "title": "F", "steps": [
+          { "field": "x", "prompt": "p", "binding": { "type": "voice" } } ] }
+        """.data(using: .utf8)!
+        XCTAssertEqual(try JSONDecoder().decode(CaptureFlow.self, from: legacy).schemaVersion, 1)
+    }
+
+    func testFutureSchemaVersionIsRejectedWithReason() {
+        let v2 = """
+        { "schema_version": 2, "id": "f", "title": "F", "steps": [
+          { "field": "x", "prompt": "p", "binding": { "type": "hologram" } } ] }
+        """.data(using: .utf8)!
+        let (flow, rejection) = CaptureFlowLibrary.decodeReporting(v2)
+        XCTAssertNil(flow)
+        // Reported as "too new", not as a pile of decode errors about the v2 binding type.
+        XCTAssertTrue(rejection?.contains("schema_version 2") == true)
+        XCTAssertTrue(rejection?.contains("newer") == true)
+    }
+
+    func testUnknownBindingTypeIsRejectedWithReason() {
+        let typo = """
+        { "id": "f", "title": "F", "steps": [
+          { "field": "x", "prompt": "p", "binding": { "type": "barcod" } } ] }
+        """.data(using: .utf8)!
+        let (flow, rejection) = CaptureFlowLibrary.decodeReporting(typo)
+        XCTAssertNil(flow)
+        XCTAssertTrue(rejection?.contains("barcod") == true, "reason should name the bad value: \(rejection ?? "nil")")
+    }
+
+    func testLoadStrictReportsRejectionsInsteadOfVanishing() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("flows_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        try CaptureFlowBuilder.encode(sampleFlow()).write(to: dir.appendingPathComponent("good.json"))
+        try Data("""
+        { "id": "bad", "title": "Bad", "steps": [
+          { "field": "x", "prompt": "p", "binding": { "type": "barcod" } } ] }
+        """.utf8).write(to: dir.appendingPathComponent("bad.json"))
+        try Data("""
+        { "schema_version": 99, "id": "future", "title": "Future", "steps": [] }
+        """.utf8).write(to: dir.appendingPathComponent("future.json"))
+
+        let (flows, rejected) = CaptureFlowLibrary.loadStrict(bundleDir: nil, overlayDir: dir)
+        XCTAssertEqual(flows.map(\.id), ["asset_inspection_v1"])
+        XCTAssertEqual(rejected.count, 2)
+        XCTAssertTrue(rejected.contains { $0.hasPrefix("bad.json:") })
+        XCTAssertTrue(rejected.contains { $0.hasPrefix("future.json:") && $0.contains("newer") })
+    }
+
+    func testExplicitLibraryHasNoRejections() {
+        XCTAssertTrue(CaptureFlowLibrary(vaultId: "v", flows: [sampleFlow()]).rejected.isEmpty)
+    }
+
+    // MARK: - Audit event (BM P2)
+
+    func testAuditEventCarriesFlowAssetAndFields() {
+        var record = CaptureRecord(flowId: "asset_inspection_v1", sessionId: "s", assetId: "47B")
+        record.set("gauge", value: .number(118, unit: "psig"), provenance: Provenance(method: "voice_number"))
+        record.set("sev", value: .option("major"), provenance: Provenance(method: "enum"))
+        record.finishedAt = Date(timeIntervalSince1970: 99)
+
+        let event = record.auditEvent
+        XCTAssertEqual(event.kind, .captureRecordSaved)
+        XCTAssertEqual(event.timestamp, Date(timeIntervalSince1970: 99))
+        XCTAssertEqual(event.payload?["flow_id"]?.value as? String, "asset_inspection_v1")
+        XCTAssertEqual(event.payload?["asset_id"]?.value as? String, "47B")
+        let fields = event.payload?["fields"]?.value as? [Any]
+        XCTAssertEqual(fields?.count, 2)
+        let first = fields?.first as? [String: Any]
+        XCTAssertEqual(first?["field"] as? String, "gauge")
+        XCTAssertEqual(first?["value"] as? String, "118 psig")
+        XCTAssertEqual(first?["method"] as? String, "voice_number")
+    }
+
     // MARK: - CaptureRecord round-trip
 
     func testCaptureRecordRoundTrips() throws {

--- a/OpenGlassesTests/OfflineQueueTests.swift
+++ b/OpenGlassesTests/OfflineQueueTests.swift
@@ -85,6 +85,26 @@ final class OfflineQueueTests: XCTestCase {
         XCTAssertEqual(reopened.pending().first?.id, id)
     }
 
+    func testCaptureRecordKindSurvivesRestart() throws {
+        // BM P2: finished capture flows enqueue as the typed .captureRecord kind (not bare
+        // .logEntry) and the kind round-trips through the SQLite store across a restart.
+        let path = tempPath()
+        var record = CaptureRecord(flowId: "asset_inspection_v1", sessionId: "s", assetId: "47B",
+                                   startedAt: Date(timeIntervalSince1970: 1))
+        record.set("gauge", value: .number(118, unit: "psig"),
+                   provenance: Provenance(method: "voice_number", at: Date(timeIntervalSince1970: 2)))
+        do {
+            let q = OfflineQueue(path: path)
+            q.enqueue(QueuedOp(kind: .captureRecord, sessionId: "s",
+                               payload: try JSONEncoder().encode(record)))
+        }   // released → db closed
+        let reopened = OfflineQueue(path: path)
+        let back = try XCTUnwrap(reopened.pending().first)
+        XCTAssertEqual(back.kind, .captureRecord)
+        let decoded = try JSONDecoder().decode(CaptureRecord.self, from: back.payload)
+        XCTAssertEqual(decoded, record)
+    }
+
     func testPurgeDoneTombstones() {
         let q = OfflineQueue(path: tempPath())
         let a = op("s", at: 100), b = op("s", at: 200)

--- a/OpenGlassesTests/SessionExporterTests.swift
+++ b/OpenGlassesTests/SessionExporterTests.swift
@@ -36,6 +36,11 @@ final class SessionExporterTests: XCTestCase {
         service.logAssistantMessage("E5 is a compressor motor lock on Daikin units.", citations: ["error_codes.md"])
         _ = try service.startProcedure(id: "low_pressure_diagnostic")
         _ = try service.advanceProcedure(choice: nil)
+        var record = CaptureRecord(flowId: "asset_inspection_v1", sessionId: session.id, assetId: "Unit 47B")
+        record.set("gauge_psi", value: .number(118, unit: "psig"), provenance: Provenance(method: "voice_number"))
+        record.set("severity", value: .option("major"), provenance: Provenance(method: "enum"))
+        record.finishedAt = Date()
+        service.logCaptureRecord(record)
         service.recordEscalation(reason: "Readings don't match the manual flowchart")
         _ = try service.endSession(outcome: .escalated)
         // Relocate the produced session dir to the fixed sessionDir path used by the tests.
@@ -63,6 +68,28 @@ final class SessionExporterTests: XCTestCase {
 
         let proc = try XCTUnwrap(export.proceduresRun.first { $0.procedureId == "low_pressure_diagnostic" })
         XCTAssertGreaterThanOrEqual(proc.stepsCompleted, 2) // entry + one advance
+    }
+
+    func testExportIncludesCaptureRecord() throws {
+        // BM P2: a finished capture flow folds into the consolidated export.
+        _ = try makePopulatedSession()
+        let export = try XCTUnwrap(SessionExporter.buildExport(sessionDir: sessionDir))
+
+        let capture = try XCTUnwrap(export.captures.first)
+        XCTAssertEqual(capture.flowId, "asset_inspection_v1")
+        XCTAssertEqual(capture.assetId, "Unit 47B")
+        XCTAssertEqual(capture.fields.count, 2)
+        let gauge = try XCTUnwrap(capture.fields.first { $0.field == "gauge_psi" })
+        XCTAssertEqual(gauge.value, "118 psig")
+        XCTAssertEqual(gauge.method, "voice_number")
+
+        // And it survives the JSON write → decode round-trip.
+        _ = try SessionExporter.export(sessionDir: sessionDir, formats: [.json])
+        let decoder = JSONDecoder(); decoder.dateDecodingStrategy = .iso8601
+        let reloaded = try decoder.decode(
+            SessionExport.self,
+            from: Data(contentsOf: sessionDir.appendingPathComponent("audit_export.json")))
+        XCTAssertEqual(reloaded.captures, export.captures)
     }
 
     func testExportWritesJSONAndPDFFiles() throws {


### PR DESCRIPTION
Plan BM P2 — capture-flow schema safety (Plan U riders). Real migration surface now that `CaptureFlowAuthorView` ships user-authored JSON via the share sheet.

## The bugs (evidence in the plan's P2 section)

1. **Flows vanished silently.** `CaptureFlowLibrary.load()` `try?`-decoded and `compactMap`'d failures away — a v2 binding type or a typo in a hand-edited overlay made the flow disappear from the library with no feedback.
2. **No version field.** Nothing distinguished "this file is from a newer app" from "this file is corrupt".
3. **Untyped queue ops.** Finished `CaptureRecord`s enqueued as bare `.logEntry` — indistinguishable to a future networked sink — and the "audit-ready record" promise was true only via the queue: the session export never saw them.

## The fixes

- **`schema_version`** on `CaptureFlow` (absent ⇒ 1; encoded by the author/export path so authored flows carry it). `CaptureFlowLibrary.currentSchemaVersion` gates load.
- **`loadStrict` rejection reporting** (the `MCPCatalog.loadStrict` pattern): each failed file reports as `filename: reason`. A future version reads as `schema_version 2 is newer than this app supports (1)`; an unknown binding type names the bad value and its JSON path (`steps.[0].binding.type: Cannot initialize BindingType from invalid String value 'barcod'`). The `capture_flow` tool's `list` action appends the report so a broken overlay is visible where flows are browsed.
- **Typed `.captureRecord` op kind** (with `SyncStatusView` label). Existing `.logEntry` rows are untouched; unknown kinds still fall back to `.logEntry` on read.
- **Audit-export folding:** finishing a flow also appends a `capture_record` event to the session's append-only log (`CaptureRecord.auditEvent`); `SessionExporter` reconstructs these into a new `captures` array in the JSON export and a "Captured Records" section in the PDF, with per-field value + provenance method.

## Tests (8 new)

- Version round-trip, legacy (no-field) default, future-version rejection reason, unknown-binding rejection reason
- `loadStrict` over a good/bad/future directory: good flow loads, both rejects reported by filename
- Audit event carries flow/asset/fields with display values + methods
- `.captureRecord` kind + payload survive an `OfflineQueue` close/reopen
- Exporter folds the record into `captures` and it survives the JSON write → decode round-trip

Full suite green: **1668 tests, 0 failures** (iOS 27 sim, Xcode 27 beta); all 8 new tests verified individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)