### PR TITLE
Off-main activation: LiveTranslation + Transcription fallback (BJ PR2 leaves)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -3081,7 +3081,7 @@ class AppState: ObservableObject, AppStateProtocol {
                 return await self.videoRecorder.stopRecording()?.lastPathComponent
             },
             startTranslation: { [weak self] source, target in
-                self?.liveTranslation.start(from: source ?? "auto", to: target ?? "en")
+                Task { await self?.liveTranslation.start(from: source ?? "auto", to: target ?? "en") }
             },
             stopTranslation: { [weak self] in
                 self?.liveTranslation.stop()

--- a/OpenGlasses/Sources/Services/LiveTranslationService.swift
+++ b/OpenGlasses/Sources/Services/LiveTranslationService.swift
@@ -33,7 +33,7 @@ final class LiveTranslationService: ObservableObject {
 
     // MARK: - Start/Stop
 
-    func start(from source: String = "auto", to target: String = "en") {
+    func start(from source: String = "auto", to target: String = "en") async {
         guard !isActive else { return }
         sourceLanguage = source
         targetLanguage = target
@@ -56,7 +56,7 @@ final class LiveTranslationService: ObservableObject {
         translationCount = 0
         lastTranslatedText = ""
 
-        startListening()
+        await startListening()
         coexistToken = AudioSessionCoordinator.shared.beginCoexisting(.liveTranslation)
         print("🌍 Live translation started: \(source) → \(target)")
     }
@@ -80,9 +80,8 @@ final class LiveTranslationService: ObservableObject {
 
     // MARK: - Speech Recognition
 
-    private func startListening() {
+    private func startListening() async {
         // Configure audio session based on mic source preference
-        let audioSession = AVAudioSession.sharedInstance()
         do {
             let usePhoneMic = Config.usePhoneMicForTranslation
             let options: AVAudioSession.CategoryOptions = usePhoneMic
@@ -92,8 +91,9 @@ final class LiveTranslationService: ObservableObject {
             // shared session in a state the owner didn't choose. .measurement disables output
             // processing and makes iPhone-speaker TTS extremely quiet, and it was never restored on
             // stop. .default matches the wake-word baseline so audio coexists cleanly.
-            try audioSession.setCategory(.playAndRecord, mode: .default, options: options)
-            try audioSession.setActive(true)
+            // BJ PR2 follow-up: the blocking setCategory→setActive runs off-main via the coordinator.
+            try await AudioSessionCoordinator.shared.reconfigure(
+                category: .playAndRecord, mode: .default, options: options)
             print("🌍 Translation mic source: \(usePhoneMic ? "iPhone" : "glasses (Bluetooth)")")
         } catch {
             print("⚠️ LiveTranslation: audio session error: \(error)")
@@ -150,7 +150,7 @@ final class LiveTranslationService: ObservableObject {
         Task {
             try? await Task.sleep(nanoseconds: 300_000_000)
             if isActive {
-                startListening()
+                await startListening()
             }
         }
     }

--- a/OpenGlasses/Sources/Services/NativeTools/LiveTranslationTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/LiveTranslationTool.swift
@@ -43,9 +43,7 @@ struct LiveTranslationTool: NativeTool {
             if await MainActor.run(body: { service.isActive }) {
                 return "Live translation is already running. Say 'stop translating' to end it."
             }
-            await MainActor.run {
-                service.start(from: source, to: target)
-            }
+            await service.start(from: source, to: target)
             let sourceName = languageName(source)
             let targetName = languageName(target)
             return "Live translation started: \(sourceName) → \(targetName). I'll translate speech as I hear it. Say 'stop translating' when you're done."
@@ -75,7 +73,7 @@ struct LiveTranslationTool: NativeTool {
         case "set_language", "language", "set":
             if await MainActor.run(body: { service.isActive }) {
                 await MainActor.run { service.stop() }
-                await MainActor.run { service.start(from: source, to: target) }
+                await service.start(from: source, to: target)
                 return "Switched to \(languageName(source)) → \(languageName(target))."
             }
             return "Translation isn't running. Start it first with the new languages."

--- a/OpenGlasses/Sources/Services/TranscriptionService.swift
+++ b/OpenGlasses/Sources/Services/TranscriptionService.swift
@@ -58,14 +58,20 @@ class TranscriptionService: ObservableObject {
                                                availability: availability) == .onDevice
         accumulatedSamples.removeAll(keepingCapacity: true)
 
-        do {
-            try setupAndStartRecording()
-            isRecording = true
-            print("🎙️ Recording started...")
-            startNoSpeechTimer()
-        } catch {
-            print("🎙️ Recording setup failed: \(error)")
-            errorMessage = error.localizedDescription
+        // BJ PR2 follow-up: the fallback engine start may activate the shared session off the main
+        // thread now, so setup is async. Keep `startRecording()` synchronous (its ~8 callers are
+        // unchanged): mark recording optimistically, run setup on the next tick, roll back on failure.
+        isRecording = true
+        Task { @MainActor in
+            do {
+                try await setupAndStartRecording()
+                print("🎙️ Recording started...")
+                startNoSpeechTimer()
+            } catch {
+                print("🎙️ Recording setup failed: \(error)")
+                errorMessage = error.localizedDescription
+                isRecording = false
+            }
         }
     }
 
@@ -110,9 +116,9 @@ class TranscriptionService: ObservableObject {
         }
     }
 
-    private func setupAndStartRecording() throws {
+    private func setupAndStartRecording() async throws {
         if useOnDevice {
-            try setupOnDeviceCapture()
+            try await setupOnDeviceCapture()
             return
         }
 
@@ -145,6 +151,9 @@ class TranscriptionService: ObservableObject {
                 self?.recognitionRequest?.append(buffer)
             }
 
+            // BJ PR2 follow-up: activate the shared session off-main before the engine starts, so
+            // the (usually-already-active) activation never blocks the main thread. Idempotent.
+            await AudioSessionCoordinator.shared.ensureActiveOffMain()
             audioEngine.prepare()
             try audioEngine.start()
             self.fallbackAudioEngine = audioEngine
@@ -173,7 +182,7 @@ class TranscriptionService: ObservableObject {
     // MARK: - On-device capture (SenseVoice)
 
     /// Accumulate the utterance's mono float samples (the recognizer resamples to 16 kHz on decode).
-    private func setupOnDeviceCapture() throws {
+    private func setupOnDeviceCapture() async throws {
         let accumulate: @Sendable (AVAudioPCMBuffer) -> Void = { [weak self] buffer in
             guard let channels = buffer.floatChannelData, buffer.frameLength > 0 else { return }
             let samples = Array(UnsafeBufferPointer(start: channels[0], count: Int(buffer.frameLength)))
@@ -199,6 +208,8 @@ class TranscriptionService: ObservableObject {
             let inputNode = audioEngine.inputNode
             let format = inputNode.outputFormat(forBus: 0)
             inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in accumulate(buffer) }
+            // BJ PR2 follow-up: activate off-main before the engine starts (see setupAndStartRecording).
+            await AudioSessionCoordinator.shared.ensureActiveOffMain()
             audioEngine.prepare()
             try audioEngine.start()
             self.fallbackAudioEngine = audioEngine

--- a/docs/plans/BJ-audio-activation-offmain.md
+++ b/docs/plans/BJ-audio-activation-offmain.md
@@ -98,16 +98,16 @@ lease back **through the coordinator** (today that invariant is only tested at t
 
 ## PR2 — wiring the call sites (thin edge — device-verified)
 
-**Status:** 🚧 Core wiring in draft PR — WakeWordService (pause/resume/configure/interruption/
-deactivate) + TextToSpeechService (beginPause/endPause + main speech player) + `ConversationStartSequence.Deps`
-+ CarPlay/App callers routed through the coordinator; compiles + headless suites + Release green.
-**Two adjustments from the plan letter:** (1) `assumeOwnership` is **kept, not retired** — wake word
-must not deactivate-first, so it records ownership then activates through the no-deactivate
-`reconfigure` (rather than `acquireOffMain`, which deactivates first). (2) `stopSpeaking` stays
-**synchronous** (barge-in must stop *now*); only its resume-other-audio is dispatched off-main, so it
-doesn't ripple async to ~12 teardown callers. Deferred to a small follow-up (independent leaves that
-own their own session): **`LiveTranslationService` + `TranscriptionService` fallback** engine starts.
-On-glasses smoke test gates merge.
+**Status:** 🚧 Wiring shipped — core ([#220](https://github.com/straff2002/OpenGlasses/pull/220)):
+WakeWordService (pause/resume/configure/interruption/deactivate) + TextToSpeechService
+(beginPause/endPause + main speech player) + `ConversationStartSequence.Deps` + CarPlay/App callers;
+leaves ([#222](https://github.com/straff2002/OpenGlasses/pull/222)): `LiveTranslationService` +
+`TranscriptionService` fallback. Compiles + headless suites + Release green; **on-glasses smoke test
+gates merge**. **Two adjustments from the plan letter:** (1) `assumeOwnership` is **kept, not
+retired** — wake word must not deactivate-first, so it records ownership then activates through the
+no-deactivate `reconfigure` (rather than `acquireOffMain`, which deactivates first). (2) `stopSpeaking`
+stays **synchronous** (barge-in must stop *now*); only its resume-other-audio is dispatched off-main,
+so it doesn't ripple async to ~12 teardown callers.
 
 - `WakeWordService.pauseOtherAudio` / `resumeOtherAudio` / `configureAudioSession` become `async`
   and route through `reconfigure` with the **identical** category/mode/options. The `:307`


### PR DESCRIPTION
## BJ PR2 leaves — the two deferred sites · **DRAFT, on-glasses smoke test gates merge**

Finishes the audio-session inventory the [PR2 core (#220)](https://github.com/straff2002/OpenGlasses/pull/220) deferred. Both are independent leaves — each owns its own session, so neither shares the WakeWord/TTS async coupling. **No behaviour change** to categories/modes/options.

Draft for the same reason as #220: the audio behaviour (translation loop, fallback engine start) can't be validated without Ray-Ban hardware. Compiles + headless audio suites + Release green.

### LiveTranslationService
`startListening`'s `setCategory`→`setActive` now runs **off-main** via the coordinator's `reconfigure` (identical category/mode/options). `start`/`startListening`/`restartListening` are `async`; the `startTranslation` See/Act closure wraps it in a `Task` (fire-and-forget, matching the "start translating" command semantics) and `LiveTranslationTool` awaits the now-async `start` directly.

### TranscriptionService
The two fallback `engine.start()` sites — reached only when the shared WakeWord engine is absent — activate the session **off-main** via `ensureActiveOffMain()` before starting. `startRecording()` keeps its **synchronous signature** (its ~8 callers are unchanged): the now-async setup runs in a `Task` and `isRecording` flips optimistically (rolled back on failure). In the common flow the session is already active by the time transcription starts, so the pre-activation is idempotent.

### Smoke test (shares BJ PR2's session)
Live-translation start/stop/switch-language loop; a transcription turn where the shared engine is unavailable (fallback path). Scoped TPC check: LiveTranslation/Transcription-attributed hang-risk warnings gone. Realtime-attributed warnings remain (Plan BO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)