### PR TITLE
Off-main audio-session activation: seam + serialization (BJ PR1)

### DIFF
--- a/OpenGlasses/Sources/Services/Audio/AudioSessionActivator.swift
+++ b/OpenGlasses/Sources/Services/Audio/AudioSessionActivator.swift
@@ -17,11 +17,11 @@ enum AudioSessionActivator {
     ///   use it for non-fatal hints like `setPreferredSampleRate` (call them with `try?` inside;
     ///   a rejected hint must not abort activation).
     static func activate(
-        _ session: AVAudioSession,
+        _ session: AudioSessionConforming,
         category: AVAudioSession.Category,
         mode: AVAudioSession.Mode,
         options: AVAudioSession.CategoryOptions,
-        configure: (AVAudioSession) -> Void = { _ in }
+        configure: (AudioSessionConforming) -> Void = { _ in }
     ) throws {
         // Clear any stale active route first so a pending route change doesn't block activation.
         try? session.setActive(false, options: .notifyOthersOnDeactivation)
@@ -29,14 +29,14 @@ enum AudioSessionActivator {
         do {
             try session.setCategory(category, mode: mode, options: options)
             configure(session)
-            try session.setActive(true)
+            try session.setActive(true, options: [])
         } catch {
             NSLog("[Audio] Preferred session config failed (mode %@): %@ — retrying with .default",
                   mode.rawValue, error.localizedDescription)
             do {
                 try session.setCategory(category, mode: .default, options: [.defaultToSpeaker])
                 configure(session)
-                try session.setActive(true)
+                try session.setActive(true, options: [])
                 NSLog("[Audio] Activated with fallback (.default)")
             } catch {
                 throw AudioSessionError.activationFailed(error.localizedDescription)

--- a/OpenGlasses/Sources/Services/Audio/AudioSessionConforming.swift
+++ b/OpenGlasses/Sources/Services/Audio/AudioSessionConforming.swift
@@ -1,0 +1,30 @@
+import AVFoundation
+
+/// The slice of `AVAudioSession` the activator/coordinator touch, behind a protocol seam (BJ PR1).
+///
+/// Before this, `AudioSessionActivator` took a concrete `AVAudioSession` and the coordinator
+/// hard-wired `AVAudioSession.sharedInstance()`, so neither was unit-testable — the activation
+/// order, the fallback behaviour, and the release race could only be reasoned about, never asserted.
+/// A recording fake conforming to this protocol drives all of that headlessly (no live session).
+///
+/// `AVAudioSession` already implements every method with a matching signature, so its conformance
+/// is automatic apart from the `currentRoutePortTypes` projection (the full `currentRoute`
+/// description has no public initialiser, so we expose the port-type list a fake *can* construct —
+/// which is all `AudioRoutePolicy` consumes anyway).
+protocol AudioSessionConforming: AnyObject {
+    func setCategory(_ category: AVAudioSession.Category,
+                     mode: AVAudioSession.Mode,
+                     options: AVAudioSession.CategoryOptions) throws
+    func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws
+    func overrideOutputAudioPort(_ port: AVAudioSession.PortOverride) throws
+    func setPreferredSampleRate(_ sampleRate: Double) throws
+    func setPreferredIOBufferDuration(_ duration: TimeInterval) throws
+    /// Input + output port types of the current route (the subset `AudioRoutePolicy` needs).
+    var currentRoutePortTypes: [AVAudioSession.Port] { get }
+}
+
+extension AVAudioSession: AudioSessionConforming {
+    var currentRoutePortTypes: [AVAudioSession.Port] {
+        currentRoute.inputs.map(\.portType) + currentRoute.outputs.map(\.portType)
+    }
+}

--- a/OpenGlasses/Sources/Services/Audio/AudioSessionCoordinator.swift
+++ b/OpenGlasses/Sources/Services/Audio/AudioSessionCoordinator.swift
@@ -11,15 +11,37 @@ import Foundation
 /// this type adds the serial-queue safety and the real activation/deactivation.
 ///
 /// Activation goes through `AudioSessionActivator`, so the preferred → `.default` fallback and
-/// deactivate-first-to-clear-a-stale-route behaviour are unchanged.
+/// deactivate-first-to-clear-a-stale-route behaviour of the *acquire* path are unchanged.
+///
+/// **BJ PR1 — off-main activation.** Synchronous `setActive` on the main thread can stall the UI on
+/// an `AVAudioSession` route change (worst on the Bluetooth glasses path). Two additions close that,
+/// without changing any existing behaviour:
+///  - **One serial `sessionIOQueue` for both activation and deactivation** (total order). The
+///    deactivation block re-checks the ledger first, so a superseded deactivation becomes a no-op
+///    instead of tearing the session out from under a newer owner (this *closes* the prior
+///    `deactivationQueue`-vs-`acquire` race, it doesn't copy it).
+///  - **`acquireOffMain` / `reconfigure`** run activation on that queue and are awaited, so a
+///    main-actor caller hands off the blocking work. `reconfigure` re-tunes the already-active
+///    session in place with **no deactivate-first and no fallback**, so a subsystem's hand-tuned
+///    options (wake word's `mixWithOthers`) are never silently swapped.
+///
+/// The session is injected (`AudioSessionConforming`) so tests drive a fake; production uses
+/// `.shared`, which binds `AVAudioSession.sharedInstance()`.
 final class AudioSessionCoordinator: @unchecked Sendable {
     static let shared = AudioSessionCoordinator()
 
     private let stateQueue = DispatchQueue(label: "audio.session.coordinator.state")
-    private let deactivationQueue = DispatchQueue(label: "audio.session.coordinator.deactivation", qos: .userInitiated)
+    /// BJ PR1 — one serial queue for BOTH activation and deactivation, so their order is total.
+    /// Internal (not private) so a test can block it and drive the release race deterministically.
+    let sessionIOQueue = DispatchQueue(label: "audio.session.coordinator.io", qos: .userInitiated)
     private var ledger = AudioSessionLedger()
+    private let session: AudioSessionConforming
 
-    private init() {}
+    private init() { self.session = AVAudioSession.sharedInstance() }
+
+    /// Test seam — inject a fake session. Never `.shared` in tests (the AVAudioSession/Wearables
+    /// house rule: tests use fresh instances, never the shared singleton).
+    init(session: AudioSessionConforming) { self.session = session }
 
     /// The owner currently recognised as holding the shared session, or `nil` if it's free.
     var currentOwner: AudioSessionOwner? {
@@ -62,9 +84,11 @@ final class AudioSessionCoordinator: @unchecked Sendable {
         return lease
     }
 
-    /// Acquire the shared session for `owner`, configuring and activating it. Supersedes any prior
-    /// holder. On activation failure the lease is rolled back (so a failed acquire never leaves the
-    /// caller recorded as owner) and the error is rethrown.
+    /// Acquire the shared session for `owner`, configuring and activating it **on the caller's
+    /// thread**. Supersedes any prior holder. On activation failure the lease is rolled back (so a
+    /// failed acquire never leaves the caller recorded as owner) and the error is rethrown.
+    ///
+    /// For callers already off the main thread. Main-actor callers should prefer `acquireOffMain`.
     ///
     /// - Parameter configure: run after `setCategory` and before `setActive` — for non-fatal hints
     ///   like `setPreferredSampleRate` (call them with `try?` inside).
@@ -74,13 +98,13 @@ final class AudioSessionCoordinator: @unchecked Sendable {
         category: AVAudioSession.Category,
         mode: AVAudioSession.Mode,
         options: AVAudioSession.CategoryOptions,
-        configure: (AVAudioSession) -> Void = { _ in }
+        configure: (AudioSessionConforming) -> Void = { _ in }
     ) throws -> AudioSessionLease {
         let token = UUID()
         let lease = stateQueue.sync { ledger.acquire(owner, token: token).lease }
         do {
             try AudioSessionActivator.activate(
-                AVAudioSession.sharedInstance(),
+                session,
                 category: category,
                 mode: mode,
                 options: options,
@@ -89,23 +113,75 @@ final class AudioSessionCoordinator: @unchecked Sendable {
             NSLog("[AudioCoordinator] acquired by %@", owner.rawValue)
             return lease
         } catch {
-            // Roll the lease back if it's still ours so a failed acquire doesn't leave us "owner".
-            stateQueue.sync {
-                if ledger.current == lease { _ = ledger.release(lease) }
-            }
+            rollBack(lease)
             throw error
         }
     }
 
+    /// Like `acquire`, but performs the (potentially blocking) activation on `sessionIOQueue`
+    /// instead of the caller's thread, so a main-actor caller never stalls the UI on an
+    /// `AVAudioSession` route change. Supersedes any prior holder; rolls the lease back on failure.
+    @discardableResult
+    func acquireOffMain(
+        _ owner: AudioSessionOwner,
+        category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions,
+        configure: @escaping (AudioSessionConforming) -> Void = { _ in }
+    ) async throws -> AudioSessionLease {
+        let token = UUID()
+        let lease = stateQueue.sync { ledger.acquire(owner, token: token).lease }
+        do {
+            try await runOnSessionIO {
+                try AudioSessionActivator.activate(
+                    self.session, category: category, mode: mode, options: options, configure: configure)
+            }
+            NSLog("[AudioCoordinator] acquired off-main by %@", owner.rawValue)
+            return lease
+        } catch {
+            rollBack(lease)
+            throw error
+        }
+    }
+
+    /// Re-tune the **already-active** session in place: `setCategory` → optional hints → `setActive`,
+    /// on `sessionIOQueue`, with **no deactivate-first and no fallback**. For subsystems that adjust
+    /// their own live session (wake word pause/resume/configure) and must not have the session torn
+    /// down or their hand-tuned options silently swapped to `.default`. A transient failure surfaces
+    /// to the caller. Ownership is unchanged — the caller already owns (or self-owns) the session.
+    func reconfigure(
+        category: AVAudioSession.Category,
+        mode: AVAudioSession.Mode,
+        options: AVAudioSession.CategoryOptions,
+        configure: @escaping (AudioSessionConforming) -> Void = { _ in }
+    ) async throws {
+        try await runOnSessionIO {
+            try self.session.setCategory(category, mode: mode, options: options)
+            configure(self.session)
+            try self.session.setActive(true, options: [])
+        }
+    }
+
     /// Release `lease`. Deactivates the shared session only if `lease` is still the current owner;
-    /// a stale release (a newer owner has acquired since) is ignored.
+    /// a stale release (a newer owner has acquired since) is ignored. The deactivation runs on
+    /// `sessionIOQueue` and **re-checks the ledger** immediately before `setActive(false)`, so a
+    /// deactivation that was queued before a newer owner acquired becomes a no-op (BJ PR1).
     func release(_ lease: AudioSessionLease) {
         let decision = stateQueue.sync { ledger.release(lease) }
         switch decision {
         case .deactivate:
-            deactivationQueue.async {
+            sessionIOQueue.async { [self] in
+                // Re-check under the state lock: if a newer owner acquired the session between the
+                // release decision and this block running, do NOT deactivate — that would kill the
+                // live session out from under them (the race the single queue + this guard close).
+                let stillFree = stateQueue.sync { ledger.current == nil }
+                guard stillFree else {
+                    NSLog("[AudioCoordinator] deactivate suppressed — re-acquired since %@ released",
+                          lease.owner.rawValue)
+                    return
+                }
                 do {
-                    try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+                    try session.setActive(false, options: .notifyOthersOnDeactivation)
                     NSLog("[AudioCoordinator] deactivated (released by %@)", lease.owner.rawValue)
                 } catch {
                     NSLog("[AudioCoordinator] deactivate failed (%@): %@", lease.owner.rawValue, error.localizedDescription)
@@ -115,6 +191,35 @@ final class AudioSessionCoordinator: @unchecked Sendable {
             NSLog("[AudioCoordinator] stale release ignored: %@ superseded by %@", lease.owner.rawValue, by.rawValue)
         case .alreadyReleased:
             break
+        }
+    }
+
+    /// Await all currently-queued activation/deactivation to finish. With async activation the
+    /// ledger can report owner X *before* X's `setActive(true)` has actually run; callers that
+    /// consult ownership to decide audio routing (wake-word interruption handling, expert-call
+    /// precedence) await this so they act on reality, not a pending intention.
+    func activationSettled() async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            sessionIOQueue.async { cont.resume() }
+        }
+    }
+
+    // MARK: - Private
+
+    /// Roll a lease back if it's still current (a failed activation must not leave the caller owner).
+    private func rollBack(_ lease: AudioSessionLease) {
+        stateQueue.sync {
+            if ledger.current == lease { _ = ledger.release(lease) }
+        }
+    }
+
+    /// Run blocking session I/O on the single serial `sessionIOQueue`, bridged to `async`.
+    private func runOnSessionIO(_ work: @escaping () throws -> Void) async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            sessionIOQueue.async {
+                do { try work(); cont.resume() }
+                catch { cont.resume(throwing: error) }
+            }
         }
     }
 }

--- a/OpenGlassesTests/AudioSessionCoordinatorTests.swift
+++ b/OpenGlassesTests/AudioSessionCoordinatorTests.swift
@@ -1,0 +1,136 @@
+import AVFoundation
+import XCTest
+@testable import OpenGlasses
+
+/// BJ PR1 — the off-main activation seam. A recording `AudioSessionConforming` fake drives the
+/// coordinator with no live `AVAudioSession`, so the activation order, the failure rollback, the
+/// no-deactivate/no-fallback `reconfigure` contract, and the superseded-deactivation race are
+/// asserted rather than reasoned about.
+final class AudioSessionCoordinatorTests: XCTestCase {
+
+    /// Records every session call in order, plus the thread each `setActive` ran on. Injectable
+    /// failures for `setCategory` / activation.
+    final class FakeAudioSession: AudioSessionConforming, @unchecked Sendable {
+        private let lock = NSLock()
+        private(set) var calls: [String] = []
+        private(set) var categories: [(AVAudioSession.Category, AVAudioSession.Mode, AVAudioSession.CategoryOptions)] = []
+        private(set) var setActiveOnMainThread: [Bool] = []
+        var currentRoutePortTypes: [AVAudioSession.Port] = []
+
+        var setCategoryError: Error?
+        /// Thrown from `setActive(true, …)` only (an activation failure).
+        var activateError: Error?
+
+        private func record(_ s: String) { lock.lock(); calls.append(s); lock.unlock() }
+
+        func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode,
+                         options: AVAudioSession.CategoryOptions) throws {
+            record("setCategory")
+            lock.lock(); categories.append((category, mode, options)); lock.unlock()
+            if let setCategoryError { throw setCategoryError }
+        }
+        func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+            record("setActive(\(active))")
+            lock.lock(); setActiveOnMainThread.append(Thread.isMainThread); lock.unlock()
+            if active, let activateError { throw activateError }
+        }
+        func overrideOutputAudioPort(_ port: AVAudioSession.PortOverride) throws { record("override") }
+        func setPreferredSampleRate(_ sampleRate: Double) throws { record("rate") }
+        func setPreferredIOBufferDuration(_ duration: TimeInterval) throws { record("buffer") }
+
+        var containsDeactivate: Bool { lock.lock(); defer { lock.unlock() }; return calls.contains("setActive(false)") }
+    }
+
+    // MARK: - Activation runs off the caller's (main) thread
+
+    @MainActor
+    func testAcquireOffMainRunsActivationOffTheMainThread() async throws {
+        let fake = FakeAudioSession()
+        let coord = AudioSessionCoordinator(session: fake)
+        _ = try await coord.acquireOffMain(.transcription, category: .playAndRecord, mode: .default, options: [])
+        XCTAssertFalse(fake.setActiveOnMainThread.isEmpty, "activation happened")
+        XCTAssertTrue(fake.setActiveOnMainThread.allSatisfy { $0 == false },
+                      "all setActive calls run on sessionIOQueue, never the main (caller) thread")
+    }
+
+    // MARK: - setCategory before setActive; verbatim passthrough
+
+    func testAcquireConfiguresCategoryBeforeActivatingAndPassesArgsVerbatim() throws {
+        let fake = FakeAudioSession()
+        let coord = AudioSessionCoordinator(session: fake)
+        _ = try coord.acquire(.wakeWord, category: .record, mode: .measurement, options: [.mixWithOthers])
+        // Order: deactivate-first (from the activator's stale-route clear), setCategory, setActive.
+        XCTAssertEqual(fake.calls, ["setActive(false)", "setCategory", "setActive(true)"])
+        let (cat, mode, opts) = try XCTUnwrap(fake.categories.first)
+        XCTAssertEqual(cat, .record)
+        XCTAssertEqual(mode, .measurement)
+        XCTAssertEqual(opts, [.mixWithOthers])
+    }
+
+    // MARK: - Failed activation rolls the lease back through the coordinator
+
+    func testFailedActivationRollsLeaseBack() async {
+        let fake = FakeAudioSession()
+        fake.activateError = AudioSessionError.activationFailed("nope")
+        let coord = AudioSessionCoordinator(session: fake)
+        do {
+            _ = try await coord.acquireOffMain(.geminiLive, category: .playAndRecord, mode: .voiceChat, options: [])
+            XCTFail("expected activation to throw")
+        } catch {
+            XCTAssertNil(coord.currentOwner, "a failed acquire must not leave the caller recorded as owner")
+        }
+    }
+
+    // MARK: - reconfigure: no deactivate-first, no fallback
+
+    func testReconfigureNeverDeactivatesFirst() async throws {
+        let fake = FakeAudioSession()
+        let coord = AudioSessionCoordinator(session: fake)
+        try await coord.reconfigure(category: .playAndRecord, mode: .default, options: [.mixWithOthers])
+        XCTAssertEqual(fake.calls, ["setCategory", "setActive(true)"],
+                       "reconfigure re-tunes in place: no deactivate-first, just setCategory then setActive")
+    }
+
+    func testReconfigureDoesNotFallBackToDefaultOnFailure() async {
+        let fake = FakeAudioSession()
+        fake.setCategoryError = AudioSessionError.activationFailed("route busy")
+        let coord = AudioSessionCoordinator(session: fake)
+        do {
+            try await coord.reconfigure(category: .playAndRecord, mode: .voiceChat, options: [.allowBluetoothHFP])
+            XCTFail("expected the failure to surface")
+        } catch {
+            XCTAssertEqual(fake.calls, ["setCategory"],
+                           "no silent .default fallback — a single attempt, then the error surfaces")
+        }
+    }
+
+    // MARK: - Superseded deactivation is suppressed (the race)
+
+    func testSupersededDeactivationIsSuppressed() async {
+        let fake = FakeAudioSession()
+        let coord = AudioSessionCoordinator(session: fake)
+
+        let a = coord.assumeOwnership(.wakeWord)          // A owns (self-activated, no session call)
+        let gate = DispatchSemaphore(value: 0)
+        coord.sessionIOQueue.async { gate.wait() }        // hold the IO queue so ordering is deterministic
+        coord.release(a)                                  // queues A's deactivation behind the held block
+        _ = coord.assumeOwnership(.geminiLive)            // B acquires before the deactivation can run
+        gate.signal()                                     // let the IO queue drain
+        await coord.activationSettled()                   // wait for the (suppressed) deactivation block
+
+        XCTAssertFalse(fake.containsDeactivate,
+                       "a deactivation superseded by a newer owner must not tear down the live session")
+        XCTAssertEqual(coord.currentOwner, .geminiLive)
+    }
+
+    /// Sanity: an un-superseded release *does* deactivate.
+    func testUnsupersededReleaseDeactivates() async {
+        let fake = FakeAudioSession()
+        let coord = AudioSessionCoordinator(session: fake)
+        let a = coord.assumeOwnership(.wakeWord)
+        coord.release(a)
+        await coord.activationSettled()
+        XCTAssertTrue(fake.containsDeactivate, "the sole owner's release deactivates the session")
+        XCTAssertNil(coord.currentOwner)
+    }
+}


### PR DESCRIPTION
## BJ PR1 — the seam + serialization (deterministic, headless)

Plan BJ, PR1 of 2. Synchronous `AVAudioSession` activation on the main thread can stall the UI on a route change — worst on the Bluetooth glasses path, which is exactly where Xcode's Thread Performance Checker flags hang-risk. This PR builds the testable foundation and closes an existing race; **PR2 wires the ~11 call sites** and is gated on an on-glasses smoke test.

Before this, neither `AudioSessionActivator` (concrete `AVAudioSession`, no seam) nor `AudioSessionCoordinator` (hard-wired `.sharedInstance()`) was unit-testable — the activation order, the failure rollback, and the release race could only be reasoned about.

### What's here
- **`AudioSessionConforming`** — the slice of `AVAudioSession` the activator/coordinator touch, adopted by `AVAudioSession` (plus a `currentRoutePortTypes` projection, since the full `currentRoute` description has no public initialiser). Injected into both types; production binds `.shared`, tests drive a recording fake (never `.shared`, per the house rule).
- **One serial `sessionIOQueue` for both activation and deactivation** (Correction 1). The deactivation block **re-checks the ledger** and no-ops if a newer owner acquired since the release was queued — this *closes* the prior `deactivationQueue`-vs-`acquire` race (a delayed deactivation could otherwise kill a newer owner's live session mid-conversation) rather than copying it.
- **`acquireOffMain(...)`** runs activation on that queue and is awaited, so a main-actor caller hands off the blocking work. Sync `acquire` stays for already-off-main callers (realtime).
- **`reconfigure(...)`** re-tunes the already-active session in place with **no deactivate-first and no `.default` fallback** (Correction 2) — wake word's hand-tuned `mixWithOthers` options are never silently swapped and the live session is never torn down.
- **`activationSettled()`** barrier — with async activation the ledger can report owner X before X's `setActive(true)` has run; callers that consult ownership for routing await this to see reality.

**No behaviour change** to the existing acquire/release paths or to categories/options/modes.

### Tests
`AudioSessionCoordinatorTests` (7) via a recording fake: off-main activation (never the caller's main thread), `setCategory`-before-`setActive` + verbatim arg passthrough, failed-activation rollback **through the coordinator**, `reconfigure` no-deactivate-first / no-fallback (both directions), and the **superseded-deactivation race** driven deterministically by holding `sessionIOQueue`. Existing `AudioSessionLedger`/`AudioSessionError`/`ExpertCallAudioCoordinator` suites stay green; full Release build green (Xcode 27 sim).

### Follow-up (not this PR)
- **PR2** async-ifies the WakeWordService / TTS / LiveTranslation / Transcription call sites through `reconfigure`/`acquireOffMain` — a breaking change to named seams (`ConversationStartSequence.Deps`, TTS pause/stop, `returnToWakeWord` ordering), gated on the on-glasses smoke test + scoped TPC check.
- Realtime-manager activation stays out of scope (deliberate main-hop from Plan AP); it's **Plan BO**, sequenced after PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)