### PR TITLE
Make geofencing actually fire: real delegate, Always auth, honest messaging (BK P1)

### DIFF
--- a/OpenGlasses/Info.plist
+++ b/OpenGlasses/Info.plist
@@ -143,6 +143,8 @@
 		</array>
 		<key>NSLocationWhenInUseUsageDescription</key>
 	<string>OpenGlasses uses your location to provide contextually relevant answers based on where you are.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>OpenGlasses uses your location in the background to alert you when you arrive at or leave a place you set a location reminder for.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>OpenGlasses needs microphone access to listen for wake words and transcribe your voice commands.</string>
 	<key>NSMotionUsageDescription</key>

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -1042,7 +1042,9 @@ class AppState: ObservableObject, AppStateProtocol {
                     await self.speechService.speak(message, urgency: urgency, mirrorToHUD: false)
                 }
             }
-            geofenceTool.restoreGeofences()
+            // BK P1: wire the region-event forwarders (via LocationService's single delegate) and
+            // re-arm saved geofences. Without this the alert path was dead code.
+            geofenceTool.activate()
         }
 
         // OpenClaw WebSocket — triage notifications through the agent before speaking

--- a/OpenGlasses/Sources/Services/LocationService.swift
+++ b/OpenGlasses/Sources/Services/LocationService.swift
@@ -1,6 +1,24 @@
 import Foundation
 import CoreLocation
 
+/// The region-monitoring surface a geofence tool needs (BK P1). Abstracting it lets `GeofenceTool`
+/// route through the app's single `CLLocationManager`/delegate (`LocationService`) in production,
+/// and lets tests inject a fake so entering/exiting a region, the authorization state, and the
+/// 20-region cap are all drivable headlessly (no `CLLocationManager` on GPU / no permission prompt).
+@MainActor
+protocol RegionMonitoring: AnyObject {
+    var regionAuthorizationStatus: CLAuthorizationStatus { get }
+    var monitoredRegionCount: Int { get }
+    func regionMonitoringAvailable() -> Bool
+    func requestAlwaysAuthorization()
+    func startMonitoringRegion(_ region: CLCircularRegion)
+    func stopMonitoringRegion(_ region: CLCircularRegion)
+    /// Fired on a region enter (`didEnter == true`) / exit (`false`).
+    var onRegionEvent: ((CLRegion, _ didEnter: Bool) -> Void)? { get set }
+    /// Fired when authorization becomes `authorizedAlways` — the moment deferred geofences can arm.
+    var onBecameAuthorizedAlways: (() -> Void)? { get set }
+}
+
 /// Provides the user's current location for LLM context
 @MainActor
 class LocationService: NSObject, ObservableObject {
@@ -11,6 +29,10 @@ class LocationService: NSObject, ObservableObject {
 
     private let locationManager = CLLocationManager()
     // private let geocoder = CLGeocoder() // Deprecated in iOS 26
+
+    /// Region-monitoring event forwarders (BK P1). Set by `GeofenceTool.activate()`.
+    var onRegionEvent: ((CLRegion, Bool) -> Void)?
+    var onBecameAuthorizedAlways: (() -> Void)?
 
     override init() {
         super.init()
@@ -81,6 +103,19 @@ class LocationService: NSObject, ObservableObject {
     }
 }
 
+// MARK: - RegionMonitoring (BK P1)
+
+extension LocationService: RegionMonitoring {
+    var regionAuthorizationStatus: CLAuthorizationStatus { locationManager.authorizationStatus }
+    var monitoredRegionCount: Int { locationManager.monitoredRegions.count }
+    func regionMonitoringAvailable() -> Bool {
+        CLLocationManager.isMonitoringAvailable(for: CLCircularRegion.self)
+    }
+    func requestAlwaysAuthorization() { locationManager.requestAlwaysAuthorization() }
+    func startMonitoringRegion(_ region: CLCircularRegion) { locationManager.startMonitoring(for: region) }
+    func stopMonitoringRegion(_ region: CLCircularRegion) { locationManager.stopMonitoring(for: region) }
+}
+
 // MARK: - CLLocationManagerDelegate
 
 extension LocationService: CLLocationManagerDelegate {
@@ -100,6 +135,8 @@ extension LocationService: CLLocationManagerDelegate {
                 self.isAuthorized = true
                 manager.startUpdatingLocation()
                 print("📍 Location authorized")
+                // BK P1: geofences deferred while permission was pending can arm now.
+                if status == .authorizedAlways { self.onBecameAuthorizedAlways?() }
             case .denied, .restricted:
                 self.isAuthorized = false
                 self.locationError = "Location access denied"
@@ -114,6 +151,23 @@ extension LocationService: CLLocationManagerDelegate {
         Task { @MainActor in
             print("📍 Location error: \(error.localizedDescription)")
             self.locationError = error.localizedDescription
+        }
+    }
+
+    // MARK: Region monitoring (BK P1) — the callbacks that were missing, so a geofence can fire.
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
+        Task { @MainActor in self.onRegionEvent?(region, true) }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
+        Task { @MainActor in self.onRegionEvent?(region, false) }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, monitoringDidFailFor region: CLRegion?, withError error: Error) {
+        Task { @MainActor in
+            print("📍 Region monitoring failed for \(region?.identifier ?? "?"): \(error.localizedDescription)")
+            self.locationError = "Region monitoring failed: \(error.localizedDescription)"
         }
     }
 }

--- a/OpenGlasses/Sources/Services/NativeTools/GeofenceTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/GeofenceTool.swift
@@ -46,7 +46,10 @@ final class GeofenceTool: NativeTool, @unchecked Sendable {
         "required": ["action"]
     ]
 
-    private let locationManager: CLLocationManager
+    /// The region-monitoring seam (BK P1): production routes through `LocationService`'s single
+    /// `CLLocationManager`/delegate; tests inject a fake. Replaces the tool's own orphaned manager
+    /// (which never set `.delegate`, so no region event could ever reach `handleRegionEvent`).
+    private let regionMonitor: RegionMonitoring
     private let locationService: LocationService
 
     /// Callback to speak alerts via TTS, with an urgency for rate/prefix.
@@ -66,9 +69,50 @@ final class GeofenceTool: NativeTool, @unchecked Sendable {
         let createdAt: Date
     }
 
-    init(locationService: LocationService) {
+    init(locationService: LocationService, regionMonitor: RegionMonitoring? = nil) {
         self.locationService = locationService
-        self.locationManager = CLLocationManager()
+        self.regionMonitor = regionMonitor ?? locationService
+    }
+
+    /// Wire the region-event callbacks and re-arm saved geofences (BK P1). Called by AppState once
+    /// the tool is registered; safe to call again. Without this the delegate had no forwarder and
+    /// `handleRegionEvent` was dead code.
+    @MainActor
+    func activate() {
+        regionMonitor.onRegionEvent = { [weak self] region, didEnter in
+            self?.handleRegionEvent(region: region, didEnter: didEnter)
+        }
+        regionMonitor.onBecameAuthorizedAlways = { [weak self] in
+            self?.restoreGeofences()
+        }
+        restoreGeofences()
+    }
+
+    // MARK: - Armability (pure)
+
+    /// Whether a new region can be armed right now, and why not (BK P1). Reliable geofencing needs
+    /// **Always** authorization (When-In-Use only delivers while the app is foregrounded), the OS
+    /// caps monitored regions at 20, and a device may not support region monitoring at all.
+    enum Armability: Equatable {
+        case ok
+        case needsPermission   // notDetermined — request Always, arm on grant
+        case denied            // denied/restricted/When-In-Use — can't deliver reliably
+        case unavailable       // device can't monitor regions
+        case atCapacity        // 20-region OS cap reached
+    }
+
+    static func armability(status: CLAuthorizationStatus, monitoringAvailable: Bool, monitoredCount: Int) -> Armability {
+        guard monitoringAvailable else { return .unavailable }
+        switch status {
+        case .authorizedAlways:
+            return monitoredCount >= 20 ? .atCapacity : .ok
+        case .notDetermined:
+            return .needsPermission
+        case .authorizedWhenInUse, .denied, .restricted:
+            return .denied
+        @unknown default:
+            return .denied
+        }
     }
 
     func execute(args: [String: Any]) async throws -> String {
@@ -82,9 +126,9 @@ final class GeofenceTool: NativeTool, @unchecked Sendable {
         case "list":
             return listGeofences()
         case "delete":
-            return deleteGeofence(args: args)
+            return await deleteGeofence(args: args)
         case "clear":
-            return clearAllGeofences()
+            return await clearAllGeofences()
         default:
             return "Unknown action '\(action)'. Use 'create', 'list', 'delete', or 'clear'."
         }
@@ -123,12 +167,6 @@ final class GeofenceTool: NativeTool, @unchecked Sendable {
         let trigger = (args["trigger"] as? String)?.lowercased() ?? "enter"
         let message = args["message"] as? String ?? "You've \(trigger == "exit" ? "left" : "arrived at") \(name)."
 
-        // Check iOS region monitoring limit (20 regions max)
-        var reminders = loadReminders()
-        if reminders.count >= 19 { // Leave 1 slot buffer
-            return "Maximum geofence limit reached (20). Delete some first with action='delete'."
-        }
-
         let reminder = GeofenceReminder(
             id: UUID().uuidString,
             name: name,
@@ -139,17 +177,39 @@ final class GeofenceTool: NativeTool, @unchecked Sendable {
             message: message,
             createdAt: Date()
         )
+        let triggerDesc = trigger == "both" ? "enter or leave" : trigger
 
+        // Pre-flight the monitoring capability on the main actor (BK P1). Return an HONEST message
+        // when it can't be armed, rather than the old unconditional "I'll alert you" success.
+        return await MainActor.run {
+            switch Self.armability(
+                status: regionMonitor.regionAuthorizationStatus,
+                monitoringAvailable: regionMonitor.regionMonitoringAvailable(),
+                monitoredCount: regionMonitor.monitoredRegionCount
+            ) {
+            case .ok:
+                persist(reminder)
+                registerRegion(for: reminder)
+                return "Geofence '\(name)' created. I'll alert you when you \(triggerDesc) within \(Int(radius))m of that location."
+            case .needsPermission:
+                persist(reminder)   // arms automatically once Always is granted (onBecameAuthorizedAlways)
+                regionMonitor.requestAlwaysAuthorization()
+                return "To alert you at '\(name)' I need \"Always\" location access. I've asked for it — grant Always and I'll start watching for it."
+            case .denied:
+                return "I can't set a location reminder for '\(name)' — geofence alerts need \"Always\" location access, which isn't granted. Enable it in Settings → OpenGlasses → Location."
+            case .unavailable:
+                return "This device can't monitor geofence regions, so I can't set a location reminder."
+            case .atCapacity:
+                return "You already have the maximum of 20 geofence reminders. Delete one first with action='delete'."
+            }
+        }
+    }
+
+    /// Append a reminder to the saved set.
+    private func persist(_ reminder: GeofenceReminder) {
+        var reminders = loadReminders()
         reminders.append(reminder)
         saveReminders(reminders)
-
-        // Register with CLLocationManager
-        await MainActor.run {
-            registerRegion(for: reminder)
-        }
-
-        let triggerDesc = trigger == "both" ? "enter or leave" : trigger
-        return "Geofence '\(name)' created. I'll alert you when you \(triggerDesc) within \(Int(radius))m of that location."
     }
 
     // MARK: - List
@@ -169,7 +229,7 @@ final class GeofenceTool: NativeTool, @unchecked Sendable {
 
     // MARK: - Delete
 
-    private func deleteGeofence(args: [String: Any]) -> String {
+    private func deleteGeofence(args: [String: Any]) async -> String {
         guard let name = args["name"] as? String, !name.isEmpty else {
             return "Specify the name of the geofence to delete."
         }
@@ -183,28 +243,16 @@ final class GeofenceTool: NativeTool, @unchecked Sendable {
         let removed = reminders.remove(at: index)
         saveReminders(reminders)
 
-        // Unregister from CLLocationManager
-        let region = CLCircularRegion(
-            center: CLLocationCoordinate2D(latitude: removed.latitude, longitude: removed.longitude),
-            radius: removed.radius,
-            identifier: removed.id
-        )
-        locationManager.stopMonitoring(for: region)
-
+        await MainActor.run { regionMonitor.stopMonitoringRegion(region(for: removed)) }
         return "Geofence '\(removed.name)' deleted."
     }
 
     // MARK: - Clear
 
-    private func clearAllGeofences() -> String {
+    private func clearAllGeofences() async -> String {
         let reminders = loadReminders()
-        for r in reminders {
-            let region = CLCircularRegion(
-                center: CLLocationCoordinate2D(latitude: r.latitude, longitude: r.longitude),
-                radius: r.radius,
-                identifier: r.id
-            )
-            locationManager.stopMonitoring(for: region)
+        await MainActor.run {
+            for r in reminders { regionMonitor.stopMonitoringRegion(region(for: r)) }
         }
         saveReminders([])
         return "All geofence reminders cleared."
@@ -212,10 +260,10 @@ final class GeofenceTool: NativeTool, @unchecked Sendable {
 
     // MARK: - Region Registration
 
-    private func registerRegion(for reminder: GeofenceReminder) {
+    /// The `CLCircularRegion` for a reminder (id-keyed so region events resolve back to it).
+    private func region(for reminder: GeofenceReminder) -> CLCircularRegion {
         let center = CLLocationCoordinate2D(latitude: reminder.latitude, longitude: reminder.longitude)
         let region = CLCircularRegion(center: center, radius: reminder.radius, identifier: reminder.id)
-
         switch reminder.trigger {
         case "enter":
             region.notifyOnEntry = true
@@ -227,16 +275,21 @@ final class GeofenceTool: NativeTool, @unchecked Sendable {
             region.notifyOnEntry = true
             region.notifyOnExit = true
         }
-
-        locationManager.startMonitoring(for: region)
+        return region
     }
 
-    /// Re-register all saved geofences (call on app launch)
+    @MainActor
+    private func registerRegion(for reminder: GeofenceReminder) {
+        regionMonitor.startMonitoringRegion(region(for: reminder))
+    }
+
+    /// Re-register all saved geofences (call on app launch / when Always is granted). Only arms
+    /// when Always authorization is in place — otherwise the OS won't deliver events anyway.
+    @MainActor
     func restoreGeofences() {
+        guard regionMonitor.regionAuthorizationStatus == .authorizedAlways else { return }
         let reminders = loadReminders()
-        for reminder in reminders {
-            registerRegion(for: reminder)
-        }
+        for reminder in reminders { registerRegion(for: reminder) }
         if !reminders.isEmpty {
             print("📍 Restored \(reminders.count) geofence(s)")
         }

--- a/OpenGlassesTests/GeofenceToolTests.swift
+++ b/OpenGlassesTests/GeofenceToolTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+import CoreLocation
+@testable import OpenGlasses
+
+/// Plan BK P1 — geofencing must actually fire. Before this, `GeofenceTool` built its own
+/// `CLLocationManager` and never set a delegate, so `handleRegionEvent` (the only path to the TTS
+/// alert) was dead code, and `createGeofence` promised an alert it could never deliver. Driven
+/// through an injected `RegionMonitoring` fake: region events reach the alert, and `createGeofence`
+/// returns an honest can't-arm message when authorization/capability won't allow it.
+@MainActor
+final class GeofenceToolTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: "geofence_reminders")
+    }
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: "geofence_reminders")
+        super.tearDown()
+    }
+
+    /// Fully controllable region monitor — no CLLocationManager, no permission prompt.
+    @MainActor
+    final class FakeRegionMonitor: RegionMonitoring {
+        var regionAuthorizationStatus: CLAuthorizationStatus = .authorizedAlways
+        var monitoredRegionCount = 0
+        var available = true
+        private(set) var started: [CLCircularRegion] = []
+        private(set) var stopped: [CLCircularRegion] = []
+        var alwaysRequested = 0
+        var onRegionEvent: ((CLRegion, Bool) -> Void)?
+        var onBecameAuthorizedAlways: (() -> Void)?
+
+        func regionMonitoringAvailable() -> Bool { available }
+        func requestAlwaysAuthorization() { alwaysRequested += 1 }
+        func startMonitoringRegion(_ region: CLCircularRegion) { started.append(region); monitoredRegionCount = started.count }
+        func stopMonitoringRegion(_ region: CLCircularRegion) { stopped.append(region) }
+        func fire(_ region: CLRegion, didEnter: Bool) { onRegionEvent?(region, didEnter) }
+    }
+
+    private func tool(_ monitor: FakeRegionMonitor) -> GeofenceTool {
+        GeofenceTool(locationService: LocationService(), regionMonitor: monitor)
+    }
+
+    private func createArgs(name: String = "office", trigger: String = "enter") -> [String: Any] {
+        ["action": "create", "name": name, "latitude": 37.0, "longitude": -122.0, "trigger": trigger]
+    }
+
+    // MARK: - Armability (pure)
+
+    func testArmabilityMatrix() {
+        XCTAssertEqual(GeofenceTool.armability(status: .authorizedAlways, monitoringAvailable: true, monitoredCount: 0), .ok)
+        XCTAssertEqual(GeofenceTool.armability(status: .authorizedAlways, monitoringAvailable: true, monitoredCount: 20), .atCapacity)
+        XCTAssertEqual(GeofenceTool.armability(status: .notDetermined, monitoringAvailable: true, monitoredCount: 0), .needsPermission)
+        XCTAssertEqual(GeofenceTool.armability(status: .authorizedWhenInUse, monitoringAvailable: true, monitoredCount: 0), .denied)
+        XCTAssertEqual(GeofenceTool.armability(status: .denied, monitoringAvailable: true, monitoredCount: 0), .denied)
+        XCTAssertEqual(GeofenceTool.armability(status: .restricted, monitoringAvailable: true, monitoredCount: 0), .denied)
+        XCTAssertEqual(GeofenceTool.armability(status: .authorizedAlways, monitoringAvailable: false, monitoredCount: 0), .unavailable)
+    }
+
+    // MARK: - createGeofence honest messaging (no false promises)
+
+    func testCreateArmsAndMonitorsWithAlways() async throws {
+        let m = FakeRegionMonitor()
+        let reply = try await tool(m).execute(args: createArgs())
+        XCTAssertTrue(reply.contains("I'll alert you"), reply)
+        XCTAssertEqual(m.started.count, 1, "the region must actually be monitored")
+    }
+
+    func testCreateWithWhenInUseReturnsCantArm() async throws {
+        let m = FakeRegionMonitor(); m.regionAuthorizationStatus = .authorizedWhenInUse
+        let reply = try await tool(m).execute(args: createArgs())
+        XCTAssertTrue(reply.contains("Always"), reply)
+        XCTAssertTrue(m.started.isEmpty, "must not claim monitoring without Always")
+    }
+
+    func testCreateWithDeniedReturnsCantArm() async throws {
+        let m = FakeRegionMonitor(); m.regionAuthorizationStatus = .denied
+        let reply = try await tool(m).execute(args: createArgs())
+        XCTAssertTrue(reply.contains("isn't granted"), reply)
+        XCTAssertTrue(m.started.isEmpty)
+    }
+
+    func testCreateWithMonitoringUnavailableReturnsCantArm() async throws {
+        let m = FakeRegionMonitor(); m.available = false
+        let reply = try await tool(m).execute(args: createArgs())
+        XCTAssertTrue(reply.contains("can't monitor"), reply)
+        XCTAssertTrue(m.started.isEmpty)
+    }
+
+    func testCreateNotDeterminedRequestsAlways() async throws {
+        let m = FakeRegionMonitor(); m.regionAuthorizationStatus = .notDetermined
+        let reply = try await tool(m).execute(args: createArgs())
+        XCTAssertEqual(m.alwaysRequested, 1, "must request Always permission")
+        XCTAssertTrue(reply.contains("asked for it"), reply)
+        XCTAssertTrue(m.started.isEmpty, "not armed until Always is granted")
+    }
+
+    func testTwentyFirstRegionReturnsCantArm() async throws {
+        let m = FakeRegionMonitor(); m.monitoredRegionCount = 20   // OS cap already reached
+        let reply = try await tool(m).execute(args: createArgs())
+        XCTAssertTrue(reply.contains("maximum of 20"), reply)
+        XCTAssertTrue(m.started.isEmpty)
+    }
+
+    // MARK: - Region events reach the alert (the whole point)
+
+    func testEnteringRegionFiresTheAlert() async throws {
+        let m = FakeRegionMonitor()
+        let t = tool(m)
+        var alerts: [String] = []
+        t.onAlert = { msg, _ in alerts.append(msg) }
+        t.activate()   // wires the region-event forwarder
+        _ = try await t.execute(args: createArgs(name: "office"))
+
+        let region = try XCTUnwrap(m.started.last, "created geofence should be monitored")
+        m.fire(region, didEnter: true)
+        XCTAssertEqual(alerts.count, 1, "entering the region must fire the alert")
+        XCTAssertTrue(alerts[0].contains("office"), alerts.first ?? "")
+    }
+
+    func testExitEventUsesLeftWording() async throws {
+        let m = FakeRegionMonitor()
+        let t = tool(m)
+        var alerts: [String] = []
+        t.onAlert = { msg, _ in alerts.append(msg) }
+        t.activate()
+        _ = try await t.execute(args: createArgs(name: "home", trigger: "exit"))
+
+        let region = try XCTUnwrap(m.started.last)
+        m.fire(region, didEnter: false)
+        XCTAssertTrue(alerts.first?.contains("left") == true, alerts.first ?? "")
+    }
+
+    func testUnknownRegionEventDoesNotFire() async throws {
+        let m = FakeRegionMonitor()
+        let t = tool(m)
+        var fired = false
+        t.onAlert = { _, _ in fired = true }
+        t.activate()
+        // A region we never created (no matching reminder) is ignored.
+        m.fire(CLCircularRegion(center: .init(latitude: 0, longitude: 0), radius: 50, identifier: "ghost"), didEnter: true)
+        XCTAssertFalse(fired)
+    }
+
+    func testGrantingAlwaysArmsDeferredGeofences() async throws {
+        // Created while permission is pending → saved but not armed. Granting Always arms it.
+        let m = FakeRegionMonitor(); m.regionAuthorizationStatus = .notDetermined
+        let t = tool(m)
+        t.activate()   // wires onBecameAuthorizedAlways; restore is a no-op while notDetermined
+        _ = try await t.execute(args: createArgs(name: "gym"))
+        XCTAssertTrue(m.started.isEmpty)
+
+        m.regionAuthorizationStatus = .authorizedAlways
+        m.onBecameAuthorizedAlways?()   // the delegate flip
+        XCTAssertEqual(m.started.count, 1, "the deferred geofence arms once Always is granted")
+    }
+}


### PR DESCRIPTION
Plan BK P1 — the other 🔴: `GeofenceTool` was listed Tier 2 **DONE** but was a silent stub end-to-end.

## The bug (all verified)

- `GeofenceTool` built its **own** `CLLocationManager` and never set `.delegate` — no region event could reach it.
- The app's only `CLLocationManagerDelegate` (`LocationService`) had `didUpdateLocations`/`didChangeAuthorization`/`didFailWithError` but **no** `didEnterRegion`/`didExitRegion`/`monitoringDidFailFor`.
- `handleRegionEvent` — the only path to the TTS/HUD alert — had **zero callers** (dead code).
- The app **never** called `requestAlwaysAuthorization()`; region monitoring needs Always, and the `NSLocationAlwaysAndWhenInUseUsageDescription` Info.plist key was missing (so the request would be a silent no-op anyway).

Net: "remind me when I get to the office" persisted a reminder, replied *"I'll alert you when you arrive,"* and no alert could ever fire.

## The fix

- **Real delegate.** Region monitoring routes through `LocationService`'s single manager/delegate (one manager, created on main), which gains the missing region callbacks forwarding to `handleRegionEvent` → `onAlert`.
- **Injectable seam** (part of the deliverable — none existed). New `@MainActor protocol RegionMonitoring` abstracts the monitoring surface: `LocationService` conforms in production; tests inject a fake to drive region events, authorization, and the 20-region cap with no `CLLocationManager` and no permission prompt.
- **Always authorization + honest messaging.** `createGeofence` pre-flights via a pure `armability(status:monitoringAvailable:monitoredCount:)`:
  - `authorizedAlways` + under cap → arm + monitor.
  - `notDetermined` → request Always, save the reminder, arm automatically when granted (`onBecameAuthorizedAlways` → `restoreGeofences`).
  - `When-In-Use` / `denied` / `restricted` → honest "needs Always" can't-arm message (When-In-Use only delivers foregrounded).
  - monitoring unavailable → can't-arm.
  - 20 monitored regions (the OS cap, checked against the **real** count) → can't-arm.
  Added the missing `NSLocationAlwaysAndWhenInUseUsageDescription` Info.plist key.
- **AppState** calls `geofenceTool.activate()` (wires the forwarders + re-arms saved geofences) instead of the old bare `restoreGeofences()`.

## Tests (11 new, `GeofenceToolTests`, headless via the fake)

- `armability` matrix across every auth state + availability + capacity
- All five `createGeofence` outcomes — arm-and-monitor; When-In-Use / denied / unavailable / at-capacity each return a can't-arm message and **do not** monitor (no false "I'll alert you")
- `notDetermined` requests Always and doesn't arm yet
- **Entering a registered region fires the alert** with the place name; exit uses "left" wording; an unknown region is ignored
- A geofence created while permission was pending **arms once Always is granted**

Full suite green: **1741 tests, 0 failures** (iOS 27 sim, Xcode 27 beta); all 11 verified by name. One CoreSimulator runner-hang flake, recovered with erase+boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)