### PR TITLE
Origin-aware remote-command policy + audit (BN P2)

### DIFF
--- a/OpenGlasses/Sources/App/Views/RemoteInvokeAuditView.swift
+++ b/OpenGlasses/Sources/App/Views/RemoteInvokeAuditView.swift
@@ -22,9 +22,18 @@ struct RemoteInvokeAuditView: View {
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                         }
-                        Text(entry.disposition)
-                            .font(.caption)
-                            .foregroundStyle(entry.disposition == "allowed" ? .green : .orange)
+                        HStack(spacing: 6) {
+                            // Per-origin attribution (Plan BN P2): tag the caller so a specific
+                            // gateway/peer's activity is traceable in the log.
+                            Text(entry.origin)
+                                .font(.caption2.monospaced())
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 1)
+                                .background(Capsule().fill(.quaternary))
+                            Text(entry.disposition)
+                                .font(.caption)
+                                .foregroundStyle(entry.disposition == "allowed" ? .green : .orange)
+                        }
                     }
                     .padding(.vertical, 2)
                 }

--- a/OpenGlasses/Sources/Services/OpenClaw/RemoteInvoke/RemoteCommandOrigin.swift
+++ b/OpenGlasses/Sources/Services/OpenClaw/RemoteInvoke/RemoteCommandOrigin.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Who issued a remote-invoke command (Plan BN P2). The remote-invoke policy plane was
+/// caller-blind: one shared rate-bucket set and un-attributed audit entries, so a chatty MCP peer
+/// could starve the gateway's budget and BL P4's "every call attributed to the peer's API key" had
+/// no seam. Origin threads a caller identity through `decide()`, the rate state (per-origin
+/// buckets), and the audit trail.
+///
+/// One identity story, two transports (plan point 4): the outbound gateway socket authenticates
+/// with the Plan AR `deviceId`/Ed25519 pair; an inbound MCP peer is identified by its API key
+/// (BL P4). Both land here as an `origin` — no second mechanism.
+enum RemoteCommandOrigin: Hashable, Codable {
+    case gateway                 // the OpenClaw gateway socket (Plan BH — the only caller today)
+    case mcpPeer(id: String)     // an MCP peer driving the glasses, keyed by its API-key id (BL P4)
+
+    /// Stable label for the audit trail + rate-bucket key: "gateway" / "peer:<id>".
+    var label: String {
+        switch self {
+        case .gateway:          return "gateway"
+        case .mcpPeer(let id):  return "peer:\(id)"
+        }
+    }
+
+    /// Human-facing name for the activity log and the shared consent surface.
+    var displayName: String {
+        switch self {
+        case .gateway:          return "Gateway"
+        case .mcpPeer(let id):  return id.isEmpty ? "MCP peer" : "Peer \(id)"
+        }
+    }
+
+    /// Bridge to the shared consent surface (Plan BN P1): an MCP-peer origin asks as an ops peer,
+    /// the gateway as the gateway — so BL P4's capture consent is attributed without a second map.
+    var consentSource: RemoteActionSource {
+        switch self {
+        case .gateway:          return .gateway
+        case .mcpPeer(let id):  return .opsPeer(label: displayName)
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/OpenClaw/RemoteInvoke/RemoteCommandPolicy.swift
+++ b/OpenGlasses/Sources/Services/OpenClaw/RemoteInvoke/RemoteCommandPolicy.swift
@@ -26,14 +26,21 @@ struct TokenBucket: Equatable {
     }
 }
 
-/// Per-class token buckets for a remote-invoke session.
+/// Per-origin, per-class token buckets for a remote-invoke session (Plan BN P2). Each origin
+/// (gateway, or a distinct MCP peer) gets its own independent bucket set, created lazily on first
+/// contact and full at that moment — so a chatty peer can't starve the gateway's budget.
 struct RemoteInvokeRateState: Equatable {
-    private var buckets: [RemoteCommandClass: TokenBucket]
+    private var byOrigin: [RemoteCommandOrigin: [RemoteCommandClass: TokenBucket]]
+
+    init(now: Date) {
+        // Pre-create the gateway origin so its behavior (and its tests) is byte-identical.
+        byOrigin = [.gateway: Self.freshBuckets(now: now)]
+    }
 
     /// Defaults: generous for reads, tight for anything that acts. Bursts are the capacity;
     /// sustained rates are the refill (per minute in the comments).
-    init(now: Date) {
-        buckets = [
+    private static func freshBuckets(now: Date) -> [RemoteCommandClass: TokenBucket] {
+        [
             .observe: TokenBucket(capacity: 10, refillPerSecond: 30.0 / 60.0, now: now),  // 30/min
             .output: TokenBucket(capacity: 5, refillPerSecond: 10.0 / 60.0, now: now),    // 10/min
             .capture: TokenBucket(capacity: 2, refillPerSecond: 4.0 / 60.0, now: now),    // 4/min
@@ -41,11 +48,19 @@ struct RemoteInvokeRateState: Equatable {
         ]
     }
 
-    mutating func tryConsume(_ commandClass: RemoteCommandClass, now: Date) -> Bool {
+    /// Consume one token from `origin`'s `commandClass` bucket (per-origin isolation).
+    mutating func tryConsume(_ origin: RemoteCommandOrigin, _ commandClass: RemoteCommandClass, now: Date) -> Bool {
+        var buckets = byOrigin[origin] ?? Self.freshBuckets(now: now)
         guard var bucket = buckets[commandClass] else { return false }
         let allowed = bucket.tryConsume(now: now)
         buckets[commandClass] = bucket
+        byOrigin[origin] = buckets
         return allowed
+    }
+
+    /// Convenience for the gateway origin — keeps the original two-arg call site working.
+    mutating func tryConsume(_ commandClass: RemoteCommandClass, now: Date) -> Bool {
+        tryConsume(.gateway, commandClass, now: now)
     }
 }
 
@@ -98,6 +113,7 @@ enum RemoteCommandPolicy {
 
     static func decide(
         command: RemoteGlassesCommand,
+        origin: RemoteCommandOrigin = .gateway,
         agentModeEnabled: Bool,
         toggles: Toggles,
         rateState: inout RemoteInvokeRateState,
@@ -113,7 +129,8 @@ enum RemoteCommandPolicy {
         default: break
         }
 
-        guard rateState.tryConsume(commandClass, now: now) else {
+        // Rate limits are keyed per origin (Plan BN P2), so one caller can't spend another's budget.
+        guard rateState.tryConsume(origin, commandClass, now: now) else {
             return .deny(.rateLimited(commandClass))
         }
         return .allow

--- a/OpenGlasses/Sources/Services/OpenClaw/RemoteInvoke/RemoteInvokeService.swift
+++ b/OpenGlasses/Sources/Services/OpenClaw/RemoteInvoke/RemoteInvokeService.swift
@@ -11,14 +11,31 @@ enum RemoteInvokeError: LocalizedError {
 struct RemoteInvokeAuditEntry: Codable, Identifiable, Equatable {
     let id: UUID
     let timestamp: Date
+    /// Who issued the command — "gateway" / "peer:<id>" (Plan BN P2). Attributes each row so a
+    /// specific caller's activity is traceable.
+    let origin: String
     let action: String
     let disposition: String   // "allowed" / "denied: …" / "unsupported" / "malformed" / "failed: …" / "declined"
 
-    init(id: UUID = UUID(), timestamp: Date = Date(), action: String, disposition: String) {
+    init(id: UUID = UUID(), timestamp: Date = Date(), origin: String = RemoteCommandOrigin.gateway.label,
+         action: String, disposition: String) {
         self.id = id
         self.timestamp = timestamp
+        self.origin = origin
         self.action = action
         self.disposition = disposition
+    }
+
+    // Backward-compatible decode: entries persisted before BN P2 have no `origin` — default them
+    // to the gateway (the only caller that existed then) so the saved log still loads.
+    enum CodingKeys: String, CodingKey { case id, timestamp, origin, action, disposition }
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        timestamp = try c.decode(Date.self, forKey: .timestamp)
+        origin = try c.decodeIfPresent(String.self, forKey: .origin) ?? RemoteCommandOrigin.gateway.label
+        action = try c.decode(String.self, forKey: .action)
+        disposition = try c.decode(String.self, forKey: .disposition)
     }
 }
 
@@ -56,22 +73,25 @@ final class RemoteInvokeService: ObservableObject {
     }
 
     /// Handle one decoded inbound frame. Returns the reply to send, or `nil` when the frame is
-    /// not a request at all (events/responses are the caller's business).
-    func handleFrame(_ json: [String: Any]) async -> [String: Any]? {
+    /// not a request at all (events/responses are the caller's business). `origin` attributes the
+    /// caller (Plan BN P2) — the gateway socket passes the default; an MCP peer (BL P4) passes
+    /// `.mcpPeer(id:)` so it gets its own rate budget and audit rows.
+    func handleFrame(_ json: [String: Any], origin: RemoteCommandOrigin = .gateway) async -> [String: Any]? {
         guard let request = RemoteCommandParser.parse(json) else { return nil }
 
         switch request.outcome {
         case .malformed(let reason):
-            audit(action: "malformed", disposition: "malformed: \(reason)")
+            audit(origin: origin, action: "malformed", disposition: "malformed: \(reason)")
             return RemoteInvokeReply.malformed(id: request.id, reason: reason)
 
         case .unsupported(let action):
-            audit(action: action, disposition: "unsupported")
+            audit(origin: origin, action: action, disposition: "unsupported")
             return RemoteInvokeReply.unsupported(id: request.id, action: action)
 
         case .command(let command):
             let decision = RemoteCommandPolicy.decide(
                 command: command,
+                origin: origin,
                 agentModeEnabled: environment.agentModeEnabled(),
                 toggles: environment.toggles(),
                 rateState: &rateState,
@@ -79,19 +99,19 @@ final class RemoteInvokeService: ObservableObject {
             )
             switch decision {
             case .deny(let reason):
-                audit(action: command.canonicalAction, disposition: "denied: \(reason.code)")
+                audit(origin: origin, action: command.canonicalAction, disposition: "denied: \(reason.code)")
                 return RemoteInvokeReply.denied(id: request.id, reason: reason)
 
             case .allow:
                 switch await executor.execute(command) {
                 case .success(let payload):
-                    audit(action: command.canonicalAction, disposition: "allowed")
+                    audit(origin: origin, action: command.canonicalAction, disposition: "allowed")
                     return RemoteInvokeReply.success(id: request.id, payload: payload)
                 case .declined:
-                    audit(action: command.canonicalAction, disposition: "declined")
+                    audit(origin: origin, action: command.canonicalAction, disposition: "declined")
                     return RemoteInvokeReply.failure(id: request.id, message: "User declined the request")
                 case .failed(let message):
-                    audit(action: command.canonicalAction, disposition: "failed: \(message)")
+                    audit(origin: origin, action: command.canonicalAction, disposition: "failed: \(message)")
                     return RemoteInvokeReply.failure(id: request.id, message: message)
                 }
             }
@@ -105,8 +125,8 @@ final class RemoteInvokeService: ObservableObject {
 
     // MARK: - Private
 
-    private func audit(action: String, disposition: String) {
-        auditLog.insert(RemoteInvokeAuditEntry(action: action, disposition: disposition), at: 0)
+    private func audit(origin: RemoteCommandOrigin, action: String, disposition: String) {
+        auditLog.insert(RemoteInvokeAuditEntry(origin: origin.label, action: action, disposition: disposition), at: 0)
         if auditLog.count > Self.auditLimit { auditLog = Array(auditLog.prefix(Self.auditLimit)) }
         if let data = try? JSONEncoder().encode(auditLog) {
             UserDefaults.standard.set(data, forKey: Self.auditKey)

--- a/OpenGlassesTests/RemoteCommandOriginTests.swift
+++ b/OpenGlassesTests/RemoteCommandOriginTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan BN P2 — origin-aware remote-command policy: per-origin rate buckets (a chatty peer can't
+/// starve the gateway), origin-attributed audit entries, and the consent-surface bridge. The
+/// gateway-origin behaviour is byte-identical, guarded by the unchanged `RemoteCommandPolicyTests`.
+final class RemoteCommandOriginTests: XCTestCase {
+
+    private let t0 = Date(timeIntervalSince1970: 1_000_000)
+
+    // MARK: - Origin identity
+
+    func testOriginLabelsDisplayAndConsentBridge() {
+        XCTAssertEqual(RemoteCommandOrigin.gateway.label, "gateway")
+        XCTAssertEqual(RemoteCommandOrigin.mcpPeer(id: "acme").label, "peer:acme")
+        XCTAssertEqual(RemoteCommandOrigin.gateway.displayName, "Gateway")
+        XCTAssertEqual(RemoteCommandOrigin.mcpPeer(id: "acme").displayName, "Peer acme")
+        XCTAssertEqual(RemoteCommandOrigin.mcpPeer(id: "").displayName, "MCP peer")
+        // Bridges to the shared consent surface (BN P1): gateway → .gateway, peer → .opsPeer.
+        XCTAssertEqual(RemoteCommandOrigin.gateway.consentSource, .gateway)
+        XCTAssertEqual(RemoteCommandOrigin.mcpPeer(id: "acme").consentSource, .opsPeer(label: "Peer acme"))
+        // Distinct peers are distinct dictionary keys.
+        XCTAssertNotEqual(RemoteCommandOrigin.mcpPeer(id: "a"), RemoteCommandOrigin.mcpPeer(id: "b"))
+    }
+
+    // MARK: - Per-origin rate isolation (pure state)
+
+    func testOriginsHaveIndependentRateBuckets() {
+        var rate = RemoteInvokeRateState(now: t0)
+        let peer = RemoteCommandOrigin.mcpPeer(id: "acme")
+
+        // Exhaust the gateway capture bucket (capacity 2).
+        XCTAssertTrue(rate.tryConsume(.gateway, .capture, now: t0))
+        XCTAssertTrue(rate.tryConsume(.gateway, .capture, now: t0))
+        XCTAssertFalse(rate.tryConsume(.gateway, .capture, now: t0))
+
+        // The peer's bucket is created full and independent.
+        XCTAssertTrue(rate.tryConsume(peer, .capture, now: t0))
+        XCTAssertTrue(rate.tryConsume(peer, .capture, now: t0))
+        XCTAssertFalse(rate.tryConsume(peer, .capture, now: t0))
+
+        // Two distinct peers don't share a budget either.
+        XCTAssertTrue(rate.tryConsume(.mcpPeer(id: "other"), .capture, now: t0))
+    }
+
+    func testTwoArgConvenienceTargetsTheGateway() {
+        var rate = RemoteInvokeRateState(now: t0)
+        // The legacy two-arg form and the explicit gateway form share one bucket.
+        XCTAssertTrue(rate.tryConsume(.capture, now: t0))          // gateway, token 1
+        XCTAssertTrue(rate.tryConsume(.gateway, .capture, now: t0)) // gateway, token 2
+        XCTAssertFalse(rate.tryConsume(.capture, now: t0))         // gateway exhausted
+    }
+
+    // MARK: - Per-origin decide
+
+    func testDecideKeepsGatewayAndPeerBudgetsSeparate() {
+        var rate = RemoteInvokeRateState(now: t0)
+        func decide(_ cmd: RemoteGlassesCommand, _ origin: RemoteCommandOrigin) -> RemoteCommandPolicy.Decision {
+            RemoteCommandPolicy.decide(
+                command: cmd, origin: origin, agentModeEnabled: true,
+                toggles: .init(observe: true, output: true, capture: true),
+                rateState: &rate, now: t0)
+        }
+
+        // The gateway spends its whole capture budget...
+        XCTAssertEqual(decide(.capturePhoto, .gateway), .allow)
+        XCTAssertEqual(decide(.capturePhoto, .gateway), .allow)
+        XCTAssertEqual(decide(.capturePhoto, .gateway), .deny(.rateLimited(.capture)))
+        // ...the peer is unaffected, and a second peer is independent again.
+        XCTAssertEqual(decide(.capturePhoto, .mcpPeer(id: "p1")), .allow)
+        XCTAssertEqual(decide(.capturePhoto, .mcpPeer(id: "p2")), .allow)
+    }
+
+    func testDefaultOriginMatchesExplicitGateway() {
+        var a = RemoteInvokeRateState(now: t0)
+        var b = RemoteInvokeRateState(now: t0)
+        let toggles = RemoteCommandPolicy.Toggles(observe: true, output: true, capture: true)
+        // Same sequence via the default origin and via explicit .gateway → identical decisions.
+        for _ in 0..<3 {
+            let viaDefault = RemoteCommandPolicy.decide(
+                command: .capturePhoto, agentModeEnabled: true, toggles: toggles, rateState: &a, now: t0)
+            let viaGateway = RemoteCommandPolicy.decide(
+                command: .capturePhoto, origin: .gateway, agentModeEnabled: true, toggles: toggles, rateState: &b, now: t0)
+            XCTAssertEqual(viaDefault, viaGateway)
+        }
+    }
+
+    // MARK: - Audit entry origin + backward-compatible decode
+
+    func testAuditEntryDefaultsOriginToGateway() {
+        let entry = RemoteInvokeAuditEntry(action: "device_status", disposition: "allowed")
+        XCTAssertEqual(entry.origin, "gateway")
+    }
+
+    func testAuditEntryDecodesLegacyRowWithoutOrigin() throws {
+        // A row persisted before BN P2 has no `origin` key — it must still load, as the gateway.
+        let legacy = Data("""
+        {"id":"\(UUID().uuidString)","timestamp":0,"action":"device_status","disposition":"allowed"}
+        """.utf8)
+        let entry = try JSONDecoder().decode(RemoteInvokeAuditEntry.self, from: legacy)
+        XCTAssertEqual(entry.origin, "gateway")
+        XCTAssertEqual(entry.action, "device_status")
+        XCTAssertEqual(entry.disposition, "allowed")
+    }
+
+    func testAuditEntryRoundTripsPeerOrigin() throws {
+        let entry = RemoteInvokeAuditEntry(origin: "peer:acme", action: "capture_photo", disposition: "allowed")
+        let back = try JSONDecoder().decode(RemoteInvokeAuditEntry.self, from: JSONEncoder().encode(entry))
+        XCTAssertEqual(back, entry)
+        XCTAssertEqual(back.origin, "peer:acme")
+    }
+}

--- a/OpenGlassesTests/RemoteInvokeServiceTests.swift
+++ b/OpenGlassesTests/RemoteInvokeServiceTests.swift
@@ -169,4 +169,34 @@ final class RemoteInvokeServiceTests: XCTestCase {
         let second = service()
         XCTAssertEqual(second.auditLog.first?.action, "device_status")
     }
+
+    // MARK: - Origin attribution (Plan BN P2)
+
+    func testAuditEntryCarriesOrigin() async {
+        let svc = service()
+        _ = await svc.handleFrame(invoke("device_status"))                                 // gateway (default)
+        _ = await svc.handleFrame(invoke("device_status"), origin: .mcpPeer(id: "acme"))    // peer
+        XCTAssertEqual(svc.auditLog[0].origin, "peer:acme", "newest is the peer call")
+        XCTAssertEqual(svc.auditLog[1].origin, "gateway")
+    }
+
+    func testPeerRateBudgetIsIndependentOfGateway() async {
+        let svc = service()   // capture on; fixed clock, so no refill
+        // Exhaust the gateway capture bucket (capacity 2).
+        _ = await svc.handleFrame(invoke("capture_photo"))
+        _ = await svc.handleFrame(invoke("capture_photo"))
+        let gatewayDenied = await svc.handleFrame(invoke("capture_photo"))
+        XCTAssertEqual((gatewayDenied?["error"] as? [String: String])?["code"], "denied.rate_limited.capture")
+
+        // A peer arriving now has its own full capture budget — not starved by the gateway.
+        let peerOk = await svc.handleFrame(invoke("capture_photo"), origin: .mcpPeer(id: "acme"))
+        XCTAssertEqual(peerOk?["ok"] as? Bool, true)
+    }
+
+    func testPeerOriginPersistsAcrossInstances() async {
+        let first = service()
+        _ = await first.handleFrame(invoke("device_status"), origin: .mcpPeer(id: "acme"))
+        let second = service()
+        XCTAssertEqual(second.auditLog.first?.origin, "peer:acme")
+    }
 }


### PR DESCRIPTION
Plan BN P2 — the origin seam for remote invoke, and the named prerequisite for BL PR4.

## The gap (Plan BH, verified)

`RemoteCommandPolicy.decide(command:agentModeEnabled:toggles:rateState:now:)` took no caller identity; `RemoteInvokeAuditEntry` recorded only action + disposition; rate state was one shared bucket set. Consequences: a chatty MCP peer starves the gateway's rate budget, audit entries can't be attributed, and BL P4's "every call attributed to the peer's API key" is unimplementable on the shipped seam.

## The fix

- **`RemoteCommandOrigin`** (new) — `.gateway` / `.mcpPeer(id:)`, `Hashable` + `Codable`. Carries a `label` (bucket key + audit tag: `gateway` / `peer:acme`), a `displayName`, and a **`consentSource` bridge** to BN P1's `RemoteActionSource` (`.gateway` / `.opsPeer(label:)`) — so BL P4's capture consent attributes through the shared consent surface with no second map.
- **Per-origin rate buckets** — `RemoteInvokeRateState` is now keyed by origin; each caller gets its own bucket set, created full at first contact. The gateway origin is pre-created in `init` so its behaviour is **byte-identical** (guarded by the untouched `RemoteCommandPolicyTests`). A legacy two-arg `tryConsume(_:now:)` convenience still targets the gateway.
- **`decide()`** gains `origin: RemoteCommandOrigin = .gateway` — the default keeps every existing call site and test unchanged.
- **Audit** — `RemoteInvokeAuditEntry` carries `origin`, with a backward-compatible decoder (pre-BN-P2 rows load as `gateway` so the saved log still loads). `handleFrame(_:origin:)` threads it (gateway socket passes the default; BL P4 passes `.mcpPeer(id:)`), and `RemoteInvokeAuditView` tags each row with an origin capsule.

Plan point 4 — one identity story, two transports: the outbound gateway socket authenticates with the Plan AR `deviceId`/Ed25519 pair; an inbound MCP peer is its API key (BL P4). Both land here as an `origin`, no second mechanism.

## Tests (11 new)

- **Pure** (`RemoteCommandOriginTests`): origin label/displayName + consent bridge, distinct-peer inequality; per-origin bucket isolation (state-level and through `decide`); default-origin decisions ≡ explicit `.gateway`; audit-entry origin default; legacy row (no `origin`) decodes as gateway; peer origin round-trips
- **Service** (`RemoteInvokeServiceTests`): audit entries carry the origin; an exhausted gateway capture budget doesn't starve a fresh peer; peer origin persists across instances

Existing gateway policy + service tests untouched. Full suite: **1722 tests, 0 failures** (iOS 27 sim, Xcode 27 beta); all 11 new verified by name.

This completes Plan BN. BL PR4 can now attribute each peer call to its origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)