### PR TITLE
Local-model prompt budget: model-derived cap, truncate-to-fit, bounded memory (BK P2)

### DIFF
--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -110,13 +110,6 @@ final class LocalLLMService: ObservableObject {
         "mlx-community/SmolVLM2-500M-Video-Instruct-mlx",
     ]
 
-    /// Hard ceiling on the tokenized prompt fed to an on-device model. Prefill + KV cache for a
-    /// 2B model scale with sequence length; an ~8k-token prompt (the full ~100-tool system
-    /// prompt) exhausted memory and got the app Jetsam-killed on an iPhone. Well above any lean
-    /// prompt the agent path now builds, so it only trips on a pathological input — where a
-    /// catchable throw beats an uncatchable OOM process kill.
-    static let maxPromptTokens = 4096
-
     /// Whether the currently loaded model supports vision.
     var isVisionModel: Bool {
         guard let id = loadedModelId else { return false }
@@ -260,32 +253,40 @@ final class LocalLLMService: ObservableObject {
         isGenerating = true
         defer { isGenerating = false }
 
-        // Build messages for chat template
-        var messages: [[String: String]] = [
-            ["role": "system", "content": systemPrompt]
-        ]
-        for turn in history {
-            messages.append(["role": turn.role, "content": turn.content])
-        }
-        messages.append(["role": "user", "content": userMessage])
-
-        // Tokenize using chat template — some models don't support system role,
-        // so fall back to prepending system prompt to the first user message.
+        // Tokenize a candidate history exactly as the model will — chat template, with the
+        // no-system-role fallback some small models need. Used both to measure truncation
+        // candidates and to produce the final token ids.
         let tokenizer = await container.tokenizer
-        let tokens: [Int]
-        do {
-            tokens = try tokenizer.applyChatTemplate(messages: messages)
-        } catch {
-            print("⚠️ Chat template failed with system role, retrying without: \(error.localizedDescription)")
-            // Merge system prompt into first user message
-            var fallbackMessages: [[String: String]] = []
-            for turn in history {
-                fallbackMessages.append(["role": turn.role, "content": turn.content])
+        func tokenize(_ hist: [(role: String, content: String)]) throws -> [Int] {
+            var messages: [[String: String]] = [["role": "system", "content": systemPrompt]]
+            for turn in hist { messages.append(["role": turn.role, "content": turn.content]) }
+            messages.append(["role": "user", "content": userMessage])
+            do {
+                return try tokenizer.applyChatTemplate(messages: messages)
+            } catch {
+                // Merge the system prompt into the user turn for models without a system role.
+                var fallback: [[String: String]] = []
+                for turn in hist { fallback.append(["role": turn.role, "content": turn.content]) }
+                fallback.append(["role": "user", "content": systemPrompt + "\n\nUser: " + userMessage])
+                return try tokenizer.applyChatTemplate(messages: fallback)
             }
-            let combinedUserMessage = systemPrompt + "\n\nUser: " + userMessage
-            fallbackMessages.append(["role": "user", "content": combinedUserMessage])
-            tokens = try tokenizer.applyChatTemplate(messages: fallbackMessages)
         }
+
+        // BK P2: budget the prompt from the *loaded model's* context window minus the generation
+        // reserve (prompt + up to 512 new tokens must both fit, or generation OOMs mid-stream —
+        // an uncatchable per-token kill), then truncate oldest-history-first to fit instead of
+        // hard-rejecting. Only a prompt that can't be trimmed under budget (system + current turn
+        // alone too big) throws `.promptTooLong` — catchable, so the caller can fall back to cloud.
+        let budget = LocalModelBudget.promptBudget(for: loadedModelId)
+        let trimmedHistory = try LocalModelBudget.historyFittingBudget(
+            history: history, budget: budget
+        ) { try tokenize($0).count }
+        if trimmedHistory.count < history.count {
+            NSLog("🔬 LocalLLM.generate trimmed history %d→%d turns to fit budget %d",
+                  history.count, trimmedHistory.count, budget)
+        }
+        let tokens = try tokenize(trimmedHistory)
+
         // Build a 2D (1, L) batch, not a 1D (L,) array. The Gemma 4 / 3n forward pass
         // indexes x.dim(2) and fatally crashes ("SmallVector out of range") on 1D input —
         // its prepare() path doesn't expand 1D internally (ml-explore/mlx-swift-lm#240).
@@ -294,13 +295,6 @@ final class LocalLLMService: ObservableObject {
         // NSLog (not print) so it survives the fatal MLX crash in the unified log,
         // confirming the 2D fix is live and what shape reaches the model.
         NSLog("🔬 LocalLLM.generate model=%@ tokenIDs.shape=%@ count=%d", loadedModelId ?? "?", "\(tokenIDs.shape)", tokens.count)
-
-        // Refuse a prompt that would OOM the device. MLX allocation failure is an *uncatchable*
-        // trap (it Jetsam-kills the process), so we must reject BEFORE feeding it to the model —
-        // a catchable error lets the caller fall back to cloud instead of the app dying.
-        guard tokens.count <= Self.maxPromptTokens else {
-            throw LocalLLMError.promptTooLong(tokens: tokens.count, limit: Self.maxPromptTokens)
-        }
 
         let input = LMInput(text: .init(tokens: tokenIDs))
 

--- a/OpenGlasses/Sources/Services/LocalModelBudget.swift
+++ b/OpenGlasses/Sources/Services/LocalModelBudget.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Pure prompt-budget logic for on-device (MLX) generation (BK P2).
+///
+/// Replaces the old single model-agnostic `maxPromptTokens = 4096` constant. Three problems it
+/// fixes:
+///  1. **Model-agnostic cap.** A flat 4096 ignored that different models have different real
+///     context windows. The budget is now derived per loaded model from a table (with a
+///     conservative default for user-typed / unknown ids).
+///  2. **No generation headroom.** The old cap let a prompt fill the *entire* window, so
+///     prompt + up to 512 generated tokens overflowed *during* generation — relocating the
+///     uncatchable per-token OOM from submit-time to mid-stream. The budget subtracts the
+///     generation reserve (and a small safety margin).
+///  3. **Hard reject with no recovery.** The caller now uses `historyFittingBudget` to trim
+///     oldest history first and only throws when even the minimal prompt (system + current turn)
+///     overflows.
+///
+/// No MLX import — deliberately headless-testable.
+enum LocalModelBudget {
+    /// Tokens reserved for the model's own output. Must match `GenerateParameters(maxTokens:)`
+    /// in `LocalLLMService.generate`; if that changes, change this.
+    static let generationReserve = 512
+
+    /// Small extra cushion for chat-template scaffolding and count drift between our estimate and
+    /// the model's actual tokenization.
+    static let safetyMargin = 128
+
+    /// Conservative context window (tokens) for an id we don't recognise. Matches the old flat
+    /// cap so unknown / user-typed model ids are no worse off than before — but the budget below
+    /// still subtracts the generation reserve, closing the mid-stream-overflow hole.
+    static let defaultContextWindow = 4096
+
+    /// Effective (memory-safe) context window per known model id. These are intentionally *below*
+    /// each model's theoretical maximum: the on-device ceiling is device memory, not the model's
+    /// advertised window. An ~8k-token prompt to a 2B model already Jetsam-killed the app on an
+    /// iPhone, so larger models stay at the conservative floor and only the tiny models — which
+    /// are cheap to prefill — get more room.
+    static let contextWindows: [String: Int] = [
+        "mlx-community/Qwen2.5-0.5B-Instruct-4bit": 8192,
+        "mlx-community/SmolVLM2-500M-Video-Instruct-mlx": 8192,
+        "mlx-community/Qwen2.5-3B-Instruct-4bit": 4096,
+        "mlx-community/gemma-2-2b-it-4bit": 4096,
+        "mlx-community/gemma-4-e2b-it-4bit": 4096,
+        "mlx-community/SmolVLM2-2.2B-Instruct-mlx": 4096,
+    ]
+
+    /// Real context window for a model id, or the conservative default for an unknown id.
+    static func contextWindow(for modelId: String?) -> Int {
+        guard let modelId, let window = contextWindows[modelId] else { return defaultContextWindow }
+        return window
+    }
+
+    /// Maximum tokenized-prompt length for a model: its window minus the generation reserve and a
+    /// safety margin. Never returns less than a small floor so a mis-entered window can't produce a
+    /// zero/negative budget that rejects every prompt.
+    static func promptBudget(for modelId: String?) -> Int {
+        promptBudget(contextWindow: contextWindow(for: modelId))
+    }
+
+    /// Budget from an explicit window (unit-test entry point).
+    static func promptBudget(contextWindow: Int) -> Int {
+        max(minimumBudget, contextWindow - generationReserve - safetyMargin)
+    }
+
+    /// Floor so a tiny/misconfigured window still admits the minimal system + turn prompt.
+    static let minimumBudget = 512
+
+    /// Trim conversation history so the tokenized prompt fits `budget`, dropping the **oldest**
+    /// turns first (the current user turn and system prompt are never dropped). Pure: the caller
+    /// injects `tokenCount`, which tokenizes a candidate history the same way the model will.
+    ///
+    /// Returns the history to actually feed the model. Throws `promptTooLong` only when even an
+    /// empty history (system + current turn alone) exceeds the budget — genuine overflow that P2b's
+    /// cascade will later route to a bigger-window model.
+    static func historyFittingBudget(
+        history: [(role: String, content: String)],
+        budget: Int,
+        tokenCount: (_ history: [(role: String, content: String)]) throws -> Int
+    ) throws -> [(role: String, content: String)] {
+        var kept = history
+        while true {
+            let count = try tokenCount(kept)
+            if count <= budget { return kept }
+            if kept.isEmpty {
+                throw LocalLLMError.promptTooLong(tokens: count, limit: budget)
+            }
+            kept = Array(kept.dropFirst())   // drop the oldest exchange and re-measure
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/SemanticMemoryStore.swift
+++ b/OpenGlasses/Sources/Services/SemanticMemoryStore.swift
@@ -178,6 +178,19 @@ class SemanticMemoryStore: ObservableObject {
         systemPromptContext(query: nil)
     }
 
+    /// BK P2 — bound the memory block so it can't silently balloon the prompt past the on-device
+    /// budget as the store grows. Every branch is capped: at most `maxMemoryLines` entries per
+    /// section (the semantic-hit path was already limited to 8; these caps extend the same
+    /// discipline to the sorted global fallback, persona, and gateway paths, which previously
+    /// dumped the *entire* store), and each value is clamped to `maxValueChars`.
+    static let maxMemoryLines = 8
+    static let maxValueChars = 300
+
+    private static func clampValue(_ value: String) -> String {
+        guard value.count > maxValueChars else { return value }
+        return String(value.prefix(maxValueChars)) + "…"
+    }
+
     /// Returns a formatted memory context for injection into the system prompt.
     /// When `query` is provided, global memories are filtered to the most relevant
     /// via semantic search, keeping token usage lean.
@@ -192,24 +205,28 @@ class SemanticMemoryStore: ObservableObject {
         if hasGlobal {
             let pairs: [(String, String)]
             if let q = query, !q.isEmpty, embedder.isAvailable {
-                let results = semanticSearch(query: q, limit: 8, namespace: "global")
+                let results = semanticSearch(query: q, limit: Self.maxMemoryLines, namespace: "global")
                 pairs = results.isEmpty
                     ? memories.sorted { $0.key < $1.key }
                     : results.map { ($0.keyName, $0.value) }
             } else {
+                // No query / embedder unavailable / retrieval off: previously dumped the whole
+                // store. Clamp to the same cap so a large global store can't overflow the budget.
                 pairs = memories.sorted { $0.key < $1.key }
             }
-            let lines = pairs.map { "- \($0.0): \($0.1)" }
+            let lines = pairs.prefix(Self.maxMemoryLines).map { "- \($0.0): \(Self.clampValue($0.1))" }
             sections.append("SHARED MEMORY (facts about the user — reference naturally):\n\(lines.joined(separator: "\n"))")
         }
 
         if hasPersona, let pid = activePersonaId {
-            let lines = personaMemories.sorted { $0.key < $1.key }.map { "- \($0.key): \($0.value)" }
+            let lines = personaMemories.sorted { $0.key < $1.key }
+                .prefix(Self.maxMemoryLines)
+                .map { "- \($0.key): \(Self.clampValue($0.value))" }
             sections.append("PERSONA MEMORY (\(pid)):\n\(lines.joined(separator: "\n"))")
         }
 
         if hasGateway {
-            let lines = gatewayMemories.map { "- \($0)" }
+            let lines = gatewayMemories.prefix(Self.maxMemoryLines).map { "- \(Self.clampValue($0))" }
             sections.append("GATEWAY MEMORY (other devices):\n\(lines.joined(separator: "\n"))")
         }
 

--- a/OpenGlassesTests/LocalModelBudgetTests.swift
+++ b/OpenGlassesTests/LocalModelBudgetTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import OpenGlasses
+
+/// BK P2 — the on-device prompt budget is now derived per model (window − generation reserve −
+/// margin) and the caller truncates oldest-history-first to fit, only hard-failing when the
+/// minimal prompt (system + current turn) can't fit any window. All pure/headless.
+final class LocalModelBudgetTests: XCTestCase {
+
+    // MARK: - Budget calculation
+
+    func testBudgetSubtractsGenerationReserveAndMargin() {
+        // The concrete review example: a 4096 window must NOT admit a 4096-token prompt, or
+        // prompt + 512 generated tokens overflows mid-stream.
+        let budget = LocalModelBudget.promptBudget(contextWindow: 4096)
+        XCTAssertEqual(budget, 4096 - LocalModelBudget.generationReserve - LocalModelBudget.safetyMargin)
+        XCTAssertLessThan(budget, 4096, "must leave room for the model's own 512-token output")
+    }
+
+    func testUnknownModelFallsBackToConservativeDefault() {
+        XCTAssertEqual(LocalModelBudget.contextWindow(for: "some/model-nobody-knows"),
+                       LocalModelBudget.defaultContextWindow)
+        XCTAssertEqual(LocalModelBudget.contextWindow(for: nil),
+                       LocalModelBudget.defaultContextWindow)
+    }
+
+    func testKnownModelUsesItsTableWindow() {
+        // A tiny model gets a larger memory-safe window than the conservative default.
+        XCTAssertGreaterThan(
+            LocalModelBudget.contextWindow(for: "mlx-community/Qwen2.5-0.5B-Instruct-4bit"),
+            LocalModelBudget.defaultContextWindow)
+    }
+
+    func testBudgetNeverGoesBelowFloor() {
+        // A mis-entered tiny window can't produce a zero/negative budget that rejects everything.
+        XCTAssertEqual(LocalModelBudget.promptBudget(contextWindow: 10),
+                       LocalModelBudget.minimumBudget)
+    }
+
+    // MARK: - Truncation: drop oldest history first
+
+    /// Each history turn counts as 10 tokens; system + user baseline is 20. Lets us drive the
+    /// pure truncation loop deterministically without a real tokenizer.
+    private func fakeCount(_ hist: [(role: String, content: String)]) -> Int {
+        20 + hist.count * 10
+    }
+
+    func testUnderBudgetKeepsAllHistory() throws {
+        let history = [("user", "a"), ("assistant", "b")].map { (role: $0.0, content: $0.1) }
+        let kept = try LocalModelBudget.historyFittingBudget(history: history, budget: 100) {
+            fakeCount($0)
+        }
+        XCTAssertEqual(kept.count, 2)
+    }
+
+    func testOverBudgetDropsOldestFirstUntilFits() throws {
+        // 5 turns → 20 + 50 = 70 tokens. Budget 40 admits (40-20)/10 = 2 turns.
+        let history = (0..<5).map { (role: "user", content: "turn\($0)") }
+        let kept = try LocalModelBudget.historyFittingBudget(history: history, budget: 40) {
+            fakeCount($0)
+        }
+        XCTAssertEqual(kept.count, 2)
+        XCTAssertEqual(kept.map(\.content), ["turn3", "turn4"],
+                       "oldest dropped, the most recent turns are preserved")
+        XCTAssertLessThanOrEqual(fakeCount(kept), 40)
+    }
+
+    func testMinimalPromptStillTooBigThrowsPromptTooLong() {
+        // Baseline (system + current turn) alone is 20 tokens; a budget of 15 can never fit.
+        let history = [(role: "user", content: "x")]
+        XCTAssertThrowsError(
+            try LocalModelBudget.historyFittingBudget(history: history, budget: 15) { fakeCount($0) }
+        ) { error in
+            guard case LocalLLMError.promptTooLong = error else {
+                return XCTFail("expected .promptTooLong, got \(error)")
+            }
+        }
+    }
+}

--- a/OpenGlassesTests/LocalModelRoutingTests.swift
+++ b/OpenGlassesTests/LocalModelRoutingTests.swift
@@ -22,14 +22,18 @@ final class LocalModelRoutingTests: XCTestCase {
                       "only genuine VLMs belong in the vision factory route")
     }
 
-    /// The on-device prompt guard must sit below the observed OOM point (an ~8.2k-token prompt
-    /// Jetsam-killed the app) yet well above the lean agent prompt, so it only trips on a
-    /// pathological input — where a catchable throw beats an uncatchable memory kill.
-    func testOnDevicePromptGuardIsBelowTheObservedOOMPoint() {
-        XCTAssertLessThan(LocalLLMService.maxPromptTokens, 8241,
-                          "must reject before the size that actually OOM-killed the app")
-        XCTAssertGreaterThanOrEqual(LocalLLMService.maxPromptTokens, 2048,
-                          "but leave headroom for a normal lean prompt + some history")
+    /// The on-device prompt budget (BK P2) must sit below the observed OOM point (an ~8.2k-token
+    /// prompt Jetsam-killed the app) yet leave headroom for a normal lean prompt + some history —
+    /// for every recommended model and for an unknown/user-typed id.
+    func testOnDevicePromptBudgetIsBelowTheObservedOOMPoint() {
+        let ids = LocalLLMService.recommendedModels.map(\.id) + [nil, "some/unknown-model"]
+        for id in ids {
+            let budget = LocalModelBudget.promptBudget(for: id)
+            XCTAssertLessThan(budget, 8241,
+                              "budget for \(id ?? "nil") must sit below the OOM point")
+            XCTAssertGreaterThanOrEqual(budget, 2048,
+                              "budget for \(id ?? "nil") must leave headroom for a lean prompt + history")
+        }
     }
 
     func testPromptTooLongErrorIsDescriptive() {

--- a/OpenGlassesTests/MemoryInjectionBoundsTests.swift
+++ b/OpenGlassesTests/MemoryInjectionBoundsTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import OpenGlasses
+
+/// BK P2(c) — the memory block injected into the system prompt must stay bounded so it can't
+/// silently balloon the on-device prompt past budget as the store grows. Every branch caps the
+/// number of entries and clamps per-value length; here we exercise the global-fallback and gateway
+/// paths (no embedder / no query — the branch that previously dumped the whole store) plus the
+/// per-value clamp. Headless: a temp-dir store, no model.
+@MainActor
+final class MemoryInjectionBoundsTests: XCTestCase {
+
+    private func makeStore() -> SemanticMemoryStore {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return SemanticMemoryStore(directory: dir)
+    }
+
+    private func bulletLines(_ text: String) -> [String] {
+        text.components(separatedBy: "\n").filter { $0.hasPrefix("- ") }
+    }
+
+    func testGlobalFallbackBranchIsCappedNotDumped() {
+        let store = makeStore()
+        for i in 0..<20 { store.rememberGlobal("fact\(i)", value: "value \(i)") }
+        // query: nil ⇒ the sorted global fallback branch that used to inject the entire store.
+        let context = store.systemPromptContext(query: nil) ?? ""
+        XCTAssertLessThanOrEqual(bulletLines(context).count, SemanticMemoryStore.maxMemoryLines,
+                                 "global memory must be capped, not dumped wholesale")
+    }
+
+    func testGatewayMemoriesAreCapped() {
+        let store = makeStore()
+        store.gatewayMemories = (0..<20).map { "gateway fact \($0)" }
+        let context = store.systemPromptContext(query: nil) ?? ""
+        XCTAssertLessThanOrEqual(bulletLines(context).count, SemanticMemoryStore.maxMemoryLines)
+    }
+
+    func testLongValueIsClamped() {
+        let store = makeStore()
+        let huge = String(repeating: "x", count: 500)
+        store.rememberGlobal("bio", value: huge)
+        let context = store.systemPromptContext(query: nil) ?? ""
+        XCTAssertFalse(context.contains(huge), "the full over-length value must not be injected")
+        XCTAssertTrue(context.contains("…"), "an over-length value is truncated with an ellipsis")
+        // No injected value line exceeds the clamp (+ ellipsis + bullet scaffolding).
+        for line in bulletLines(context) {
+            XCTAssertLessThanOrEqual(line.count, SemanticMemoryStore.maxValueChars + 20)
+        }
+    }
+}


### PR DESCRIPTION
## BK P2 — Local-model prompt budget

Adversarial-review remediation (Plan BK, phase P2). The `maxPromptTokens = 4096` crash-guard is real but the *failure experience* wasn't: it was model-agnostic, ignored generation headroom, hard-rejected with no recovery, and the memory block that fed it could balloon unbounded.

### Changes
- **`LocalModelBudget`** (new, pure/headless): per-model context-window table + conservative default for unknown/user-typed ids; `promptBudget = window − 512 generation reserve − margin` (a full-window prompt + up to 512 generated tokens overflowed *during* generation — an uncatchable per-token OOM). `historyFittingBudget` drops **oldest history first** and throws `promptTooLong` only when the minimal prompt (system + current turn) can't fit — still catchable, so the caller can fall back to cloud.
- **`generate()`** derives the budget from the loaded model and truncates at the tokenizer before submit; the old fixed guard and dead constant are removed.
- **`SemanticMemoryStore.systemPromptContext`** caps every branch (global-fallback, persona, gateway) at `maxMemoryLines` and clamps per-value length. The no-query / embedder-unavailable global branch previously injected the *entire* store, so turns that worked last week started failing as memory grew.

### Scope
P2b (model cascade on overflow) and P2c (audible model-switch narration) remain follow-up phases. On genuine overflow this still throws `promptTooLong` — exactly what P2's own tests specify — and P2b will later route that to a bigger-window model.

### Tests
`LocalModelBudgetTests` (budget math, unknown-id default, floor, oldest-first truncation, minimal-overflow throw), `MemoryInjectionBoundsTests` (global/gateway caps + value clamp), updated `LocalModelRoutingTests` budget assertion. Full suite + Release build green (Xcode 27 sim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)