### PR TITLE
Model cascade: fall over to the next model on overflow / rate-limit / empty (BK P2b)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2736,26 +2736,45 @@ class AppState: ObservableObject, AppStateProtocol {
             await ConversationTurnRunner.run(.init(
                 send: { [self] in
                     let rawResponse: String
-                    if useLocalAgent {
-                        // Fast path: on-device Gemma 4 agent
-                        rawResponse = try await llmService.sendViaLocalAgent(
-                            query,
-                            locationContext: classification.relevantSections.contains(.location) ? locationService.locationContext : nil,
-                            memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? query : nil) : nil
-                        )
-                    } else {
-                        // Standard path: cloud LLM
+                    let backgrounded = UIApplication.shared.applicationState == .background
+                    let locationCtx = classification.relevantSections.contains(.location) ? locationService.locationContext : nil
+                    let memoryCtx = Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? query : nil) : nil
+                    // Cloud send with automatic model fall-over (BK P2b): active model leads, then
+                    // the user's fallback order — spills on overflow / rate-limit / empty completion.
+                    func cloudCascade() async throws -> String {
                         let imageData = await smartCameraImageData(for: query)
-                        rawResponse = try await llmService.sendMessage(
+                        return try await llmService.sendMessageCascading(
                             query,
-                            locationContext: classification.relevantSections.contains(.location) ? locationService.locationContext : nil,
+                            locationContext: locationCtx,
                             imageData: imageData,
-                            memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? query : nil) : nil,
+                            memoryContext: memoryCtx,
                             playbookContext: classification.relevantSections.contains(.playbook) ? playbookStore.playbookContext() : nil,
                             nowPlayingContext: nowPlayingAtStart?.promptContext,
                             shortcutsContext: ShortcutsCatalog.shared.promptBlock(),
-                            promptSections: classification.relevantSections
+                            promptSections: classification.relevantSections,
+                            backgrounded: backgrounded
                         )
+                    }
+                    if useLocalAgent {
+                        // Fast path: on-device Gemma 4 agent — but spill to the cloud cascade if it
+                        // can't serve the turn (BK P2b: prefer local for cost, fall over to cloud).
+                        do {
+                            rawResponse = try await llmService.sendViaLocalAgent(
+                                query,
+                                locationContext: locationCtx,
+                                memoryContext: memoryCtx
+                            )
+                        } catch is CancellationError {
+                            throw CancellationError()
+                        } catch {
+                            guard Config.modelCascadeEnabled,
+                                  ModelFallbackChain.classify(error) != .terminalForTurn,
+                                  !Task.isCancelled else { throw error }
+                            print("🔀 Local agent failed (\(error)) — cascading to cloud")
+                            rawResponse = try await cloudCascade()
+                        }
+                    } else {
+                        rawResponse = try await cloudCascade()
                     }
                     nowPlayingAtStart = nil  // consumed for this turn
                     return rawResponse
@@ -2861,13 +2880,14 @@ class AppState: ObservableObject, AppStateProtocol {
                     } else {
                         image = await smartCameraImageData(for: query)
                     }
-                    return try await llmService.sendMessage(
+                    return try await llmService.sendMessageCascading(
                         query,
                         locationContext: locationService.locationContext,
                         imageData: image,
                         memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? query : nil) : nil,
                         playbookContext: playbookStore.playbookContext(),
                         shortcutsContext: ShortcutsCatalog.shared.promptBlock(),
+                        backgrounded: UIApplication.shared.applicationState == .background,
                         onToken: { [weak self] chunk in
                             guard let self, let id = streamThreadId else { return }
                             if self.streamingTurn?.threadId == id { self.streamingTurn?.text += chunk }

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -510,6 +510,62 @@ class LLMService: ObservableObject {
         return rawResponse
     }
 
+    // MARK: - Model Cascade (BK P2b)
+
+    /// `sendMessage` with automatic fall-over to the next model when the active one can't serve the
+    /// turn (`promptTooLong`, `429`/quota, empty completion, …). The active model leads; the user's
+    /// fallback order (then the remaining saved models) follow. Between hops the active model is
+    /// swapped and the conversation history is rewound to its pre-turn snapshot so a failed attempt
+    /// never leaves half a turn (or a duplicated user turn) behind. The active model is always
+    /// restored on exit, so a cascade is transparent to the caller's own switch/restore bookkeeping.
+    ///
+    /// Falls straight through to a single `sendMessage` when the cascade is disabled or there's only
+    /// one candidate. Exhaustion throws the *last real* error (not a generic line) so the caller can
+    /// speak the true reason.
+    func sendMessageCascading(_ text: String, locationContext: String? = nil, imageData: Data? = nil, memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil, backgrounded: Bool = false, onToken: ((String) -> Void)? = nil, onStreamReset: (() -> Void)? = nil, onModelSwitch: ((_ from: ModelConfig?, _ to: ModelConfig?, _ failure: ModelFallbackChain.FailureClass) async -> Void)? = nil) async throws -> String {
+
+        func send() async throws -> String {
+            try await sendMessage(text, locationContext: locationContext, imageData: imageData, memoryContext: memoryContext, agentContext: agentContext, playbookContext: playbookContext, nowPlayingContext: nowPlayingContext, shortcutsContext: shortcutsContext, promptSections: promptSections, onToken: onToken, onStreamReset: onStreamReset)
+        }
+
+        let candidates = ModelFallbackChain.candidates(
+            activeId: Config.activeModelId, saved: Config.savedModels,
+            fallbackOrder: Config.modelFallbackOrder)
+        guard Config.modelCascadeEnabled, candidates.count > 1 else {
+            return try await send()
+        }
+
+        let startId = Config.activeModelId
+        let historySnapshot = conversationHistory
+        let savedById = Dictionary(Config.savedModels.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
+        defer {
+            Config.setActiveModelId(startId)
+            refreshActiveModel()
+        }
+
+        return try await ModelCascade.run(
+            candidates: candidates,
+            needs: .init(requiresVision: imageData != nil, isBackgrounded: backgrounded),
+            maxAttempts: min(candidates.count, 4),
+            isCancelled: { Task.isCancelled },
+            onSwitch: { from, to, failure in
+                // Rewind the partial UI stream and log the hop; P2c narrates it out loud.
+                onStreamReset?()
+                print("🔀 Model cascade: \(from.id) → \(to.id) (\(failure))")
+                await onModelSwitch?(savedById[from.id], savedById[to.id], failure)
+            },
+            attempt: { [weak self] candidate in
+                guard let self else { throw LLMError.invalidConfiguration("LLM service released") }
+                // Start each attempt from the clean pre-turn history so a failed hop doesn't leave a
+                // dangling/duplicated turn, and point the active model at this candidate.
+                self.conversationHistory = historySnapshot
+                Config.setActiveModelId(candidate.id)
+                self.refreshActiveModel()
+                return try await send()
+            }
+        )
+    }
+
     // MARK: - Plan-then-execute (Plan S)
 
     /// Decide whether to route `text` through the plan-then-execute loop (Plan S Phase 2).

--- a/OpenGlasses/Sources/Services/ModelFallbackChain.swift
+++ b/OpenGlasses/Sources/Services/ModelFallbackChain.swift
@@ -1,0 +1,232 @@
+import Foundation
+
+/// Pure model-cascade decision logic (BK P2b).
+///
+/// Today a turn is single-shot: `ModelRoutingPolicy` picks one model, `ConversationTurnRunner`
+/// calls `send()` once, and any error — `promptTooLong`, a `429`/quota, an empty completion —
+/// falls straight to the generic error line, throwing away the intent to fall over to another
+/// model. This type supplies the two deterministic decisions a cascade needs:
+///
+///  1. **`classify(_:)`** — is a failure worth retrying on a *different* model, fatal to the whole
+///     turn, or fatal only to *this* candidate (skip it, try the next)?
+///  2. **`next(...)`** — given the ordered candidate list and what's already been tried, which
+///     model to hop to, honouring capability filters (vision), the on-device background rule, and
+///     the "bigger context window" requirement after an overflow.
+///
+/// No UIKit / no live services — deliberately headless-testable. The live driver
+/// (`LLMService.sendMessageCascading`) wires these to real provider calls.
+enum ModelFallbackChain {
+
+    // MARK: - Candidate
+
+    /// One model the cascade may hop to. Derived from a `ModelConfig` by `candidates(...)`.
+    struct Candidate: Equatable {
+        let id: String
+        /// Provider is on-device MLX (`.local`) — must be skipped while the app is backgrounded
+        /// (Metal work throws `.backgrounded`). ([[project_local_model_background]])
+        let isLocalMLX: Bool
+        /// Whether this model accepts image input (`ModelConfig.visionEnabled`).
+        let supportsVision: Bool
+        /// Effective prompt window in tokens. On-device models use their real (memory-safe)
+        /// window; cloud models use a large sentinel so a local overflow always finds a bigger one.
+        let contextTokens: Int
+    }
+
+    /// Sentinel window for cloud models — far larger than any prompt we build, so `promptTooLong`
+    /// on a local model always resolves to a cloud candidate.
+    static let cloudContextTokens = 1_000_000
+
+    // MARK: - Failure classification
+
+    enum FailureClass: Equatable {
+        /// Transient / model-specific — retry on the next eligible model (`429`, quota, timeout,
+        /// empty completion, interrupted stream).
+        case retryOtherModel
+        /// The prompt overflowed this model — retry only on a model with a *bigger* window.
+        case needsBiggerWindow
+        /// Fatal for this candidate only (bad/expired key for this provider) — skip it, try next.
+        case terminalForCandidate
+        /// Fatal for the whole turn — every model would fail identically (malformed request,
+        /// invalid configuration) or the user cancelled. Don't cascade.
+        case terminalForTurn
+    }
+
+    /// Classify a thrown error into a cascade decision.
+    static func classify(_ error: Error) -> FailureClass {
+        if error is CancellationError { return .terminalForTurn }
+
+        if let local = error as? LocalLLMError {
+            switch local {
+            case .promptTooLong: return .needsBiggerWindow
+            case .backgrounded: return .retryOtherModel   // a cloud candidate can still run
+            case .modelNotLoaded, .generationFailed, .alreadyGenerating, .alreadyDownloading:
+                return .retryOtherModel
+            }
+        }
+
+        if let llm = error as? LLMError {
+            switch llm {
+            case .missingAPIKey:
+                // Per-candidate: a missing/expired credential (incl. refreshed-OAuth failure,
+                // which surfaces here) kills only this provider — another may still work.
+                return .terminalForCandidate
+            case .invalidConfiguration:
+                return .terminalForTurn
+            case .invalidResponse, .streamInterrupted:
+                // Empty completion (P3) / mid-stream death — transient, try another model.
+                return .retryOtherModel
+            case .apiError(_, let status, _):
+                return classifyStatus(status)
+            }
+        }
+
+        // URLError timeouts / connectivity — transient, worth another model.
+        if let url = error as? URLError {
+            switch url.code {
+            case .timedOut, .networkConnectionLost, .cannotConnectToHost,
+                 .notConnectedToInternet, .dnsLookupFailed:
+                return .retryOtherModel
+            default:
+                return .retryOtherModel
+            }
+        }
+
+        // Unknown error — one more model is cheap; the attempt cap bounds it.
+        return .retryOtherModel
+    }
+
+    private static func classifyStatus(_ status: Int) -> FailureClass {
+        switch status {
+        case 429, 402, 408:            return .retryOtherModel        // rate-limit / quota / timeout
+        case 401, 403:                 return .terminalForCandidate   // auth — this provider only
+        case 400, 422:                 return .terminalForTurn        // malformed — fails everywhere
+        case 500...599:                return .retryOtherModel        // provider blip
+        default:                       return .retryOtherModel
+        }
+    }
+
+    // MARK: - Next candidate
+
+    /// What the turn requires of any candidate it hops to.
+    struct TurnNeeds: Equatable {
+        /// The turn carries an image — text-only models can't serve it.
+        let requiresVision: Bool
+        /// The app is backgrounded — on-device MLX models can't run.
+        let isBackgrounded: Bool
+    }
+
+    /// The next model to try after the current one failed, or `nil` when the chain is exhausted.
+    /// - `failure` gates whether we cascade at all (`.terminalForTurn` ⇒ `nil`) and, for
+    ///   `.needsBiggerWindow`, restricts to candidates with a larger window than `currentWindow`.
+    /// - `tried` are ids already attempted this turn (never retried).
+    static func next(
+        candidates: [Candidate],
+        tried: Set<String>,
+        needs: TurnNeeds,
+        failure: FailureClass,
+        currentWindow: Int
+    ) -> Candidate? {
+        guard failure != .terminalForTurn else { return nil }
+        return candidates.first { candidate in
+            guard !tried.contains(candidate.id) else { return false }
+            if needs.requiresVision && !candidate.supportsVision { return false }
+            if needs.isBackgrounded && candidate.isLocalMLX { return false }
+            if failure == .needsBiggerWindow && candidate.contextTokens <= currentWindow { return false }
+            return true
+        }
+    }
+
+    // MARK: - Candidate list from Config
+
+    /// Build the ordered cascade from the active model + a user-defined fallback order, de-duped.
+    /// The active model leads (it's already been chosen for the turn); `fallbackOrder` ids follow
+    /// in the user's cost/preference order; any remaining saved models trail so a cascade never
+    /// dead-ends while an untried model exists. Unknown ids in `fallbackOrder` are ignored.
+    ///
+    /// No foreground-hop / app-Shortcut providers exist in the current provider set, so every saved
+    /// model is a valid automatic candidate; if one is ever added it must be excluded here (it
+    /// would break hands-free operation — see the plan's guardrails).
+    static func candidates(
+        activeId: String,
+        saved: [ModelConfig],
+        fallbackOrder: [String]
+    ) -> [Candidate] {
+        let byId = Dictionary(saved.map { ($0.id, $0) }, uniquingKeysWith: { a, _ in a })
+        var orderedIds: [String] = []
+        var seen = Set<String>()
+        func push(_ id: String) {
+            guard byId[id] != nil, !seen.contains(id) else { return }
+            seen.insert(id); orderedIds.append(id)
+        }
+        push(activeId)
+        fallbackOrder.forEach(push)
+        saved.forEach { push($0.id) }
+        return orderedIds.compactMap { byId[$0] }.map(candidate(from:))
+    }
+
+    /// Map a saved model to a cascade candidate.
+    static func candidate(from config: ModelConfig) -> Candidate {
+        let provider = config.llmProvider
+        let isLocalMLX = provider == .local
+        let window = isLocalMLX
+            ? LocalModelBudget.contextWindow(for: config.model)
+            : cloudContextTokens
+        return Candidate(
+            id: config.id,
+            isLocalMLX: isLocalMLX,
+            supportsVision: config.visionEnabled,
+            contextTokens: window
+        )
+    }
+}
+
+/// Pure cascade driver (BK P2b): run one turn over an ordered candidate chain, hopping on a
+/// retry-worthy failure until a model succeeds or the chain is exhausted. The `attempt` closure
+/// runs the real provider call for a candidate; the driver owns only the retry/next/cap decisions,
+/// so it's unit-tested headlessly with fakes.
+enum ModelCascade {
+    /// - Parameters:
+    ///   - maxAttempts: hard cap on provider calls (bounds latency + token spend even on a long chain).
+    ///   - isCancelled: re-checked between hops so a barge-in during one hop doesn't launch the next.
+    ///   - onSwitch: invoked once per hop, *before* the retry (the P2c narration seam).
+    ///   - attempt: run the turn on this candidate; throws to trigger a hop.
+    /// - Returns: the first successful response.
+    /// - Throws: `CancellationError` on barge-in; otherwise the *last real* error when the chain is
+    ///   exhausted, the attempt cap is hit, or the failure is terminal for the turn.
+    static func run(
+        candidates: [ModelFallbackChain.Candidate],
+        needs: ModelFallbackChain.TurnNeeds,
+        maxAttempts: Int,
+        isCancelled: () -> Bool = { false },
+        onSwitch: (_ from: ModelFallbackChain.Candidate,
+                   _ to: ModelFallbackChain.Candidate,
+                   _ failure: ModelFallbackChain.FailureClass) async -> Void = { _, _, _ in },
+        attempt: (ModelFallbackChain.Candidate) async throws -> String
+    ) async throws -> String {
+        guard var current = candidates.first else {
+            throw LLMError.missingAPIKey("No model configured")
+        }
+        var tried = Set<String>()
+        var attempts = 0
+        while true {
+            attempts += 1
+            tried.insert(current.id)
+            do {
+                return try await attempt(current)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                // A barge-in between hops maps to cancellation (→ onCancelled), never a spoken error.
+                if isCancelled() { throw CancellationError() }
+                let failure = ModelFallbackChain.classify(error)
+                guard failure != .terminalForTurn, attempts < maxAttempts else { throw error }
+                guard let next = ModelFallbackChain.next(
+                    candidates: candidates, tried: tried, needs: needs,
+                    failure: failure, currentWindow: current.contextTokens
+                ) else { throw error }
+                await onSwitch(current, next, failure)
+                current = next
+            }
+        }
+    }
+}

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -283,6 +283,24 @@ struct Config {
 
     static func setAutoModelRoutingEnabled(_ enabled: Bool) { autoModelRoutingEnabled = enabled }
 
+    /// Whether a failed turn cascades to the next model instead of erroring (BK P2b). When on, a
+    /// `promptTooLong`/`429`/quota/empty-completion failure spills to the next candidate — the
+    /// stated cost preference: prefer the active (often local) model, fall over to cloud only when
+    /// it can't handle the turn. Default on.
+    @UserDefaultsBacked("modelCascadeEnabled", default: true) static var modelCascadeEnabled: Bool
+
+    static func setModelCascadeEnabled(_ enabled: Bool) { modelCascadeEnabled = enabled }
+
+    private static let modelFallbackOrderKey = "modelFallbackOrder"
+
+    /// User-ordered fallback model ids the cascade tries after the active model (cost preference:
+    /// local first, then progressively more capable/expensive cloud). Empty ⇒ the cascade falls
+    /// back on the remaining saved models in their existing order.
+    static var modelFallbackOrder: [String] {
+        get { UserDefaults.standard.stringArray(forKey: modelFallbackOrderKey) ?? [] }
+        set { UserDefaults.standard.set(newValue, forKey: modelFallbackOrderKey) }
+    }
+
     /// Get the model explicitly assigned to a tier by the user.
     /// Falls back to keyword-based auto-detection if no model is assigned.
     static func modelForTier(_ tier: ModelTier) -> ModelConfig? {

--- a/OpenGlassesTests/ModelCascadeTests.swift
+++ b/OpenGlassesTests/ModelCascadeTests.swift
@@ -1,0 +1,233 @@
+import XCTest
+@testable import OpenGlasses
+
+/// BK P2b — the model cascade. A turn walks an ordered candidate chain and only surfaces an error
+/// when every eligible candidate is exhausted. All pure/headless: error classification, next-hop
+/// selection, the candidate builder, and the driver loop over fake attempts.
+final class ModelCascadeTests: XCTestCase {
+
+    // MARK: - classify
+
+    func testPromptTooLongNeedsBiggerWindow() {
+        XCTAssertEqual(ModelFallbackChain.classify(LocalLLMError.promptTooLong(tokens: 5000, limit: 3456)),
+                       .needsBiggerWindow)
+    }
+
+    func testRateLimitAndQuotaRetryOtherModel() {
+        for status in [429, 402, 408, 500, 503] {
+            XCTAssertEqual(
+                ModelFallbackChain.classify(LLMError.apiError(provider: "x", statusCode: status, message: nil)),
+                .retryOtherModel, "status \(status) should hop to another model")
+        }
+    }
+
+    func testAuthErrorIsTerminalForCandidateOnly() {
+        for status in [401, 403] {
+            XCTAssertEqual(
+                ModelFallbackChain.classify(LLMError.apiError(provider: "x", statusCode: status, message: nil)),
+                .terminalForCandidate, "auth failure kills only this provider")
+        }
+    }
+
+    func testMalformedRequestIsTerminalForTurn() {
+        for status in [400, 422] {
+            XCTAssertEqual(
+                ModelFallbackChain.classify(LLMError.apiError(provider: "x", statusCode: status, message: nil)),
+                .terminalForTurn, "a malformed request fails identically everywhere")
+        }
+    }
+
+    func testMissingKeyIsPerCandidateAndInvalidConfigIsTerminal() {
+        XCTAssertEqual(ModelFallbackChain.classify(LLMError.missingAPIKey("no key")), .terminalForCandidate)
+        XCTAssertEqual(ModelFallbackChain.classify(LLMError.invalidConfiguration("bad")), .terminalForTurn)
+    }
+
+    func testEmptyCompletionAndBackgroundedRetryOtherModel() {
+        XCTAssertEqual(ModelFallbackChain.classify(LLMError.invalidResponse("Local")), .retryOtherModel)
+        XCTAssertEqual(ModelFallbackChain.classify(LocalLLMError.backgrounded), .retryOtherModel)
+    }
+
+    func testCancellationIsTerminalForTurn() {
+        XCTAssertEqual(ModelFallbackChain.classify(CancellationError()), .terminalForTurn)
+    }
+
+    // MARK: - next
+
+    private func cloud(_ id: String, vision: Bool = true) -> ModelFallbackChain.Candidate {
+        .init(id: id, isLocalMLX: false, supportsVision: vision, contextTokens: ModelFallbackChain.cloudContextTokens)
+    }
+    private func local(_ id: String, window: Int = 4096) -> ModelFallbackChain.Candidate {
+        .init(id: id, isLocalMLX: true, supportsVision: false, contextTokens: window)
+    }
+    private let anyTurn = ModelFallbackChain.TurnNeeds(requiresVision: false, isBackgrounded: false)
+
+    func testNextReturnsFirstUntriedEligible() {
+        let list = [local("a"), cloud("b")]
+        let next = ModelFallbackChain.next(candidates: list, tried: ["a"], needs: anyTurn,
+                                           failure: .retryOtherModel, currentWindow: 4096)
+        XCTAssertEqual(next?.id, "b")
+    }
+
+    func testNextSkipsLocalMLXWhenBackgrounded() {
+        let list = [local("a"), local("b"), cloud("c")]
+        let next = ModelFallbackChain.next(
+            candidates: list, tried: ["a"],
+            needs: .init(requiresVision: false, isBackgrounded: true),
+            failure: .retryOtherModel, currentWindow: 4096)
+        XCTAssertEqual(next?.id, "c", "backgrounded turn skips on-device MLX candidates")
+    }
+
+    func testNextSkipsTextOnlyForVisionTurn() {
+        let list = [cloud("a", vision: false), cloud("b", vision: true)]
+        let next = ModelFallbackChain.next(
+            candidates: list, tried: ["a"],
+            needs: .init(requiresVision: true, isBackgrounded: false),
+            failure: .retryOtherModel, currentWindow: ModelFallbackChain.cloudContextTokens)
+        XCTAssertEqual(next?.id, "b", "a vision turn skips text-only candidates")
+    }
+
+    func testNeedsBiggerWindowPicksALargerWindow() {
+        let list = [local("small", window: 4096), local("also-small", window: 4096), cloud("big")]
+        let next = ModelFallbackChain.next(candidates: list, tried: ["small"], needs: anyTurn,
+                                           failure: .needsBiggerWindow, currentWindow: 4096)
+        XCTAssertEqual(next?.id, "big", "overflow skips same-size windows and picks a bigger one")
+    }
+
+    func testTerminalForTurnHasNoNext() {
+        let list = [cloud("a"), cloud("b")]
+        XCTAssertNil(ModelFallbackChain.next(candidates: list, tried: ["a"], needs: anyTurn,
+                                             failure: .terminalForTurn, currentWindow: 0))
+    }
+
+    func testExhaustedChainHasNoNext() {
+        let list = [cloud("a"), cloud("b")]
+        XCTAssertNil(ModelFallbackChain.next(candidates: list, tried: ["a", "b"], needs: anyTurn,
+                                             failure: .retryOtherModel, currentWindow: 0))
+    }
+
+    // MARK: - candidate builder from Config
+
+    private func config(_ id: String, provider: LLMProvider, model: String = "m") -> ModelConfig {
+        ModelConfig(id: id, name: id, provider: provider.rawValue, apiKey: "k", model: model, baseURL: "")
+    }
+
+    func testCandidatesLeadWithActiveThenFallbackThenRest() {
+        let saved = [config("cloud1", provider: .anthropic),
+                     config("cloud2", provider: .openai),
+                     config("localm", provider: .local, model: "mlx-community/Qwen2.5-0.5B-Instruct-4bit")]
+        let chain = ModelFallbackChain.candidates(
+            activeId: "localm", saved: saved, fallbackOrder: ["cloud2"])
+        XCTAssertEqual(chain.map(\.id), ["localm", "cloud2", "cloud1"],
+                       "active leads, then user fallback order, then the remaining saved model")
+    }
+
+    func testCandidatesDedupeAndIgnoreUnknownIds() {
+        let saved = [config("a", provider: .anthropic), config("b", provider: .openai)]
+        let chain = ModelFallbackChain.candidates(
+            activeId: "a", saved: saved, fallbackOrder: ["a", "ghost", "b"])
+        XCTAssertEqual(chain.map(\.id), ["a", "b"], "duplicates and unknown ids are dropped")
+    }
+
+    func testLocalCandidateCarriesItsRealWindow() {
+        let saved = [config("localm", provider: .local, model: "mlx-community/Qwen2.5-0.5B-Instruct-4bit")]
+        let chain = ModelFallbackChain.candidates(activeId: "localm", saved: saved, fallbackOrder: [])
+        XCTAssertTrue(chain[0].isLocalMLX)
+        XCTAssertEqual(chain[0].contextTokens,
+                       LocalModelBudget.contextWindow(for: "mlx-community/Qwen2.5-0.5B-Instruct-4bit"))
+    }
+
+    // MARK: - driver
+
+    private func run(_ candidates: [ModelFallbackChain.Candidate],
+                     maxAttempts: Int = 4,
+                     isCancelled: @escaping () -> Bool = { false },
+                     attempt: @escaping (ModelFallbackChain.Candidate) async throws -> String)
+    async throws -> (String, [String]) {
+        var switches: [String] = []
+        let out = try await ModelCascade.run(
+            candidates: candidates, needs: anyTurn, maxAttempts: maxAttempts,
+            isCancelled: isCancelled,
+            onSwitch: { from, to, _ in switches.append("\(from.id)->\(to.id)") },
+            attempt: attempt)
+        return (out, switches)
+    }
+
+    func testFirstAttemptSuccessDoesNotHop() async throws {
+        let (out, switches) = try await run([cloud("a"), cloud("b")]) { _ in "ok" }
+        XCTAssertEqual(out, "ok")
+        XCTAssertTrue(switches.isEmpty)
+    }
+
+    func testHopsOnRateLimitThenSucceeds() async throws {
+        let (out, switches) = try await run([cloud("a"), cloud("b")]) { c in
+            if c.id == "a" { throw LLMError.apiError(provider: "a", statusCode: 429, message: nil) }
+            return "from-\(c.id)"
+        }
+        XCTAssertEqual(out, "from-b")
+        XCTAssertEqual(switches, ["a->b"])
+    }
+
+    func testExhaustedChainThrowsLastRealError() async {
+        do {
+            _ = try await run([cloud("a"), cloud("b")]) { c in
+                throw LLMError.apiError(provider: c.id, statusCode: 429, message: "rl-\(c.id)")
+            }
+            XCTFail("expected throw")
+        } catch let LLMError.apiError(_, _, message) {
+            XCTAssertEqual(message, "rl-b", "surfaces the LAST candidate's real error, not a generic line")
+        } catch { XCTFail("unexpected \(error)") }
+    }
+
+    func testAttemptCapIsHonoured() async {
+        var calls = 0
+        do {
+            _ = try await run([cloud("a"), cloud("b"), cloud("c"), cloud("d")], maxAttempts: 2) { _ in
+                calls += 1
+                throw LLMError.apiError(provider: "x", statusCode: 429, message: nil)
+            }
+            XCTFail("expected throw")
+        } catch { XCTAssertEqual(calls, 2, "stops at the attempt cap even with candidates left") }
+    }
+
+    func testTerminalForTurnDoesNotCascade() async {
+        var calls = 0
+        do {
+            _ = try await run([cloud("a"), cloud("b")]) { _ in
+                calls += 1
+                throw LLMError.invalidConfiguration("malformed")
+            }
+            XCTFail("expected throw")
+        } catch { XCTAssertEqual(calls, 1, "a turn-terminal failure never tries a second model") }
+    }
+
+    func testSingleCandidateMissingKeyThrows() async {
+        do {
+            _ = try await run([cloud("a")]) { _ in throw LLMError.missingAPIKey("no key") }
+            XCTFail("expected throw")
+        } catch let LLMError.missingAPIKey(msg) {
+            XCTAssertEqual(msg, "no key")
+        } catch { XCTFail("unexpected \(error)") }
+    }
+
+    func testMissingKeyHopsToNextCandidate() async throws {
+        let (out, switches) = try await run([cloud("a"), cloud("b")]) { c in
+            if c.id == "a" { throw LLMError.missingAPIKey("no key for a") }
+            return "from-\(c.id)"
+        }
+        XCTAssertEqual(out, "from-b", "a per-provider credential failure skips to the next model")
+        XCTAssertEqual(switches, ["a->b"])
+    }
+
+    func testCancellationBetweenHopsStopsChain() async {
+        var calls = 0
+        do {
+            _ = try await run([cloud("a"), cloud("b")], isCancelled: { calls >= 1 }) { _ in
+                calls += 1
+                throw LLMError.apiError(provider: "x", statusCode: 429, message: nil)
+            }
+            XCTFail("expected cancellation")
+        } catch is CancellationError {
+            XCTAssertEqual(calls, 1, "a barge-in after hop 1 must not launch hop 2")
+        } catch { XCTFail("unexpected \(error)") }
+    }
+}


### PR DESCRIPTION
## BK P2b — Model cascade / fallback chain

Adversarial-review remediation (Plan BK, phase P2b). Today a turn is **single-shot**: `ModelRoutingPolicy` picks one model, `ConversationTurnRunner` calls `send()` once, and any failure — `promptTooLong`, a `429`/quota, an empty completion — falls straight to *"Sorry, I encountered an error."* The intent to fall over was thrown away even though the rate-limit is perfectly distinguishable.

This walks an ordered candidate chain and only surfaces an error when **every eligible candidate is exhausted** — the stated cost preference: prefer the active (often local) model, spill to cloud when it can't serve the turn, spill to the next cloud when one hits its limit.

### Deterministic core (headless)
- **`ModelFallbackChain.classify(error)`** → `retryOtherModel` / `needsBiggerWindow` / `terminalForCandidate` / `terminalForTurn`. `promptTooLong` → bigger window; `429`/`402`/`408`/`5xx`/timeout/empty/interrupted → retry another model; `401`/`403`/`missingAPIKey` → skip this provider only (OAuth-expiry surfaces as `missingAPIKey`, so it's per-candidate, not chain-killing); `400`/`422`/`invalidConfiguration`/cancellation → terminal for the turn.
- **`next(...)`** picks the next untried eligible candidate, honouring capability filters (a vision turn skips text-only models), the **background rule** (skip on-device MLX when backgrounded), and the **bigger-window** requirement after an overflow.
- **`candidates(...)`** builds the chain: active model leads, then the user's `modelFallbackOrder`, then remaining saved models, de-duped; unknown ids ignored.
- **`ModelCascade.run`** drives the loop over fake-able attempts, caps attempts (`min(chain, 4)`), re-checks cancellation between hops, and throws the **last real error** on exhaustion.

### Live wiring
- **`LLMService.sendMessageCascading`** wraps `sendMessage`: swaps the active model per hop and rewinds `conversationHistory` to its pre-turn snapshot so a failed hop leaves no dangling/duplicated turn; always restores the active model on exit (transparent to the caller's own switch/restore bookkeeping). Single-candidate or cascade-off falls straight through to one `sendMessage`.
- Wired into the **voice** and **typed** send paths, plus a **local-agent → cloud spill** (the primary "prefer local, fall over to cloud" case).
- `onModelSwitch` is the seam **P2c** fills with an audible "switching model" notice; today the hop is logged and the partial UI stream is reset.
- `Config.modelCascadeEnabled` (default **on**) + `modelFallbackOrder`.

### Scope
**P2c** (audible model-switch narration) remains the follow-up phase — the hook is in place, no narration yet. Usage/cost tracking per attempt (Plan AU) rides on each `sendMessage` call unchanged.

### Tests
`ModelCascadeTests` (24): classify matrix, next-hop capability/background/window filters, candidate builder ordering + dedupe, driver hop-then-succeed / exhaust-throws-last-error / attempt-cap / terminal-no-cascade / missing-key-hops / cancel-between-hops. Adjacent LLM/model suites + Release build green (Xcode 27 sim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)