### PR TITLE
Fix local-model location context, persona addressing, and classifier gating gaps

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2778,7 +2778,10 @@ class AppState: ObservableObject, AppStateProtocol {
                             locationContext: locationCtx,
                             imageData: imageData,
                             memoryContext: memoryCtx,
-                            playbookContext: classification.relevantSections.contains(.playbook) ? playbookStore.playbookContext() : nil,
+                            // Unconditional like the photo path: the classifier never sets .playbook
+                            // (mid-playbook utterances — "done", "next" — match no keyword list), and
+                            // playbookContext() already returns nil when no playbook is active.
+                            playbookContext: playbookStore.playbookContext(),
                             nowPlayingContext: nowPlayingAtStart?.promptContext,
                             shortcutsContext: ShortcutsCatalog.shared.promptBlock(),
                             promptSections: classification.relevantSections,

--- a/OpenGlasses/Sources/Services/ConversationClassifier.swift
+++ b/OpenGlasses/Sources/Services/ConversationClassifier.swift
@@ -107,9 +107,12 @@ struct ConversationClassifier {
     // MARK: - Tier 0: Direct Tool Calls
 
     /// Match patterns that can be resolved with a direct tool call, skipping the LLM.
+    /// The time/steps/battery groups are gated by `isBareQuery`: "what time is it" is answerable
+    /// by reading the clock, but "what time does the game start" merely *contains* the pattern and
+    /// must reach the LLM — a substring match here would speak the current time as the answer.
     private func matchDirectToolCall(_ text: String, words: [String.SubSequence]) -> DirectToolCall? {
         // Time/date queries
-        if matchesAny(text, patterns: timePatterns) {
+        if let matched = matchedPattern(text, patterns: timePatterns), isBareQuery(text, matched: matched) {
             return DirectToolCall(toolName: "get_datetime", arguments: [:])
         }
 
@@ -127,17 +130,37 @@ struct ConversationClassifier {
         }
 
         // Step count
-        if matchesAny(text, patterns: stepPatterns) {
+        if let matched = matchedPattern(text, patterns: stepPatterns), isBareQuery(text, matched: matched) {
             return DirectToolCall(toolName: "step_count", arguments: [:])
         }
 
         // Device info / battery
-        if matchesAny(text, patterns: batteryPatterns) {
+        if let matched = matchedPattern(text, patterns: batteryPatterns), isBareQuery(text, matched: matched) {
             return DirectToolCall(toolName: "device_info", arguments: [:])
         }
 
         return nil
     }
+
+    /// First pattern the text contains (these groups use no regex patterns).
+    private func matchedPattern(_ text: String, patterns: [String]) -> String? {
+        patterns.first { text.contains($0) }
+    }
+
+    /// True when removing the matched pattern leaves only filler — the query IS the pattern
+    /// ("what time is it now?"), not a larger question containing it. False negatives are safe:
+    /// they fall through to the LLM, which answers correctly via tools.
+    private func isBareQuery(_ text: String, matched: String) -> Bool {
+        let remainder = text.replacingOccurrences(of: matched, with: " ")
+        let leftover = remainder.split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        return leftover.allSatisfy { fillerWords.contains(String($0)) }
+    }
+
+    private let fillerWords: Set<String> = [
+        "is", "it", "the", "right", "now", "today", "currently", "please",
+        "hey", "tell", "me", "do", "i", "have", "left", "my", "on", "at",
+        "moment", "how", "s", "phone"
+    ]
 
     // MARK: - Tier 1: Prompt Section Detection
 
@@ -191,8 +214,13 @@ struct ConversationClassifier {
     private func estimateComplexity(_ text: String, words: [String.SubSequence], hasImage: Bool, conversationTurnCount: Int) -> Double {
         var score: Double = 0.0
 
-        // Word count — longer requests tend to be more complex
-        let wordCount = words.count
+        // Word count — longer requests tend to be more complex.
+        // CJK scripts don't use spaces, so a whole Chinese/Japanese sentence splits to one
+        // "word" — which scored every CJK query as trivial and routed it to the fast tier
+        // (i.e. the 2B local model) regardless of actual complexity. Approximate CJK words
+        // as characters/2 (Chinese averages ~1.5–2 characters per word).
+        let cjkCount = text.unicodeScalars.filter { Self.isCJK($0) }.count
+        let wordCount = cjkCount > 0 ? max(words.count, cjkCount / 2) : words.count
         if wordCount <= 5 { score += 0.0 }
         else if wordCount <= 15 { score += 0.15 }
         else if wordCount <= 30 { score += 0.3 }
@@ -246,21 +274,31 @@ struct ConversationClassifier {
         "look at", "what is this", "what's this", "whats this",
         "read this", "identify", "what do you see", "describe what",
         "scan", "qr code", "barcode", "what does this say",
-        "translate this", "read the sign", "what brand"
+        "translate this", "read the sign", "what brand",
+        // zh
+        "看看", "这是什么", "扫描", "识别", "读一下", "二维码"
     ]
 
     private let locationPatterns = [
         "nearby", "near me", "closest", "around here",
         "how far", "directions to", "navigate", "take me to",
         "where am i", "where is", "find a", "restaurants",
-        "coffee", "pharmacy", "gas station", "parking"
+        "coffee", "pharmacy", "gas station", "parking",
+        // Weather is implicitly "here" — without USER LOCATION in the prompt the model
+        // asks "what city are you in?" instead of answering (or calling get_weather).
+        "weather", "forecast", "rain", "umbrella",
+        "sunrise", "sunset", "how hot", "how cold",
+        // zh — the app ships Chinese presets; English-only patterns dropped these sections
+        "天气", "附近", "哪里", "在哪", "导航", "下雨", "预报", "多远"
     ]
 
     private let smartHomePatterns = [
         "turn on the", "turn off the", "lights", "light",
         "lock", "unlock", "thermostat", "temperature",
         "scene", "smart home", "home assistant",
-        "fan", "blinds", "curtains", "garage"
+        "fan", "blinds", "curtains", "garage",
+        // zh
+        "开灯", "关灯", "灯光", "空调", "锁门", "开锁", "窗帘"
     ]
 
     private let toolTriggerPatterns = [
@@ -270,7 +308,10 @@ struct ConversationClassifier {
         "call", "text", "message", "send", "calculate",
         "convert", "translate", "define", "news",
         "play", "pause", "skip", "music",
-        "shortcut", "note", "save", "remember"
+        "shortcut", "note", "save", "remember",
+        // zh
+        "天气", "提醒", "定时", "闹钟", "日历", "搜索",
+        "翻译", "新闻", "播放", "计算", "笔记", "备忘"
     ]
 
     private let socialPatterns = [
@@ -288,24 +329,42 @@ struct ConversationClassifier {
         "and then", "after that", "also", "first .* then",
         "plan my", "organize", "schedule my",
         "compare", "summarize", "research",
-        "find .* and call", "look up .* and send"
+        "find .* and call", "look up .* and send",
+        // zh
+        "然后", "接着", "总结", "帮我规划", "对比"
     ]
 
     private let reasoningPatterns = [
         "explain", "why", "how does", "what are the pros",
         "analyze", "evaluate", "recommend", "suggest",
         "what should i", "help me decide", "think about",
-        "what would happen", "is it better to"
+        "what would happen", "is it better to",
+        // zh
+        "为什么", "解释", "分析", "比较", "建议", "推荐", "怎么办"
     ]
 
     private let simpleFactPatterns = [
         "what is the capital", "how tall is", "who invented",
         "when was", "how old is", "what color",
         "yes", "no", "ok", "sure", "thanks", "thank you",
-        "good morning", "hello", "hi", "hey"
+        "good morning", "hello", "hi", "hey",
+        // zh
+        "你好", "谢谢", "好的", "早上好"
     ]
 
     // MARK: - Helpers
+
+    /// CJK unified ideographs, kana, and hangul — scripts written without spaces.
+    static func isCJK(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        case 0x4E00...0x9FFF, 0x3400...0x4DBF,   // CJK unified ideographs (+ extension A)
+             0x3040...0x309F, 0x30A0...0x30FF,   // hiragana, katakana
+             0xAC00...0xD7AF:                     // hangul syllables
+            return true
+        default:
+            return false
+        }
+    }
 
     /// Check if text matches any pattern in the list. Supports simple regex.
     private func matchesAny(_ text: String, patterns: [String]) -> Bool {

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -184,9 +184,13 @@ class LLMService: ObservableObject {
     /// reduced tool block, so the model still has usable tools. Used by every on-device path
     /// (active-model `sendMessage` and fast-tier `sendViaLocalAgent`) so they can't diverge.
     static func leanOnDevicePrompt(locationContext: String?, memoryContext: String?, hasImage: Bool, turn: String) async -> String {
-        await buildSystemPrompt(
+        let prompt = await buildSystemPrompt(
             locationContext: locationContext, includeTools: false, includeOpenClaw: false,
             hasImage: hasImage, memoryContext: memoryContext, turn: turn)
+        // Gemma-style templates have no separate system channel — this whole prompt is merged
+        // into the model's first *user* turn, and a small model can flip roles and reply to
+        // "OpenGlasses" instead of the wearer. Pin the speaker identity explicitly.
+        return prompt + "\n\nThe person speaking to you is the user wearing the glasses. Address them directly as \"you\". Never address OpenGlasses — that is your own name."
     }
 
     private static func buildSystemPrompt(locationContext: String?, includeTools: Bool, includeOpenClaw: Bool, hasImage: Bool, nativeToolNames: [String] = [], nativeToolDescriptions: [(name: String, description: String)] = [], gatewayToolNames: [String] = [], memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil, turn: String? = nil) async -> String {
@@ -2074,6 +2078,16 @@ class LLMService: ObservableObject {
     }
     #endif
 
+    /// The reduced tool set a local model is offered — only simple, reliable, self-contained tools
+    /// (each resolves its own inputs, e.g. `get_weather`/`where_am_i` read LocationService directly,
+    /// so the 2B model never has to supply coordinates it doesn't have).
+    static let localSafeTools: Set<String> = [
+        "get_weather", "get_datetime", "calculate", "set_timer",
+        "flashlight", "brightness", "calendar", "reminder",
+        "set_alarm", "step_count", "device_info", "music_control",
+        "where_am_i"
+    ]
+
     // Unlike the cloud providers, the on-device path is deliberately NOT on the shared `runToolLoop`
     // driver (Plan BG P3). On-device models don't expose a structured tool-use API — they emit
     // `<tool_call>` markup — so this path is single-shot with a reduced tool set and one optional
@@ -2092,13 +2106,7 @@ class LLMService: ObservableObject {
         // Build tool instructions — use minimal set for local models
         var fullPrompt = systemPrompt
         if includeTools, let router = nativeToolRouter {
-            // Local models get a reduced tool set — only simple, reliable tools
-            let localSafeTools: Set<String> = [
-                "get_weather", "get_datetime", "calculate", "set_timer",
-                "flashlight", "brightness", "calendar", "reminder",
-                "set_alarm", "step_count", "device_info", "music_control"
-            ]
-            let toolNames = router.registry.toolNames.filter { localSafeTools.contains($0) }
+            let toolNames = router.registry.toolNames.filter { Self.localSafeTools.contains($0) }
             if !toolNames.isEmpty {
                 fullPrompt += """
 
@@ -2334,6 +2342,10 @@ extension LLMService {
     nonisolated static func cleanedNonEmptyLocalAnswer(_ raw: String) throws -> String {
         let cleaned = raw
             .replacingOccurrences(of: #"<tool_call>.*?</tool_call>"#, with: "", options: .regularExpression)
+            // A small model fed a merged (no-system-role) prompt can answer in transcript
+            // style — "OpenGlasses: ..." / "Assistant: ..." — and TTS would speak the label.
+            .replacingOccurrences(of: #"^\s*(OpenGlasses|Assistant|AI|Model)\s*:\s*"#,
+                                  with: "", options: [.regularExpression, .caseInsensitive])
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { throw LLMError.invalidResponse("Local") }
         return cleaned

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -301,9 +301,11 @@ final class LocalLLMService: ObservableObject {
                 return try tokenizer.applyChatTemplate(messages: messages)
             } catch {
                 // Merge the system prompt into the user turn for models without a system role.
+                // No "User:" transcript label — a small model reads a speaker-labelled dialogue
+                // and can flip roles, replying *as* the user addressed to the persona name.
                 var fallback: [[String: String]] = []
                 for turn in hist { fallback.append(["role": turn.role, "content": turn.content]) }
-                fallback.append(["role": "user", "content": systemPrompt + "\n\nUser: " + userMessage])
+                fallback.append(["role": "user", "content": systemPrompt + "\n\n" + userMessage])
                 return try tokenizer.applyChatTemplate(messages: fallback)
             }
         }

--- a/OpenGlasses/Sources/Services/LocationService.swift
+++ b/OpenGlasses/Sources/Services/LocationService.swift
@@ -23,12 +23,12 @@ protocol RegionMonitoring: AnyObject {
 @MainActor
 class LocationService: NSObject, ObservableObject {
     @Published var currentLocation: CLLocation?
-    @Published var currentPlacemark: CLPlacemark?
+    /// Human-readable place for the current location (reverse geocoded).
+    @Published var geocodedPlace: String?
     @Published var locationError: String?
     @Published var isAuthorized: Bool = false
 
     private let locationManager = CLLocationManager()
-    // private let geocoder = CLGeocoder() // Deprecated in iOS 26
 
     /// Region-monitoring event forwarders (BK P1). Set by `GeofenceTool.activate()`.
     var onRegionEvent: ((CLRegion, Bool) -> Void)?
@@ -60,46 +60,20 @@ class LocationService: NSObject, ObservableObject {
 
     /// Returns a human-readable location string for LLM context
     var locationContext: String? {
-        guard let placemark = currentPlacemark else {
-            guard let location = currentLocation else { return nil }
-            return String(format: "%.4f, %.4f", location.coordinate.latitude, location.coordinate.longitude)
-        }
-
-        var parts: [String] = []
-        if let name = placemark.name { parts.append(name) }
-        if let locality = placemark.locality { parts.append(locality) }
-        if let adminArea = placemark.administrativeArea { parts.append(adminArea) }
-        if let country = placemark.country { parts.append(country) }
-
-        // Deduplicate (name sometimes equals locality)
-        var seen = Set<String>()
-        let unique = parts.filter { seen.insert($0).inserted }
-
-        return unique.isEmpty ? nil : unique.joined(separator: ", ")
+        if let geocodedPlace { return geocodedPlace }
+        guard let location = currentLocation else { return nil }
+        return String(format: "%.4f, %.4f", location.coordinate.latitude, location.coordinate.longitude)
     }
 
-    /// Reverse geocode the current location to get a placemark
+    /// Reverse geocode the current location to a human-readable place. A small on-device model
+    /// can't map raw coordinates to a city, so the USER LOCATION prompt line needs a place name;
+    /// coordinates remain the fallback while geocoding is pending or offline.
     private func reverseGeocode(_ location: CLLocation) {
-        // Disabled due to CLGeocoder deprecation warning
-        /*
-        geocoder.reverseGeocodeLocation(location) { [weak self] placemarks, error in
-            Task { @MainActor in
-                if let error = error {
-                    print("📍 Geocoding failed: \(error.localizedDescription)")
-                    self?.locationError = "Geocoding failed: \(error.localizedDescription)"
-                    // Still have coordinates as fallback
-                    return
-                }
-
-                if let placemark = placemarks?.first {
-                    self?.currentPlacemark = placemark
-                    print("📍 Location: \(self?.locationContext ?? "unknown")")
-                } else {
-                    print("📍 Geocoding returned no results")
-                }
-            }
+        Task { @MainActor [weak self] in
+            guard let place = await GeocodingHelper.reverseGeocode(location) else { return }
+            self?.geocodedPlace = place.cityState ?? place.fullAddress
+            print("📍 Location: \(self?.geocodedPlace ?? "unknown")")
         }
-        */
     }
 }
 

--- a/OpenGlassesTests/ConversationClassifierTests.swift
+++ b/OpenGlassesTests/ConversationClassifierTests.swift
@@ -82,6 +82,28 @@ final class ConversationClassifierTests: XCTestCase {
         }
     }
 
+    /// A larger question that merely *contains* a Tier-0 pattern must reach the LLM —
+    /// a substring match would speak the current time/date as the "answer".
+    func testEmbeddedPatternsDoNotShortCircuitToDirectCall() {
+        let queries = [
+            "what time does the game start",
+            "what day is the concert",
+            "what time is sunset in tokyo",
+            "how much battery does my tesla have",
+            "how many steps are in this recipe",
+        ]
+        for query in queries {
+            XCTAssertNil(classifier.classify(query).directToolCall,
+                         "'\(query)' should go to the LLM, not a direct tool call")
+        }
+    }
+
+    func testBareQueriesWithFillerStillMatchDirectly() {
+        XCTAssertEqual(classifier.classify("what time is it right now").directToolCall?.toolName, "get_datetime")
+        XCTAssertEqual(classifier.classify("hey what's the date today").directToolCall?.toolName, "get_datetime")
+        XCTAssertEqual(classifier.classify("how's my phone battery").directToolCall?.toolName, "device_info")
+    }
+
     // MARK: - Tier 1: Prompt Section Detection
 
     func testVisionSectionDetectedForImageInput() {
@@ -102,6 +124,23 @@ final class ConversationClassifierTests: XCTestCase {
         let queries = ["restaurants nearby", "find a pharmacy near me", "directions to the airport"]
         for query in queries {
             let result = classifier.classify(query)
+            XCTAssertTrue(result.relevantSections.contains(.location),
+                          "'\(query)' should include location section")
+        }
+    }
+
+    /// Weather is implicitly about "here": without the .location section the send path passes
+    /// locationContext = nil, the prompt has no USER LOCATION line, and the on-device model
+    /// asks "what city are you in?" instead of answering.
+    func testWeatherQueriesIncludeLocationSection() {
+        let queries = [
+            "what's the weather", "weather forecast for tomorrow",
+            "will it rain today", "do i need an umbrella",
+            "when is sunset", "how hot is it today",
+        ]
+        for query in queries {
+            let result = classifier.classify(query)
+            XCTAssertNil(result.directToolCall, "'\(query)' should reach the LLM, not a direct tool")
             XCTAssertTrue(result.relevantSections.contains(.location),
                           "'\(query)' should include location section")
         }
@@ -132,6 +171,31 @@ final class ConversationClassifierTests: XCTestCase {
             XCTAssertTrue(result.relevantSections.contains(.openClaw),
                           "'\(query)' should include OpenClaw section")
         }
+    }
+
+    // MARK: - CJK (no-space scripts)
+
+    /// English-only patterns + space-split word counts used to classify every CJK query as
+    /// trivial (one "word" → fast tier → 2B local model) with no location/smart-home sections.
+    func testChineseWeatherQueryIncludesLocationAndTools() {
+        let result = classifier.classify("今天天气怎么样")
+        XCTAssertTrue(result.relevantSections.contains(.location), "天气 should include location")
+        XCTAssertTrue(result.relevantSections.contains(.tools), "天气 should include tools")
+    }
+
+    func testChineseSmartHomeDetected() {
+        XCTAssertTrue(classifier.classify("帮我开灯").relevantSections.contains(.smartHome))
+    }
+
+    func testChineseComplexQueryIsNotFastTier() {
+        // Analysis + comparison + chaining in one long sentence — must not route to the fast tier.
+        let result = classifier.classify("帮我分析一下这两种方案的优缺点然后推荐一个")
+        XCTAssertNotEqual(result.modelTier, .fast,
+                          "long analytical Chinese query must not be scored as trivial")
+    }
+
+    func testChineseGreetingStaysFastTier() {
+        XCTAssertEqual(classifier.classify("你好").modelTier, .fast)
     }
 
     func testUnspecificQueryDefaultsToTools() {

--- a/OpenGlassesTests/LLMLocalAnswerTests.swift
+++ b/OpenGlassesTests/LLMLocalAnswerTests.swift
@@ -8,6 +8,13 @@ import XCTest
 /// Anthropic/Gemini empty-completion guards.
 final class LLMLocalAnswerTests: XCTestCase {
 
+    func testLocalSafeToolsIncludeSelfContainedLocationTools() {
+        // Both resolve their own coordinates from LocationService, so the 2B model can fetch
+        // location/weather on demand instead of claiming it has no GPS access.
+        XCTAssertTrue(LLMService.localSafeTools.contains("where_am_i"))
+        XCTAssertTrue(LLMService.localSafeTools.contains("get_weather"))
+    }
+
     func testKeepsRealTextTrimmed() throws {
         XCTAssertEqual(try LLMService.cleanedNonEmptyLocalAnswer("Hello there"), "Hello there")
         XCTAssertEqual(try LLMService.cleanedNonEmptyLocalAnswer("  padded  "), "padded")
@@ -17,6 +24,18 @@ final class LLMLocalAnswerTests: XCTestCase {
         XCTAssertEqual(
             try LLMService.cleanedNonEmptyLocalAnswer(#"The answer is 42 <tool_call>{"name":"x","arguments":{}}</tool_call>"#),
             "The answer is 42")
+    }
+
+    func testStripsLeadingSpeakerLabel() throws {
+        // A small model fed a merged (no-system-role) prompt can answer in transcript style;
+        // the persona label must never reach TTS.
+        XCTAssertEqual(try LLMService.cleanedNonEmptyLocalAnswer("OpenGlasses: It's sunny today."),
+                       "It's sunny today.")
+        XCTAssertEqual(try LLMService.cleanedNonEmptyLocalAnswer("Assistant: Sure."), "Sure.")
+        XCTAssertEqual(try LLMService.cleanedNonEmptyLocalAnswer("  model:  Hello"), "Hello")
+        // A colon later in the sentence is untouched.
+        XCTAssertEqual(try LLMService.cleanedNonEmptyLocalAnswer("Note: bring an umbrella"),
+                       "Note: bring an umbrella")
     }
 
     func testEmptyOrWhitespaceThrowsInvalidResponseLocal() {

--- a/OpenGlassesTests/LocationServiceTests.swift
+++ b/OpenGlassesTests/LocationServiceTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+import CoreLocation
+@testable import OpenGlasses
+
+/// Tests for the location string injected into LLM prompts as "USER LOCATION: ...".
+/// Uses fresh instances with properties set directly — no CLLocationManager fix or
+/// network geocoding is exercised, so these run headlessly.
+@MainActor
+final class LocationServiceTests: XCTestCase {
+
+    func testLocationContextNilWithoutFix() {
+        let service = LocationService()
+        XCTAssertNil(service.locationContext)
+    }
+
+    func testLocationContextFallsBackToCoordinates() {
+        let service = LocationService()
+        service.currentLocation = CLLocation(latitude: -36.8485, longitude: 174.7633)
+        XCTAssertEqual(service.locationContext, "-36.8485, 174.7633")
+    }
+
+    func testLocationContextPrefersGeocodedPlace() {
+        let service = LocationService()
+        service.currentLocation = CLLocation(latitude: -36.8485, longitude: 174.7633)
+        service.geocodedPlace = "Auckland, New Zealand"
+        XCTAssertEqual(service.locationContext, "Auckland, New Zealand")
+    }
+}

--- a/project.base.yml
+++ b/project.base.yml
@@ -108,7 +108,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "305"
+        CURRENT_PROJECT_VERSION: "306"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -176,7 +176,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "305"
+        CURRENT_PROJECT_VERSION: "306"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -214,7 +214,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "305"
+        CURRENT_PROJECT_VERSION: "306"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "305"
+        CURRENT_PROJECT_VERSION: "306"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "305"
+        CURRENT_PROJECT_VERSION: "306"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## Problem

Console session 2026-07-13 19:08: on-device Gemma answered a weather question with "I do not currently have access to your real-time GPS location", asked "What city are you in?", and addressed its reply to "OpenGlasses" instead of the user.

## Root causes & fixes

**Location never reached the prompt.** The classifier had "weather" only in `toolTriggerPatterns`, so the turn classified without `.location` and the send path passed `locationContext: nil` — the lean on-device prompt genuinely had no USER LOCATION line. Weather/forecast/rain/sunrise/etc. now map to `.location` (fixes the cloud path on the same turn type too).

**Location was raw coordinates anyway.** `LocationService` reverse geocoding had been fully commented out since the CLGeocoder deprecation. Rewired through the existing MapKit `GeocodingHelper`; coordinates remain the fallback while geocoding is pending or offline.

**Persona addressing.** Gemma's chat template merges the system prompt into the first *user* turn, which invites a small model to reply to "OpenGlasses". Three layers: the lean prompt now pins the speaker identity explicitly; the no-system-role template fallback no longer injects a transcript-style "User:" label; and leading `OpenGlasses:`/`Assistant:`/`AI:`/`Model:` labels are stripped before TTS.

## Same-family fixes from a follow-up audit

- **Playbook context never reached the main voice turn** — the `.playbook` gate was always false (the classifier never sets it). Now passed unconditionally like the photo path; `playbookContext()` self-gates on an active session.
- **`where_am_i` joins the local tool whitelist** (hoisted to a testable `LLMService.localSafeTools`), giving the on-device model on-demand location.
- **Tier-0 direct calls gated by `isBareQuery`** — "what time does the game start" / "what day is the concert" / "how much battery does my tesla have" now reach the LLM instead of getting the clock or phone battery read at them; bare asks ("what time is it right now", "how's my phone battery") stay on the instant path.
- **CJK queries no longer defeat the classifier** — complexity counts CJK characters (÷2) instead of space-split words (a Chinese sentence scored as one "word" and auto-routed everything to the fast tier / 2B local model), plus Chinese patterns for location/weather, smart home, vision, tools, reasoning, chaining, and greetings.

## Verification

- Full unit suite green on iOS 27 simulator (rebased onto latest main first; PR #228's LocalLLMService change auto-merged cleanly)
- Release configuration build green (unsigned, generic iOS destination)
- New coverage: weather→location classification, CJK sections/tiering, bare-vs-embedded Tier-0 gating, speaker-label stripping, `locationContext` preference order (place name → coordinates → nil), `localSafeTools` membership
- Build bumped to 306 across all five spec pairs

🤖 Generated with [Claude Code](https://claude.com/claude-code)