### PR TITLE
Guard the local path against silent dead air (BK P3)

### DIFF
--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -2141,10 +2141,9 @@ class LLMService: ObservableObject {
                 finalResponse = textBefore.isEmpty ? resultText : "\(textBefore) \(resultText)"
             }
 
-            let cleanFinal = finalResponse
-                .replacingOccurrences(of: #"<tool_call>.*?</tool_call>"#, with: "", options: .regularExpression)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-
+            // BK P3: an all-markup / empty final (e.g. the model answers the tool result with
+            // another <tool_call>) must surface as an error, not silent dead air at the speaker.
+            let cleanFinal = try Self.cleanedNonEmptyLocalAnswer(finalResponse)
             conversationHistory.append(["role": "assistant", "content": cleanFinal])
             trimHistory()
             return cleanFinal
@@ -2175,9 +2174,12 @@ class LLMService: ObservableObject {
             )
         }
 
-        conversationHistory.append(["role": "assistant", "content": finalAnswer])
+        // BK P3: reject an empty local completion (immediate EOS / all-markup) instead of
+        // speaking silence — matches the Anthropic/Gemini empty-completion guards.
+        let validated = try Self.cleanedNonEmptyLocalAnswer(finalAnswer)
+        conversationHistory.append(["role": "assistant", "content": validated])
         trimHistory()
-        return finalAnswer
+        return validated
     }
 
     // MARK: - Local Agent Model
@@ -2260,6 +2262,20 @@ extension ToolResult {
 extension LLMService {
     /// Strip `<think>...</think>` blocks from LLM output.
     /// Returns the spoken text (without think tags) and the extracted reasoning (if any).
+    /// Strip `<tool_call>` markup + trim, then require a non-empty result (BK P3). A sub-1B local
+    /// model can emit only `<tool_call>` markup (stripped to nothing) or an immediate EOS —
+    /// `TextToSpeechService.speak` drops an empty string silently, so the turn is total dead air:
+    /// no TTS, no tone, no HUD, no error. Anthropic and Gemini already reject an empty completion;
+    /// the local path must too. Throws `invalidResponse("Local")` on empty so the turn surfaces as
+    /// an error (which the P2b cascade can later act on) instead of silence. Pure + headless.
+    nonisolated static func cleanedNonEmptyLocalAnswer(_ raw: String) throws -> String {
+        let cleaned = raw
+            .replacingOccurrences(of: #"<tool_call>.*?</tool_call>"#, with: "", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { throw LLMError.invalidResponse("Local") }
+        return cleaned
+    }
+
     static func stripThinkTags(_ text: String) -> (spoken: String, reasoning: String?) {
         let pattern = "<think>[\\s\\S]*?</think>"
         guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {

--- a/OpenGlassesTests/LLMLocalAnswerTests.swift
+++ b/OpenGlassesTests/LLMLocalAnswerTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import OpenGlasses
+
+/// BK P3 — the local path must not produce silent dead air. A completion that strips to empty (all
+/// `<tool_call>` markup, or an immediate EOS) is rejected as an error rather than handed to TTS as
+/// an empty string (which it drops silently). Both `sendLocal` return paths — the tool-call
+/// `cleanFinal` and the no-tool `finalAnswer` — run through this one validator, matching the
+/// Anthropic/Gemini empty-completion guards.
+final class LLMLocalAnswerTests: XCTestCase {
+
+    func testKeepsRealTextTrimmed() throws {
+        XCTAssertEqual(try LLMService.cleanedNonEmptyLocalAnswer("Hello there"), "Hello there")
+        XCTAssertEqual(try LLMService.cleanedNonEmptyLocalAnswer("  padded  "), "padded")
+    }
+
+    func testStripsToolCallButKeepsSurroundingText() throws {
+        XCTAssertEqual(
+            try LLMService.cleanedNonEmptyLocalAnswer(#"The answer is 42 <tool_call>{"name":"x","arguments":{}}</tool_call>"#),
+            "The answer is 42")
+    }
+
+    func testEmptyOrWhitespaceThrowsInvalidResponseLocal() {
+        for raw in ["", "   ", "\n\t "] {
+            XCTAssertThrowsError(try LLMService.cleanedNonEmptyLocalAnswer(raw)) { error in
+                guard case LLMError.invalidResponse(let who) = error else {
+                    return XCTFail("expected invalidResponse, got \(error)")
+                }
+                XCTAssertEqual(who, "Local")
+            }
+        }
+    }
+
+    func testToolCallOnlyOutputThrows() {
+        // A model that answers with nothing but tool-call markup → stripped to empty → error,
+        // not an empty string forwarded to the speaker (the whole point of BK P3).
+        XCTAssertThrowsError(
+            try LLMService.cleanedNonEmptyLocalAnswer(#"<tool_call>{"name":"weather","arguments":{}}</tool_call>"#)
+        ) { error in
+            guard case LLMError.invalidResponse = error else {
+                return XCTFail("expected invalidResponse, got \(error)")
+            }
+        }
+        // Whitespace padding around the markup is still empty after cleaning.
+        XCTAssertThrowsError(try LLMService.cleanedNonEmptyLocalAnswer("  <tool_call>{}</tool_call>  \n"))
+    }
+}


### PR DESCRIPTION
Plan BK P3 — the local path silently produced dead air. Also the stated prerequisite for the P2b cascade (empty-completion must be a surfaced error before it can be classified retry-worthy).

## The bug

Anthropic and Gemini both reject an empty completion (`LLMService.swift:1328`, `:1818`); `sendLocal` had no equivalent guard, and `TextToSpeechService.speak` drops an empty string silently. A sub-1B model emitting only `<tool_call>` markup (stripped to empty) or an immediate EOS yielded total silence — no TTS, no tone, no HUD, no error.

## The fix

- **New pure helper** `LLMService.cleanedNonEmptyLocalAnswer(_:)` (`nonisolated static`, matching the other pure statics) — strips `<tool_call>` markup, trims, and throws `LLMError.invalidResponse("Local")` on empty, mirroring the cloud providers.
- **Both `sendLocal` return paths** route through it — the tool-call `cleanFinal` (the model can answer a tool result with *another* `<tool_call>`) and the no-tool `finalAnswer`. Extracting the check to one helper is the headless test seam the plan called for (no `ModelContainer` needed).

The empty case now throws instead of returning `""`, so the turn surfaces as an error rather than silence. P2b will later classify it as retry-worthy; P3 just makes it observable.

## Tests (4, pure/headless — `LLMLocalAnswerTests`)

- Keeps and trims real text
- Strips a trailing `<tool_call>` but preserves the surrounding text
- `""` / whitespace throws `invalidResponse("Local")`
- Tool-call-only output (with/without whitespace padding) throws

Full suite green: **1745 tests, 0 failures** (iOS 27 sim, Xcode 27 beta); all 4 verified by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)