### PR TITLE
Bump mlx-swift-lm 3.31.3 → 3.31.4 (+ mlx-swift 0.31.6)

### DIFF
--- a/ci_scripts/Package.resolved
+++ b/ci_scripts/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
-        "version" : "0.31.3"
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
       }
     },
     {
@@ -50,8 +50,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
-        "version" : "3.31.3"
+        "revision" : "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
+        "version" : "3.31.4"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -131,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {

--- a/project.base.yml
+++ b/project.base.yml
@@ -64,7 +64,7 @@ packages:
     from: "2.2.5"
   mlx-swift-lm:
     url: https://github.com/ml-explore/mlx-swift-lm.git
-    version: "3.31.3"
+    version: "3.31.4"
   swift-huggingface:
     url: https://github.com/huggingface/swift-huggingface.git
     from: "0.1.0"
@@ -108,7 +108,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "311"
+        CURRENT_PROJECT_VERSION: "312"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -176,7 +176,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "311"
+        CURRENT_PROJECT_VERSION: "312"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -214,7 +214,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "311"
+        CURRENT_PROJECT_VERSION: "312"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "311"
+        CURRENT_PROJECT_VERSION: "312"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "311"
+        CURRENT_PROJECT_VERSION: "312"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## Summary

Dependency bump to the latest `mlx-swift-lm` release (June 30) — two months of upstream fixes, several squarely on our local-model paths:

- **Gemma 4 quality fixes** — MoE router softmax order, vision pooler kernel derivation, `Gemma3NText` ropeOffset. Gemma 4 E2B is our default local agent, so these affect the model most users actually run.
- **Token-shape tolerance** — "tolerate 1D token inputs in Gemma 4 VLM forward pass" and "flatten 2D inputs in TokenRing.loadPrompt": additive fixes on exactly the 1-D vs (1,L) landmine we've documented; our existing factory-specific handling stays valid.
- **Local tool calling** — stringified JSON tool-call arguments handled, tools schema passed to the parser for type-aware parsing.
- **Stability** — Qwen VLM text-only crash fix, CIContext/IOSurface exhaustion fixes in media processing, fp32 SSM state precision.

Timing note: upstream flags the *next* release as requiring a newer swift-tools-version (newer Xcode) — 3.31.4 is explicitly the recommended isolate tag, so this is a good version to sit on.

`ci_scripts/Package.resolved` refreshed for the Xcode Cloud post-clone copy (now 21 pins; `mlx-swift` moved transitively to 0.31.6). One local wrinkle worth knowing: the SPM cache for this package had corrupt refs (`cannot lock ref`) and silently kept the old pin until the cached repo was deleted — if Xcode Cloud resolution ever sticks at 3.31.3, that's the shape of it.

## Testing
- Full suite on the new dependency: 1890 tests, failures limited to the 18 known keychain-without-signing cases.
- Release build green including `Metadata.appintents`.
- On-device: a local-model smoke (Gemma 4 E2B generation + a local tool call) is worth adding to the next device session given the router/tool-parsing changes.

Build 312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)