### PR TITLE
Bump version to 2026.7, build 305

### DIFF
--- a/project.base.yml
+++ b/project.base.yml
@@ -107,8 +107,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
-        MARKETING_VERSION: "2.2.0"
-        CURRENT_PROJECT_VERSION: "11"
+        MARKETING_VERSION: "2026.7"
+        CURRENT_PROJECT_VERSION: "305"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -175,8 +175,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
-        MARKETING_VERSION: "2.2.0"
-        CURRENT_PROJECT_VERSION: "11"
+        MARKETING_VERSION: "2026.7"
+        CURRENT_PROJECT_VERSION: "305"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -213,8 +213,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
-        MARKETING_VERSION: "2.2.0"
-        CURRENT_PROJECT_VERSION: "11"
+        MARKETING_VERSION: "2026.7"
+        CURRENT_PROJECT_VERSION: "305"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -19,8 +19,8 @@ targets:
         # Must equal the iOS app's PRODUCT_BUNDLE_IDENTIFIER — override BOTH in
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
-        MARKETING_VERSION: "2.2.0"
-        CURRENT_PROJECT_VERSION: "11"
+        MARKETING_VERSION: "2026.7"
+        CURRENT_PROJECT_VERSION: "305"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -51,8 +51,8 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
-        MARKETING_VERSION: "2.2.0"
-        CURRENT_PROJECT_VERSION: "11"
+        MARKETING_VERSION: "2026.7"
+        CURRENT_PROJECT_VERSION: "305"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
Moves to **calendar versioning**: `MARKETING_VERSION` `2.2.0 → 2026.7`, `CURRENT_PROJECT_VERSION` `11 → 305`.

Updated across all five target pairs so the app and its extensions stay in lockstep (App Store rejects version mismatches between an app and its extensions):
- `project.base.yml` — App, Share Extension, Widget
- `project.watch.yml` — Watch app, Watch Widget

Info.plists reference `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)`, so no plist edits. The `.xcodeproj` is generated (not committed) — regenerated locally and verified both values resolve consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)