### PR TITLE
Chat SSE hardening: mid-stream errors throw, transient retry, per-iteration reset (BM P9)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2849,6 +2849,12 @@ class AppState: ObservableObject, AppStateProtocol {
                         onToken: { [weak self] chunk in
                             guard let self, let id = streamThreadId else { return }
                             if self.streamingTurn?.threadId == id { self.streamingTurn?.text += chunk }
+                        },
+                        onStreamReset: { [weak self] in
+                            // A new tool-loop iteration is starting (BM P9): drop the previous
+                            // iteration's text so the bubble never shows intermediate+final concatenated.
+                            guard let self, let id = streamThreadId else { return }
+                            if self.streamingTurn?.threadId == id { self.streamingTurn?.text = "" }
                         }
                     )
                 },

--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -645,7 +645,7 @@ struct SettingsView: View {
             } header: {
                 Text("About")
             } footer: {
-                Text("OpenGlasses is an open-source community project. Join the Discord for help, ideas, and to share what you've built.")
+                Text("OpenGlasses © 2026 Skunkworks NZ Ltd. All rights reserved. Free for personal, non-commercial use — commercial use requires a licence.\n\nJoin the Discord for help, ideas, and to share what you've built.")
             }
         }
         .navigationTitle("Settings")

--- a/OpenGlasses/Sources/App/Views/ToolsSettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/ToolsSettingsView.swift
@@ -5,7 +5,7 @@ import UserNotifications
 import HealthKit
 
 /// Lists all registered native tools with toggle, description, and parameter info.
-/// Part of the open-source transparency — users can see and control what the AI can do.
+/// Transparency surface — users can see and control what the AI can do.
 struct ToolsSettingsView: View {
     @ObservedObject var appState: AppState
     @State private var disabledTools: Set<String> = Config.disabledTools

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -149,6 +149,10 @@ class LLMService: ObservableObject {
     /// Local on-device LLM service (MLX Swift)
     var localLLMService: LocalLLMService?
 
+    /// Session the SSE streaming helpers use. Injectable purely so tests can stub `URLProtocol`
+    /// and exercise the stream parsing/error paths headlessly (BM P9); production uses `.shared`.
+    var streamingSession: URLSession = .shared
+
 
     #if canImport(FoundationModels)
     private var _appleSession: Any?
@@ -414,10 +418,12 @@ class LLMService: ObservableObject {
         )
     }
 
-    /// - Parameter onToken: optional per-token callback for streaming the final assistant reply
-    ///   into the UI as it's generated. Currently honoured by the on-device (`local`) provider;
-    ///   cloud providers ignore it and return the full reply on completion.
-    func sendMessage(_ text: String, locationContext: String? = nil, imageData: Data? = nil, memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil, onToken: ((String) -> Void)? = nil) async throws -> String {
+    /// - Parameter onToken: optional per-token callback for streaming the assistant reply into the
+    ///   UI as it's generated (honoured by the Anthropic, OpenAI-compatible, and local providers).
+    /// - Parameter onStreamReset: invoked at the start of each streamed tool-loop iteration so the
+    ///   caller can clear its accumulated bubble — intermediate tool-turn text must never
+    ///   concatenate with the final reply (BM P9).
+    func sendMessage(_ text: String, locationContext: String? = nil, imageData: Data? = nil, memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil, onToken: ((String) -> Void)? = nil, onStreamReset: (() -> Void)? = nil) async throws -> String {
         isProcessing = true
         defer { isProcessing = false }
 
@@ -479,7 +485,7 @@ class LLMService: ObservableObject {
         let rawResponse: String
         switch provider {
         case .anthropic:
-            rawResponse = try await sendAnthropic(text, systemPrompt: fullPrompt, config: modelConfig, includeTools: includeTools, imageData: imageData, onToken: onToken)
+            rawResponse = try await sendAnthropic(text, systemPrompt: fullPrompt, config: modelConfig, includeTools: includeTools, imageData: imageData, onToken: onToken, onStreamReset: onStreamReset)
         case .gemini:
             rawResponse = try await sendGemini(text, systemPrompt: fullPrompt, config: modelConfig, includeTools: includeTools, imageData: imageData)
         case .local:
@@ -487,7 +493,7 @@ class LLMService: ObservableObject {
         case .appleOnDevice:
             rawResponse = try await sendAppleOnDevice(text, systemPrompt: fullPrompt)
         case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom:
-            rawResponse = try await sendOpenAICompatible(text, systemPrompt: fullPrompt, config: modelConfig, includeTools: includeTools, imageData: imageData, onToken: onToken)
+            rawResponse = try await sendOpenAICompatible(text, systemPrompt: fullPrompt, config: modelConfig, includeTools: includeTools, imageData: imageData, onToken: onToken, onStreamReset: onStreamReset)
         }
 
         // Strip <think> tags: keep reasoning in history but don't speak it
@@ -1177,7 +1183,9 @@ class LLMService: ObservableObject {
         }
     }
 
-    private func sendAnthropic(_ text: String, systemPrompt: String, config: ModelConfig, includeTools: Bool, imageData: Data?, onToken: ((String) -> Void)? = nil) async throws -> String {
+    // Internal (not private) so the BM P9 fixture tests can drive the full streamed tool loop
+    // through a stubbed `streamingSession`.
+    func sendAnthropic(_ text: String, systemPrompt: String, config: ModelConfig, includeTools: Bool, imageData: Data?, onToken: ((String) -> Void)? = nil, onStreamReset: (() -> Void)? = nil) async throws -> String {
         // An explicit API key wins; otherwise fall back to a connected Claude account (OAuth).
         let apiKey = await AnthropicAuth.resolveCredential(apiKey: config.apiKey)
         guard !apiKey.isEmpty else {
@@ -1267,7 +1275,16 @@ class LLMService: ObservableObject {
                 let content: [[String: Any]]
                 let stopReason: String?
                 if let onToken {
-                    (content, stopReason) = try await self.streamAnthropicContent(request: request, model: config.model, onToken: onToken)
+                    // New tool-loop iteration: clear the caller's accumulated bubble first, so an
+                    // intermediate tool turn's text never concatenates with the final reply (BM P9).
+                    onStreamReset?()
+                    let flag = TokenDeliveryFlag()
+                    (content, stopReason) = try await self.withTransientSSERetries(tokenFlag: flag) {
+                        try await self.streamAnthropicContent(request: request, model: config.model) { token in
+                            flag.mark()
+                            onToken(token)
+                        }
+                    }
                 } else {
                     let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -1362,7 +1379,7 @@ class LLMService: ObservableObject {
         return nil
     }
 
-    private func sendOpenAICompatible(_ text: String, systemPrompt: String, config: ModelConfig, includeTools: Bool, imageData: Data?, onToken: ((String) -> Void)? = nil) async throws -> String {
+    private func sendOpenAICompatible(_ text: String, systemPrompt: String, config: ModelConfig, includeTools: Bool, imageData: Data?, onToken: ((String) -> Void)? = nil, onStreamReset: (() -> Void)? = nil) async throws -> String {
         let provider = config.llmProvider
         let apiKey = config.apiKey
         let authorization = try Self.openAICompatibleAuthorization(provider: provider, apiKey: apiKey)
@@ -1485,7 +1502,16 @@ class LLMService: ObservableObject {
                 // the reconstructed `message` (content + tool_calls) feeds the shared tool loop unchanged.
                 let message: [String: Any]
                 if let onToken {
-                    message = try await self.streamOpenAIMessage(request: request, provider: provider, model: config.model, onToken: onToken)
+                    // New tool-loop iteration: clear the caller's accumulated bubble first, so an
+                    // intermediate tool turn's text never concatenates with the final reply (BM P9).
+                    onStreamReset?()
+                    let flag = TokenDeliveryFlag()
+                    message = try await self.withTransientSSERetries(tokenFlag: flag) {
+                        try await self.streamOpenAIMessage(request: request, provider: provider, model: config.model) { token in
+                            flag.mark()
+                            onToken(token)
+                        }
+                    }
                 } else {
                     let (data, response) = try await URLSession.shared.data(for: request)
 
@@ -1573,12 +1599,60 @@ class LLMService: ObservableObject {
 
     // MARK: - Streaming (SSE) — Chat tab live token delivery
 
+    /// Whether an SSE failure is worth an automatic retry (BM P9) — rate limits (429), server-side
+    /// errors/overload (5xx incl. Anthropic 529), transient network drops, and interrupted streams
+    /// whose reason reads as overload/truncation. Mirrors `RealtimeReconnect`'s
+    /// fatal-vs-recoverable split for the chat path.
+    nonisolated static func isTransientSSEError(_ error: Error) -> Bool {
+        switch error {
+        case LLMError.apiError(_, let status, _):
+            return status == 429 || (500...599).contains(status)
+        case LLMError.streamInterrupted(_, let reason):
+            let r = reason.lowercased()
+            return r.contains("overloaded") || r.contains("rate_limit")
+                || r.contains("server_error") || r.contains("truncated")
+        case let urlError as URLError:
+            return [.timedOut, .networkConnectionLost, .notConnectedToInternet,
+                    .cannotConnectToHost, .dnsLookupFailed].contains(urlError.code)
+        default:
+            return false
+        }
+    }
+
+    /// Reference-typed flag the streaming retry uses to know whether any token already reached the
+    /// UI — a failure after visible partial text must surface as an error, never silently retry
+    /// into duplicated output.
+    final class TokenDeliveryFlag {
+        private(set) var delivered = false
+        func mark() { delivered = true }
+    }
+
+    /// Retry `attempt` on transient SSE failures with `RealtimeReconnect` backoff (BM P9). Retries
+    /// only while no token has been delivered; gives up after the policy's attempts or on the
+    /// first non-transient error.
+    func withTransientSSERetries<T>(policy: RealtimeReconnect.Policy = .init(maxAttempts: 2, maxBackoffSeconds: 4),
+                                    tokenFlag: TokenDeliveryFlag,
+                                    _ attempt: () async throws -> T) async throws -> T {
+        var failures = 0
+        while true {
+            do {
+                return try await attempt()
+            } catch {
+                failures += 1
+                guard !tokenFlag.delivered, Self.isTransientSSEError(error),
+                      let delay = policy.delay(forAttempt: failures) else { throw error }
+                print("🔁 SSE transient failure (attempt \(failures)) — retrying in \(delay)s: \(error.localizedDescription)")
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+        }
+    }
+
     /// Stream an OpenAI-compatible chat-completions response, invoking `onToken` for each text
     /// delta, and return a reconstructed `message` dict (same shape as `choices[].message`) so the
     /// caller's tool loop runs identically to the buffered path. Only used when a streaming caller
     /// (the Chat tab) passes `onToken`; every other caller keeps the buffered path.
-    private func streamOpenAIMessage(request: URLRequest, provider: LLMProvider, model: String, onToken: @escaping (String) -> Void) async throws -> [String: Any] {
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+    func streamOpenAIMessage(request: URLRequest, provider: LLMProvider, model: String, onToken: @escaping (String) -> Void) async throws -> [String: Any] {
+        let (bytes, response) = try await streamingSession.bytes(for: request)
         guard let http = response as? HTTPURLResponse else { throw LLMError.invalidResponse(provider.displayName) }
         guard http.statusCode == 200 else {
             var data = Data()
@@ -1593,13 +1667,22 @@ class LLMService: ObservableObject {
         var fullContent = ""
         var toolAcc: [Int: (id: String, name: String, args: String)] = [:]  // tool_calls accumulate by index
         var usage = StreamingUsageAccumulator()   // from the final include_usage chunk
+        var sawDone = false
 
         for try await line in bytes.lines {
             guard line.hasPrefix("data:") else { continue }
             let payload = line.dropFirst(5).trimmingCharacters(in: .whitespaces)
             if payload.isEmpty { continue }
-            if payload == "[DONE]" { break }
+            if payload == "[DONE]" { sawDone = true; break }
             guard let obj = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any] else { continue }
+            // A mid-stream error event means the response died — the partial content must never
+            // return as a successful turn (BM P9).
+            if let err = obj["error"] as? [String: Any] {
+                let msg = err["message"] as? String ?? "stream error"
+                let kind = err["type"] as? String
+                throw LLMError.streamInterrupted(provider: provider.displayName,
+                                                 reason: kind.map { "\($0): \(msg)" } ?? msg)
+            }
             usage.consumeOpenAI(obj)   // the usage chunk has empty choices, so parse it before the guard
             guard let choice = (obj["choices"] as? [[String: Any]])?.first,
                   let delta = choice["delta"] as? [String: Any] else { continue }
@@ -1622,6 +1705,12 @@ class LLMService: ObservableObject {
             }
         }
 
+        // Premature EOF (connection dropped before "[DONE]") is truncation, not success.
+        guard sawDone else {
+            throw LLMError.streamInterrupted(provider: provider.displayName,
+                                             reason: "stream ended before [DONE] — response truncated")
+        }
+
         recordUsage(provider: provider, model: model, tokensIn: usage.tokensIn, tokensOut: usage.tokensOut,
                     cacheWriteTokens: usage.cacheWriteTokens, cacheReadTokens: usage.cacheReadTokens)
 
@@ -1637,8 +1726,8 @@ class LLMService: ObservableObject {
     /// Stream an Anthropic Messages response, invoking `onToken` for each text delta, and return
     /// the reconstructed content blocks + stop reason so the caller's tool loop runs identically to
     /// the buffered path. Only used when a streaming caller (the Chat tab) passes `onToken`.
-    private func streamAnthropicContent(request: URLRequest, model: String, onToken: @escaping (String) -> Void) async throws -> (content: [[String: Any]], stopReason: String?) {
-        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+    func streamAnthropicContent(request: URLRequest, model: String, onToken: @escaping (String) -> Void) async throws -> (content: [[String: Any]], stopReason: String?) {
+        let (bytes, response) = try await streamingSession.bytes(for: request)
         guard let http = response as? HTTPURLResponse else { throw LLMError.invalidResponse("Anthropic") }
         guard http.statusCode == 200 else {
             var data = Data()
@@ -1652,6 +1741,7 @@ class LLMService: ObservableObject {
         var toolJSON: [Int: String] = [:]         // accumulated input_json per tool_use block
         var stopReason: String?
         var usage = StreamingUsageAccumulator()   // input from message_start, output from message_delta
+        var sawMessageStop = false
 
         for try await line in bytes.lines {
             guard line.hasPrefix("data:") else { continue }
@@ -1684,9 +1774,25 @@ class LLMService: ObservableObject {
                 if let delta = obj["delta"] as? [String: Any], let sr = delta["stop_reason"] as? String {
                     stopReason = sr
                 }
+            case "message_stop":
+                sawMessageStop = true
+            case "error":
+                // A mid-stream error event (e.g. overloaded_error) means the response died — the
+                // partial content must never return as a successful turn (BM P9).
+                let err = obj["error"] as? [String: Any]
+                let msg = err?["message"] as? String ?? "stream error"
+                let kind = err?["type"] as? String
+                throw LLMError.streamInterrupted(provider: "Anthropic",
+                                                 reason: kind.map { "\($0): \(msg)" } ?? msg)
             default:
                 break
             }
+        }
+
+        // Premature EOF (connection dropped before message_stop) is truncation, not success.
+        guard sawMessageStop else {
+            throw LLMError.streamInterrupted(provider: "Anthropic",
+                                             reason: "stream ended before message_stop — response truncated")
         }
 
         // Finalize tool_use blocks: parse the accumulated partial JSON into `input`.
@@ -2187,6 +2293,10 @@ enum LLMError: LocalizedError {
     case invalidResponse(String)
     case invalidConfiguration(String)
     case apiError(provider: String, statusCode: Int, message: String?)
+    /// A streaming response died mid-flight — a mid-stream `error` event or a connection that
+    /// ended before the terminator (`[DONE]` / `message_stop`). Partial content must never be
+    /// returned as a successful turn (BM P9).
+    case streamInterrupted(provider: String, reason: String)
 
     var errorDescription: String? {
         switch self {
@@ -2196,6 +2306,8 @@ enum LLMError: LocalizedError {
         case .apiError(let provider, let code, let msg):
             if let msg { return "\(provider) error \(code): \(msg)" }
             return "\(provider) error: \(code)"
+        case .streamInterrupted(let provider, let reason):
+            return "\(provider) stream interrupted: \(reason)"
         }
     }
 }

--- a/OpenGlassesTests/LLMStreamingTests.swift
+++ b/OpenGlassesTests/LLMStreamingTests.swift
@@ -1,0 +1,289 @@
+import XCTest
+@testable import OpenGlasses
+
+/// BM P9 — chat SSE hardening. Fixture streams for both providers through a `URLProtocol` stub
+/// (no network, no keys): delta assembly, tool-call accumulation, mid-stream `error` events and
+/// premature EOF throwing instead of returning partials as success, the transient-retry policy,
+/// and the per-iteration stream reset that keeps intermediate tool-turn text out of the bubble.
+@MainActor
+final class LLMStreamingTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        SSEQueueProtocol.queue = []
+    }
+
+    private func service() -> LLMService {
+        let s = LLMService()
+        s.streamingSession = SSEQueueProtocol.session()
+        return s
+    }
+
+    private var request: URLRequest { URLRequest(url: URL(string: "https://api.test/v1")!) }
+
+    // MARK: - Anthropic fixtures
+
+    /// A turn that streams text, then a tool_use block, then stops for tool use.
+    private let anthropicToolTurn = """
+    data: {"type":"message_start","message":{}}
+
+    data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+    data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Checking"}}
+
+    data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tu_1","name":"get_weather"}}
+
+    data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"city\\":"}}
+
+    data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\\"Auckland\\"}"}}
+
+    data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}
+
+    data: {"type":"message_stop"}
+
+    """
+
+    /// A final turn: plain text, end_turn, message_stop.
+    private let anthropicFinalTurn = """
+    data: {"type":"message_start","message":{}}
+
+    data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+    data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"It is "}}
+
+    data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"sunny."}}
+
+    data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}
+
+    data: {"type":"message_stop"}
+
+    """
+
+    // MARK: - Anthropic stream parsing
+
+    func testAnthropicStreamAssemblesBlocksToolInputAndStopReason() async throws {
+        SSEQueueProtocol.queue = [(200, anthropicToolTurn)]
+        var tokens = ""
+        let (content, stopReason) = try await service().streamAnthropicContent(
+            request: request, model: "m") { tokens += $0 }
+
+        XCTAssertEqual(tokens, "Checking")
+        XCTAssertEqual(stopReason, "tool_use")
+        XCTAssertEqual(content.count, 2)
+        XCTAssertEqual(content[0]["text"] as? String, "Checking")
+        XCTAssertEqual(content[1]["name"] as? String, "get_weather")
+        XCTAssertEqual((content[1]["input"] as? [String: Any])?["city"] as? String, "Auckland")
+    }
+
+    func testAnthropicMidStreamErrorThrowsInsteadOfReturningPartial() async {
+        let body = """
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial"}}
+
+        data: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}
+
+        """
+        SSEQueueProtocol.queue = [(200, body)]
+        var tokens = ""
+        do {
+            _ = try await service().streamAnthropicContent(request: request, model: "m") { tokens += $0 }
+            XCTFail("mid-stream error must throw, not return the partial as success")
+        } catch let LLMError.streamInterrupted(provider, reason) {
+            XCTAssertEqual(provider, "Anthropic")
+            XCTAssertTrue(reason.contains("overloaded_error"), "got: \(reason)")
+            XCTAssertEqual(tokens, "partial", "tokens before the error still streamed to the UI")
+        } catch {
+            XCTFail("expected .streamInterrupted, got \(error)")
+        }
+    }
+
+    func testAnthropicPrematureEOFThrows() async {
+        // Connection dropped before message_stop — truncation, not success.
+        let body = """
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"half an ans"}}
+
+        """
+        SSEQueueProtocol.queue = [(200, body)]
+        do {
+            _ = try await service().streamAnthropicContent(request: request, model: "m") { _ in }
+            XCTFail("premature EOF must throw")
+        } catch let LLMError.streamInterrupted(_, reason) {
+            XCTAssertTrue(reason.contains("truncated"), "got: \(reason)")
+        } catch {
+            XCTFail("expected .streamInterrupted, got \(error)")
+        }
+    }
+
+    // MARK: - OpenAI stream parsing
+
+    func testOpenAIStreamAssemblesContentAndToolCalls() async throws {
+        let body = """
+        data: {"choices":[{"delta":{"content":"Hel"}}]}
+
+        data: {"choices":[{"delta":{"content":"lo"}}]}
+
+        data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"get_weather","arguments":"{\\"cit"}}]}}]}
+
+        data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"y\\":\\"AKL\\"}"}}]}}]}
+
+        data: [DONE]
+
+        """
+        SSEQueueProtocol.queue = [(200, body)]
+        var tokens = ""
+        let message = try await service().streamOpenAIMessage(
+            request: request, provider: .openai, model: "m") { tokens += $0 }
+
+        XCTAssertEqual(tokens, "Hello")
+        XCTAssertEqual(message["content"] as? String, "Hello")
+        let calls = message["tool_calls"] as? [[String: Any]]
+        XCTAssertEqual(calls?.count, 1)
+        let fn = calls?.first?["function"] as? [String: Any]
+        XCTAssertEqual(fn?["name"] as? String, "get_weather")
+        XCTAssertEqual(fn?["arguments"] as? String, #"{"city":"AKL"}"#)
+    }
+
+    func testOpenAIMidStreamErrorThrows() async {
+        let body = """
+        data: {"choices":[{"delta":{"content":"part"}}]}
+
+        data: {"error":{"type":"server_error","message":"The server is overloaded"}}
+
+        """
+        SSEQueueProtocol.queue = [(200, body)]
+        do {
+            _ = try await service().streamOpenAIMessage(request: request, provider: .openai, model: "m") { _ in }
+            XCTFail("mid-stream error must throw")
+        } catch let LLMError.streamInterrupted(_, reason) {
+            XCTAssertTrue(reason.contains("server_error"), "got: \(reason)")
+        } catch {
+            XCTFail("expected .streamInterrupted, got \(error)")
+        }
+    }
+
+    func testOpenAIPrematureEOFBeforeDoneThrows() async {
+        SSEQueueProtocol.queue = [(200, "data: {\"choices\":[{\"delta\":{\"content\":\"cut off\"}}]}\n\n")]
+        do {
+            _ = try await service().streamOpenAIMessage(request: request, provider: .openai, model: "m") { _ in }
+            XCTFail("EOF before [DONE] must throw")
+        } catch let LLMError.streamInterrupted(_, reason) {
+            XCTAssertTrue(reason.contains("truncated"), "got: \(reason)")
+        } catch {
+            XCTFail("expected .streamInterrupted, got \(error)")
+        }
+    }
+
+    // MARK: - Transient retry policy
+
+    func testTransientClassification() {
+        XCTAssertTrue(LLMService.isTransientSSEError(LLMError.apiError(provider: "p", statusCode: 429, message: nil)))
+        XCTAssertTrue(LLMService.isTransientSSEError(LLMError.apiError(provider: "p", statusCode: 529, message: nil)))
+        XCTAssertTrue(LLMService.isTransientSSEError(LLMError.apiError(provider: "p", statusCode: 503, message: nil)))
+        XCTAssertFalse(LLMService.isTransientSSEError(LLMError.apiError(provider: "p", statusCode: 401, message: nil)))
+        XCTAssertFalse(LLMService.isTransientSSEError(LLMError.apiError(provider: "p", statusCode: 400, message: nil)))
+        XCTAssertTrue(LLMService.isTransientSSEError(LLMError.streamInterrupted(provider: "p", reason: "overloaded_error: Overloaded")))
+        XCTAssertTrue(LLMService.isTransientSSEError(LLMError.streamInterrupted(provider: "p", reason: "stream ended before [DONE] — response truncated")))
+        XCTAssertFalse(LLMService.isTransientSSEError(LLMError.streamInterrupted(provider: "p", reason: "invalid_request_error: bad tool schema")))
+        XCTAssertTrue(LLMService.isTransientSSEError(URLError(.networkConnectionLost)))
+        XCTAssertFalse(LLMService.isTransientSSEError(LLMError.invalidResponse("p")))
+    }
+
+    func testRetrySucceedsAfterTransient429() async throws {
+        let svc = service()
+        var attempts = 0
+        let result: String = try await svc.withTransientSSERetries(
+            policy: .init(maxAttempts: 2, maxBackoffSeconds: 0.05),
+            tokenFlag: LLMService.TokenDeliveryFlag()) {
+            attempts += 1
+            if attempts == 1 { throw LLMError.apiError(provider: "p", statusCode: 429, message: "rate limited") }
+            return "ok"
+        }
+        XCTAssertEqual(result, "ok")
+        XCTAssertEqual(attempts, 2)
+    }
+
+    func testNoRetryAfterTokensReachedTheUI() async {
+        let svc = service()
+        let flag = LLMService.TokenDeliveryFlag()
+        flag.mark()
+        var attempts = 0
+        do {
+            let _: String = try await svc.withTransientSSERetries(tokenFlag: flag) {
+                attempts += 1
+                throw LLMError.apiError(provider: "p", statusCode: 429, message: nil)
+            }
+            XCTFail("should rethrow")
+        } catch {
+            XCTAssertEqual(attempts, 1, "a failure after visible partial text must not silently retry")
+        }
+    }
+
+    func testNoRetryOnNonTransientError() async {
+        let svc = service()
+        var attempts = 0
+        do {
+            let _: String = try await svc.withTransientSSERetries(tokenFlag: LLMService.TokenDeliveryFlag()) {
+                attempts += 1
+                throw LLMError.apiError(provider: "p", statusCode: 401, message: "bad key")
+            }
+            XCTFail("should rethrow")
+        } catch {
+            XCTAssertEqual(attempts, 1)
+        }
+    }
+
+    // MARK: - Tool loop: accumulator reset per iteration
+
+    func testStreamedToolLoopResetsAccumulatorPerIteration() async throws {
+        // Two streamed iterations: a tool_use turn ("Checking") then the final reply. The caller's
+        // accumulator (mirroring AppState's streaming bubble) must be reset at each iteration so
+        // the bubble ends with ONLY the final text — never "CheckingIt is sunny.".
+        SSEQueueProtocol.queue = [(200, anthropicToolTurn), (200, anthropicFinalTurn)]
+        let svc = service()   // no tool router: the tool call fails but the loop continues
+
+        var bubble = ""
+        var resets = 0
+        let config = ModelConfig(id: "t", name: "t", provider: "anthropic",
+                                 apiKey: "sk-test", model: "claude-test", baseURL: "")
+        let response = try await svc.sendAnthropic(
+            "what's the weather", systemPrompt: "sys", config: config,
+            includeTools: true, imageData: nil,
+            onToken: { bubble += $0 },
+            onStreamReset: { resets += 1; bubble = "" })
+
+        XCTAssertEqual(resets, 2, "each streamed iteration must reset the accumulator")
+        XCTAssertEqual(bubble, "It is sunny.", "bubble must hold only the final iteration's text")
+        XCTAssertEqual(response, "It is sunny.")
+        XCTAssertTrue(SSEQueueProtocol.queue.isEmpty, "both canned turns consumed")
+    }
+}
+
+// MARK: - SSE stub (queue of canned responses, popped per request)
+
+final class SSEQueueProtocol: URLProtocol {
+    nonisolated(unsafe) static var queue: [(status: Int, body: String)] = []
+
+    static func session() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SSEQueueProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let next = Self.queue.isEmpty ? (status: 200, body: "") : Self.queue.removeFirst()
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: next.status,
+            httpVersion: "HTTP/1.1", headerFields: ["Content-Type": "text/event-stream"])!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(next.body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
Plan BM P9 — chat SSE hardening (Plan AK riders). Pairs with the P3 SSE usage-capture code.

## The bugs (verified, plan's P9 section)

1. **Silent truncation.** The Anthropic event switch (`LLMService.swift:1638-1663` pre-change) handled only content events — a mid-stream `{"type":"error"}` (e.g. `overloaded_error`) hit `default: break` and the **partial** content returned as a successful turn: persisted, spoken, appended to history. Same shape on the OpenAI path (mid-stream `error` line skipped by the `choices` guard; premature EOF before `[DONE]` = success).
2. **Resilience asymmetry.** Realtime voice has `RealtimeReconnect` (Plan BD); chat SSE was single-shot — a transient 429/529 threw straight to `errorMessage`.
3. **Bubble concatenation.** Every tool-loop iteration streams (`body["stream"] = true` per iteration) and AppState's accumulator never reset between iterations — bubbles could show intermediate+final text concatenated until the persisted swap.

## The fixes

- **`LLMError.streamInterrupted`** — both parsers throw on a mid-stream `error` event (typed reason included) and on a stream that ends before its terminator (`message_stop` / `[DONE]`). Partials can never return as success.
- **`withTransientSSERetries`** — `RealtimeReconnect.Policy` backoff for 429/5xx (incl. Anthropic 529), transient `URLError`s, and overload/truncation interruptions. Guarded by a `TokenDeliveryFlag`: retries happen **only while no token has reached the UI** — a failure after visible partial text surfaces as an error rather than silently retrying into duplicated output.
- **`onStreamReset`** — fires at the start of each streamed tool-loop iteration on both providers; AppState clears the streaming bubble on it, so intermediate tool-turn text never concatenates with the final reply. (`sendMessage` gains the optional parameter; only the Chat-tab caller uses it.)
- **`streamingSession` seam** — both SSE helpers use an injectable session (the `MockURLProtocol` precedent), converting the previously "needs real keys + device" verification into headless fixture tests. Only a live-credential smoke stays device-bound.

## Tests (11 new, all fixture-driven, no network/keys)

- Anthropic: delta assembly + `tool_use` input JSON accumulation + stop reason; mid-stream `overloaded_error` → throws (tokens already shown are acknowledged, nothing returns as success); EOF before `message_stop` → throws "truncated"
- OpenAI: content + `tool_calls` assembly through `[DONE]`; mid-stream error line → throws; EOF before `[DONE]` → throws
- Retry policy: classification matrix (429/529/503 yes, 401/400 no, overload/truncation reasons yes, invalid_request no, connection-lost yes); 429 → retry → succeed; no retry after tokens delivered; no retry on non-transient
- **Full streamed tool loop** (two canned Anthropic turns through a stubbed session): the accumulator resets per iteration and ends holding only the final reply — never `"CheckingIt is sunny."`

Full suite green: **1694 tests, 0 failures** (iOS 27 sim, Xcode 27 beta); all 11 verified individually by name. One CoreSimulator runner-hang flake mid-way, recovered with the standard erase+boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)