### PR TITLE
Shared consent surface P1: close code_agent self-approval hole + unify confirm (BN P1)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -648,6 +648,8 @@ class AppState: ObservableObject, AppStateProtocol {
         }
         toolConfirmationCoordinator.onSpeakPrompt = { [weak self] prompt in
             guard let self else { return }
+            // Shared consent surface (BN P1): spoken prompt + in-lens HUD card together.
+            self.glassesDisplay.showNotification(title: "Approve?", body: prompt, icon: .info, duration: 10)
             Task { @MainActor in
                 await self.speechService.speak(prompt)
             }
@@ -939,6 +941,13 @@ class AppState: ObservableObject, AppStateProtocol {
         AgentSessionService.shared.configure(registry: makeAgentRegistry(), speak: { [weak self] line in
             Task { @MainActor in await self?.speechService.speak(line) }
         })
+        // BN P1: a `code_agent confirm` tool call only raises the user-distinct consent prompt —
+        // it can never approve itself (the prompt-injection → self-approved-push hole).
+        AgentSessionService.shared.requestUserConsent = { [weak self] request in
+            guard let self else { return false }
+            return await self.toolConfirmationCoordinator.requestConfirmation(
+                toolName: "code_agent", summary: request.summary, source: request.source)
+        }
 
         // Configure Navigation Assist (Plan J) similarly.
         NavigationAssistService.shared.configure(camera: cameraService, llm: llmService, tts: speechService)
@@ -2574,6 +2583,15 @@ class AppState: ObservableObject, AppStateProtocol {
     }
 
     func handleTranscription(_ text: String) async {
+        // Shared consent surface, voice half (BN P1): while an approve/deny prompt is pending, a
+        // short spoken yes/no answers THE PROMPT — never the model. Checked before the
+        // isProcessing guard because the turn that raised the prompt is still in flight,
+        // suspended on the coordinator.
+        if toolConfirmationCoordinator.pending != nil, toolConfirmationCoordinator.resolveByVoice(text) {
+            currentTranscription = text
+            print("🛡️ Consent prompt answered by voice: \(text)")
+            return
+        }
         guard !isProcessing else {
             print("⚠️ Already processing, ignoring: \(text)")
             return

--- a/OpenGlasses/Sources/App/RootView.swift
+++ b/OpenGlasses/Sources/App/RootView.swift
@@ -32,25 +32,19 @@ struct RootView: View {
     }
 }
 
-/// Presents an Approve / Deny prompt for a pending high-impact tool call.
+/// Presents the shared, source-attributed consent card for a pending remote/high-impact action
+/// (BN P1) — one surface for agent confirms, gateway capture consent, and assistant tool calls.
 private struct ToolConfirmationModifier: ViewModifier {
     @ObservedObject var coordinator: ToolConfirmationCoordinator
 
     func body(content: Content) -> some View {
-        content.confirmationDialog(
-            "Confirm action",
-            isPresented: Binding(
-                get: { coordinator.pending != nil },
-                set: { if !$0 { coordinator.resolve(false) } }
-            ),
-            titleVisibility: .visible,
-            presenting: coordinator.pending
-        ) { pending in
-            Button("Approve", role: .destructive) { coordinator.resolve(true) }
-            Button("Cancel", role: .cancel) { coordinator.resolve(false) }
-        } message: { pending in
-            Text(pending.summary)
+        content.overlay(alignment: .bottom) {
+            if let pending = coordinator.pending {
+                RemoteActionConsentView(pending: pending) { coordinator.resolve($0) }
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
+        .animation(.easeOut(duration: 0.2), value: coordinator.pending?.id)
     }
 }
 

--- a/OpenGlasses/Sources/App/Views/RemoteActionConsentView.swift
+++ b/OpenGlasses/Sources/App/Views/RemoteActionConsentView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// The shared remote-action consent card (Plan BN P1): ONE surface for Plan N coding-agent
+/// confirms, Plan BH gateway capture consent, and the assistant's own high-impact tool calls —
+/// source-attributed, paired with the coordinator's spoken prompt and the voice yes/no path
+/// (`ToolConfirmationCoordinator.resolveByVoice`).
+struct RemoteActionConsentView: View {
+    let pending: PendingToolConfirmation
+    let respond: (Bool) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("\(pending.source.line) wants:", systemImage: sourceIcon)
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            Text(pending.summary)
+                .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 12) {
+                Button {
+                    respond(false)
+                } label: {
+                    Text("Deny").frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+
+                Button(role: .destructive) {
+                    respond(true)
+                } label: {
+                    Text("Approve").frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+
+            Text("Say \"yes\" or \"no\", or tap.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+        .padding(16)
+        .background(RoundedRectangle(cornerRadius: 16).fill(.regularMaterial))
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(.quaternary))
+        .padding(.horizontal, 16)
+        .padding(.bottom, 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(pending.source.line) wants: \(pending.summary). Approve or deny?")
+    }
+
+    private var sourceIcon: String {
+        switch pending.source {
+        case .assistant:   return "sparkles"
+        case .codingAgent: return "hammer"
+        case .gateway:     return "network"
+        case .opsPeer:     return "building.2"
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/AgentHarness/AgentSessionService.swift
+++ b/OpenGlasses/Sources/Services/AgentHarness/AgentSessionService.swift
@@ -29,6 +29,12 @@ final class AgentSessionService: ObservableObject {
     /// Injected speaker. AppState wires `TextToSpeechService`; tests capture the lines.
     var speak: (String) -> Void = { _ in }
 
+    /// User-distinct consent seam (BN P1): wired by AppState to the shared consent surface
+    /// (`ToolConfirmationCoordinator`); tests inject grants/denials. When nil, a tool-called
+    /// confirm fails CLOSED — approval must come from a real user prompt, never from tool-call
+    /// output (the prompt-injection → self-approved-push hole).
+    var requestUserConsent: ((RemoteActionConsentRequest) async -> Bool)?
+
     private var eventTask: Task<Void, Never>?
 
     init() {}
@@ -137,7 +143,28 @@ final class AgentSessionService: ObservableObject {
         eventTask = nil
     }
 
+    /// Entry for the `code_agent confirm` tool call (BN P1). The model's call is only a REQUEST
+    /// to show the user-distinct consent prompt — a prompt-injected turn (web result, OCR'd sign,
+    /// ambient caption) can raise the question, but never answer it. Denying at the prompt
+    /// cancels the run, the same safety default as `respondToConfirmation(approved: false)`.
+    func confirmPendingActionViaUserPrompt() async -> String {
+        guard let run = activeRun, run.status == .awaitingInput else {
+            return "There's nothing waiting for confirmation."
+        }
+        guard let requestUserConsent else {
+            return "Approval needs the on-screen confirm prompt, which isn't available right now — nothing was approved."
+        }
+        let request = RemoteActionConsentRequest(
+            source: .codingAgent,
+            summary: awaitingInputPrompt ?? "proceed with the pending action")
+        let granted = await requestUserConsent(request)
+        await respondToConfirmation(approved: granted)
+        return granted ? "Confirmed — the agent will proceed." : "Okay, I won't proceed."
+    }
+
     /// Answer an `awaitingInput` confirmation. Declining cancels the run (safety default).
+    /// The grant must be user-originated: reach here via `confirmPendingActionViaUserPrompt`
+    /// (tool path, coordinator-prompted) or a direct UI control — never straight from a model turn.
     func respondToConfirmation(approved: Bool) async {
         guard let harness = activeHarness, let run = activeRun, run.status == .awaitingInput else { return }
         try? await harness.respondToInput(run, approved: approved)

--- a/OpenGlasses/Sources/Services/NativeTools/AgentControlTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/AgentControlTool.swift
@@ -73,8 +73,9 @@ struct AgentControlTool: NativeTool {
             return "Cancelling the agent run."
 
         case "confirm", "approve", "yes":
-            await session.respondToConfirmation(approved: true)
-            return "Confirmed — the agent will proceed."
+            // BN P1: the tool call only ASKS — approval comes from the user-distinct consent
+            // prompt. A prompt-injected turn can reach this case; it must never self-approve.
+            return await session.confirmPendingActionViaUserPrompt()
 
         case "deny", "decline", "no":
             await session.respondToConfirmation(approved: false)

--- a/OpenGlasses/Sources/Services/RemoteActionConsent.swift
+++ b/OpenGlasses/Sources/Services/RemoteActionConsent.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// Who is asking for a remote/agentic action (Plan BN P1) — every consent prompt carries its
+/// origin, the same narration principle as BK P2c. Shared by Plan N (coding-agent confirms),
+/// Plan BH (gateway remote invoke), and Plan BL (an MCP ops peer driving the glasses).
+enum RemoteActionSource: Equatable {
+    case assistant              // the local assistant's own high-impact tool call
+    case codingAgent            // Plan N remote agent run
+    case gateway                // Plan BH gateway remote invoke
+    case opsPeer(label: String) // Plan BL MCP peer
+
+    /// The subject of the consent sentence: "The coding agent wants: …".
+    var line: String {
+        switch self {
+        case .assistant:          return "The assistant"
+        case .codingAgent:        return "The coding agent"
+        case .gateway:            return "The gateway"
+        case .opsPeer(let label): return label.isEmpty ? "An ops platform" : label
+        }
+    }
+}
+
+/// One consent ask: the source plus what it wants. Pure prompt composition so the HUD card and
+/// the spoken prompt always carry the attribution.
+struct RemoteActionConsentRequest: Equatable {
+    let source: RemoteActionSource
+    let summary: String
+
+    /// Source-attributed line for the card + audit: "The gateway wants: take a photo".
+    var attributedSummary: String { "\(source.line) wants: \(summary)" }
+
+    /// The spoken form.
+    var spokenPrompt: String { "\(attributedSummary). Approve?" }
+}
+
+/// PURE voice yes/no interpretation for a pending consent prompt (the voice half of the shared
+/// surface). Deliberately conservative: only short, unambiguous utterances count — anything else
+/// returns `nil` and flows to the normal turn pipeline. Never guess an approval.
+enum RemoteActionVoiceConsent {
+
+    /// `true` = approve, `false` = deny, `nil` = not a consent answer.
+    static func interpret(_ text: String) -> Bool? {
+        let normalized = text.lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: ".,!?"))
+        guard !normalized.isEmpty, normalized.split(separator: " ").count <= 3 else { return nil }
+        if matches(normalized, any: approvals) { return true }
+        if matches(normalized, any: denials) { return false }
+        return nil
+    }
+
+    private static let approvals: Set<String> = [
+        "yes", "yep", "yeah", "approve", "approved", "confirm", "confirmed",
+        "go ahead", "do it", "proceed", "ok", "okay",
+    ]
+    private static let denials: Set<String> = [
+        "no", "nope", "deny", "denied", "cancel", "stop", "decline", "abort", "don't",
+    ]
+    /// Trailing words that don't change the answer ("yes please", "cancel it").
+    private static let politeness: Set<String> = ["please", "thanks", "sure", "it", "that"]
+
+    private static func matches(_ text: String, any phrases: Set<String>) -> Bool {
+        if phrases.contains(text) { return true }
+        for phrase in phrases where text.hasPrefix(phrase + " ") {
+            let rest = text.dropFirst(phrase.count + 1).split(separator: " ").map(String.init)
+            if !rest.isEmpty, rest.allSatisfy({ politeness.contains($0) }) { return true }
+        }
+        return false
+    }
+}

--- a/OpenGlasses/Sources/Services/ToolConfirmationCoordinator.swift
+++ b/OpenGlasses/Sources/Services/ToolConfirmationCoordinator.swift
@@ -7,6 +7,8 @@ struct PendingToolConfirmation: Identifiable {
     let toolName: String
     /// Human-readable description of what will happen (e.g. "Send a message to Mom: …").
     let summary: String
+    /// Who is asking (BN P1) — drives the source line on the consent card + spoken prompt.
+    let source: RemoteActionSource
     fileprivate let continuation: CheckedContinuation<Bool, Never>
 }
 
@@ -29,12 +31,13 @@ final class ToolConfirmationCoordinator: ObservableObject {
 
     /// Suspend until the user approves or denies `toolName`. Returns `true` to proceed.
     /// If another confirmation is already outstanding, the new request is denied to avoid stacking
-    /// prompts (the model can retry after the user has dealt with the first one).
-    func requestConfirmation(toolName: String, summary: String) async -> Bool {
+    /// prompts (the model can retry after the user has dealt with the first one). `source`
+    /// attributes the ask on the card and in the spoken prompt (BN P1).
+    func requestConfirmation(toolName: String, summary: String, source: RemoteActionSource = .assistant) async -> Bool {
         if pending != nil { return false }
-        onSpeakPrompt?("Confirm: \(summary)?")
+        onSpeakPrompt?(RemoteActionConsentRequest(source: source, summary: summary).spokenPrompt)
         return await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            pending = PendingToolConfirmation(toolName: toolName, summary: summary, continuation: continuation)
+            pending = PendingToolConfirmation(toolName: toolName, summary: summary, source: source, continuation: continuation)
         }
     }
 
@@ -43,5 +46,16 @@ final class ToolConfirmationCoordinator: ObservableObject {
         guard let p = pending else { return }
         pending = nil
         p.continuation.resume(returning: approved)
+    }
+
+    /// Voice half of the shared consent surface (BN P1): interpret a wearer utterance as an
+    /// answer to the pending prompt. Returns `true` when the utterance was consumed (the prompt
+    /// resolved); `false` leaves the prompt pending and the utterance for the normal turn
+    /// pipeline. Never resolves on an ambiguous phrase.
+    @discardableResult
+    func resolveByVoice(_ text: String) -> Bool {
+        guard pending != nil, let approved = RemoteActionVoiceConsent.interpret(text) else { return false }
+        resolve(approved)
+        return true
     }
 }

--- a/OpenGlassesTests/RemoteActionConsentTests.swift
+++ b/OpenGlassesTests/RemoteActionConsentTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan BN P1 — the shared remote-action consent surface: the self-approval hole is closed (a
+/// `code_agent confirm` tool call can raise the user-distinct prompt but never answer it), the
+/// coordinator carries a source line, and the voice yes/no path resolves only unambiguous answers.
+@MainActor
+final class RemoteActionConsentTests: XCTestCase {
+
+    // MARK: - Prompt composition (source attribution)
+
+    func testConsentPromptCarriesTheSource() {
+        XCTAssertEqual(
+            RemoteActionConsentRequest(source: .codingAgent, summary: "push to main").attributedSummary,
+            "The coding agent wants: push to main")
+        XCTAssertEqual(
+            RemoteActionConsentRequest(source: .gateway, summary: "take a photo").spokenPrompt,
+            "The gateway wants: take a photo. Approve?")
+        XCTAssertEqual(
+            RemoteActionConsentRequest(source: .opsPeer(label: "Ops platform"), summary: "take a photo").attributedSummary,
+            "Ops platform wants: take a photo")
+        XCTAssertEqual(
+            RemoteActionConsentRequest(source: .opsPeer(label: ""), summary: "x").attributedSummary,
+            "An ops platform wants: x")
+        XCTAssertEqual(
+            RemoteActionConsentRequest(source: .assistant, summary: "send a message").attributedSummary,
+            "The assistant wants: send a message")
+    }
+
+    // MARK: - Voice yes/no interpretation
+
+    func testVoiceConsentInterpretation() {
+        // Approvals.
+        for phrase in ["yes", "Yes.", "yep", "approve", "go ahead", "do it", "okay", "yes please"] {
+            XCTAssertEqual(RemoteActionVoiceConsent.interpret(phrase), true, "\(phrase) should approve")
+        }
+        // Denials.
+        for phrase in ["no", "No!", "nope", "cancel", "deny", "stop", "cancel it", "abort"] {
+            XCTAssertEqual(RemoteActionVoiceConsent.interpret(phrase), false, "\(phrase) should deny")
+        }
+        // Ambiguous / unrelated → nil (flows to the normal turn pipeline; never guess).
+        for phrase in ["what's the weather", "yes and also send it to everyone I know",
+                       "don't do it unless it's safe", "", "maybe", "okay cancel"] {
+            XCTAssertNil(RemoteActionVoiceConsent.interpret(phrase), "\(phrase) must not resolve a prompt")
+        }
+    }
+
+    // MARK: - Coordinator: source + voice resolution
+
+    func testCoordinatorPendingCarriesSourceAndSpeaksAttributedPrompt() async {
+        let coordinator = ToolConfirmationCoordinator()
+        var spoken: [String] = []
+        coordinator.onSpeakPrompt = { spoken.append($0) }
+
+        let task = Task {
+            await coordinator.requestConfirmation(toolName: "code_agent", summary: "push to main", source: .codingAgent)
+        }
+        // Let the request suspend and publish.
+        while coordinator.pending == nil { await Task.yield() }
+
+        XCTAssertEqual(coordinator.pending?.source, .codingAgent)
+        XCTAssertEqual(spoken, ["The coding agent wants: push to main. Approve?"])
+
+        coordinator.resolve(true)
+        let approved = await task.value
+        XCTAssertTrue(approved)
+        XCTAssertNil(coordinator.pending)
+    }
+
+    func testCoordinatorVoiceResolution() async {
+        let coordinator = ToolConfirmationCoordinator()
+        let task = Task {
+            await coordinator.requestConfirmation(toolName: "t", summary: "s", source: .gateway)
+        }
+        while coordinator.pending == nil { await Task.yield() }
+
+        // An ambiguous phrase is NOT consumed and leaves the prompt pending.
+        XCTAssertFalse(coordinator.resolveByVoice("what's the time"))
+        XCTAssertNotNil(coordinator.pending)
+
+        // A clear "no" is consumed and denies.
+        XCTAssertTrue(coordinator.resolveByVoice("no"))
+        let approved = await task.value
+        XCTAssertFalse(approved)
+
+        // Nothing pending → voice is never consumed.
+        XCTAssertFalse(coordinator.resolveByVoice("yes"))
+    }
+
+    // MARK: - The self-approval hole (Plan N confirm)
+
+    private func awaitingService(_ mock: ConsentStubHarness) async -> AgentSessionService {
+        let service = AgentSessionService()
+        service.setHarness(mock)
+        _ = await service.dispatch(prompt: "p", project: nil)
+        service.handle(.awaitingInput(prompt: "Push to main?"))
+        return service
+    }
+
+    func testConfirmToolCallFailsClosedWithoutConsentSurface() async {
+        // No consent seam wired (the injected-turn scenario in a headless context): the tool
+        // call must NOT approve anything.
+        let mock = ConsentStubHarness()
+        let service = await awaitingService(mock)
+
+        let reply = await service.confirmPendingActionViaUserPrompt()
+        XCTAssertTrue(reply.contains("nothing was approved"), "got: \(reply)")
+        XCTAssertEqual(service.activeRun?.status, .awaitingInput, "the run must stay waiting")
+        XCTAssertNil(mock.respondedApproved, "the harness must never hear an approval")
+    }
+
+    func testConfirmToolCallRoutesThroughUserPromptAndGrantApproves() async {
+        let mock = ConsentStubHarness()
+        let service = await awaitingService(mock)
+
+        var requests: [RemoteActionConsentRequest] = []
+        service.requestUserConsent = { request in
+            requests.append(request)
+            return true   // the wearer approves at the real prompt
+        }
+
+        let reply = await service.confirmPendingActionViaUserPrompt()
+        XCTAssertEqual(reply, "Confirmed — the agent will proceed.")
+        XCTAssertEqual(service.activeRun?.status, .running)
+        XCTAssertEqual(mock.respondedApproved, true)
+        // The prompt is source-attributed with the run's own awaiting prompt.
+        XCTAssertEqual(requests, [RemoteActionConsentRequest(source: .codingAgent, summary: "Push to main?")])
+    }
+
+    func testConfirmToolCallDeniedAtPromptCancelsRun() async {
+        let mock = ConsentStubHarness()
+        let service = await awaitingService(mock)
+        service.requestUserConsent = { _ in false }   // the wearer denies
+
+        let reply = await service.confirmPendingActionViaUserPrompt()
+        XCTAssertEqual(reply, "Okay, I won't proceed.")
+        XCTAssertEqual(service.activeRun?.status, .cancelled, "decline still cancels (safety default)")
+        XCTAssertEqual(mock.respondedApproved, false)
+    }
+
+    func testConfirmToolCallWithNothingPendingIsRefused() async {
+        let service = AgentSessionService()
+        service.requestUserConsent = { _ in
+            XCTFail("no prompt should be shown when nothing is awaiting input")
+            return true
+        }
+        let reply = await service.confirmPendingActionViaUserPrompt()
+        XCTAssertEqual(reply, "There's nothing waiting for confirmation.")
+    }
+}
+
+/// Minimal scripted harness recording what the session tells it.
+private final class ConsentStubHarness: AgentHarness {
+    let kind: AgentHarnessKind = .custom
+    var displayName: String { "Stub" }
+    var isConfigured: Bool { true }
+    private(set) var respondedApproved: Bool?
+
+    func start(prompt: String, project: String?) async throws -> AgentRun {
+        AgentRun(id: "run1", harness: kind, prompt: prompt, project: project, status: .running, startedAt: Date())
+    }
+    func events(for run: AgentRun) -> AsyncStream<AgentEvent> { AsyncStream { $0.finish() } }
+    func status(_ run: AgentRun) async throws -> AgentRunStatus { run.status }
+    func cancel(_ run: AgentRun) async throws {}
+    func respondToInput(_ run: AgentRun, approved: Bool) async throws { respondedApproved = approved }
+}


### PR DESCRIPTION
Plan BN P1 — the highest-severity open finding from the 2026-07-10 sweep. One consent surface for Plan N, Plan BH, and (later) Plan BL, and it closes a live injection→push hole.

## The vulnerability (Plan N)

`code_agent {action:"confirm"}` approved a pending irreversible agent action (`AgentControlTool.swift:75-77`) with **no user-distinct check** — any LLM turn could call it. A prompt-injected turn (web result, OCR'd sign, ambient caption — the BK P0 vector) could confirm its own push to main. Contrast Plan BH capture, which already routes through `ToolConfirmationCoordinator` (a real user prompt).

## The fix

- **Self-approval closed.** `confirm` now calls `AgentSessionService.confirmPendingActionViaUserPrompt()`, which only *raises* the user-distinct prompt — the grant must come from the wearer (UI tap / voice), never from tool-call output. **Fails closed** when no consent seam is wired (headless). `deny` still cancels directly: the injection risk is self-*approval*, never self-denial.
- **One shared surface.** Extracted the coordinator's prompt into `RemoteActionConsentView` — a source-attributed HUD card + spoken prompt + voice yes/no (`ToolConfirmationCoordinator.resolveByVoice`). Consumed by Plan N (`code_agent`), Plan BH gateway capture (now `.gateway`-attributed), and the assistant's own high-impact tool calls. Replaces the old bare `confirmationDialog`.
- **Source attribution.** Every request carries a source line — "The coding agent wants: push to main" / "The gateway wants: take a photo" — the same narration principle as BK P2c. `RemoteActionSource` already covers `.opsPeer(label:)`, so BL P4's MCP-peer attribution drops into the same surface (P2's job to thread the origin through policy/audit).
- **Voice half.** While a prompt is pending, a short unambiguous "yes"/"no" answers *the prompt* — checked before the `isProcessing` guard because the turn that raised it is suspended on the coordinator. Anything longer or ambiguous (≤3 words, exact match required) flows to the normal turn pipeline; approvals are never guessed.

## Tests (8 new, `RemoteActionConsentTests`)

- Prompt composition carries the source for all four origins
- `RemoteActionVoiceConsent.interpret`: approvals/denials resolve, ambiguous ("yes and also send it to everyone", "maybe", "okay cancel", "") → `nil`
- Coordinator publishes the source, speaks the attributed prompt, and resolves by voice (ambiguous phrase leaves it pending; clear "no" denies; nothing pending → not consumed)
- The `confirm` tool call: fails closed without the surface (harness never hears an approval, run stays `awaitingInput`); routes through the prompt and approves on grant; cancels the run on denial; refused with nothing pending

Existing `AgentSessionTests` (confirm/decline paths) stay green — the plan's named regression guard. Full suite: **1711 tests, 0 failures** (iOS 27 sim, Xcode 27 beta); all 8 verified by name.

P2 (origin-aware policy + audit, the BL P4 prerequisite) follows as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)