### PR TITLE
Route audio-session activation off-main at the call sites (BJ PR2 core)

### DIFF
--- a/OpenGlasses/Sources/App/CarPlaySceneDelegate.swift
+++ b/OpenGlasses/Sources/App/CarPlaySceneDelegate.swift
@@ -168,7 +168,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         Task { @MainActor in
             guard let appState = AppStateProvider.shared else { return }
             appState.wakeWordService.carPlayMode = true
-            appState.wakeWordService.reconfigureAudioSession()
+            await appState.wakeWordService.reconfigureAudioSession()
             appState.wakeWordService.stopListening()
             try? await Task.sleep(nanoseconds: 100_000_000)
             await appState.handleWakeWordDetected()
@@ -186,7 +186,7 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
         Task { @MainActor in
             guard let appState = AppStateProvider.shared else { return }
             appState.speechService.stopSpeaking()
-            appState.wakeWordService.deactivateAudioSession()
+            await appState.wakeWordService.deactivateAudioSession()
             appState.isListening = false
             appState.inConversation = false
         }

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -324,7 +324,7 @@ struct OpenGlassesApp: App {
                         if !appState.wakeWordService.isListening && !appState.isListening && appState.isConnected && !appState.micMuted && !Config.silentMode {
                             print("🎤 Restarting wake word listener after foreground...")
                             // Re-configure audio session in case Bluetooth route changed
-                            appState.wakeWordService.reconfigureAudioSessionIfNeeded()
+                            await appState.wakeWordService.reconfigureAudioSessionIfNeeded()
                             // Small delay for route to stabilize after foregrounding
                             try? await Task.sleep(nanoseconds: 500_000_000)
                             try? await appState.wakeWordService.startListening()
@@ -423,7 +423,7 @@ class AppState: ObservableObject, AppStateProtocol {
                     // Let the Bluetooth audio link settle before grabbing the mic.
                     try? await Task.sleep(nanoseconds: 2_500_000_000)
                     guard self.isConnected else { return }  // bail if it dropped again
-                    self.wakeWordService.reconfigureAudioSessionIfNeeded()
+                    await self.wakeWordService.reconfigureAudioSessionIfNeeded()
                     if self.listeningEnabled && !self.isListening {
                         try? await self.wakeWordService.startListening()
                     }
@@ -1755,7 +1755,7 @@ class AppState: ObservableObject, AppStateProtocol {
             speechService.stopSpeaking()
             liveActivityManager.end()
             // Release any audio pause held by an in-flight conversation so Music/Podcasts resume.
-            wakeWordService.forceResumeOtherAudio()
+            Task { await wakeWordService.forceResumeOtherAudio() }
             isListening = false
             NSLog("[Listening] Disabled")
         }
@@ -2286,7 +2286,7 @@ class AppState: ObservableObject, AppStateProtocol {
         print("🎤 Action Button: starting direct transcription (no wake word)")
         Task {
             // Configure audio (uses glasses mic if connected, phone mic otherwise)
-            wakeWordService.configureAudioSession()
+            await wakeWordService.configureAudioSession()
             // manual: true — this is an explicit user trigger (Action Button / Siri / tap),
             // so the reply speaks through the phone speaker even with no glasses connected.
             await handleWakeWordDetected(manual: true)
@@ -2311,11 +2311,11 @@ class AppState: ObservableObject, AppStateProtocol {
         // The engine-before-listening ordering lives (tested) in ConversationStartSequence.
         await ConversationStartSequence.run(.init(
             beginConversation: { [self] in inConversation = true },
-            configureAudioSession: { [self] in wakeWordService.configureAudioSession() },
+            configureAudioSession: { [self] in await wakeWordService.configureAudioSession() },
             ensureAudioEngineRunning: { [self] in try await wakeWordService.ensureAudioEngineRunning() },
             markListening: { [self] in isListening = true },
             snapshotNowPlaying: { [self] in nowPlayingAtStart = NowPlayingSnapshot.current() },
-            pauseOtherAudio: { [self] in wakeWordService.pauseOtherAudio() },
+            pauseOtherAudio: { [self] in await wakeWordService.pauseOtherAudio() },
             playAcknowledgmentTone: { [self] in speechService.playAcknowledgmentTone() },
             startRecording: { [self] in transcriptionService.startRecording() },
             updateLiveActivity: { [self] in updateLiveActivity() }
@@ -3459,7 +3459,7 @@ class AppState: ObservableObject, AppStateProtocol {
         // Resume podcasts/music after active listening
         let resumedMedia = nowPlayingAtStart
         nowPlayingAtStart = nil
-        wakeWordService.resumeOtherAudio()
+        await wakeWordService.resumeOtherAudio()
         speechService.playDisconnectTone()
         // Announce what's resuming (e.g. "Resuming Hardcore History by Dan Carlin")
         if let media = resumedMedia {

--- a/OpenGlasses/Sources/Services/Audio/AudioSessionCoordinator.swift
+++ b/OpenGlasses/Sources/Services/Audio/AudioSessionCoordinator.swift
@@ -153,12 +153,30 @@ final class AudioSessionCoordinator: @unchecked Sendable {
         category: AVAudioSession.Category,
         mode: AVAudioSession.Mode,
         options: AVAudioSession.CategoryOptions,
+        activeOptions: AVAudioSession.SetActiveOptions = [],
         configure: @escaping (AudioSessionConforming) -> Void = { _ in }
     ) async throws {
         try await runOnSessionIO {
             try self.session.setCategory(category, mode: mode, options: options)
             configure(self.session)
-            try self.session.setActive(true, options: [])
+            try self.session.setActive(true, options: activeOptions)
+        }
+    }
+
+    /// Ensure the shared session is active, on `sessionIOQueue`, without changing its category or
+    /// ownership (BJ PR2). For a coexisting rider (TTS playback) whose `AVAudioPlayer.play()` would
+    /// otherwise *implicitly* activate the session on the main thread when no exclusive owner has
+    /// activated it (CarPlay / call-active, where wake word's pause early-returns). `setActive(true)`
+    /// is idempotent when already active.
+    func ensureActiveOffMain() async {
+        try? await runOnSessionIO { try self.session.setActive(true, options: []) }
+    }
+
+    /// Deactivate the shared session off-main when there is no lease to `release` (a rare fallback —
+    /// wake word normally holds a lease). Prefer `release(_:)`, which also honours ownership.
+    func deactivateOffMain() async {
+        try? await runOnSessionIO {
+            try self.session.setActive(false, options: .notifyOthersOnDeactivation)
         }
     }
 

--- a/OpenGlasses/Sources/Services/Flow/ConversationStartSequence.swift
+++ b/OpenGlasses/Sources/Services/Flow/ConversationStartSequence.swift
@@ -15,8 +15,9 @@ enum ConversationStartSequence {
     struct Deps {
         /// Mark the conversation active (`inConversation = true`).
         let beginConversation: @MainActor () -> Void
-        /// Configure the shared audio session for recording.
-        let configureAudioSession: @MainActor () -> Void
+        /// Configure the shared audio session for recording. Async since BJ PR2 — the blocking
+        /// activation now runs off-main through the coordinator.
+        let configureAudioSession: @MainActor () async -> Void
         /// Bring the shared audio engine up. Failure must not abort the start — the
         /// transcription path has its own fallback engine.
         let ensureAudioEngineRunning: @MainActor () async throws -> Void
@@ -25,7 +26,8 @@ enum ConversationStartSequence {
         /// Snapshot what's playing before pausing it.
         let snapshotNowPlaying: @MainActor () -> Void
         /// Pause podcasts/music so the user can speak clearly (skips if call in progress).
-        let pauseOtherAudio: @MainActor () -> Void
+        /// Async since BJ PR2 (off-main session reconfigure).
+        let pauseOtherAudio: @MainActor () async -> Void
         /// Play the acknowledgment tone.
         let playAcknowledgmentTone: @MainActor () -> Void
         /// Start transcribing the user's turn.
@@ -38,11 +40,11 @@ enum ConversationStartSequence {
     static func run(_ deps: Deps) async {
         deps.beginConversation()
         // Audio session + engine BEFORE marking ourselves as listening (see type comment).
-        deps.configureAudioSession()
+        await deps.configureAudioSession()
         try? await deps.ensureAudioEngineRunning()
         deps.markListening()
         deps.snapshotNowPlaying()
-        deps.pauseOtherAudio()
+        await deps.pauseOtherAudio()
         deps.playAcknowledgmentTone()
         deps.startRecording()
         deps.updateLiveActivity()

--- a/OpenGlasses/Sources/Services/TextToSpeechService.swift
+++ b/OpenGlasses/Sources/Services/TextToSpeechService.swift
@@ -107,21 +107,23 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
     /// own the mic), so it registers as non-exclusive — never preempting or deactivating the session.
     private var coexistToken: UUID?
 
-    private func beginPause() {
+    private func beginPause() async {
         guard !didHoldPause else { return }
-        wakeWordService?.pauseOtherAudio()
+        didHoldPause = true   // set before the await so a concurrent beginPause can't double-hold
+        await wakeWordService?.pauseOtherAudio()
         coexistToken = AudioSessionCoordinator.shared.beginCoexisting(.textToSpeech)
-        didHoldPause = true
     }
 
-    private func endPause() {
+    private func endPause() async {
         guard didHoldPause else { return }
         didHoldPause = false
         if let token = coexistToken {
             coexistToken = nil
             AudioSessionCoordinator.shared.endCoexisting(token)
         }
-        wakeWordService?.resumeOtherAudio()
+        // BJ PR2: await the resume so a teardown (barge-in / stopSpeaking) doesn't return before
+        // other audio is actually restored (was fire-and-forget).
+        await wakeWordService?.resumeOtherAudio()
     }
 
     // MARK: - Public API
@@ -208,7 +210,7 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
         }
 
         isSpeaking = true
-        beginPause()
+        await beginPause()
 
         // Wrap the actual speech work in a trackable task
         let task = Task { @MainActor [weak self] in
@@ -226,7 +228,7 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
         // Only clear isSpeaking if this generation is still current
         if gen == speechGeneration {
             isSpeaking = false
-            endPause()
+            await endPause()
             print("🔊 TTS: Finished speaking")
         }
     }
@@ -349,7 +351,9 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
         audioPlayer = nil
         synthesizer.stopSpeaking(at: .immediate)
         isSpeaking = false
-        endPause()
+        // BJ PR2: the immediate teardown above stays synchronous (barge-in must stop *now*); the
+        // resume-other-audio is inherently off-main now, so dispatch it without blocking the stop.
+        Task { await endPause() }
         speechContinuation?.resume()
         speechContinuation = nil
     }
@@ -612,6 +616,11 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
         let player = try AVAudioPlayer(data: data)
         self.audioPlayer = player
         player.prepareToPlay()
+
+        // BJ PR2: ensure the session is active off-main *before* play(), which would otherwise
+        // implicitly activate it on the main thread when no exclusive owner has (CarPlay / call-active,
+        // where wake word's pause early-returns). Idempotent when already active.
+        await AudioSessionCoordinator.shared.ensureActiveOffMain()
 
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             self.speechContinuation = continuation

--- a/OpenGlasses/Sources/Services/WakeWordService.swift
+++ b/OpenGlasses/Sources/Services/WakeWordService.swift
@@ -105,9 +105,9 @@ class WakeWordService: NSObject, ObservableObject {
     }
 
     /// Force reconfigure audio session (e.g. when mic source changes)
-    func reconfigureAudioSession() {
+    func reconfigureAudioSession() async {
         audioSessionConfigured = false
-        configureAudioSession()
+        await configureAudioSession()
     }
 
     /// Pause other audio (podcasts, music) while actively listening.
@@ -119,7 +119,7 @@ class WakeWordService: NSObject, ObservableObject {
     /// whole interaction and only resume after everything finishes.
     private var pauseHoldCount: Int = 0
 
-    func pauseOtherAudio() {
+    func pauseOtherAudio() async {
         guard !carPlayMode else { return }
         // Never interrupt an active phone or FaceTime call
         let callObserver = CXCallObserver()
@@ -128,12 +128,13 @@ class WakeWordService: NSObject, ObservableObject {
             print("🎤 Active call detected — skipping audio pause")
             return
         }
+        // BJ PR2: mutate the refcount synchronously *before* the first await, so nested
+        // beginPause/endPause still nest cleanly across the suspension point below.
         pauseHoldCount += 1
         guard pauseHoldCount == 1 else {
             print("🎤 Audio already paused (hold count \(pauseHoldCount))")
             return
         }
-        let session = AVAudioSession.sharedInstance()
         let useGlassesMic = Config.useGlassesMicForWakeWord
         // Omitting mixWithOthers/duckOthers causes iOS to interrupt (pause) other audio apps
         let options: AVAudioSession.CategoryOptions = useGlassesMic
@@ -142,10 +143,13 @@ class WakeWordService: NSObject, ObservableObject {
         // .default (NOT .measurement): .measurement disables system audio processing/gain,
         // which makes TTS playback extremely quiet on the iPhone speaker. The wake-word /
         // command capture works fine in .default (see resumeOtherAudio, which already does this).
-        try? session.setCategory(.playAndRecord, mode: .default, options: options)
-        try? session.setActive(true)
-        // Belt-and-suspenders: when not on a Bluetooth (glasses) route, force the main
-        // speaker so playback never ends up stuck on the receiver/earpiece.
+        // BJ PR2: the blocking setCategory→setActive runs off-main through the coordinator's
+        // `reconfigure` (no deactivate-first, no fallback — the hand-tuned options are preserved).
+        try? await AudioSessionCoordinator.shared.reconfigure(
+            category: .playAndRecord, mode: .default, options: options)
+        // Cheap, non-blocking route hints stay inline (they are not the TPC hang source — the
+        // blocking activation above is what moved off-main).
+        let session = AVAudioSession.sharedInstance()
         let onBluetooth = session.currentRoute.outputs.contains {
             [.bluetoothHFP, .bluetoothA2DP, .bluetoothLE].contains($0.portType)
         }
@@ -157,15 +161,15 @@ class WakeWordService: NSObject, ObservableObject {
 
     /// Restore other audio (podcasts, music) after active listening ends.
     /// The .notifyOthersOnDeactivation flag tells paused apps to resume.
-    func resumeOtherAudio() {
+    func resumeOtherAudio() async {
         guard !carPlayMode else { return }
         guard pauseHoldCount > 0 else { return }
+        // BJ PR2: decrement synchronously before any await (see pauseOtherAudio).
         pauseHoldCount -= 1
         guard pauseHoldCount == 0 else {
             print("🎤 Audio still held by \(pauseHoldCount) other holder(s) — not resuming yet")
             return
         }
-        let session = AVAudioSession.sharedInstance()
         let useGlassesMic = Config.useGlassesMicForWakeWord
         let options: AVAudioSession.CategoryOptions = useGlassesMic
             ? [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
@@ -173,17 +177,18 @@ class WakeWordService: NSObject, ObservableObject {
         // .default (not .measurement) so concurrent music/podcasts keep playing cleanly
         // while the wake-word listener runs — .measurement disables system audio
         // processing and fights other audio even with .mixWithOthers.
-        try? session.setCategory(.playAndRecord, mode: .default, options: options)
         // notifyOthersOnDeactivation tells paused apps (Music, Podcasts) they can resume.
-        try? session.setActive(true, options: .notifyOthersOnDeactivation)
+        try? await AudioSessionCoordinator.shared.reconfigure(
+            category: .playAndRecord, mode: .default, options: options,
+            activeOptions: .notifyOthersOnDeactivation)
         print("🎤 Restored audio mix — other apps can resume")
     }
 
     /// Force release of any held pauses — used when listening is toggled off entirely.
-    func forceResumeOtherAudio() {
+    func forceResumeOtherAudio() async {
         guard pauseHoldCount > 0 else { return }
         pauseHoldCount = 1  // resumeOtherAudio will decrement to 0 and restore
-        resumeOtherAudio()
+        await resumeOtherAudio()
     }
 
     /// When "use glasses mic" is on, explicitly prefer a Bluetooth input belonging to the
@@ -208,54 +213,68 @@ class WakeWordService: NSObject, ObservableObject {
         }
     }
 
-    /// Configure the shared audio session once — call before first use
-    func configureAudioSession() {
+    /// Configure the shared audio session once — call before first use.
+    ///
+    /// BJ PR2: records baseline ownership (`assumeOwnership`) then activates **off-main** through the
+    /// coordinator's `reconfigure` (no deactivate-first, no `.default` fallback — the hand-tuned
+    /// `mixWithOthers` options must survive). `assumeOwnership` is deliberately kept rather than
+    /// retired: wake word must not deactivate-first, so `acquireOffMain` (which does) is wrong here —
+    /// ownership is recorded and the activation runs through the no-deactivate `reconfigure`.
+    func configureAudioSession() async {
         guard !audioSessionConfigured else { return }
+        // Register as the baseline owner first (supersedes any prior lease); the reconfigure below
+        // performs the real activation while keeping the tuned config.
+        sessionLease = AudioSessionCoordinator.shared.assumeOwnership(.wakeWord)
+
+        let category: AVAudioSession.Category = .playAndRecord
+        let mode: AVAudioSession.Mode
+        let options: AVAudioSession.CategoryOptions
+        if carPlayMode {
+            // In CarPlay mode, only activate recording when explicitly requested (voice control
+            // template showing). Otherwise use playback-only to avoid disrupting car audio.
+            mode = .voiceChat
+            options = [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
+        } else {
+            let useGlassesMic = Config.useGlassesMicForWakeWord
+            // .default (not .measurement) so other audio coexists cleanly with the always-on
+            // listener — see resumeOtherAudio for the same rationale.
+            mode = .default
+            options = useGlassesMic
+                ? [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
+                : [.mixWithOthers, .defaultToSpeaker]
+        }
+
         do {
-            let audioSession = AVAudioSession.sharedInstance()
-
-            // In CarPlay mode, only activate recording when explicitly requested
-            // (voice control template showing). Otherwise use playback-only to
-            // avoid disrupting car audio.
-            if carPlayMode {
-                try audioSession.setCategory(.playAndRecord, mode: .voiceChat, options: [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker])
-                try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
-                audioSessionConfigured = true
-                print("🎤 CarPlay mode: .playAndRecord + .voiceChat (voice control active)")
-            } else {
-                let useGlassesMic = Config.useGlassesMicForWakeWord
-                let options: AVAudioSession.CategoryOptions = useGlassesMic
-                    ? [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
-                    : [.mixWithOthers, .defaultToSpeaker]
-                // .default (not .measurement) so other audio coexists cleanly with the
-                // always-on listener — see resumeOtherAudio for the same rationale.
-                try audioSession.setCategory(.playAndRecord, mode: .default, options: options)
-                try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
-                preferGlassesMicIfAvailable(audioSession)
-                audioSessionConfigured = true
-                print("🎤 Mic source: \(useGlassesMic ? "glasses (Bluetooth)" : "phone (built-in)")")
-            }
-
-            // Register as the baseline owner. We self-activated above (keeping the tuned
-            // mixWithOthers config), so this only records ownership; it supersedes any prior lease.
-            sessionLease = AudioSessionCoordinator.shared.assumeOwnership(.wakeWord)
-
-            let route = audioSession.currentRoute
-            for input in route.inputs {
-                print("🎤 Audio input: \(input.portName) (\(input.portType.rawValue))")
-            }
-            for output in route.outputs {
-                print("🔊 Audio output: \(output.portName) (\(output.portType.rawValue))")
-            }
-            print("🎤 Audio session configured: .playAndRecord with Bluetooth")
-
-            // Handle audio interruptions + route changes. Tokens are owned and removed before any
-            // re-registration (Plan BE) — the old code discarded them, leaking a fresh pair on
-            // every reconfigure so one route change fired N duplicate handlers after N reconnects.
-            installSessionObservers(audioSession: audioSession)
+            try await AudioSessionCoordinator.shared.reconfigure(
+                category: category, mode: mode, options: options,
+                activeOptions: .notifyOthersOnDeactivation)
         } catch {
             print("🎤 Failed to configure audio session: \(error)")
+            return
         }
+        audioSessionConfigured = true
+
+        let audioSession = AVAudioSession.sharedInstance()
+        if carPlayMode {
+            print("🎤 CarPlay mode: .playAndRecord + .voiceChat (voice control active)")
+        } else {
+            preferGlassesMicIfAvailable(audioSession)
+            print("🎤 Mic source: \(Config.useGlassesMicForWakeWord ? "glasses (Bluetooth)" : "phone (built-in)")")
+        }
+
+        let route = audioSession.currentRoute
+        for input in route.inputs {
+            print("🎤 Audio input: \(input.portName) (\(input.portType.rawValue))")
+        }
+        for output in route.outputs {
+            print("🔊 Audio output: \(output.portName) (\(output.portType.rawValue))")
+        }
+        print("🎤 Audio session configured: .playAndRecord with Bluetooth")
+
+        // Handle audio interruptions + route changes. Tokens are owned and removed before any
+        // re-registration (Plan BE) — the old code discarded them, leaking a fresh pair on
+        // every reconfigure so one route change fired N duplicate handlers after N reconnects.
+        installSessionObservers(audioSession: audioSession)
     }
 
     /// Register the interruption + route-change observers exactly once per configuration, removing
@@ -304,8 +323,12 @@ class WakeWordService: NSObject, ObservableObject {
             let hasBluetooth = route.inputs.contains { $0.portType == .bluetoothHFP }
             if hasBluetooth {
                 print("🎤 Audio interruption ended — restarting listener (Bluetooth active)")
-                try? AVAudioSession.sharedInstance().setActive(true)
-                Task { try? await startListening() }
+                // BJ PR2: reactivate off-main through the coordinator (was a main-thread setActive),
+                // then restart — one Task so the reactivate precedes the listener start.
+                Task {
+                    await AudioSessionCoordinator.shared.ensureActiveOffMain()
+                    try? await startListening()
+                }
             } else {
                 print("🎤 Audio interruption ended — NOT restarting (no Bluetooth)")
             }
@@ -346,7 +369,7 @@ class WakeWordService: NSObject, ObservableObject {
                 Task {
                     try? await Task.sleep(nanoseconds: 500_000_000)
                     audioSessionConfigured = false
-                    configureAudioSession()
+                    await configureAudioSession()
                     try? await startListening()
                 }
             } else {
@@ -396,7 +419,7 @@ class WakeWordService: NSObject, ObservableObject {
         }
 
         // Ensure audio session is configured
-        configureAudioSession()
+        await configureAudioSession()
 
         // Retry up to 3 times with increasing delay if audio engine fails
         var lastError: Error?
@@ -424,23 +447,21 @@ class WakeWordService: NSObject, ObservableObject {
 
     /// Fully deactivate the audio session — use when CarPlay voice control is dismissed
     /// so car audio (FM radio, other apps) can resume.
-    func deactivateAudioSession() {
+    func deactivateAudioSession() async {
         cleanupAudioEngine()
         isListening = false
         audioSessionConfigured = false
         if let lease = sessionLease {
             // Release through the coordinator: it deactivates only if wake word is still the
             // current owner, so this can't tear down a live Gemini/OpenAI session that preempted us.
+            // The deactivation itself runs off-main on the coordinator's sessionIOQueue (BJ PR1).
             sessionLease = nil
             AudioSessionCoordinator.shared.release(lease)
             print("🎤 Audio session released (CarPlay voice ended)")
         } else {
-            do {
-                try AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-                print("🎤 Audio session deactivated (CarPlay voice ended)")
-            } catch {
-                print("🎤 Failed to deactivate audio session: \(error)")
-            }
+            // BJ PR2: rare no-lease fallback — deactivate off-main via the coordinator too.
+            await AudioSessionCoordinator.shared.deactivateOffMain()
+            print("🎤 Audio session deactivated (CarPlay voice ended)")
         }
     }
 
@@ -814,7 +835,7 @@ class WakeWordService: NSObject, ObservableObject {
 
     /// Re-configure audio session if Bluetooth route changed (glasses disconnect/reconnect)
     /// Call this before startListening() when recovering from background or route change
-    func reconfigureAudioSessionIfNeeded() {
+    func reconfigureAudioSessionIfNeeded() async {
         let route = AVAudioSession.sharedInstance().currentRoute
         let hasBluetooth = route.inputs.contains { $0.portType == .bluetoothHFP } ||
                            route.outputs.contains { $0.portType == .bluetoothHFP || $0.portType == .bluetoothA2DP }
@@ -836,7 +857,7 @@ class WakeWordService: NSObject, ObservableObject {
 
         // Force reconfigure to pick up new route
         audioSessionConfigured = false
-        configureAudioSession()
+        await configureAudioSession()
     }
 
     private func restartRecognition() {

--- a/docs/plans/BJ-audio-activation-offmain.md
+++ b/docs/plans/BJ-audio-activation-offmain.md
@@ -98,6 +98,17 @@ lease back **through the coordinator** (today that invariant is only tested at t
 
 ## PR2 — wiring the call sites (thin edge — device-verified)
 
+**Status:** 🚧 Core wiring in draft PR — WakeWordService (pause/resume/configure/interruption/
+deactivate) + TextToSpeechService (beginPause/endPause + main speech player) + `ConversationStartSequence.Deps`
++ CarPlay/App callers routed through the coordinator; compiles + headless suites + Release green.
+**Two adjustments from the plan letter:** (1) `assumeOwnership` is **kept, not retired** — wake word
+must not deactivate-first, so it records ownership then activates through the no-deactivate
+`reconfigure` (rather than `acquireOffMain`, which deactivates first). (2) `stopSpeaking` stays
+**synchronous** (barge-in must stop *now*); only its resume-other-audio is dispatched off-main, so it
+doesn't ripple async to ~12 teardown callers. Deferred to a small follow-up (independent leaves that
+own their own session): **`LiveTranslationService` + `TranscriptionService` fallback** engine starts.
+On-glasses smoke test gates merge.
+
 - `WakeWordService.pauseOtherAudio` / `resumeOtherAudio` / `configureAudioSession` become `async`
   and route through `reconfigure` with the **identical** category/mode/options. The `:307`
   interruption-ended path and `:439` deactivation fallback route through the coordinator too;


### PR DESCRIPTION
## BJ PR2 (core) — wiring the call sites · **DRAFT, on-glasses smoke test gates merge**

Wires the app's hottest audio paths through the BJ PR1 coordinator so the blocking `setCategory`→`setActive` runs on `sessionIOQueue`, off the main thread (the Thread Performance Checker hang-risk, worst on the Bluetooth glasses route). **No behaviour change** to categories/modes/options — each call site keeps its exact flags.

Opened as a **draft**: per the plan, audio ordering / route changes / interruption recovery cannot be validated without Ray-Ban hardware, so this needs your on-glasses smoke test before merge. It compiles + all affected headless suites + Release are green.

### WakeWordService
- `pauseOtherAudio` / `resumeOtherAudio` / `configureAudioSession` / `reconfigureAudioSession[IfNeeded]` / `deactivateAudioSession` are now `async` and route the blocking activation through the coordinator's `reconfigure` (**no deactivate-first, no `.default` fallback** — the hand-tuned `mixWithOthers` options survive). Cheap non-blocking route hints (speaker override, preferred input) stay inline.
- `pauseHoldCount` is mutated **synchronously before the first await**, so nested begin/end still nest.
- Interruption-ended reactivation and the no-lease deactivate fallback go through the coordinator (`ensureActiveOffMain` / `deactivateOffMain`).

### TextToSpeechService
- `beginPause`/`endPause` are `async` (await the off-main pause/resume). The main speech player awaits `ensureActiveOffMain()` before `play()` — the site reachable without a prior activation in CarPlay / call-active.

### Two deliberate adjustments from the plan letter
1. **`assumeOwnership` is kept, not retired.** Wake word must not deactivate-first, so `acquireOffMain` (which does) is wrong; it records ownership then activates through the no-deactivate `reconfigure`.
2. **`stopSpeaking` stays synchronous** — barge-in must stop *now*. Only its resume-other-audio is dispatched off-main, so it doesn't ripple `async` to the ~12 teardown callers (which never awaited the resume before anyway).

### Seams updated
`ConversationStartSequence.Deps` types `configureAudioSession`/`pauseOtherAudio` as `async` (the sync test recorders satisfy the async closure type unchanged); `returnToWakeWord`, CarPlay start/stop, foreground/reconnect restart, and `startDirectTranscription` await the configure. Coordinator gains `reconfigure(activeOptions:)`, `ensureActiveOffMain`, `deactivateOffMain`.

### Deferred (small follow-up)
`LiveTranslationService` + `TranscriptionService` fallback engine starts — independent leaves that own their own session; each needs its own async chain + its own smoke check. Their TPC warnings remain until then.

### Smoke test (required before merge)
Wake word start, tap-to-talk, TTS playback, pause-and-resume-other-audio (music → ask → resumes, tone/speech order intact), a Bluetooth route change mid-session, live translation loop, and a phone-call interruption recovery. Scoped TPC check: WakeWordService/TTS hang-risk warnings gone; LiveTranslation/Transcription + realtime warnings expected to remain (tracked as follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)