### PR TITLE
Stop personal Info.plist from silently going stale (ITMS-90683 root cause)

### DIFF
--- a/Scripts/setup-local-dev.sh
+++ b/Scripts/setup-local-dev.sh
@@ -33,7 +33,13 @@ targets:
       base:
         CODE_SIGN_ENTITLEMENTS: Config/Entitlements/Personal/OpenGlasses.entitlements
         DEVELOPMENT_TEAM: ${team}
-        INFOPLIST_FILE: Config/Info/Info.personal.plist
+        # By default the app builds from the committed OpenGlasses/Info.plist so new
+        # usage-description keys can never go stale in a personal copy (that caused an
+        # App Store ITMS-90683 "missing NSLocationAlwaysAndWhenInUseUsageDescription").
+        # ONLY rebranders (custom bundle id / display name) need a personal plist —
+        # uncomment the next line and keep Config/Info/Info.personal.plist in sync with
+        # OpenGlasses/Info.plist by hand:
+        #   INFOPLIST_FILE: Config/Info/Info.personal.plist
         PRODUCT_BUNDLE_IDENTIFIER: ${app_bundle}
 
   GlassesActivityWidget:
@@ -61,7 +67,9 @@ restore_from_commit() {
 
   git show "$commit:OpenGlasses/OpenGlasses.entitlements" > Config/Entitlements/Personal/OpenGlasses.entitlements
   git show "$commit:GlassesActivityWidget/GlassesActivityWidget.entitlements" > Config/Entitlements/Personal/GlassesActivityWidget.entitlements
-  git show "$commit:OpenGlasses/Info.plist" > Config/Info/Info.personal.plist
+  # Seed the (opt-in, rebrand-only) personal Info.plist from the CURRENT committed plist, not the
+  # old signing-recovery commit — otherwise it starts life missing every key added since.
+  cp OpenGlasses/Info.plist Config/Info/Info.personal.plist
 
   local team
   team="$(development_team_from_commit "$commit")"

--- a/project.local.yml.example
+++ b/project.local.yml.example
@@ -7,12 +7,15 @@ targets:
       base:
         CODE_SIGN_ENTITLEMENTS: Config/Entitlements/Personal/OpenGlasses.entitlements
         DEVELOPMENT_TEAM: YOUR_APPLE_TEAM_ID
-        # NOTE: this REPLACES the app's entire Info.plist — Info.personal.plist must be a
-        # full plist (all CFBundle*/usage keys) plus the MWDAT dict, not MWDAT-only.
-        # `./Scripts/setup-local-dev.sh` seeds it correctly from OpenGlasses/Info.plist.
-        # If you also change PRODUCT_BUNDLE_IDENTIFIER (rebrand), override
+        # Leave the app on the committed OpenGlasses/Info.plist (the default) so newly added
+        # usage-description keys can't go stale in a personal copy — a stale copy caused an
+        # App Store ITMS-90683 ("missing NSLocationAlwaysAndWhenInUseUsageDescription").
+        # ONLY uncomment the override below if you REBRAND (custom bundle id / display name):
+        # it REPLACES the app's entire Info.plist, so Info.personal.plist must be a FULL plist
+        # (all CFBundle*/usage keys) that you keep in sync with OpenGlasses/Info.plist by hand.
+        # If you also change PRODUCT_BUNDLE_IDENTIFIER, override
         # WK_COMPANION_APP_BUNDLE_IDENTIFIER on the OpenGlassesWatch target to match.
-        INFOPLIST_FILE: Config/Info/Info.personal.plist
+        # INFOPLIST_FILE: Config/Info/Info.personal.plist
 
   GlassesActivityWidget:
     settings:


### PR DESCRIPTION
## The bug
An App Store upload failed with **ITMS-90683: missing `NSLocationAlwaysAndWhenInUseUsageDescription`** — even though the committed `OpenGlasses/Info.plist` has had that key since the geofencing work.

## Root cause (not in app code)
`project.local.yml` (the gitignored personal signing config) overrides `INFOPLIST_FILE` to `Config/Info/Info.personal.plist`. That personal plist is a **one-time snapshot** `setup-local-dev.sh` took from an **old commit**, and it never re-syncs. So every usage-description key added to the real `Info.plist` *after* setup silently goes missing from the archived app:
- `NSLocalNetworkUsageDescription` + `NSBonjourServices` (LAN server scanner)
- `NSLocationAlwaysAndWhenInUseUsageDescription` (geofencing)

The override only ever existed to support **rebranding** (custom bundle id / display name) — the plist holds no other per-developer content — so defaulting to it is pure drift risk.

## Fix (make the default safe)
- `setup-local-dev.sh` no longer writes `INFOPLIST_FILE` into the generated `project.local.yml` — the app builds from the committed `OpenGlasses/Info.plist`, always current. The override is now **opt-in and documented as rebrand-only**.
- When a rebrander does opt in, `Info.personal.plist` is seeded by copying the **current** working `OpenGlasses/Info.plist`, not the old signing-recovery commit.
- `project.local.yml.example` comments the override out with the same guidance.

**No app-code change** — the committed `Info.plist` was always correct.

## Action for existing local setups
Drop the `INFOPLIST_FILE: Config/Info/Info.personal.plist` line from your (gitignored) `project.local.yml`, or re-run `./Scripts/setup-local-dev.sh`. Verified locally: the app target now uses `OpenGlasses/Info.plist` and the built bundle contains all three keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)