### PR TITLE
Local generation: honour barge-in cancellation + one-at-a-time entry guard (BK P4)

### DIFF
--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -2085,6 +2085,11 @@ class LLMService: ObservableObject {
                 history: history,
                 onToken: onToken
             )
+        } catch is CancellationError {
+            // BK P4: a barge-in cancels the local generation. Propagate CancellationError UNWRAPPED
+            // so ConversationTurnRunner maps it to onCancelled (partial reply not spoken) instead
+            // of onError. Wrapping it in LLMError here would speak the generic error line.
+            throw CancellationError()
         } catch let error as LocalLLMError {
             // Propagate .backgrounded unwrapped so callers (e.g. AgentScheduler) can
             // tell "can't run on-device in background" apart from a real failure and
@@ -2136,6 +2141,8 @@ class LLMService: ObservableObject {
                     systemPrompt: fullPrompt,
                     history: updatedHistory
                 )
+            } catch is CancellationError {
+                throw CancellationError()   // BK P4: a barge-in during the tool-result regen cancels too
             } catch {
                 // If re-generation fails, just return the tool result directly
                 finalResponse = textBefore.isEmpty ? resultText : "\(textBefore) \(resultText)"

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -215,6 +215,13 @@ final class LocalLLMService: ObservableObject {
         // kIOGPUCommandBufferCallbackErrorBackgroundExecutionNotPermitted, which MLX
         // surfaces as an *uncatchable* C++ exception that terminates the process.
         // Refuse early with a catchable Swift error so callers can defer instead.
+        // BK P4: one generation at a time per ModelContainer. A fast follow-up (or a stray
+        // concurrent call) must not enter while a generation is live — two token loops on one
+        // container is undefined. Checked before we flip `isGenerating`. (The sequential
+        // re-generations inside `sendLocal` are strictly one-at-a-time and won't trip this.)
+        guard !isGenerating else {
+            throw LocalLLMError.alreadyGenerating
+        }
         guard UIApplication.shared.applicationState != .background else {
             throw LocalLLMError.backgrounded
         }
@@ -287,32 +294,54 @@ final class LocalLLMService: ObservableObject {
         let parameters = GenerateParameters(maxTokens: 512, temperature: 0.7, topP: 0.9)
         let stream = try await container.generate(input: input, parameters: parameters)
 
-        var output = ""
-        // Drive the stream manually so we can bail out *before* requesting the next
-        // token — i.e. before MLX submits the next Metal command buffer. Stopping
-        // here avoids the uncatchable background-GPU crash; whatever tokens we have
-        // so far are returned (or .backgrounded is thrown if nothing was produced).
+        // Drive the stream through the pure loop below so we can bail out *before* requesting the
+        // next token — before MLX submits the next Metal command buffer. Non-text generations
+        // (`.info`/`.toolCall`) are skipped; the loop keeps pulling until a text chunk or the end.
         var iterator = stream.makeAsyncIterator()
+        let output = try await Self.drainTokenStream(
+            nextChunk: {
+                while let generation = await iterator.next() {
+                    if case .chunk(let text) = generation { return text }
+                    // .info / .toolCall / unknown — not spoken text; keep pulling.
+                }
+                return nil
+            },
+            isBackgrounded: { [weak self] in
+                (self?.enteredBackgroundDuringGeneration ?? false) || UIApplication.shared.applicationState == .background
+            },
+            onToken: onToken
+        )
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Pure token-drain loop (BK P4). Accumulates text chunks, honouring:
+    /// - **Barge-in cancellation** — checked every iteration *before* pulling the next token, and
+    ///   it always **throws `CancellationError`** (never a partial return). `ConversationTurnRunner`
+    ///   maps `CancellationError` → `onCancelled`, the only path where a barge-in doesn't speak the
+    ///   partial reply. Without this the MLX loop polled only background state, so `stop`/barge-in
+    ///   marked the task cancelled but inference ran to completion (GPU/battery burn).
+    /// - **Mid-stream backgrounding** — bail before the next Metal eval (uncatchable GPU crash);
+    ///   return what we have, or throw `.backgrounded` if nothing was produced.
+    ///
+    /// `nextChunk`/`isBackgrounded` are injected so a fake stream drives this headlessly (no MLX
+    /// model / GPU). Returns the accumulated (untrimmed) output.
+    static func drainTokenStream(
+        nextChunk: () async -> String?,
+        isBackgrounded: () -> Bool,
+        onToken: ((String) -> Void)?
+    ) async throws -> String {
+        var output = ""
         while true {
-            if enteredBackgroundDuringGeneration || UIApplication.shared.applicationState == .background {
+            try Task.checkCancellation()
+            if isBackgrounded() {
                 if output.isEmpty { throw LocalLLMError.backgrounded }
                 break
             }
-            guard let generation = await iterator.next() else { break }
-            switch generation {
-            case .chunk(let text):
-                output += text
-                onToken?(text)
-            case .info:
-                break  // Generation complete info
-            case .toolCall:
-                break  // Handled at a higher level via text parsing
-            @unknown default:
-                break
-            }
+            guard let text = await nextChunk() else { break }
+            output += text
+            onToken?(text)
         }
-
-        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return output
     }
 
     // MARK: - Storage Info
@@ -395,6 +424,7 @@ enum LocalLLMError: LocalizedError {
     case generationFailed(String)
     case backgrounded
     case promptTooLong(tokens: Int, limit: Int)
+    case alreadyGenerating
 
     var errorDescription: String? {
         switch self {
@@ -406,6 +436,8 @@ enum LocalLLMError: LocalizedError {
             return "On-device models can't run while the app is in the background. Switch to a cloud model for background tasks."
         case .promptTooLong(let tokens, let limit):
             return "Prompt is too long for the on-device model (\(tokens) tokens; limit \(limit)). Switch to a cloud model for this request."
+        case .alreadyGenerating:
+            return "The on-device model is already generating a response. Wait for it to finish."
         }
     }
 }

--- a/OpenGlassesTests/LocalGenerationCancellationTests.swift
+++ b/OpenGlassesTests/LocalGenerationCancellationTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import OpenGlasses
+
+/// BK P4 — local generation must honour barge-in cancellation and run one-at-a-time. The token
+/// loop previously polled only background state, so `stop`/barge-in marked the task cancelled but
+/// MLX inference ran to completion (GPU/battery burn). Driven through the injected
+/// `drainTokenStream` seam (no MLX model / GPU) and the `isGenerating` entry guard.
+@MainActor
+final class LocalGenerationCancellationTests: XCTestCase {
+
+    // MARK: - drainTokenStream: normal + backgrounding
+
+    func testAccumulatesChunksAndFiresOnToken() async throws {
+        var remaining = ["Hello", " ", "world"]
+        var tokens: [String] = []
+        let out = try await LocalLLMService.drainTokenStream(
+            nextChunk: { remaining.isEmpty ? nil : remaining.removeFirst() },
+            isBackgrounded: { false },
+            onToken: { tokens.append($0) }
+        )
+        XCTAssertEqual(out, "Hello world")
+        XCTAssertEqual(tokens, ["Hello", " ", "world"])
+    }
+
+    func testBackgroundingMidStreamReturnsPartial() async throws {
+        var count = 0
+        let out = try await LocalLLMService.drainTokenStream(
+            nextChunk: { count += 1; return "tok\(count)" },
+            isBackgrounded: { count >= 2 },   // backgrounds after two tokens flow
+            onToken: nil
+        )
+        XCTAssertEqual(out, "tok1tok2", "returns what was produced before backgrounding")
+    }
+
+    func testBackgroundingWithNoOutputThrowsBackgrounded() async {
+        do {
+            _ = try await LocalLLMService.drainTokenStream(
+                nextChunk: { "x" }, isBackgrounded: { true }, onToken: nil)
+            XCTFail("expected .backgrounded")
+        } catch let error as LocalLLMError {
+            guard case .backgrounded = error else { return XCTFail("expected .backgrounded, got \(error)") }
+        } catch {
+            XCTFail("expected LocalLLMError.backgrounded, got \(error)")
+        }
+    }
+
+    // MARK: - Barge-in cancellation ALWAYS throws (never a partial return)
+
+    func testCancellationThrowsCancellationErrorNotPartial() async {
+        let producing = XCTestExpectation(description: "producing tokens")
+        producing.assertForOverFulfill = false
+        // An unbounded stream: the ONLY way the task completes is cancellation throwing.
+        let task = Task { () -> String in
+            try await LocalLLMService.drainTokenStream(
+                nextChunk: { await Task.yield(); return "x" },
+                isBackgrounded: { false },
+                onToken: { _ in producing.fulfill() }
+            )
+        }
+        await fulfillment(of: [producing], timeout: 2.0)
+
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("barge-in must throw CancellationError, not return a partial reply")
+        } catch is CancellationError {
+            // Correct — ConversationTurnRunner maps CancellationError → onCancelled, the only path
+            // where the partial reply isn't spoken.
+        } catch {
+            XCTFail("expected CancellationError, got \(error)")
+        }
+    }
+
+    func testAlreadyCancelledThrowsBeforePullingAnyToken() async {
+        var pulled = 0
+        let task = Task { () -> String in
+            // Cancel the task from within before it starts, so the first checkCancellation fires.
+            try await LocalLLMService.drainTokenStream(
+                nextChunk: { pulled += 1; return "x" },
+                isBackgrounded: { false },
+                onToken: nil
+            )
+        }
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("expected CancellationError")
+        } catch is CancellationError {
+            // ok
+        } catch {
+            XCTFail("expected CancellationError, got \(error)")
+        }
+    }
+
+    // MARK: - Entry guard: one generation at a time
+
+    func testConcurrentGenerateThrowsAlreadyGenerating() async {
+        let service = LocalLLMService()
+        service.isGenerating = true   // a generation is already live
+        do {
+            _ = try await service.generate(userMessage: "hi", systemPrompt: "sys")
+            XCTFail("a second concurrent generate must be refused")
+        } catch let error as LocalLLMError {
+            guard case .alreadyGenerating = error else {
+                return XCTFail("expected .alreadyGenerating, got \(error)")
+            }
+        } catch {
+            XCTFail("expected LocalLLMError.alreadyGenerating, got \(error)")
+        }
+    }
+}


### PR DESCRIPTION
Plan BK P4 — local on-device generation ignored barge-in.

## The bug

`generate()`'s token loop (`LocalLLMService.swift:295-313`) checked background state every iteration but **never `Task.isCancelled`**. `currentLLMTask?.cancel()` on "stop"/barge-in marks the task cancelled, but the loop didn't poll it — so MLX inference ran to completion (GPU/battery burn) even though the reply was correctly not spoken. There was also **no `isGenerating` entry guard**, so a fast follow-up could enter `generate()` concurrently on one `ModelContainer`.

## The fix

- **Cancellation-aware token loop.** Extracted the drive loop into a pure, injectable `drainTokenStream(nextChunk:isBackgrounded:onToken:)` that calls `Task.checkCancellation()` at the top of every iteration — *before* pulling the next token (before MLX submits the next Metal command buffer). **Cancellation always throws `CancellationError`** (never a partial return): `ConversationTurnRunner` maps `CancellationError` → `onCancelled` (verified `ConversationTurnRunner.swift:49-50`), the only path where a barge-in doesn't speak the partial reply. Mid-stream backgrounding behaviour is unchanged (return partial, or throw `.backgrounded` if nothing was produced).
- **Propagation fix.** `sendLocal`'s catch blocks wrapped every error into `LLMError.invalidResponse` (main generate) or swallowed it into the tool-result fallback — either would have re-mapped `CancellationError` to `onError` and spoken the generic error line. Both now re-throw `CancellationError` unwrapped.
- **One-at-a-time entry guard.** `generate()` refuses re-entry with a new `LocalLLMError.alreadyGenerating` when a generation is live, checked before flipping `isGenerating`. (The sequential re-generations inside `sendLocal` are strictly one-at-a-time and don't trip it.)
- **Seam.** The closure-based `drainTokenStream` is the headless test seam the plan required — a fake stream drives it with no MLX model / GPU.

## Tests (6, `LocalGenerationCancellationTests`)

- Accumulates chunks + fires `onToken` per chunk
- Mid-stream backgrounding returns the partial; backgrounding with no output throws `.backgrounded`
- **Cancellation throws `CancellationError`, not a partial** — an unbounded stream (so the only way the task finishes is cancellation firing), plus an already-cancelled task throwing before pulling
- Concurrent `generate()` while `isGenerating` throws `.alreadyGenerating`

Full suite green: **1751 tests, 0 failures** (iOS 27 sim, Xcode 27 beta); all 6 verified by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)