### PR TITLE
Diarization visibility: speaker chips on captions, tap-to-name (BM P7)

### DIFF
--- a/OpenGlasses/Sources/App/Views/AmbientCaptionOverlay.swift
+++ b/OpenGlasses/Sources/App/Views/AmbientCaptionOverlay.swift
@@ -2,18 +2,25 @@ import SwiftUI
 
 /// Floating overlay that displays real-time ambient captions.
 /// Shows the current live caption and recent history, auto-fading old entries.
+/// Diarized captions carry a tappable speaker chip (BM P7) — tap to name the speaker; names
+/// persist through `SpeakerRegistry` and merge-on-same-name keeps colours consistent.
 struct AmbientCaptionOverlay: View {
     @ObservedObject var captionService: AmbientCaptionService
+
+    /// Bumped after a rename so chip labels re-resolve (the registry itself isn't observable).
+    @State private var registryVersion = 0
+    @State private var renameSpeakerId: Int?
+    @State private var renameText = ""
+
+    private var isRenaming: Binding<Bool> {
+        Binding(get: { renameSpeakerId != nil }, set: { if !$0 { renameSpeakerId = nil } })
+    }
 
     var body: some View {
         VStack(spacing: 4) {
             // Recent history (faded)
             ForEach(captionService.captionHistory.prefix(3).reversed()) { entry in
-                Text(entry.text)
-                    .font(.system(size: 14, weight: .regular))
-                    .foregroundStyle(.white.opacity(0.5))
-                    .lineLimit(2)
-                    .multilineTextAlignment(.center)
+                historyRow(entry)
             }
 
             // Current live caption
@@ -34,9 +41,61 @@ struct AmbientCaptionOverlay: View {
                     .accessibilityAddTraits(.updatesFrequently)
             }
         }
+        .id(registryVersion)
         .padding(.horizontal, 20)
         .transition(.opacity)
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Live captions")
+        .alert("Name this speaker", isPresented: isRenaming) {
+            TextField("Name", text: $renameText)
+            Button("Save") {
+                if let id = renameSpeakerId {
+                    captionService.speakerRegistry.setName(renameText, for: id)
+                    registryVersion += 1
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Captions from this voice will show this name. Give two chips the same name to merge them.")
+        }
+    }
+
+    @ViewBuilder
+    private func historyRow(_ entry: AmbientCaptionService.CaptionEntry) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            if let chip = SpeakerChipModel.chip(speaker: entry.speaker, registry: captionService.speakerRegistry) {
+                SpeakerChipView(chip: chip) {
+                    renameText = captionService.speakerRegistry.name(for: chip.speakerId) ?? ""
+                    renameSpeakerId = chip.speakerId
+                }
+            }
+            Text(entry.text)
+                .font(.system(size: 14, weight: .regular))
+                .foregroundStyle(.white.opacity(0.5))
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+        }
+    }
+}
+
+/// Small tappable capsule naming the diarized speaker of a caption row (Plan AQ visibility).
+/// The palette has `SpeakerRegistry.paletteSize` slots; `chip.colorIndex` is already in range.
+private struct SpeakerChipView: View {
+    static let palette: [Color] = [.gray, .blue, .green, .orange, .purple, .pink, .teal, .indigo]
+
+    let chip: SpeakerChip
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            Text(chip.label)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(Self.palette[chip.colorIndex % Self.palette.count].opacity(0.85)))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Speaker \(chip.label). Tap to name.")
     }
 }

--- a/OpenGlasses/Sources/Services/Diarization/SpeakerChipModel.swift
+++ b/OpenGlasses/Sources/Services/Diarization/SpeakerChipModel.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// What a caption row's speaker chip shows (BM P7). Pure value produced by `SpeakerChipModel` so
+/// chip presence / label / colour are unit-testable; the SwiftUI capsule in
+/// `AmbientCaptionOverlay` is the thin edge.
+struct SpeakerChip: Equatable {
+    let speakerId: Int
+    let label: String
+    let colorIndex: Int
+}
+
+/// PURE chip decision for a caption entry: no speaker id (the single-speaker /
+/// diarization-off path never sets one) ⇒ no chip; otherwise the registry resolves the display
+/// name (or "Speaker N") and the stable palette slot, including merge-on-same-name
+/// canonicalisation.
+enum SpeakerChipModel {
+    static func chip(speaker: Int?, registry: SpeakerRegistry) -> SpeakerChip? {
+        guard let speaker else { return nil }
+        return SpeakerChip(
+            speakerId: speaker,
+            label: registry.displayLabel(for: speaker),
+            colorIndex: registry.colorIndex(for: speaker))
+    }
+}

--- a/OpenGlassesTests/SpeakerDiarizationCoreTests.swift
+++ b/OpenGlassesTests/SpeakerDiarizationCoreTests.swift
@@ -106,6 +106,49 @@ final class SpeakerDiarizationCoreTests: XCTestCase {
         XCTAssertEqual(reloaded.namedSpeakerIds, [1])
     }
 
+    // MARK: - Speaker chips (BM P7)
+
+    func testNoChipWithoutSpeakerId() {
+        // The diarization-off / single-speaker path never sets a speaker id
+        // (`finalizeCaption` defaults it to nil) — those captions get no chip.
+        XCTAssertNil(SpeakerChipModel.chip(speaker: nil, registry: freshRegistry()))
+        let entry = AmbientCaptionService.CaptionEntry(text: "hello", timestamp: Date())
+        XCTAssertNil(SpeakerChipModel.chip(speaker: entry.speaker, registry: freshRegistry()))
+    }
+
+    func testChipForUnnamedSpeakerShowsDefaultLabelAndStableColor() {
+        let r = freshRegistry()
+        let chip = SpeakerChipModel.chip(speaker: 1, registry: r)
+        XCTAssertEqual(chip, SpeakerChip(speakerId: 1, label: "Speaker 2", colorIndex: r.colorIndex(for: 1)))
+    }
+
+    func testChipRenameRoundTripsThroughRegistry() {
+        let suite = UserDefaults(suiteName: "diarization.tests.\(UUID().uuidString)")!
+        let r = SpeakerRegistry(defaults: suite, storageKey: "names")
+        XCTAssertEqual(SpeakerChipModel.chip(speaker: 0, registry: r)?.label, "Speaker 1")
+
+        // The chip's tap-to-name action writes through the registry…
+        r.setName("Alice", for: 0)
+        XCTAssertEqual(SpeakerChipModel.chip(speaker: 0, registry: r)?.label, "Alice")
+
+        // …persists across a relaunch…
+        let reloaded = SpeakerRegistry(defaults: suite, storageKey: "names")
+        XCTAssertEqual(SpeakerChipModel.chip(speaker: 0, registry: reloaded)?.label, "Alice")
+
+        // …and clearing reverts to the default label.
+        reloaded.setName(nil, for: 0)
+        XCTAssertEqual(SpeakerChipModel.chip(speaker: 0, registry: reloaded)?.label, "Speaker 1")
+    }
+
+    func testChipsMergeOnSameName() {
+        let r = freshRegistry()
+        r.setName("Bob", for: 0)
+        r.setName("Bob", for: 5)
+        let merged = SpeakerChipModel.chip(speaker: 5, registry: r)
+        XCTAssertEqual(merged?.label, "Bob")
+        XCTAssertEqual(merged?.colorIndex, SpeakerChipModel.chip(speaker: 0, registry: r)?.colorIndex)
+    }
+
     // MARK: - PCMConverter
 
     func testDownmixAveragesChannels() {


### PR DESCRIPTION
Plan BM P7 — Plan AQ's promoted visibility item. `CaptionEntry.speaker` was populated by the diarized path (`AmbientCaptionService.swift:235-243`) but no view consumed it, while `DiarizationSettingsView.swift:72` instructed "Tap a speaker chip on a caption to name them" — a UI that didn't exist. This also gates the AQ live-WebSocket device validation: no point validating an invisible feature.

## What's here

- **`SpeakerChipModel` (new, pure)** — the deterministic chip decision: a caption with no speaker id (the single-speaker / diarization-off path never sets one) gets **no chip**; otherwise the chip carries the registry-resolved label ("Speaker N" or the assigned name) and the stable palette slot, with merge-on-same-name canonicalisation so a returning speaker under a fresh Deepgram id keeps their colour. The SwiftUI capsule is the thin edge, per house style.
- **`AmbientCaptionOverlay`** — history rows with a speaker id render a small tappable coloured capsule before the text. Tapping opens a name alert (pre-filled with the current name) that writes through `SpeakerRegistry.setName`; the alert message notes that giving two chips the same name merges them. A local version counter re-resolves labels after a rename (the registry isn't observable). The live-caption line and the diarization-off rendering are unchanged.

The settings copy now describes a real UI; no copy changes needed.

## Tests (4 new, in SpeakerDiarizationCoreTests)

- No chip when `speaker == nil` (including a default-constructed `CaptionEntry` — the off path)
- Unnamed speaker → "Speaker N" label with the registry's stable colour index
- Tap-to-name round-trip: rename reflects in the chip, persists across a registry relaunch, and clearing reverts to the default label
- Two ids named identically merge: same label, same colour

Full suite green: **1683 tests, 0 failures** (iOS 27 sim, Xcode 27 beta); all 4 new tests verified individually by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)