### PR TITLE
Small verified fixes: switch_harness cases, custom-harness hygiene, realtime resume guard (BM P5)

### DIFF
--- a/OpenGlasses/Sources/App/Views/AgentHarnessSettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/AgentHarnessSettingsView.swift
@@ -55,7 +55,12 @@ struct AgentHarnessSettingsView: View {
             } header: {
                 Text("Custom endpoint")
             } footer: {
-                Text("Point OpenGlasses at any agent endpoint you already run. {id} is replaced with the run id, e.g. https://host/runs/{id}.")
+                if let issue = config.transportIssue {
+                    Label(issue, systemImage: "lock.slash")
+                        .foregroundStyle(.red)
+                } else {
+                    Text("Point OpenGlasses at any agent endpoint you already run. {id} is replaced with the run id, e.g. https://host/runs/{id}.")
+                }
             }
 
             Section("Authentication") {

--- a/OpenGlasses/Sources/Services/AgentHarness/Adapters/CustomHarnessConfig.swift
+++ b/OpenGlasses/Sources/Services/AgentHarness/Adapters/CustomHarnessConfig.swift
@@ -25,10 +25,32 @@ struct CustomHarnessConfig: Codable, Equatable {
     var idPath: String = "id"
     var statusPath: String = "status"
 
-    /// Minimum viable config: a parseable start URL.
+    /// Minimum viable config: a parseable, transport-secure start URL. The auth token rides every
+    /// request, so `http://` is refused except to loopback (a local bridge in development) — BM P5.
     var isConfigured: Bool {
         let trimmed = startURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        return !trimmed.isEmpty && URL(string: trimmed) != nil
+        guard !trimmed.isEmpty, let url = URL(string: trimmed) else { return false }
+        return Self.isTransportSecure(url)
+    }
+
+    /// Why the start URL is refused, for the settings UI — or `nil` when it's empty or acceptable.
+    var transportIssue: String? {
+        let trimmed = startURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let url = URL(string: trimmed), !Self.isTransportSecure(url) else { return nil }
+        return "Use https — over http the auth token is sent in cleartext (http is allowed only for localhost)."
+    }
+
+    /// https anywhere; http only to loopback hosts.
+    static func isTransportSecure(_ url: URL) -> Bool {
+        switch url.scheme?.lowercased() {
+        case "https":
+            return true
+        case "http":
+            let host = url.host?.lowercased() ?? ""
+            return host == "localhost" || host == "127.0.0.1" || host == "::1" || host.hasSuffix(".localhost")
+        default:
+            return false
+        }
     }
 }
 
@@ -49,8 +71,7 @@ extension CustomHarnessConfig {
 
     /// The status URL for `runID` from the template, or `nil` if no template is set.
     func statusURL(runID: String) -> URL? {
-        let filled = statusURLTemplate.replacingOccurrences(of: "{id}", with: runID)
-        guard !filled.isEmpty else { return nil }
+        guard let filled = fillTemplate(statusURLTemplate, runID: runID) else { return nil }
         return URL(string: filled)
     }
 
@@ -65,14 +86,25 @@ extension CustomHarnessConfig {
 
     /// Build the cancel (POST) request for `runID`, or `nil` if no cancel template is set.
     func cancelRequest(runID: String) -> URLRequest? {
-        let filled = cancelURLTemplate.replacingOccurrences(of: "{id}", with: runID)
-        guard !filled.isEmpty, let url = URL(string: filled) else { return nil }
+        guard let filled = fillTemplate(cancelURLTemplate, runID: runID),
+              let url = URL(string: filled) else { return nil }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         applyAuth(&request)
         request.timeoutInterval = 15
         return request
     }
+
+    /// `{id}` filled with the **percent-encoded** run id (BM P5). The id comes from the server's
+    /// own response, so path/query metacharacters ("../", "?", "#") must not be able to rewrite
+    /// the request URL. `nil` when the template is empty.
+    private func fillTemplate(_ template: String, runID: String) -> String? {
+        guard !template.isEmpty,
+              let encoded = runID.addingPercentEncoding(withAllowedCharacters: Self.runIDAllowed) else { return nil }
+        return template.replacingOccurrences(of: "{id}", with: encoded)
+    }
+
+    private static let runIDAllowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
 
     private func applyAuth(_ request: inout URLRequest) {
         guard !authHeader.isEmpty, !authValue.isEmpty else { return }

--- a/OpenGlasses/Sources/Services/AgentHarness/AgentModels.swift
+++ b/OpenGlasses/Sources/Services/AgentHarness/AgentModels.swift
@@ -18,6 +18,13 @@ enum AgentHarnessKind: String, CaseIterable, Codable, Identifiable {
         case .custom:       return "Custom endpoint"
         }
     }
+
+    /// Case-insensitive lookup ("codexcloud" → .codexCloud). The `switch_harness` tool lowercases
+    /// what the LLM passes, which can never equal a camelCase raw value (BM P5).
+    static func matching(_ raw: String) -> AgentHarnessKind? {
+        let folded = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return allCases.first { $0.rawValue.lowercased() == folded }
+    }
 }
 
 /// Lifecycle of a single remote agent run, normalized across harnesses.

--- a/OpenGlasses/Sources/Services/Audio/AudioInterruptionPolicy.swift
+++ b/OpenGlasses/Sources/Services/Audio/AudioInterruptionPolicy.swift
@@ -50,6 +50,13 @@ enum AudioInterruptionPolicy {
         }
     }
 
+    /// Whether an engine owning `engineOwner` may reactivate the shared audio session once an
+    /// interruption ends. A resume after a phone call must not stomp whoever acquired the session
+    /// in the meantime — the same ledger check `WakeWordService` applies before reclaiming (BM P5).
+    static func mayResume(engineOwner: AudioSessionOwner, currentOwner: AudioSessionOwner?) -> Bool {
+        currentOwner == engineOwner
+    }
+
     /// Decide how to respond to an `AVAudioSession.routeChangeNotification`.
     ///
     /// A device appearing or disappearing mid-call (the glasses connecting/dropping off the

--- a/OpenGlasses/Sources/Services/Audio/RealtimeAudioEngine.swift
+++ b/OpenGlasses/Sources/Services/Audio/RealtimeAudioEngine.swift
@@ -411,6 +411,14 @@ final class RealtimeAudioEngine {
     }
 
     private func resumeAfterInterruptionOnQueue() {
+        // Only reactivate if this engine still owns the shared session — a resume after a phone
+        // call must not stomp whoever acquired it meanwhile (wake word, the other realtime engine).
+        let owner = AudioSessionCoordinator.shared.currentOwner
+        guard AudioInterruptionPolicy.mayResume(engineOwner: config.owner, currentOwner: owner) else {
+            NSLog("%@ Interruption ended — NOT resuming; session owned by %@",
+                  config.logPrefix, owner?.rawValue ?? "nobody")
+            return
+        }
         let session = AVAudioSession.sharedInstance()
         do {
             try session.setActive(true)

--- a/OpenGlasses/Sources/Services/NativeTools/AgentControlTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/AgentControlTool.swift
@@ -35,7 +35,7 @@ struct AgentControlTool: NativeTool {
                 ],
                 "harness": [
                     "type": "string",
-                    "enum": ["openclaw", "custom"],
+                    "enum": AgentHarnessKind.allCases.map(\.rawValue),
                     "description": "For action=switch_harness: which configured backend to make the default.",
                 ],
             ],
@@ -81,9 +81,10 @@ struct AgentControlTool: NativeTool {
             return "Okay, I won't proceed."
 
         case "switch_harness", "switch":
-            guard let raw = (args["harness"] as? String)?.lowercased(),
-                  let kind = AgentHarnessKind(rawValue: raw) else {
-                return "Which agent backend? Try OpenClaw or Custom."
+            guard let raw = args["harness"] as? String,
+                  let kind = AgentHarnessKind.matching(raw) else {
+                let options = AgentHarnessKind.allCases.map(\.displayName).joined(separator: ", ")
+                return "Which agent backend? Options: \(options)."
             }
             guard session.registry?.harness(for: kind)?.isConfigured == true else {
                 return "\(kind.displayName) isn't configured. Set it up in Settings first."

--- a/OpenGlassesTests/AgentCustomHarnessTests.swift
+++ b/OpenGlassesTests/AgentCustomHarnessTests.swift
@@ -23,6 +23,34 @@ final class AgentCustomHarnessTests: XCTestCase {
         XCTAssertTrue(config().isConfigured)
     }
 
+    func testIsConfiguredRequiresSecureTransport() {
+        // The auth token rides every request — plain http is refused except to loopback (BM P5).
+        XCTAssertFalse(config(start: "http://agent.test/start").isConfigured)
+        XCTAssertNotNil(config(start: "http://agent.test/start").transportIssue)
+        XCTAssertTrue(config(start: "http://localhost:8080/start").isConfigured)
+        XCTAssertTrue(config(start: "http://127.0.0.1/start").isConfigured)
+        XCTAssertNil(config().transportIssue)                 // https is fine
+        XCTAssertNil(CustomHarnessConfig().transportIssue)    // empty isn't a transport issue
+        XCTAssertFalse(config(start: "ftp://agent.test/start").isConfigured)
+    }
+
+    func testRunIDIsPercentEncodedInTemplates() {
+        // The run id comes from the server's own response — path/query metacharacters must not
+        // rewrite the request URL (BM P5).
+        let c = config()
+        XCTAssertEqual(c.statusURL(runID: "../admin")?.absoluteString,
+                       "https://agent.test/runs/..%2Fadmin")
+        XCTAssertEqual(c.statusURL(runID: "r?x=1#f")?.absoluteString,
+                       "https://agent.test/runs/r%3Fx%3D1%23f")
+        XCTAssertEqual(c.statusURL(runID: "run-9.a_b~c")?.absoluteString,
+                       "https://agent.test/runs/run-9.a_b~c")   // plain ids untouched
+
+        var withCancel = config()
+        withCancel.cancelURLTemplate = "https://agent.test/runs/{id}/cancel"
+        XCTAssertEqual(withCancel.cancelRequest(runID: "a/b")?.url?.absoluteString,
+                       "https://agent.test/runs/a%2Fb/cancel")
+    }
+
     func testConfigCodableRoundTrip() throws {
         let original = config()
         let data = try JSONEncoder().encode(original)
@@ -190,6 +218,43 @@ final class AgentCustomHarnessTests: XCTestCase {
         AgentSessionService.shared.setRegistry(AgentHarnessRegistry([StubHarness(kind: .custom, configured: false)]))
         let unconfigured = try await AgentControlTool().execute(args: ["action": "switch_harness", "harness": "custom"])
         XCTAssertTrue(unconfigured.contains("isn't configured"))
+    }
+
+    // MARK: - switch_harness case handling (BM P5)
+
+    func testHarnessKindMatchingIsCaseInsensitive() {
+        XCTAssertEqual(AgentHarnessKind.matching("codexcloud"), .codexCloud)
+        XCTAssertEqual(AgentHarnessKind.matching("CODEXCLOUD"), .codexCloud)
+        XCTAssertEqual(AgentHarnessKind.matching(" clauderemote "), .claudeRemote)
+        XCTAssertEqual(AgentHarnessKind.matching("openclaw"), .openclaw)
+        XCTAssertEqual(AgentHarnessKind.matching("Custom"), .custom)
+        XCTAssertNil(AgentHarnessKind.matching("nope"))
+    }
+
+    func testToolSchemaEnumeratesEveryHarnessKind() {
+        let props = AgentControlTool().parametersSchema["properties"] as? [String: Any]
+        let harness = props?["harness"] as? [String: Any]
+        XCTAssertEqual(Set(harness?["enum"] as? [String] ?? []),
+                       Set(AgentHarnessKind.allCases.map(\.rawValue)))
+    }
+
+    func testToolSwitchHarnessReachesPhase3Harnesses() async throws {
+        // The old lowercased-rawValue lookup could never match codexCloud/claudeRemote, making
+        // voice-switching to the Phase 3 harnesses impossible.
+        let priorMode = Config.agentModeEnabled
+        let priorDefault = Config.defaultAgentHarness
+        defer {
+            Config.setAgentModeEnabled(priorMode)
+            Config.setDefaultAgentHarness(priorDefault)
+        }
+        Config.setAgentModeEnabled(true)
+        AgentSessionService.shared.setRegistry(
+            AgentHarnessRegistry([StubHarness(kind: .codexCloud, configured: true)]))
+
+        let out = try await AgentControlTool().execute(
+            args: ["action": "switch_harness", "harness": "codexcloud"])
+        XCTAssertTrue(out.contains("Switched"), "got: \(out)")
+        XCTAssertEqual(Config.defaultAgentHarness, .codexCloud)
     }
 }
 

--- a/OpenGlassesTests/AudioInterruptionPolicyTests.swift
+++ b/OpenGlassesTests/AudioInterruptionPolicyTests.swift
@@ -75,4 +75,16 @@ final class AudioInterruptionPolicyTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - Resume ownership (BM P5)
+
+    func testMayResumeOnlyWhenEngineStillOwnsTheSession() {
+        // A resume after a phone call must not stomp whoever acquired the session meanwhile.
+        XCTAssertTrue(AudioInterruptionPolicy.mayResume(engineOwner: .openAIRealtime, currentOwner: .openAIRealtime))
+        XCTAssertTrue(AudioInterruptionPolicy.mayResume(engineOwner: .geminiLive, currentOwner: .geminiLive))
+        XCTAssertFalse(AudioInterruptionPolicy.mayResume(engineOwner: .openAIRealtime, currentOwner: .wakeWord))
+        XCTAssertFalse(AudioInterruptionPolicy.mayResume(engineOwner: .geminiLive, currentOwner: .openAIRealtime))
+        // A released session (nobody owns it) is also not ours to reactivate.
+        XCTAssertFalse(AudioInterruptionPolicy.mayResume(engineOwner: .openAIRealtime, currentOwner: nil))
+    }
 }


### PR DESCRIPTION
Plan BM P5 — the bundled mechanical fixes, one PR as planned. (The fourth P5 item, keyless Custom sends, already landed in #191's branch.)

## 1. `switch_harness` could never reach the Phase 3 harnesses

The schema enumerated `["openclaw","custom"]` (`AgentControlTool.swift:38`) and the lookup did `AgentHarnessKind(rawValue: raw.lowercased())` — `"codexcloud"` never equals the camelCase `codexCloud`, so voice-switching to OpenAI Codex / Claude Code (remote) was impossible.

- Schema enum is now generated from `AgentHarnessKind.allCases` (can't drift again)
- New case-insensitive `AgentHarnessKind.matching()`; the unknown-backend reply lists all four options

## 2. Custom-harness hygiene (Plan N)

- **Transport:** `isConfigured` accepted `http://` — the auth token rides every request in cleartext. Now https is required; http is allowed only to loopback hosts (local Agent SDK bridge development). The settings footer shows a red explanation instead of a mysteriously disabled Save button.
- **`{id}` injection:** the run id substituted into the status/cancel URL templates comes from the server's own response; `../`, `?`, `#` could rewrite the request URL. The substitution now percent-encodes everything outside `[alphanumerics -._~]`.

## 3. Realtime resume owner check (Plan AP)

`resumeAfterInterruptionOnQueue` (`RealtimeAudioEngine.swift:413`) reactivated the shared audio session with no `currentOwner` check — a resume after a phone call could stomp whoever acquired the session meanwhile (wake word, or the other realtime engine). It now consults the coordinator ledger through a new pure `AudioInterruptionPolicy.mayResume(engineOwner:currentOwner:)`, mirroring the existing `WakeWordService` guard. This was the stated prerequisite for any AP/BJ on-glasses smoke test.

## Tests (6 new)

- `matching()` case/whitespace matrix; schema enum covers every harness kind; end-to-end tool switch to `codexCloud` succeeds and persists the default
- https ✓ / http ✗ / http+loopback ✓ / ftp ✗ transport matrix, with `transportIssue` populated only for insecure non-empty URLs
- Percent-encoding: `../admin` → `..%2Fadmin`, `r?x=1#f` → `r%3Fx%3D1%23f`, plain ids untouched, cancel template covered
- `mayResume` ownership matrix incl. released-session (nil owner) → no resume

Full suite green: **1666 tests, 0 failures** (iOS 27 sim, Xcode 27 beta). Two targeted verification runs hit the known intermittent CoreSimulator "runner hung" flake; after the standard erase+boot recovery both remaining tests passed by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)