### PR TITLE
Fix concurrency + cleanup warnings; quiet Xcode recommended-settings prompt

### DIFF
--- a/OpenGlasses/Sources/Services/LocalServerScanner.swift
+++ b/OpenGlasses/Sources/Services/LocalServerScanner.swift
@@ -61,8 +61,11 @@ final class LocalServerScanner {
     /// endpoint resolution is device-validated).
     private func browseHosts(for seconds: TimeInterval) async -> [String] {
         await withCheckedContinuation { (continuation: CheckedContinuation<[String], Never>) in
-            var hosts = Set<String>()
-            var resumed = false
+            // The NWBrowser handlers are `@Sendable` and the timeout closure is passed to
+            // `asyncAfter`, so the shared browse state must be data-race-free (a hard error under
+            // the Swift 6 language mode). A lock-guarded collector confines `hosts` + the
+            // resume-once flag; browser teardown hops back to the main actor.
+            let collector = HostCollector()
             let browser = NWBrowser(for: .bonjour(type: "_http._tcp", domain: nil), using: .tcp)
             self.browser = browser
 
@@ -70,17 +73,18 @@ final class LocalServerScanner {
                 for result in results {
                     if case let .service(name, _, _, _) = result.endpoint {
                         let host = name.hasSuffix(".local") ? name : "\(name).local"
-                        hosts.insert(host)
+                        collector.insert(host)
                     }
                 }
             }
 
-            let finish: () -> Void = { [weak self] in
-                guard !resumed else { return }
-                resumed = true
-                self?.browser?.cancel()
-                self?.browser = nil
-                continuation.resume(returning: Array(hosts))
+            let finish: @Sendable () -> Void = { [weak self] in
+                guard collector.claimFinish() else { return }
+                Task { @MainActor in
+                    self?.browser?.cancel()
+                    self?.browser = nil
+                }
+                continuation.resume(returning: collector.snapshot())
             }
 
             browser.stateUpdateHandler = { state in
@@ -89,5 +93,32 @@ final class LocalServerScanner {
             browser.start(queue: .main)
             DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: finish)
         }
+    }
+}
+
+/// Data-race-free accumulator for a Bonjour browse: the browser's `@Sendable` handlers and the
+/// timeout closure can run on different threads, so the discovered hosts and the resume-once flag
+/// live behind a lock rather than as captured `var`s.
+private final class HostCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var hosts = Set<String>()
+    private var finished = false
+
+    func insert(_ host: String) {
+        lock.lock(); defer { lock.unlock() }
+        hosts.insert(host)
+    }
+
+    func snapshot() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return Array(hosts)
+    }
+
+    /// Returns `true` for the first caller only — the winner performs the single continuation resume.
+    func claimFinish() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if finished { return false }
+        finished = true
+        return true
     }
 }

--- a/OpenGlasses/Sources/Services/NativeTools/FitnessCoachingTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/FitnessCoachingTool.swift
@@ -147,9 +147,11 @@ struct FitnessCoachingTool: NativeTool {
     /// deflection — the built `PoseAnalyzer` was never called, so "check form via camera" was a
     /// false claim. Now it actually runs Vision pose estimation on the frame, or gives honest
     /// guidance when no camera view is available.
+    @MainActor
     private func checkForm(args: [String: Any]) async -> String {
         let exercise = (args["exercise"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "your exercise"
-        guard let frame = await frameProvider?() else {
+        // `frameProvider` is `@MainActor`; on the main actor this is a plain call (no await).
+        guard let frame = frameProvider?() else {
             return "To check your form, make sure the glasses camera can see you doing \(exercise), then ask again."
         }
         return PoseAnalyzer.analyzeForm(image: frame, exercise: exercise)

--- a/OpenGlasses/Sources/Services/OpenClaw/RemoteInvoke/RemoteCommandOrigin.swift
+++ b/OpenGlasses/Sources/Services/OpenClaw/RemoteInvoke/RemoteCommandOrigin.swift
@@ -34,7 +34,7 @@ enum RemoteCommandOrigin: Hashable, Codable {
     var consentSource: RemoteActionSource {
         switch self {
         case .gateway:          return .gateway
-        case .mcpPeer(let id):  return .opsPeer(label: displayName)
+        case .mcpPeer:          return .opsPeer(label: displayName)
         }
     }
 }

--- a/project.base.yml
+++ b/project.base.yml
@@ -13,9 +13,9 @@ options:
   deploymentTarget:
     iOS: "26.0"
     watchOS: "26.0"
-  # Sets LastUpgradeCheck (26.5 -> 2650). Keep in step with the project's Xcode
+  # Sets LastUpgradeCheck (27.0 -> 2700). Keep in step with the project's Xcode
   # baseline so Xcode's "Update to recommended settings" validation stays quiet.
-  xcodeVersion: "26.5"
+  xcodeVersion: "27.0"
   generateEmptyDirectories: true
   developmentLanguage: en
   knownRegions:


### PR DESCRIPTION
Clears the four warnings Xcode surfaced, plus the "Update to recommended settings" prompt. No behaviour change; build + Release green.

### `LocalServerScanner.swift` — the two Swift-6 concurrency warnings
The Bonjour browse kept its mutable state (`hosts` set + resume-once flag) as captured `var`s, mutated from both the `@Sendable` `NWBrowser` handlers and the `asyncAfter` timeout closure — *"Mutation of captured var 'hosts' in concurrently-executing code"* (an error under the Swift 6 language mode) and *"Converting non-Sendable function value…"*. Fixed by confining that state behind a lock-guarded `HostCollector` (`@unchecked Sendable`); the `finish` closure is now `@Sendable` and browser teardown hops back to the main actor.

### `FitnessCoachingTool.swift` — *"No 'async' operations occur within 'await'"*
`checkForm` is now `@MainActor`, so calling the `@MainActor frameProvider` is a same-actor call and the redundant `await` is gone. (The call site in `execute` already awaits `checkForm`, now a real actor hop.)

### `RemoteCommandOrigin.swift` — *"Immutable value 'id' was never used"*
`case .mcpPeer(let id)` in `consentSource` bound `id` but used `displayName`; dropped the binding.

### "Update to recommended settings"
The `.xcodeproj` is generated by XcodeGen (not committed), so this is driven by `xcodeVersion` in `project.base.yml` (→ `LastUpgradeCheck`) — the file's own comment names it as the knob for exactly this prompt. Bumped 26.5 → 27.0 (`LastUpgradeCheck` 2650 → 2700) to match Xcode 27. Harmless to Xcode 26.5 users — a higher `LastUpgradeCheck` never re-prompts an older IDE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)