### PR TITLE
Owner gate: Simple-Mode exit + optional Settings lock (BM P10)

### DIFF
--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -8,6 +8,12 @@ struct SettingsView: View {
 
     // Model configs editing
     @State private var simpleModeEnabled = Config.simpleModeEnabled
+
+    // Owner gate (BM P10): Simple-Mode exit always asks; Settings entry asks when the flag is on.
+    @State private var settingsOwnerGateEnabled = Config.settingsOwnerGateEnabled
+    @State private var settingsLocked = Config.settingsOwnerGateEnabled
+    @State private var exitGate = OwnerGateMachine()
+    @State private var entryGate = OwnerGateMachine()
     @State private var modelConfigs: [ModelConfig] = Config.savedModels
     @State private var editingModel: ModelConfig? = nil
     @State private var showAddModel = false
@@ -598,14 +604,25 @@ struct SettingsView: View {
 
             }
 
-            // MARK: Simple Mode (always visible so the owner can leave it)
+            // MARK: Simple Mode (always visible so the owner can leave it — behind the owner gate)
             Section {
-                Toggle(isOn: $simpleModeEnabled) {
+                Toggle(isOn: Binding(
+                    get: { simpleModeEnabled },
+                    set: { requestSimpleModeChange(to: $0) }
+                )) {
                     Label("Simple Mode", systemImage: "dial.low")
                 }
-                .onChange(of: simpleModeEnabled) { _, v in Config.simpleModeEnabled = v }
+                Toggle(isOn: $settingsOwnerGateEnabled) {
+                    Label("Lock Settings", systemImage: "faceid")
+                }
+                .onChange(of: settingsOwnerGateEnabled) { _, v in Config.settingsOwnerGateEnabled = v }
+                if exitGate.lastFailed {
+                    Label("Couldn't verify it's you — Simple Mode stays on.", systemImage: "exclamationmark.triangle")
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
             } footer: {
-                Text("Hides model, persona, behavior, tool, integration, and advanced settings — for handing the device to someone who just needs it to work. Everything keeps running exactly as configured.")
+                Text("Simple Mode hides model, persona, behavior, tool, integration, and advanced settings — for handing the device to someone who just needs it to work. Leaving it asks for Face ID or your passcode. Lock Settings asks every time Settings opens.")
             }
 
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -666,6 +683,68 @@ struct SettingsView: View {
         }
         .onDisappear {
             saveSettings()
+        }
+        // Owner gate on Settings entry (BM P10, opt-in): an opaque cover — never a blur that
+        // leaks decrypted key fields — until device-owner auth grants entry.
+        .overlay {
+            if settingsLocked { settingsLockCover }
+        }
+        .onAppear {
+            if settingsLocked { authenticateSettingsEntry() }
+        }
+    }
+
+    // MARK: - Owner gate (BM P10)
+
+    private var settingsLockCover: some View {
+        ZStack {
+            Color(.systemGroupedBackground).ignoresSafeArea()
+            VStack(spacing: 16) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 44))
+                    .foregroundStyle(.secondary)
+                Text("Settings are locked")
+                    .font(.headline)
+                if entryGate.lastFailed {
+                    Text("Authentication failed. Try again.")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+                Button {
+                    authenticateSettingsEntry()
+                } label: {
+                    Label("Unlock", systemImage: "faceid")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
+    private func authenticateSettingsEntry() {
+        guard entryGate.begin() else { return }
+        OwnerGateAuth.authenticate(reason: "Unlock OpenGlasses Settings") { granted in
+            entryGate.finish(success: granted)
+            if entryGate.consume() {
+                withAnimation(.easeOut(duration: 0.2)) { settingsLocked = false }
+            }
+        }
+    }
+
+    /// Simple-Mode toggle path: turning it ON is immediate; turning it OFF (re-exposing the owner
+    /// surface, incl. decrypted API-key fields) needs a fresh device-owner grant every time.
+    private func requestSimpleModeChange(to newValue: Bool) {
+        guard OwnerGatePolicy.requiresGate(togglingSimpleModeTo: newValue, currentlyEnabled: simpleModeEnabled) else {
+            simpleModeEnabled = newValue
+            Config.simpleModeEnabled = newValue
+            return
+        }
+        guard exitGate.begin() else { return }
+        OwnerGateAuth.authenticate(reason: "Verify it's you to leave Simple Mode") { granted in
+            exitGate.finish(success: granted)
+            if exitGate.consume() {
+                simpleModeEnabled = false
+                Config.simpleModeEnabled = false
+            }
         }
     }
 

--- a/OpenGlasses/Sources/Services/OwnerGate.swift
+++ b/OpenGlasses/Sources/Services/OwnerGate.swift
@@ -1,0 +1,82 @@
+import Foundation
+import LocalAuthentication
+
+/// PURE owner-gate state machine (BM P10). Simple Mode hides the owner Settings surface, but its
+/// exit was a plain toggle — anyone holding the phone could flip it and regain Settings, including
+/// API-key fields that render decrypted. Exiting Simple Mode (and, optionally, entering Settings)
+/// now needs a device-owner grant. This is the PIN half of Plan AJ's deferred "profiles + PIN",
+/// extracted; full multi-profile storage stays deferred in AJ. The `LAContext` evaluation lives in
+/// `OwnerGateAuth` (the thin edge); every decision is here and unit-tested.
+struct OwnerGateMachine: Equatable {
+    enum State: Equatable {
+        case locked          // gate engaged
+        case authenticating  // an auth prompt is in flight
+        case unlocked        // owner verified — a single-use grant
+    }
+
+    private(set) var state: State = .locked
+    /// Whether the most recent attempt failed — drives the "try again" UI.
+    private(set) var lastFailed = false
+
+    /// Request an unlock. Returns `true` when the caller should start an auth prompt; `false`
+    /// while one is already in flight or the gate already holds a grant (no double-prompting).
+    mutating func begin() -> Bool {
+        guard state == .locked else { return false }
+        state = .authenticating
+        lastFailed = false
+        return true
+    }
+
+    /// Report the auth outcome. Ignored unless an attempt is in flight (a stale callback can't
+    /// unlock a gate that was never asked).
+    mutating func finish(success: Bool) {
+        guard state == .authenticating else { return }
+        state = success ? .unlocked : .locked
+        lastFailed = !success
+    }
+
+    /// Consume the single-use grant (e.g. actually exit Simple Mode). Returns whether a grant was
+    /// available; the gate relocks either way, so the next exit needs fresh auth.
+    mutating func consume() -> Bool {
+        defer { if state == .unlocked { state = .locked } }
+        return state == .unlocked
+    }
+
+    mutating func relock() {
+        state = .locked
+        lastFailed = false
+    }
+}
+
+/// PURE gate-applicability decisions.
+enum OwnerGatePolicy {
+    /// Only *leaving* Simple Mode needs the gate — entering it (locking the device down before a
+    /// hand-off) never does, and re-asserting the current value is a no-op.
+    static func requiresGate(togglingSimpleModeTo newValue: Bool, currentlyEnabled: Bool) -> Bool {
+        currentlyEnabled && !newValue
+    }
+
+    /// With no device auth available (no passcode set) the gate fails OPEN: it can't be stronger
+    /// than the device itself, and permanently locking the owner out would be worse.
+    static func grantWithoutPrompt(authAvailable: Bool) -> Bool {
+        !authAvailable
+    }
+}
+
+/// Thin `LAContext` edge for the owner gate: Face ID / Touch ID with device-passcode fallback
+/// (`.deviceOwnerAuthentication` includes both). Same shape as `BiometricLockView`'s HIPAA lock.
+enum OwnerGateAuth {
+    /// Prompt for device-owner auth and call back on the main queue.
+    static func authenticate(reason: String, completion: @escaping (Bool) -> Void) {
+        let context = LAContext()
+        var error: NSError?
+        guard context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) else {
+            let granted = OwnerGatePolicy.grantWithoutPrompt(authAvailable: false)
+            DispatchQueue.main.async { completion(granted) }
+            return
+        }
+        context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, _ in
+            DispatchQueue.main.async { completion(success) }
+        }
+    }
+}

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -1423,6 +1423,10 @@ struct Config {
     /// Pure UI gating: nothing about routing or behavior changes. Default off.
     @UserDefaultsBacked("simpleModeEnabled", default: false) static var simpleModeEnabled: Bool
 
+    /// Require device-owner auth (Face ID / passcode) to open Settings at all (BM P10). Exiting
+    /// Simple Mode always asks regardless of this flag. Default off.
+    @UserDefaultsBacked("settingsOwnerGateEnabled", default: false) static var settingsOwnerGateEnabled: Bool
+
     // MARK: - Uncertainty Web Search (Plan BI)
 
     /// Local backends (MLX, Apple Foundation) can't tool-call `web_search`; when on, a hedged or

--- a/OpenGlassesTests/OwnerGateTests.swift
+++ b/OpenGlassesTests/OwnerGateTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import OpenGlasses
+
+/// BM P10 — the owner gate on Simple-Mode exit (and optional Settings entry): the pure state
+/// machine and applicability policy. The `LAContext` prompt is the thin edge.
+final class OwnerGateTests: XCTestCase {
+
+    // MARK: - State machine
+
+    func testBeginOnlyFromLocked() {
+        var gate = OwnerGateMachine()
+        XCTAssertEqual(gate.state, .locked)
+        XCTAssertTrue(gate.begin())
+        XCTAssertEqual(gate.state, .authenticating)
+        XCTAssertFalse(gate.begin(), "no double-prompting while an attempt is in flight")
+
+        gate.finish(success: true)
+        XCTAssertEqual(gate.state, .unlocked)
+        XCTAssertFalse(gate.begin(), "an existing grant needs no new prompt")
+    }
+
+    func testFinishSuccessUnlocksFailureRelocks() {
+        var gate = OwnerGateMachine()
+        _ = gate.begin()
+        gate.finish(success: false)
+        XCTAssertEqual(gate.state, .locked)
+        XCTAssertTrue(gate.lastFailed)
+
+        XCTAssertTrue(gate.begin(), "a failed attempt allows a retry")
+        XCTAssertFalse(gate.lastFailed, "starting a retry clears the failure flag")
+        gate.finish(success: true)
+        XCTAssertEqual(gate.state, .unlocked)
+        XCTAssertFalse(gate.lastFailed)
+    }
+
+    func testStaleFinishIgnoredUnlessAuthenticating() {
+        var gate = OwnerGateMachine()
+        gate.finish(success: true)
+        XCTAssertEqual(gate.state, .locked, "a stale callback can't unlock a gate that never asked")
+
+        _ = gate.begin()
+        gate.finish(success: true)
+        gate.finish(success: false)
+        XCTAssertEqual(gate.state, .unlocked, "a late failure can't revoke a delivered grant")
+        XCTAssertFalse(gate.lastFailed)
+    }
+
+    func testGrantIsSingleUse() {
+        var gate = OwnerGateMachine()
+        _ = gate.begin()
+        gate.finish(success: true)
+
+        XCTAssertTrue(gate.consume())
+        XCTAssertEqual(gate.state, .locked, "consuming relocks — the next exit needs fresh auth")
+        XCTAssertFalse(gate.consume(), "a grant can't be spent twice")
+    }
+
+    func testConsumeWithoutGrantFails() {
+        var gate = OwnerGateMachine()
+        XCTAssertFalse(gate.consume())
+        _ = gate.begin()
+        XCTAssertFalse(gate.consume(), "in-flight auth is not a grant")
+        XCTAssertEqual(gate.state, .authenticating, "a failed consume doesn't disturb the attempt")
+    }
+
+    func testRelockClearsEverything() {
+        var gate = OwnerGateMachine()
+        _ = gate.begin()
+        gate.finish(success: false)
+        gate.relock()
+        XCTAssertEqual(gate.state, .locked)
+        XCTAssertFalse(gate.lastFailed)
+    }
+
+    // MARK: - Policy
+
+    func testOnlySimpleModeExitRequiresGate() {
+        // Leaving Simple Mode (re-exposing the owner surface) → gate.
+        XCTAssertTrue(OwnerGatePolicy.requiresGate(togglingSimpleModeTo: false, currentlyEnabled: true))
+        // Entering it (locking down before a hand-off) → free.
+        XCTAssertFalse(OwnerGatePolicy.requiresGate(togglingSimpleModeTo: true, currentlyEnabled: false))
+        // Re-asserting the current value is a no-op either way.
+        XCTAssertFalse(OwnerGatePolicy.requiresGate(togglingSimpleModeTo: true, currentlyEnabled: true))
+        XCTAssertFalse(OwnerGatePolicy.requiresGate(togglingSimpleModeTo: false, currentlyEnabled: false))
+    }
+
+    func testGateFailsOpenWithoutDeviceAuth() {
+        // No passcode set: the gate can't be stronger than the device — grant rather than
+        // permanently lock the owner out.
+        XCTAssertTrue(OwnerGatePolicy.grantWithoutPrompt(authAvailable: false))
+        XCTAssertFalse(OwnerGatePolicy.grantWithoutPrompt(authAvailable: true))
+    }
+
+    // MARK: - Simple-Mode exit flow (machine + policy composed, as the view drives them)
+
+    func testSimpleModeExitRequiresAGrant() {
+        var gate = OwnerGateMachine()
+        var simpleModeEnabled = true
+
+        // Denied auth → no exit.
+        XCTAssertTrue(OwnerGatePolicy.requiresGate(togglingSimpleModeTo: false, currentlyEnabled: simpleModeEnabled))
+        XCTAssertTrue(gate.begin())
+        gate.finish(success: false)
+        if gate.consume() { simpleModeEnabled = false }
+        XCTAssertTrue(simpleModeEnabled, "a denied grant must not exit Simple Mode")
+        XCTAssertTrue(gate.lastFailed)
+
+        // Granted auth → exit, and the grant is spent.
+        XCTAssertTrue(gate.begin())
+        gate.finish(success: true)
+        if gate.consume() { simpleModeEnabled = false }
+        XCTAssertFalse(simpleModeEnabled)
+        XCTAssertEqual(gate.state, .locked, "re-entering and re-exiting later needs fresh auth")
+    }
+}


### PR DESCRIPTION
Plan BM P10 — the last phase of the remediation sweep. Simple Mode (shipped in e5cdddc) hides the owner Settings surface, but its exit was a plain toggle: anyone holding the phone could flip it and regain Settings, including API-key fields that render decrypted. Conversations already have a biometric lock; Settings had none. This is the PIN half of Plan AJ's deferred "profiles + PIN", extracted — full multi-profile storage stays deferred in AJ pending a real shared-device commitment.

## What's here

- **`OwnerGateMachine` (pure)** — locked → authenticating → unlocked, with:
  - **single-use grants**: consuming relocks, so every Simple-Mode exit needs fresh auth
  - no double-prompting while an attempt is in flight or a grant is held
  - stale-callback protection: a late `finish` can neither unlock a gate that never asked nor revoke a delivered grant
- **`OwnerGatePolicy` (pure)** — only *leaving* Simple Mode is gated (entering — locking down before a hand-off — is free; re-asserting the current value is a no-op). With no device passcode, the gate **fails open**: it can't be stronger than the device itself, and permanently locking the owner out would be worse.
- **`OwnerGateAuth`** — thin `LAContext` edge: `.deviceOwnerAuthentication` (Face ID / Touch ID with device-passcode fallback), the same shape as the HIPAA `BiometricLockView`.
- **SettingsView** — the Simple-Mode toggle routes exits through the gate ("Verify it's you to leave Simple Mode"); a denied attempt shows an inline failure note and Simple Mode stays on. New opt-in **Lock Settings** toggle (`Config.settingsOwnerGateEnabled`, default off) gates Settings entry behind an **opaque** cover — deliberately not a material blur, so decrypted key fields can't leak through — auto-prompting on appear with a retry button.

## Tests (9 new, all pure)

- Machine: begin only from locked (no double-prompt, no re-prompt over a grant); success unlocks / failure relocks with retry clearing the flag; stale finishes ignored; grants are single-use; consume without a grant fails without disturbing an in-flight attempt; relock clears state
- Policy: the exit/enter/no-op matrix; fail-open without device auth
- Composed exit flow, as the view drives it: denied grant → Simple Mode stays on; granted → exits and the grant is spent (next exit needs fresh auth)

Full suite green: **1703 tests, 0 failures** (iOS 27 sim, Xcode 27 beta); all 9 verified individually by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)