### PR TITLE
Fix local Gemma fatal crash on real questions; add memory headroom gate + readout

### DIFF
--- a/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
+++ b/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
@@ -31,8 +31,20 @@ struct LocalModelManagerView: View {
                         .font(.footnote)
                         .foregroundStyle(.orange)
                 }
+                // Live memory readout: refreshes while visible so the user can watch a
+                // model load/unload. Sandboxing limits this to the app's own numbers —
+                // other apps' memory isn't visible from inside an iOS app.
+                TimelineView(.periodic(from: .now, by: 2)) { _ in
+                    LabeledContent("App memory", value: formatBytes(MemoryHeadroom.appFootprintBytes()))
+                }
+                TimelineView(.periodic(from: .now, by: 2)) { _ in
+                    let available = MemoryHeadroom.availableBytes()
+                    LabeledContent("Headroom", value: available > 0 ? formatBytes(available) : "—")
+                }
             } header: {
                 Text("Device")
+            } footer: {
+                Text("Headroom is how much more memory the app can use before iOS terminates it. A model won't load unless it fits in the current headroom with room to generate.")
             }
 
             // MARK: Downloaded Models

--- a/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
+++ b/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
@@ -13,6 +13,7 @@ struct LocalModelManagerView: View {
     @State private var loadingModelId: String?
     @State private var loadedLocalModelId: String?   // mirrors the in-memory loaded model for the UI
     @State private var loadError: String?
+    @State private var failedLoadModelId: String?    // enables Try again after e.g. a headroom refusal
 
     private var localService: LocalLLMService? {
         appState.llmService.localLLMService
@@ -91,9 +92,30 @@ struct LocalModelManagerView: View {
                     }
                 }
                 if let loadError {
-                    Label(loadError, systemImage: "exclamationmark.triangle")
-                        .font(.caption)
-                        .foregroundStyle(.red)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label(loadError, systemImage: "exclamationmark.triangle")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                        if let failedLoadModelId {
+                            // Retry seam for the headroom gate: the user swipes other apps
+                            // away, watches headroom recover, and retries without leaving
+                            // the screen.
+                            HStack(spacing: 12) {
+                                Button("Try again") { loadLocalModel(failedLoadModelId) }
+                                    .buttonStyle(.bordered)
+                                    .controlSize(.small)
+                                    .disabled(loadingModelId != nil)
+                                TimelineView(.periodic(from: .now, by: 2)) { _ in
+                                    let available = MemoryHeadroom.availableBytes()
+                                    if available > 0 {
+                                        Text("Headroom now: \(formatBytes(available))")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             } header: {
                 Text("Downloaded Models")
@@ -280,12 +302,14 @@ struct LocalModelManagerView: View {
     private func loadLocalModel(_ modelId: String) {
         loadingModelId = modelId
         loadError = nil
+        failedLoadModelId = nil
         Task {
             do {
                 try await localService?.loadModel(modelId)
                 loadedLocalModelId = modelId
             } catch {
                 loadError = error.localizedDescription
+                failedLoadModelId = modelId
             }
             loadingModelId = nil
         }

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -190,6 +190,19 @@ final class LocalLLMService: ObservableObject {
             throw LocalLLMError.backgrounded
         }
 
+        // Memory headroom gate: weights bigger than the app's remaining allocation
+        // budget don't fail cleanly — the load (or first generation) thrashes the
+        // compressor and ends in a silent Jetsam kill. Refuse with a catchable,
+        // speakable error instead. Skipped when either number is unknown (model not
+        // on disk yet, or no per-app budget on this platform — see MemoryHeadroom).
+        let modelBytes = modelSizeOnDisk(modelId)
+        let availableBytes = MemoryHeadroom.availableBytes()
+        guard MemoryHeadroom.canLoad(modelBytes: modelBytes, availableBytes: availableBytes) else {
+            throw LocalLLMError.insufficientMemory(
+                neededBytes: modelBytes + MemoryHeadroom.workingOverheadBytes,
+                availableBytes: availableBytes)
+        }
+
         isLoadingModel = true
         defer { isLoadingModel = false }
         unloadModel()
@@ -287,13 +300,21 @@ final class LocalLLMService: ObservableObject {
         }
         let tokens = try tokenize(trimmedHistory)
 
-        // Build a 2D (1, L) batch, not a 1D (L,) array. The Gemma 4 / 3n forward pass
-        // indexes x.dim(2) and fatally crashes ("SmallVector out of range") on 1D input —
-        // its prepare() path doesn't expand 1D internally (ml-explore/mlx-swift-lm#240).
-        // Other models accept (1, L) fine, so this is safe across the board.
-        let tokenIDs = MLXArray(tokens).expandedDimensions(axis: 0)
-        // NSLog (not print) so it survives the fatal MLX crash in the unified log,
-        // confirming the 2D fix is live and what shape reaches the model.
+        // Token shape depends on which factory loaded the model:
+        // - Text models (LLMModelFactory) MUST get 1D (L,) tokens. The library's default
+        //   `prepare` chunks prompts longer than the 512-token prefill step as
+        //   `y[.newAxis, ..<512]` / `y = y[512...]`, which assumes 1D — on a (1, L) batch
+        //   those slices hit axis 0, so the remainder becomes an EMPTY (0, L) array and the
+        //   next forward pass dies in QuantizedEmbedding's reshape ("cannot infer dimension"),
+        //   an uncatchable fatal MLX error. Short prompts skip the chunk loop, which is why
+        //   a (1, L) batch *appeared* to work: any real question (system prompt + tools
+        //   > 512 tokens) crashed the app.
+        // - Vision models (VLMModelFactory, e.g. SmolVLM2/Idefics3) skip that chunked
+        //   prepare and feed the tokens to the language model in one shot, so they need the
+        //   explicit (1, L) batch axis (their forward pass indexes dim(2)).
+        let tokenIDs = Self.tokenBatch(tokens, isVisionModel: Self.visionModelIds.contains(loadedModelId ?? ""))
+        // NSLog (not print) so it survives a fatal MLX crash in the unified log,
+        // confirming what shape reaches the model.
         NSLog("🔬 LocalLLM.generate model=%@ tokenIDs.shape=%@ count=%d", loadedModelId ?? "?", "\(tokenIDs.shape)", tokens.count)
 
         let input = LMInput(text: .init(tokens: tokenIDs))
@@ -334,6 +355,15 @@ final class LocalLLMService: ObservableObject {
             onToken: onToken
         )
         return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Shape token ids for the loaded model (see the call site in `generate` for why):
+    /// 1D (L,) for text-factory models — their chunked prefill slices axis 0 and an explicit
+    /// batch axis fatally breaks prompts over the prefill step size; (1, L) for vision-factory
+    /// models, whose prepare skips chunking and requires the batch axis.
+    nonisolated static func tokenBatch(_ tokens: [Int], isVisionModel: Bool) -> MLXArray {
+        let array = MLXArray(tokens)
+        return isVisionModel ? array.expandedDimensions(axis: 0) : array
     }
 
     /// Pure token-drain loop (BK P4). Accumulates text chunks, honouring:
@@ -445,6 +475,7 @@ enum LocalLLMError: LocalizedError {
     case modelNotLoaded
     case generationFailed(String)
     case backgrounded
+    case insufficientMemory(neededBytes: Int64, availableBytes: Int64)
     case promptTooLong(tokens: Int, limit: Int)
     case alreadyGenerating
     case alreadyDownloading
@@ -457,6 +488,9 @@ enum LocalLLMError: LocalizedError {
             return "Local model generation failed: \(reason)"
         case .backgrounded:
             return "On-device models can't run while the app is in the background. Switch to a cloud model for background tasks."
+        case .insufficientMemory(let needed, let available):
+            let gb = { (bytes: Int64) in String(format: "%.1f", Double(bytes) / 1_073_741_824) }
+            return "Not enough memory to load the on-device model — it needs about \(gb(needed)) GB but only \(gb(available)) GB is available. Close other apps, or switch to a cloud model."
         case .promptTooLong(let tokens, let limit):
             return "Prompt is too long for the on-device model (\(tokens) tokens; limit \(limit)). Switch to a cloud model for this request."
         case .alreadyGenerating:

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -195,8 +195,15 @@ final class LocalLLMService: ObservableObject {
         // compressor and ends in a silent Jetsam kill. Refuse with a catchable,
         // speakable error instead. Skipped when either number is unknown (model not
         // on disk yet, or no per-app budget on this platform — see MemoryHeadroom).
+        //
+        // Runs BEFORE the unload below so a refused load keeps the current model
+        // usable — but credits the outgoing model's weights back to the budget
+        // (effectiveAvailableBytes), so swapping models on a full phone isn't
+        // refused when the swap itself would fit.
         let modelBytes = modelSizeOnDisk(modelId)
-        let availableBytes = MemoryHeadroom.availableBytes()
+        let reclaimableBytes = loadedModelId.map { modelSizeOnDisk($0) } ?? 0
+        let availableBytes = MemoryHeadroom.effectiveAvailableBytes(
+            budget: MemoryHeadroom.availableBytes(), reclaimableBytes: reclaimableBytes)
         guard MemoryHeadroom.canLoad(modelBytes: modelBytes, availableBytes: availableBytes) else {
             throw LocalLLMError.insufficientMemory(
                 neededBytes: modelBytes + MemoryHeadroom.workingOverheadBytes,
@@ -490,7 +497,7 @@ enum LocalLLMError: LocalizedError {
             return "On-device models can't run while the app is in the background. Switch to a cloud model for background tasks."
         case .insufficientMemory(let needed, let available):
             let gb = { (bytes: Int64) in String(format: "%.1f", Double(bytes) / 1_073_741_824) }
-            return "Not enough memory to load the on-device model — it needs about \(gb(needed)) GB but only \(gb(available)) GB is available. Close other apps, or switch to a cloud model."
+            return "Not enough memory to load the on-device model — it needs about \(gb(needed)) GB but only \(gb(available)) GB is available. Free up about \(gb(needed - available)) GB by closing other apps, or switch to a cloud model."
         case .promptTooLong(let tokens, let limit):
             return "Prompt is too long for the on-device model (\(tokens) tokens; limit \(limit)). Switch to a cloud model for this request."
         case .alreadyGenerating:

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -51,7 +51,7 @@ final class LocalLLMService: ObservableObject {
             estimatedSize: "3.6 GB",
             hasVision: true,
             hasToolCalling: true,
-            notes: "Best on-device agent — vision, tool calling, 140+ languages",
+            notes: "Best on-device agent — vision, tool calling, 140+ languages. Uses ~4 GB while running; close other apps if it refuses to load.",
             minimumRAMGB: 8
         ),
         // Vision models (can see photos from glasses)

--- a/OpenGlasses/Sources/Services/MemoryHeadroom.swift
+++ b/OpenGlasses/Sources/Services/MemoryHeadroom.swift
@@ -32,6 +32,16 @@ enum MemoryHeadroom {
         return availableBytes >= modelBytes + workingOverheadBytes
     }
 
+    /// Budget for a load that first unloads the currently loaded model: the outgoing
+    /// model's resident weights come back the moment it unloads, so they count toward
+    /// what the incoming model can use (weights-resident ≈ size on disk for 4-bit MLX
+    /// checkpoints). Without this, swapping models on a full phone is refused even
+    /// though the swap fits. A 0 budget stays 0 — "no per-app budget on this platform"
+    /// must not become a real number that switches the gate on.
+    static func effectiveAvailableBytes(budget: Int64, reclaimableBytes: Int64) -> Int64 {
+        budget > 0 ? budget + max(0, reclaimableBytes) : 0
+    }
+
     /// Bytes this process currently occupies — `phys_footprint`, the same number
     /// Xcode's memory gauge and the jetsam accounting use.
     static func appFootprintBytes() -> Int64 {

--- a/OpenGlasses/Sources/Services/MemoryHeadroom.swift
+++ b/OpenGlasses/Sources/Services/MemoryHeadroom.swift
@@ -1,0 +1,55 @@
+import Foundation
+import os
+
+/// App memory telemetry + the pure admission rule for loading on-device models.
+///
+/// Why this exists: a model bigger than the app's remaining allocation budget doesn't
+/// fail cleanly — the load (or the first generation) drives the device into compressor
+/// thrashing and a silent Jetsam kill with no crash report. Observed 2026-07-13:
+/// gemma-4-e2b (3.6 GB weights) at 3.1 GB resident left 0.16 GB free device-wide and
+/// the kernel logged a vm-compressor-thrashing event. Checking headroom *before*
+/// loading turns that into a catchable, speakable error.
+///
+/// iOS sandboxing means an app can only see its own memory — footprint via
+/// `task_vm_info` and remaining budget via `os_proc_available_memory()`. Per-app
+/// comparisons across the system only exist retrospectively in JetsamEvent logs.
+enum MemoryHeadroom {
+
+    /// Working overhead a loaded model needs beyond its weights: KV cache, activations,
+    /// and Metal buffers during generation. Sized from the 2026-07-13 Jetsam data
+    /// (weights-sized footprint plus ~0.5–1 GB of generation-time growth).
+    static let workingOverheadBytes: Int64 = 768 * 1024 * 1024
+
+    /// Pure admission rule (headless-testable): can a model of `modelBytes` load when
+    /// the app can still allocate `availableBytes` before its jetsam limit?
+    ///
+    /// Unknown values (≤ 0) skip the gate rather than block: `modelBytes` is 0 when the
+    /// model isn't on disk yet, and `os_proc_available_memory()` returns 0 on platforms
+    /// where the budget doesn't apply (simulator, Mac). Refusing on "unknown" would
+    /// brick loading in exactly the environments that don't need the guard.
+    static func canLoad(modelBytes: Int64, availableBytes: Int64) -> Bool {
+        guard modelBytes > 0, availableBytes > 0 else { return true }
+        return availableBytes >= modelBytes + workingOverheadBytes
+    }
+
+    /// Bytes this process currently occupies — `phys_footprint`, the same number
+    /// Xcode's memory gauge and the jetsam accounting use.
+    static func appFootprintBytes() -> Int64 {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return 0 }
+        return Int64(info.phys_footprint)
+    }
+
+    /// Bytes the app can still allocate before iOS terminates it. 0 = no budget on
+    /// this platform (simulator/Mac).
+    static func availableBytes() -> Int64 {
+        Int64(os_proc_available_memory())
+    }
+}

--- a/OpenGlasses/Sources/Services/ModelFallbackChain.swift
+++ b/OpenGlasses/Sources/Services/ModelFallbackChain.swift
@@ -59,6 +59,7 @@ enum ModelFallbackChain {
             switch local {
             case .promptTooLong: return .needsBiggerWindow
             case .backgrounded: return .retryOtherModel   // a cloud candidate can still run
+            case .insufficientMemory: return .retryOtherModel   // cloud (or a smaller local model) still fits
             case .modelNotLoaded, .generationFailed, .alreadyGenerating, .alreadyDownloading:
                 return .retryOtherModel
             }

--- a/OpenGlasses/Sources/Services/TextToSpeechService.swift
+++ b/OpenGlasses/Sources/Services/TextToSpeechService.swift
@@ -366,8 +366,7 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
             let player = try AVAudioPlayer(data: toneData)
             self.tonePlayer = player
             player.volume = 0.45
-            player.prepareToPlay()
-            player.play()
+            Self.prepareAndPlayOffMain(player)
         } catch {
             print("🔊 Photo tone failed: \(error)")
         }
@@ -395,8 +394,7 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
             let player = try AVAudioPlayer(data: toneData)
             self.tonePlayer = player
             player.volume = 0.7
-            player.prepareToPlay()
-            player.play()
+            Self.prepareAndPlayOffMain(player)
         } catch {
             print("🔊 Disconnect tone failed: \(error)")
             // Single-note fallback
@@ -418,11 +416,21 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
             let player = try AVAudioPlayer(data: toneData)
             self.tonePlayer = player
             player.volume = 0.7
-            player.prepareToPlay()
-            player.play()
+            Self.prepareAndPlayOffMain(player)
         } catch {
             print("🔊 Tone failed: \(error)")
             AudioServicesPlaySystemSound(1054)
+        }
+    }
+
+    /// `prepareToPlay()` implicitly activates the audio session — synchronous I/O that
+    /// AVAudioSession warns can hang the UI when done on the main thread. AVAudioPlayer is
+    /// safe to drive from a background queue, so prepare + play happen there; the main-actor
+    /// `tonePlayer` reference (set by the caller) keeps the player alive.
+    private nonisolated static func prepareAndPlayOffMain(_ player: AVAudioPlayer) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            player.prepareToPlay()
+            player.play()
         }
     }
 

--- a/OpenGlassesTests/LocalTokenShapeTests.swift
+++ b/OpenGlassesTests/LocalTokenShapeTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Token-shape contract for on-device generation.
+///
+/// Text-factory models MUST receive 1D (L,) tokens: the library's default `prepare`
+/// chunks prompts longer than the 512-token prefill step by slicing axis 0, so an
+/// explicit (1, L) batch axis leaves an empty (0, L) remainder that fatally crashes
+/// MLX in the embedding reshape — the "local Gemma crashes on any real question" bug.
+/// Vision-factory models (SmolVLM2) skip chunked prepare and need the batch axis.
+///
+/// The shaping itself (`LocalLLMService.tokenBatch`) can't be exercised here: even
+/// constructing an MLXArray crashes on the simulator (no MLX Metal support), so the
+/// 1D-vs-2D branch is covered by the on-device path only. What IS asserted is the
+/// routing input that decides the shape.
+final class LocalTokenShapeTests: XCTestCase {
+
+    func testGemma4AgentModelIsNotRoutedAsVision() {
+        // gemma-4-e2b is a text/agentic model: it must load through LLMModelFactory and
+        // therefore take the 1D path. If someone adds it to visionModelIds, prompts over
+        // the prefill step size fatally crash on device.
+        XCTAssertFalse(LocalLLMService.visionModelIds.contains("mlx-community/gemma-4-e2b-it-4bit"))
+    }
+
+    func testVisionModelIdsAreVLMFactoryModels() {
+        // Only the SmolVLM2 checkpoints load through VLMModelFactory and take the
+        // batched (1, L) token path; everything else must stay 1D.
+        XCTAssertEqual(
+            LocalLLMService.visionModelIds,
+            [
+                "mlx-community/SmolVLM2-2.2B-Instruct-mlx",
+                "mlx-community/SmolVLM2-500M-Video-Instruct-mlx",
+            ]
+        )
+    }
+}

--- a/OpenGlassesTests/MemoryHeadroomTests.swift
+++ b/OpenGlassesTests/MemoryHeadroomTests.swift
@@ -46,7 +46,27 @@ final class MemoryHeadroomTests: XCTestCase {
         XCTAssertTrue(MemoryHeadroom.canLoad(modelBytes: 3 * gb, availableBytes: 0))
     }
 
-    func testInsufficientMemoryErrorIsSpeakable() {
+    func testSwapCreditsOutgoingModelWeights() {
+        // Full phone, gemma already loaded (3.6 GB weights reclaimable on unload).
+        // Loading a 3 GB replacement must be admitted: 1 GB raw budget + 3.6 GB
+        // reclaimed ≥ 3 GB + overhead.
+        let budget = 1 * gb
+        let effective = MemoryHeadroom.effectiveAvailableBytes(
+            budget: budget, reclaimableBytes: Int64(3.6 * Double(gb)))
+        XCTAssertTrue(MemoryHeadroom.canLoad(modelBytes: 3 * gb, availableBytes: effective))
+        // Without the credit the same swap is refused — the bug the credit fixes.
+        XCTAssertFalse(MemoryHeadroom.canLoad(modelBytes: 3 * gb, availableBytes: budget))
+    }
+
+    func testEffectiveAvailableKeepsUnknownBudgetUnknown() {
+        // budget 0 = "no per-app budget on this platform"; crediting reclaimable
+        // weights must not turn that into a real number that switches the gate on.
+        XCTAssertEqual(MemoryHeadroom.effectiveAvailableBytes(budget: 0, reclaimableBytes: 3 * gb), 0)
+        XCTAssertEqual(MemoryHeadroom.effectiveAvailableBytes(budget: 2 * gb, reclaimableBytes: 0), 2 * gb)
+        XCTAssertEqual(MemoryHeadroom.effectiveAvailableBytes(budget: 2 * gb, reclaimableBytes: -1), 2 * gb)
+    }
+
+    func testInsufficientMemoryErrorIsSpeakableAndQuantifiesTheGap() {
         let error = LocalLLMError.insufficientMemory(
             neededBytes: 4_402_341_478,   // ~4.1 GB
             availableBytes: 2_147_483_648 // 2.0 GB
@@ -54,6 +74,7 @@ final class MemoryHeadroomTests: XCTestCase {
         let message = error.errorDescription ?? ""
         XCTAssertTrue(message.contains("4.1 GB"))
         XCTAssertTrue(message.contains("2.0 GB"))
+        XCTAssertTrue(message.contains("Free up about 2.1 GB"))
         XCTAssertTrue(message.contains("cloud model"))
     }
 }

--- a/OpenGlassesTests/MemoryHeadroomTests.swift
+++ b/OpenGlassesTests/MemoryHeadroomTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Admission rule for loading on-device models (MemoryHeadroom.canLoad).
+///
+/// The gate exists because an oversized load doesn't fail cleanly — it ends in a
+/// silent Jetsam kill. The rule must refuse loads that can't fit weights + working
+/// overhead, but must NOT refuse when either number is unknown (model not on disk
+/// yet, or a platform with no per-app budget like the simulator), or it would brick
+/// loading exactly where the guard isn't needed.
+final class MemoryHeadroomTests: XCTestCase {
+
+    private let gb: Int64 = 1_073_741_824
+
+    func testLoadAllowedWithComfortableHeadroom() {
+        XCTAssertTrue(MemoryHeadroom.canLoad(modelBytes: 3 * gb, availableBytes: 6 * gb))
+    }
+
+    func testLoadRefusedWhenWeightsAloneDontFit() {
+        XCTAssertFalse(MemoryHeadroom.canLoad(modelBytes: 4 * gb, availableBytes: 3 * gb))
+    }
+
+    func testLoadRefusedWhenWeightsFitButOverheadDoesnt() {
+        // Weights fit exactly, but generation-time overhead (KV cache, activations,
+        // Metal buffers) would push past the budget — the 2026-07-13 crash pattern.
+        XCTAssertFalse(MemoryHeadroom.canLoad(modelBytes: 3 * gb, availableBytes: 3 * gb))
+    }
+
+    func testBoundaryExactFitIsAllowed() {
+        let model = 3 * gb
+        XCTAssertTrue(MemoryHeadroom.canLoad(
+            modelBytes: model,
+            availableBytes: model + MemoryHeadroom.workingOverheadBytes))
+        XCTAssertFalse(MemoryHeadroom.canLoad(
+            modelBytes: model,
+            availableBytes: model + MemoryHeadroom.workingOverheadBytes - 1))
+    }
+
+    func testUnknownModelSizeSkipsGate() {
+        // Model not on disk yet (loadContainer will download it) — size unknown.
+        XCTAssertTrue(MemoryHeadroom.canLoad(modelBytes: 0, availableBytes: 1 * gb))
+    }
+
+    func testUnknownBudgetSkipsGate() {
+        // os_proc_available_memory() returns 0 where no per-app budget applies.
+        XCTAssertTrue(MemoryHeadroom.canLoad(modelBytes: 3 * gb, availableBytes: 0))
+    }
+
+    func testInsufficientMemoryErrorIsSpeakable() {
+        let error = LocalLLMError.insufficientMemory(
+            neededBytes: 4_402_341_478,   // ~4.1 GB
+            availableBytes: 2_147_483_648 // 2.0 GB
+        )
+        let message = error.errorDescription ?? ""
+        XCTAssertTrue(message.contains("4.1 GB"))
+        XCTAssertTrue(message.contains("2.0 GB"))
+        XCTAssertTrue(message.contains("cloud model"))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -70,13 +70,15 @@ Run AI models entirely on your iPhone — no internet, no cloud, no API keys.
 
 | Model | Size | Best For |
 |-------|------|----------|
-| **Gemma 4 E2B** (default agent) | 3.6 GB | Best on-device agent — vision, tool calling, 140+ languages (needs 8 GB RAM) |
+| **Gemma 4 E2B** (default agent) | 3.6 GB | Best on-device agent — vision, tool calling, 140+ languages (8 GB RAM minimum, 12 GB recommended — uses ~4 GB while running) |
 | SmolVLM2 2.2B | 1.5 GB | Vision — sees photos + video |
 | Qwen 2.5 3B | 1.8 GB | Strong text reasoning + tool use |
 | Gemma 2 2B | 1.5 GB | Lightweight general purpose |
 | Qwen 2.5 0.5B | 0.4 GB | Ultra-light, basic |
 
 **Gemma 4 E2B** is the default on-device agent — it runs automatically when no cloud model is configured. Models are stored persistently and work fully offline after download. Toggle **Offline Mode** in Settings → Tools to disable internet-dependent tools.
+
+**Memory:** a loaded model occupies its full weight size in RAM plus working memory while generating — Gemma 4 E2B uses ~4 GB, a real load even on a 12 GB iPhone with other apps open. OpenGlasses checks available headroom before loading: if the model won't fit it tells you how much to free (swipe apps away in the app switcher) instead of letting iOS silently kill the app, and voice requests automatically fall over to a cloud model if one is configured. **Settings → AI Models → Download & Manage Models** shows the app's live memory use and remaining headroom.
 
 ### Self-Hosted Local Server (Ollama, llama.cpp, vLLM…)
 
@@ -481,7 +483,7 @@ All settings are in-app — no source code editing needed.
 | No audio through glasses | Verify Bluetooth connection in iOS Settings |
 | Glasses not connecting | Tap "Connect to Glasses"; enable Developer Mode in Meta AI app |
 | HomeKit not finding devices | HomeKit initializes on first tool call — say "list smart home devices" and wait 10s |
-| Local model crashes | Gemma 4 E2B needs ~8 GB RAM; on 6 GB devices use a smaller model (0.5B–2B) |
+| Local model won't load ("not enough memory") | Close other apps in the app switcher and use **Try again** in Download & Manage Models (live headroom shown there), or switch to a smaller model (0.5B–2B) |
 | Model download stuck | Keep app in foreground; downloads continue if briefly backgrounded |
 | "Untrusted Developer" | Settings → General → VPN & Device Management → Verify (requires internet) |
 


### PR DESCRIPTION
## The crash

Selecting the local Gemma model and asking any real question killed the app. Device crash reports (2026-07-13 15:57 / 16:13 / 16:14) all show the same uncatchable fatal MLX error: `mlx_reshape` inside `QuantizedEmbedding` in `Gemma4TextModelInner`'s forward pass.

Root cause: the across-the-board 2D `(1, L)` token batch (6e0350a) is incompatible with mlx-swift-lm's default `LLMModel.prepare`, which chunks prompts longer than the 512-token prefill step by slicing **axis 0** — assuming 1D tokens. On a `(1, L)` batch the remainder becomes an empty `(0, L)` tensor and the next forward pass aborts the process. Prompts ≤ 512 tokens skip the chunk loop entirely, which is why the workaround looked fine in smoke tests and crashed on every real question (system prompt + tools > 512 tokens). The 2D batch was only needed while gemma-4 wrongly loaded through the vision factory; after 9d5e1cb routed it to the text factory it became the bug.

**Fix:** `LocalLLMService.tokenBatch` shapes tokens per factory — 1D for text models (the library adds the batch axis itself), `(1, L)` kept for the VLM-factory SmolVLM2 models whose un-chunked `prepare` requires it. The routing contract is pinned by `LocalTokenShapeTests` (MLXArray can't be constructed on the simulator, so the shape branch itself is device-verified only).

## Memory headroom gate + readout

The 15:57 JetsamEvent shows the second failure mode: gemma-4-e2b at 3.1 GB resident, 0.16 GB free device-wide, vm-compressor-thrashing — an oversized load ends in a silent Jetsam kill, not an error. `loadModel` now refuses when weights-on-disk + a generation working overhead don't fit `os_proc_available_memory()`, throwing a catchable, speakable `insufficientMemory`; the cascade classifies it `retryOtherModel` so a cloud candidate serves the turn. The rule is a pure function (`MemoryHeadroom.canLoad`, headless tests) and skips when either number is unknown (model not downloaded; simulator/Mac). Local Models settings gains a live App memory / Headroom readout.

## Also

Tone players in `TextToSpeechService` now `prepareToPlay()`/`play()` off the main thread — `prepareToPlay` activates the audio session, the source of the `AVAudioSession_iOS.mm:978` UI-responsiveness warnings.

## Verification

- Full suite: 1817 tests, 0 failures (simulator, Xcode 27 beta destination)
- Release build (`-configuration Release`, unsigned device): succeeded
- On-device confirmation still wanted: select Local Gemini, ask any normal question (any prompt > 512 tokens exercises the fixed prefill path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)