### PR TITLE
Feature-claim honesty: send descriptions, check_form wiring, dead exempt field (BK P6)

### DIFF
--- a/OpenGlasses/Sources/Services/NativeTools/FitnessCoachingTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/FitnessCoachingTool.swift
@@ -8,6 +8,11 @@ import Vision
 struct FitnessCoachingTool: NativeTool {
     let name = "fitness_coach"
     let description = "Fitness coaching: start/stop workout tracking, log exercises, get rep counts, check form via camera, and view workout history from HealthKit."
+
+    /// Latest camera frame, for `check_form` (BK P6). Wired to `CameraService` in production; a
+    /// test injects a fake frame. `nil` (unset / no frame) ⇒ honest "no camera view" guidance
+    /// instead of the old hardcoded deflection that never ran the built `PoseAnalyzer`.
+    var frameProvider: (@MainActor () -> UIImage?)?
     let parametersSchema: [String: Any] = [
         "type": "object",
         "properties": [
@@ -71,7 +76,7 @@ struct FitnessCoachingTool: NativeTool {
         case "log_exercise":
             return logExercise(args: args)
         case "check_form":
-            return "Form checking requires a camera frame. Ask the user to show their exercise form to the camera and I'll analyze the pose."
+            return await checkForm(args: args)
         case "workout_history":
             return await getWorkoutHistory()
         case "step_goal":
@@ -136,6 +141,18 @@ struct FitnessCoachingTool: NativeTool {
         saveWorkoutNote(summary: summary)
 
         return summary
+    }
+
+    /// Analyse the wearer's form from the latest camera frame (BK P6). Previously a hardcoded
+    /// deflection — the built `PoseAnalyzer` was never called, so "check form via camera" was a
+    /// false claim. Now it actually runs Vision pose estimation on the frame, or gives honest
+    /// guidance when no camera view is available.
+    private func checkForm(args: [String: Any]) async -> String {
+        let exercise = (args["exercise"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "your exercise"
+        guard let frame = await frameProvider?() else {
+            return "To check your form, make sure the glasses camera can see you doing \(exercise), then ask again."
+        }
+        return PoseAnalyzer.analyzeForm(image: frame, exercise: exercise)
     }
 
     private func logExercise(args: [String: Any]) -> String {

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
@@ -78,7 +78,13 @@ final class NativeToolRegistry {
         }
 
         // Tier 3 tools
-        register(FitnessCoachingTool())
+        var fitnessTool = FitnessCoachingTool()
+        if let camera = cameraService {
+            // BK P6: feed check_form the latest camera frame so it actually runs PoseAnalyzer,
+            // making the tool's "check form via camera" claim true.
+            fitnessTool.frameProvider = { camera.latestFrame }
+        }
+        register(fitnessTool)
         register(FirstAidTool())
         // BK P0: register the gateway-skills tool only when the gateway is an active agentic
         // capability (configured AND Agent Mode on). Registering on `isOpenClawConfigured` alone

--- a/OpenGlasses/Sources/Services/NativeTools/SendEmailTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/SendEmailTool.swift
@@ -5,7 +5,7 @@ import UIKit
 /// Uses URL schemes to open the appropriate app with pre-filled content.
 struct MultiChannelMessageTool: NativeTool {
     let name = "send_via"
-    let description = "Send messages via WhatsApp, Telegram, or Email. For iMessage/SMS, use 'send_message' instead."
+    let description = "Opens WhatsApp, Telegram, or Email with a pre-filled message for the user to review and send — it cannot send automatically. For iMessage/SMS, use 'send_message' instead."
     let parametersSchema: [String: Any] = [
         "type": "object",
         "properties": [

--- a/OpenGlasses/Sources/Services/NativeTools/SendMessageTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/SendMessageTool.swift
@@ -5,7 +5,7 @@ import UIKit
 /// Automatically resolves contact names to phone numbers.
 struct SendMessageTool: NativeTool {
     let name = "send_message"
-    let description = "Send a text message (SMS/iMessage). Accepts a phone number OR a contact name — names are automatically looked up in Contacts. If multiple matches are found, returns options for the user to choose."
+    let description = "Opens Messages with a pre-filled SMS/iMessage for the user to review and send — it cannot send automatically. Accepts a phone number OR a contact name (auto-looked-up in Contacts); if multiple matches are found, returns options for the user to choose."
     let parametersSchema: [String: Any] = [
         "type": "object",
         "properties": [

--- a/OpenGlasses/Sources/Services/PrivacyFilterService.swift
+++ b/OpenGlasses/Sources/Services/PrivacyFilterService.swift
@@ -14,8 +14,10 @@ class PrivacyFilterService: ObservableObject {
     /// Blur radius for face anonymization
     var blurRadius: Double = 20.0
 
-    /// Known face IDs to NOT blur (the user's saved faces)
-    var exemptFaceprints: [[Float]] = []
+    // BK P6: `exemptFaceprints` (a "don't blur known contacts" list) was declared but never
+    // populated or read — the blur path blurs every detected face. Removed the dead field rather
+    // than ship a config surface that does nothing; wiring real known-contact exemption would need
+    // face-matching in the blur path (a Plan-level feature, not a mechanical honesty fix).
 
     /// Shared render context — `nonisolated` so the off-main `blurFaces` reuses this one Metal
     /// pipeline instead of building a fresh CIContext per frame (a classic per-frame GPU cost).

--- a/OpenGlassesTests/FeatureHonestyTests.swift
+++ b/OpenGlassesTests/FeatureHonestyTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+import UIKit
+@testable import OpenGlasses
+
+/// BK P6 — feature-claim honesty. The "Send" tools only open a pre-filled compose screen (they
+/// can't send automatically), and `fitness_coach check_form` was a hardcoded deflection that never
+/// ran the built `PoseAnalyzer`. These verify the descriptions are honest and that `check_form`
+/// now actually analyses a frame.
+@MainActor
+final class FeatureHonestyTests: XCTestCase {
+
+    // MARK: - "Send" tool descriptions no longer overpromise
+
+    func testSendMessageDescriptionDoesNotClaimAutoSend() {
+        let d = SendMessageTool().description
+        XCTAssertTrue(d.contains("review"), d)
+        XCTAssertTrue(d.lowercased().contains("cannot send automatically"), d)
+        XCTAssertFalse(d.hasPrefix("Send "), "must not claim it sends: \(d)")
+    }
+
+    func testSendViaDescriptionDoesNotClaimAutoSend() {
+        let d = MultiChannelMessageTool().description
+        XCTAssertTrue(d.contains("pre-filled"), d)
+        XCTAssertTrue(d.lowercased().contains("cannot send automatically"), d)
+        XCTAssertFalse(d.hasPrefix("Send "), "must not claim it sends: \(d)")
+    }
+
+    // MARK: - check_form actually runs PoseAnalyzer
+
+    func testCheckFormWithoutFrameGivesHonestGuidanceNotDeflection() async throws {
+        let tool = FitnessCoachingTool()   // no frameProvider ⇒ no camera view
+        let reply = try await tool.execute(args: ["action": "check_form", "exercise": "squats"])
+        XCTAssertTrue(reply.contains("squats"), reply)
+        XCTAssertFalse(reply.contains("Form checking requires a camera frame"),
+                       "must not return the old hardcoded deflection")
+    }
+
+    func testCheckFormWithFrameRunsPoseAnalyzer() async throws {
+        var tool = FitnessCoachingTool()
+        let frame = Self.solidImage()   // a plain image with no person in it
+        tool.frameProvider = { frame }
+
+        let reply = try await tool.execute(args: ["action": "check_form", "exercise": "push-ups"])
+        // The whole point: check_form now runs PoseAnalyzer on the frame instead of returning the
+        // old hardcoded deflection. A person-free frame resolves to a genuine Vision outcome —
+        // "No body pose detected", "Couldn't process", or (in the simulator, where body-pose
+        // estimation isn't available) "Pose analysis failed" — all of which prove the wire is live.
+        XCTAssertFalse(reply.contains("Form checking requires a camera frame"),
+                       "check_form must now run PoseAnalyzer, not deflect: \(reply)")
+        XCTAssertTrue(
+            ["No body pose detected", "Couldn't process", "Pose analysis", "pose"].contains { reply.contains($0) },
+            "expected a PoseAnalyzer result, got: \(reply)")
+    }
+
+    private static func solidImage() -> UIImage {
+        UIGraphicsImageRenderer(size: CGSize(width: 120, height: 160)).image { ctx in
+            UIColor.gray.setFill()
+            ctx.fill(CGRect(x: 0, y: 0, width: 120, height: 160))
+        }
+    }
+}


### PR DESCRIPTION
Plan BK P6 — the mechanical truthfulness fixes surfaced by the adversarial review.

## 1. "Send" tool descriptions overpromised

`send_message` (`SendMessageTool`) and `send_via` (`MultiChannelMessageTool`) only open a pre-filled compose screen — the correct safety design, and their return strings were already honest — but their LLM-facing `description` said "Send". Reworded both to *"Opens … with a pre-filled message for the user to review and send — cannot send automatically."*

## 2. `fitness_coach check_form` was a hardcoded deflection

The `check_form` case returned a canned "Form checking requires a camera frame…" string and **never called** the built `PoseAnalyzer.analyzeForm` — so the tool's "check form via camera" claim was false (dead code). Wired it up through a testable seam (`frameProvider: (@MainActor () -> UIImage?)?`), fed by `CameraService.latestFrame` in the registry (mirroring `ColorIdentifierTool`'s camera injection). `check_form` now runs Vision pose estimation on the latest frame, and falls back to honest guidance when no camera view is available. The claim is now true, and the tool is testable without a real camera / Wearables.

## 3. `PrivacyFilterService.exemptFaceprints` was dead

The "don't blur known contacts" list was declared but never populated or read (the blur path blurs every detected face). Dropped the dead field rather than ship a config surface that does nothing — real known-contact exemption would need face-matching in the blur path, a plan-level feature, not a mechanical honesty fix (noted in a comment).

## Tests (4, `FeatureHonestyTests`)

- Both send-tool descriptions assert "review" + "cannot send automatically", and don't start with a bare "Send"
- `check_form` with no frame gives honest guidance and is **not** the old deflection
- `check_form` with a frame runs `PoseAnalyzer` — proven by a genuine Vision outcome (never the canned deflection). Note: body-pose estimation isn't available in the iOS simulator, which *itself confirms* the call reaches `PoseAnalyzer` ("Pose analysis failed: Unable to setup request"); the test accepts that as a valid PoseAnalyzer result.

Full suite green: **1758 tests, 0 failures** (iOS 27 sim, Xcode 27 beta); all 4 verified by name.

This completes Plan BK's honesty tier. Remaining in BK: the P2/P2b/P2c local-model cascade trio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)