### PR TITLE
Kokoro TTS: use non-deprecated SherpaOnnxOfflineTtsGenerateWithConfig

### DIFF
--- a/OpenGlasses/Sources/Services/TTS/KokoroSynthesizer.swift
+++ b/OpenGlasses/Sources/Services/TTS/KokoroSynthesizer.swift
@@ -24,7 +24,13 @@ final class KokoroSynthesizer: @unchecked Sendable {
     func synthesizeWAV(_ text: String, speakerId: Int32 = 0, speed: Float = 1.0) throws -> Data {
         try queue.sync {
             let engine = try ttsHandle()
-            guard let audio = SherpaOnnxOfflineTtsGenerate(engine, text, speakerId, speed) else {
+            // Advanced config API (SherpaOnnxOfflineTtsGenerate — the sid/speed shorthand — is
+            // deprecated). Zero-initialised, then only sid + speed set; the create config already
+            // caps generation at one sentence, so inter-sentence `silence_scale` (0) is irrelevant.
+            var genConfig = SherpaOnnxGenerationConfig()
+            genConfig.sid = speakerId
+            genConfig.speed = speed
+            guard let audio = SherpaOnnxOfflineTtsGenerateWithConfig(engine, text, &genConfig, nil, nil) else {
                 throw KokoroError.inferenceFailed
             }
             defer { SherpaOnnxDestroyOfflineTtsGeneratedAudio(audio) }


### PR DESCRIPTION
Clears the deprecation warning at `KokoroSynthesizer.swift:27` — `SherpaOnnxOfflineTtsGenerate` (the sid/speed shorthand) is deprecated in the vendored sherpa-onnx C API in favour of `SherpaOnnxOfflineTtsGenerateWithConfig`.

Switches to the advanced-config call with a zero-initialised `SherpaOnnxGenerationConfig` carrying only `sid` + `speed` (no progress callback). The `OfflineTts` create config already sets `max_num_sentences = 1`, so the new inter-sentence `silence_scale` (0) has no effect — **behaviour unchanged**.

The file compiles under the always-on `-D KOKORO_ENABLED` flag, so a normal build verifies it: BUILD SUCCEEDED, warning gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)