### PR TITLE
Make model-download Cancel actually cancel (BK P5)

### DIFF
--- a/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
+++ b/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
@@ -119,8 +119,18 @@ struct LocalModelManagerView: View {
                                 Image(systemName: "checkmark.circle.fill")
                                     .foregroundStyle(.green)
                             } else if downloadingModelId == model.id {
-                                ProgressView(value: localService?.downloadProgress ?? 0)
-                                    .frame(width: 60)
+                                HStack(spacing: 8) {
+                                    ProgressView(value: localService?.downloadProgress ?? 0)
+                                        .frame(width: 60)
+                                    // BK P5: a real Cancel — routes through the service so the
+                                    // in-flight download is actually stopped, not just hidden.
+                                    Button("Cancel") {
+                                        localService?.cancelDownload()
+                                        downloadingModelId = nil
+                                    }
+                                    .buttonStyle(.borderless)
+                                    .controlSize(.small)
+                                }
                             } else if !model.isCompatibleWithDevice {
                                 Label("Needs 8 GB", systemImage: "memorychip")
                                     .font(.caption)
@@ -204,6 +214,8 @@ struct LocalModelManagerView: View {
                 try await localService?.downloadModel(modelId)
                 refreshDownloaded()
                 downloadingModelId = nil
+            } catch is CancellationError {
+                downloadingModelId = nil   // BK P5: user cancelled — not an error to surface
             } catch {
                 downloadError = error.localizedDescription
                 downloadingModelId = nil

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -23,6 +23,11 @@ final class LocalLLMService: ObservableObject {
     private var modelContainer: ModelContainer?
     private var activeDownloadTask: Task<Void, Error>?
 
+    /// Injectable download primitive (BK P5) so a test can drive a fake download — and its
+    /// cancellation — without touching the network. `nil` ⇒ the real `HubClient` path. Reports
+    /// fractional progress; throws (e.g. `CancellationError`) to abort.
+    var downloadFunction: ((_ modelId: String, _ onProgress: @escaping (Double) -> Void) async throws -> Void)?
+
     /// Set when the app enters the background during a generation so the token loop
     /// can stop before submitting the next Metal command buffer (forbidden in the
     /// background — see `generate`).
@@ -123,7 +128,11 @@ final class LocalLLMService: ObservableObject {
     /// Download a model from HuggingFace without loading into memory.
     /// Only one download runs at a time — call cancelDownload() first if needed.
     func downloadModel(_ modelId: String) async throws {
-        guard !isDownloading else { return }
+        // BK P5: a second download while one is live is refused with a VISIBLE error (was a silent
+        // `return`, which let a second multi-GB download start over the same shared progress state).
+        guard !isDownloading else {
+            throw LocalLLMError.alreadyDownloading
+        }
         isDownloading = true
         downloadingModelId = modelId
         downloadProgress = 0
@@ -133,18 +142,37 @@ final class LocalLLMService: ObservableObject {
             activeDownloadTask = nil
         }
 
-        guard let repoID = Repo.ID(rawValue: modelId) else {
-            throw LocalLLMError.generationFailed("Invalid model id: \(modelId)")
+        // BK P5: own the cancellable unit. Before, the real Task lived in the caller and
+        // `activeDownloadTask` was permanently nil, so `cancelDownload()` cancelled nothing and
+        // `hub.downloadSnapshot` ran to completion — Cancel was a UI-only no-op. Running the
+        // download inside `activeDownloadTask` means cancellation reaches the network/disk layer.
+        let task = Task { [weak self] in
+            guard let self else { return }
+            if let fake = self.downloadFunction {
+                try await fake(modelId) { self.downloadProgress = $0 }
+            } else {
+                guard let repoID = Repo.ID(rawValue: modelId) else {
+                    throw LocalLLMError.generationFailed("Invalid model id: \(modelId)")
+                }
+                _ = try await self.hub.downloadSnapshot(of: repoID) { @MainActor progress in
+                    self.downloadProgress = progress.fractionCompleted
+                }
+            }
         }
-        _ = try await hub.downloadSnapshot(of: repoID) { @MainActor progress in
-            self.downloadProgress = progress.fractionCompleted
+        activeDownloadTask = task
+        do {
+            try await task.value
+        } catch is CancellationError {
+            print("🚫 Model download cancelled: \(modelId)")
+            throw CancellationError()
         }
 
         downloadProgress = 1.0
         print("✅ Local model downloaded: \(modelId)")
     }
 
-    /// Cancel any in-progress download and reset state.
+    /// Cancel any in-progress download and reset state (BK P5). Now that the download runs inside
+    /// `activeDownloadTask`, this actually stops it instead of just clearing the UI flags.
     func cancelDownload() {
         activeDownloadTask?.cancel()
         activeDownloadTask = nil
@@ -425,6 +453,7 @@ enum LocalLLMError: LocalizedError {
     case backgrounded
     case promptTooLong(tokens: Int, limit: Int)
     case alreadyGenerating
+    case alreadyDownloading
 
     var errorDescription: String? {
         switch self {
@@ -438,6 +467,8 @@ enum LocalLLMError: LocalizedError {
             return "Prompt is too long for the on-device model (\(tokens) tokens; limit \(limit)). Switch to a cloud model for this request."
         case .alreadyGenerating:
             return "The on-device model is already generating a response. Wait for it to finish."
+        case .alreadyDownloading:
+            return "A model download is already in progress. Cancel it first, or wait for it to finish."
         }
     }
 }

--- a/OpenGlassesTests/LocalDownloadCancelTests.swift
+++ b/OpenGlassesTests/LocalDownloadCancelTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import OpenGlasses
+
+/// BK P5 — model-download "Cancel" was a UI-only no-op: `activeDownloadTask` was never assigned
+/// (the real Task lived in the caller), so `cancelDownload()` cancelled a nil task while the
+/// download ran to completion, and clearing `isDownloading` let a second multi-GB download start
+/// over the same progress state. Driven through the injected `downloadFunction` seam (no network).
+@MainActor
+final class LocalDownloadCancelTests: XCTestCase {
+
+    /// A long fake download that honours cancellation and reports progress.
+    private func longDownload(_ progressing: XCTestExpectation) -> (String, @escaping (Double) -> Void) async throws -> Void {
+        { _, onProgress in
+            for i in 1...1_000_000 {
+                try Task.checkCancellation()
+                onProgress(min(1.0, Double(i) / 1_000_000))
+                progressing.fulfill()
+                await Task.yield()
+            }
+        }
+    }
+
+    func testCancelDownloadStopsTheInFlightDownload() async {
+        let service = LocalLLMService()
+        let progressing = expectation(description: "downloading"); progressing.assertForOverFulfill = false
+        service.downloadFunction = longDownload(progressing)
+
+        let download = Task { try await service.downloadModel("mlx-community/whatever") }
+        await fulfillment(of: [progressing], timeout: 2.0)
+        XCTAssertTrue(service.isDownloading, "the download is live")
+
+        service.cancelDownload()
+        do {
+            try await download.value
+            XCTFail("a cancelled download must throw, not complete")
+        } catch is CancellationError {
+            // correct — the in-flight download was actually stopped
+        } catch {
+            XCTFail("expected CancellationError, got \(error)")
+        }
+        XCTAssertFalse(service.isDownloading, "state resets after cancel")
+        XCTAssertNil(service.downloadingModelId)
+    }
+
+    func testSecondDownloadWhileActiveIsRejectedWithVisibleError() async {
+        let service = LocalLLMService()
+        let progressing = expectation(description: "downloading"); progressing.assertForOverFulfill = false
+        service.downloadFunction = longDownload(progressing)
+
+        let first = Task { try? await service.downloadModel("mlx-community/model-a") }
+        await fulfillment(of: [progressing], timeout: 2.0)
+        XCTAssertTrue(service.isDownloading)
+
+        do {
+            try await service.downloadModel("mlx-community/model-b")
+            XCTFail("a second concurrent download must be rejected")
+        } catch let error as LocalLLMError {
+            guard case .alreadyDownloading = error else {
+                return XCTFail("expected .alreadyDownloading, got \(error)")
+            }
+            XCTAssertFalse(error.errorDescription?.isEmpty ?? true, "the rejection must carry a visible message")
+        } catch {
+            XCTFail("expected .alreadyDownloading, got \(error)")
+        }
+
+        service.cancelDownload()
+        _ = await first.value
+    }
+
+    func testSuccessfulDownloadReportsProgressAndCompletes() async throws {
+        let service = LocalLLMService()
+        var reached = false
+        service.downloadFunction = { _, onProgress in
+            onProgress(0.25)
+            onProgress(0.75)
+            reached = true
+        }
+        try await service.downloadModel("mlx-community/model-x")
+        XCTAssertTrue(reached, "the download function ran to completion")
+        XCTAssertEqual(service.downloadProgress, 1.0, "completes at 100%")
+        XCTAssertFalse(service.isDownloading)
+        XCTAssertNil(service.downloadingModelId)
+    }
+}


### PR DESCRIPTION
Plan BK P5 — the download "Cancel" was a UI-only no-op.

## The bug

`activeDownloadTask` (`LocalLLMService.swift:24`) was declared but **never assigned** — the real `Task` lived in the caller (`AgenticFeaturesView`). So `cancelDownload()` cancelled a permanently-nil task and just reset the published UI flags, while `hub.downloadSnapshot` kept running to completion. And because `isDownloading` was cleared, the user could start a **second** multi-GB download over the same shared progress state — both ran to completion, silently eating bandwidth/disk/battery.

## The fix

- **Service owns the cancellable unit.** `downloadModel` runs the download inside `activeDownloadTask`, so `cancelDownload()` actually reaches the network/disk layer and cancellation surfaces as `CancellationError` (which the callers already treat as "cancelled", not an error).
- **Injectable `downloadFunction` seam** (`HubClient` is a concrete `private let`, so cancelling a real download in a unit test means network) — a test injects a fake download whose cancellation is drivable with no network.
- **Visible rejection.** The `guard !isDownloading` now throws a new `LocalLLMError.alreadyDownloading` (with a real message) instead of the old silent `return`, so a swallowed tap doesn't look like a dead button.
- **Both download UIs route through the service.** `AgenticFeaturesView` already had a Cancel button and ignored `CancellationError`. `LocalModelManagerView` had **no cancel button at all** — added one beside the progress bar (routing through `cancelDownload()`), and its catch now treats `CancellationError` as a cancel rather than surfacing it as a `downloadError`.

**Deferred (noted, not in scope):** `loadModel()` drives shard downloads through `factory.loadContainer` sharing `downloadProgress` with no cancellation path — a separate concern from the user-initiated download-and-cancel flow this phase targets.

## Tests (3, `LocalDownloadCancelTests`, headless via the seam)

- `cancelDownload()` stops the in-flight fake download — it throws `CancellationError` and `isDownloading`/`downloadingModelId` reset
- A second `downloadModel` while one is active is rejected with the visible `.alreadyDownloading` error (which now reflects a truly-live download)
- Happy path reports progress and completes at `downloadProgress == 1.0`

Full suite green: **1754 tests, 0 failures** (iOS 27 sim, Xcode 27 beta); all 3 verified by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)