### PR TITLE
Plan BA: device-metadata firmware gate + broadcast negative finding

### DIFF
--- a/docs/plans/BA-android-port.md
+++ b/docs/plans/BA-android-port.md
@@ -140,6 +140,14 @@ equivalent of `.claude/rules/dat-conventions.md` during Phase 0:
   SCO connect, PCM16 mono @ 24 kHz (OpenAI-Realtime-native), `AudioRecord`/`AudioTrack`. The reference uses
   the legacy `startBluetoothSco()`; on API 31+ prefer `setCommunicationDevice(TYPE_BLE_HEADSET)`. This is the
   Android face of the iOS LE-Audio mic-routing gotcha — budget the same care here.
+- **Device observables + firmware gate:** `Wearables.devices` (`Flow<Set<DeviceIdentifier>>`) and
+  `Wearables.registrationState` are Flows to collect, and per-device
+  `Wearables.devicesMetadata[id]` streams name + a `DeviceCompatibility` — surface
+  `DEVICE_UPDATE_REQUIRED` as a "glasses firmware needs an update" prompt in Phase 0/1, or connect
+  failures look like SDK bugs. (No iOS equivalent in our bridge today; it's a new-but-cheap UX row.)
+- **Broadcast has no answer here:** the worked example's open code contains no RTMP stack (its
+  advertised platform streaming isn't in the published source) — the Phase-4 RTMP-library choice
+  for the HaishinKit port remains an open question, not a solved one.
 
 ### Reusable patterns (not code — MIT app as a worked example)
 


### PR DESCRIPTION
Two small additions to the **Verified DAT-Android API shape** section of [BA-android-port.md](https://github.com/straff2002/OpenGlasses/blob/claude/ba-dat-android-metadata/docs/plans/BA-android-port.md), from a re-read of the worked example the section is based on:

- **Device observables + firmware gate:** `Wearables.devices` / `Wearables.registrationState` are Flows, and per-device `Wearables.devicesMetadata[id]` streams a `DeviceCompatibility` — `DEVICE_UPDATE_REQUIRED` must surface as a "glasses firmware needs an update" prompt in Phase 0/1, or connect failures masquerade as SDK bugs. New-but-cheap UX row with no iOS-bridge equivalent.
- **Broadcast negative finding:** the worked example's published source contains no RTMP stack, so the Phase-4 RTMP-library choice for the HaishinKit port remains an open question rather than a solved one.

Doc-only change; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)