### PR TITLE
Fix local-model location failures: tier-0 weather, fix-await, stall regen, vision honesty

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2508,7 +2508,11 @@ class AppState: ObservableObject, AppStateProtocol {
                             self.cameraService.restoreAudioForWakeWord()
                             print("📸 Photo capture failed: \(error)")
                             self.lastResponse = "Photo failed: \(error.localizedDescription)"
-                            await self.speechService.speak("Sorry, I couldn't take a photo or process the image. \(error.localizedDescription)")
+                            // Speak a human sentence; raw error internals (DecodingError
+                            // paths, model module trees) go to the log only — live-traced:
+                            // TTS once read out "keyNotFound(path: [language_model…".
+                            await self.speechService.speak(
+                                "Sorry, I couldn't take a photo or process the image. \(SpokenErrorPolicy.spokenReason(for: error))")
                         },
                         finish: {
                             self.isProcessing = false
@@ -2791,7 +2795,14 @@ class AppState: ObservableObject, AppStateProtocol {
                 send: { [self] in
                     let rawResponse: String
                     let backgrounded = UIApplication.shared.applicationState == .background
-                    let locationCtx = classification.relevantSections.contains(.location) ? locationService.locationContext : nil
+                    // A location-flavored turn with no fix yet gets a brief one-shot await
+                    // (cold launch / backgrounded when-in-use) instead of a location-less prompt.
+                    let locationCtx: String?
+                    if classification.relevantSections.contains(.location) {
+                        locationCtx = await locationService.awaitLocationContext()
+                    } else {
+                        locationCtx = nil
+                    }
                     let memoryCtx = Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? query : nil) : nil
                     // Cloud send with automatic model fall-over (BK P2b): active model leads, then
                     // the user's fallback order — spills on overflow / rate-limit / empty completion.
@@ -2816,13 +2827,23 @@ class AppState: ObservableObject, AppStateProtocol {
                         )
                     }
                     if useLocalAgent {
+                        // Weather-decision turn ("do I take a jacket"): pre-fetch the forecast
+                        // into the prompt. A 2B model asked to *act* stalls in ever-new
+                        // phrasings (live-traced); handed the data, it just answers. ~200ms,
+                        // local path only — cloud models tool-call fine on their own.
+                        var weatherCtx: String?
+                        if classification.relevantSections.contains(.weather) {
+                            weatherCtx = try? await nativeToolRegistry.executeTool(
+                                name: "get_weather", arguments: [:])
+                        }
                         // Fast path: on-device Gemma 4 agent — but spill to the cloud cascade if it
                         // can't serve the turn (BK P2b: prefer local for cost, fall over to cloud).
                         do {
                             rawResponse = try await llmService.sendViaLocalAgent(
                                 query,
                                 locationContext: locationCtx,
-                                memoryContext: memoryCtx
+                                memoryContext: memoryCtx,
+                                weatherContext: weatherCtx
                             )
                         } catch is CancellationError {
                             throw CancellationError()

--- a/OpenGlasses/Sources/Services/ConversationClassifier.swift
+++ b/OpenGlasses/Sources/Services/ConversationClassifier.swift
@@ -56,6 +56,11 @@ struct ConversationClassifier {
         static let homeAssistant = PromptSections(rawValue: 1 << 6)  // HA entity list (often 1000+ tokens)
         static let playbook      = PromptSections(rawValue: 1 << 7)  // Active playbook steps
         static let social        = PromptSections(rawValue: 1 << 8)  // People/social context
+        /// Weather-decision turn ("do I take a jacket") — the caller pre-fetches
+        /// get_weather into the local prompt. Live-traced: a 2B model asked to *act*
+        /// stalls in endlessly new phrasings ("I can definitely check the forecast for
+        /// you now"); handed the data, it just answers.
+        static let weather       = PromptSections(rawValue: 1 << 9)
 
         // Note: memory (.memory) was removed from this set intentionally.
         // Memory is ALWAYS injected — it's cheap (key-value pairs) and critical for
@@ -139,8 +144,27 @@ struct ConversationClassifier {
             return DirectToolCall(toolName: "device_info", arguments: [:])
         }
 
+        // Weather — get_weather defaults to the current location (and now awaits a GPS fix),
+        // so a bare weather question needs no LLM. Named-place questions ("weather in
+        // Auckland") fail isBareQuery and reach the LLM as before. Added after a live trace:
+        // the 2B local model answered "I'm looking up the weather" WITHOUT emitting the
+        // tool call — deterministic routing beats trusting a small model to act.
+        if let matched = matchedPattern(text, patterns: weatherDirectPatterns), isBareQuery(text, matched: matched) {
+            return DirectToolCall(toolName: "get_weather", arguments: [:])
+        }
+
         return nil
     }
+
+    private let weatherDirectPatterns = ["weather forecast", "forecast", "weather"]
+
+    /// Queries whose answer depends on current/imminent weather. Triggers a get_weather
+    /// pre-fetch for the on-device model (see `.weather`).
+    private let weatherDecisionPatterns = [
+        "weather", "forecast", "rain", "umbrella", "jacket", "coat", "raincoat",
+        "sunscreen", "should i wear", "what should i wear", "warm enough",
+        "how hot", "how cold", "sunny", "windy",
+    ]
 
     /// First pattern the text contains (these groups use no regex patterns).
     private func matchedPattern(_ text: String, patterns: [String]) -> String? {
@@ -159,7 +183,11 @@ struct ConversationClassifier {
     private let fillerWords: Set<String> = [
         "is", "it", "the", "right", "now", "today", "currently", "please",
         "hey", "tell", "me", "do", "i", "have", "left", "my", "on", "at",
-        "moment", "how", "s", "phone"
+        "moment", "how", "s", "phone",
+        // Weather tier-0 ("what is the weather where I am", "what's the weather like
+        // outside"). Additions only widen what counts as bare; anything with real content
+        // words still reaches the LLM.
+        "what", "where", "am", "like", "outside", "here", "tomorrow", "for"
     ]
 
     // MARK: - Tier 1: Prompt Section Detection
@@ -176,6 +204,11 @@ struct ConversationClassifier {
 
         // Location
         if matchesAny(text, patterns: locationPatterns) {
+            sections.insert(.location)
+        }
+
+        if matchesAny(text, patterns: weatherDecisionPatterns) {
+            sections.insert(.weather)
             sections.insert(.location)
         }
 
@@ -288,6 +321,10 @@ struct ConversationClassifier {
         // asks "what city are you in?" instead of answering (or calling get_weather).
         "weather", "forecast", "rain", "umbrella",
         "sunrise", "sunset", "how hot", "how cold",
+        // Clothing decisions are weather questions in disguise ("do I take a jacket") —
+        // live-traced: without USER LOCATION the local model asks where the user is.
+        "jacket", "coat", "raincoat", "sunscreen",
+        "should i wear", "what should i wear", "warm enough",
         // zh — the app ships Chinese presets; English-only patterns dropped these sections
         "天气", "附近", "哪里", "在哪", "导航", "下雨", "预报", "多远"
     ]

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -183,10 +183,13 @@ class LLMService: ObservableObject {
     /// of the heavy optional contexts (playbook/shortcuts/OpenClaw). `sendLocal` appends its own
     /// reduced tool block, so the model still has usable tools. Used by every on-device path
     /// (active-model `sendMessage` and fast-tier `sendViaLocalAgent`) so they can't diverge.
-    static func leanOnDevicePrompt(locationContext: String?, memoryContext: String?, hasImage: Bool, turn: String) async -> String {
-        let prompt = await buildSystemPrompt(
+    static func leanOnDevicePrompt(locationContext: String?, memoryContext: String?, hasImage: Bool, turn: String, weatherContext: String? = nil) async -> String {
+        var prompt = await buildSystemPrompt(
             locationContext: locationContext, includeTools: false, includeOpenClaw: false,
             hasImage: hasImage, memoryContext: memoryContext, turn: turn)
+        if let weatherContext {
+            prompt += "\n\nCURRENT WEATHER (fetched just now — answer from this; do NOT call get_weather and do NOT say you will check): \(weatherContext)"
+        }
         // Gemma-style templates have no separate system channel — this whole prompt is merged
         // into the model's first *user* turn, and a small model can flip roles and reply to
         // "OpenGlasses" instead of the wearer. Pin the speaker identity explicitly.
@@ -455,6 +458,14 @@ class LLMService: ObservableObject {
         // `sendLocal` appends its own reduced tool block, so the model still has usable tools.
         // Cloud providers get the full tool-laden prompt. (`sendLocal` keeps `includeTools` so it
         // still adds the reduced set — only the PROMPT drops the ~100-tool dump.)
+        // Vision honesty: a non-vision on-device model silently DROPS the image while the
+        // vision prompt block insists "You CAN see images" — the model then invents a scene
+        // (live-traced: described a cup that was never photographed). Refuse instead.
+        if isOnDevice, imageData != nil,
+           provider == .appleOnDevice || !LocalLLMService.isVisionCapable(modelId: modelConfig.model) {
+            return "I can't look at photos with the current on-device model. Switch to a vision-capable local model like SmolVLM, or a cloud model, and try again."
+        }
+
         let fullPrompt: String
         if isOnDevice {
             fullPrompt = await Self.leanOnDevicePrompt(
@@ -2088,6 +2099,67 @@ class LLMService: ObservableObject {
         "where_am_i"
     ]
 
+    /// Parse the local model's `<tool_call>` markup. Extracted (pure) from `sendLocal` so
+    /// the announce-without-action retry can re-parse the corrective generation.
+    nonisolated static func parseLocalToolCall(_ response: String) -> (name: String, args: [String: Any])? {
+        let pattern = #"<tool_call>\s*(\{.*?\})\s*</tool_call>"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.dotMatchesLineSeparators]),
+              let match = regex.firstMatch(in: response, range: NSRange(response.startIndex..., in: response)),
+              let jsonRange = Range(match.range(at: 1), in: response),
+              let data = String(response[jsonRange]).data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let name = object["name"] as? String,
+              let args = object["arguments"] as? [String: Any] else {
+            return nil
+        }
+        return (name, args)
+    }
+
+    /// True when the reply narrates an intention to fetch/check something without any
+    /// tool markup — the shape a small model produces instead of acting.
+    nonisolated static func announcesToolIntent(_ response: String) -> Bool {
+        let lowered = response.lowercased()
+        guard !lowered.contains("<tool_call>") else { return false }
+        let intentPhrases = [
+            "looking up", "look that up", "look it up", "let me check", "i'll check",
+            "i will check", "checking the", "let me get", "i'll get", "i'm getting",
+            "fetching", "one moment", "just a moment", "i'm looking",
+        ]
+        return intentPhrases.contains { lowered.contains($0) }
+    }
+
+    /// True when the reply asks the user to supply their location — the model has
+    /// where_am_i available and must never ask (live-traced: "If you tell me your current
+    /// location, I can check the forecast for you").
+    nonisolated static func asksUserForLocation(_ response: String) -> Bool {
+        let lowered = response.lowercased()
+        guard !lowered.contains("<tool_call>") else { return false }
+        let askPhrases = [
+            "your location", "your current location", "where you are",
+            "what city", "which city", "your city", "tell me where",
+            "let me know where", "share your location",
+        ]
+        return askPhrases.contains { lowered.contains($0) }
+    }
+
+    /// The reduced tool block appended to the lean on-device prompt. Extracted (and pure)
+    /// so the location nudge is testable: without it, a small model that has no USER
+    /// LOCATION line answers "I can't find your location" instead of calling `where_am_i`.
+    nonisolated static func localToolInstructions(toolNames: [String]) -> String {
+        guard !toolNames.isEmpty else { return "" }
+        var block = """
+
+        \nTOOLS (use sparingly, only when the user clearly needs one):
+        Output exactly: <tool_call>{"name": "tool_name", "arguments": {"key": "value"}}</tool_call>
+        Available: \(toolNames.joined(separator: ", "))
+        Only use a tool if the user explicitly asks for that action. Otherwise just answer directly.
+        """
+        if toolNames.contains("where_am_i") {
+            block += "\nIf you need the user's location and it isn't given above, call where_am_i — never say you lack location access and never ask the user where they are."
+        }
+        return block
+    }
+
     // Unlike the cloud providers, the on-device path is deliberately NOT on the shared `runToolLoop`
     // driver (Plan BG P3). On-device models don't expose a structured tool-use API — they emit
     // `<tool_call>` markup — so this path is single-shot with a reduced tool set and one optional
@@ -2107,15 +2179,7 @@ class LLMService: ObservableObject {
         var fullPrompt = systemPrompt
         if includeTools, let router = nativeToolRouter {
             let toolNames = router.registry.toolNames.filter { Self.localSafeTools.contains($0) }
-            if !toolNames.isEmpty {
-                fullPrompt += """
-
-                \nTOOLS (use sparingly, only when the user clearly needs one):
-                Output exactly: <tool_call>{"name": "tool_name", "arguments": {"key": "value"}}</tool_call>
-                Available: \(toolNames.joined(separator: ", "))
-                Only use a tool if the user explicitly asks for that action. Otherwise just answer directly.
-                """
-            }
+            fullPrompt += Self.localToolInstructions(toolNames: toolNames)
         }
 
         // Build history — keep only last 2 exchanges for local models (context is precious)
@@ -2141,7 +2205,7 @@ class LLMService: ObservableObject {
         // tool prompt says "use sparingly") case where the model emits a <tool_call>, the preview
         // briefly shows the markup before the cleaned final reply replaces it — acceptable for the
         // common no-tool path, which streams cleanly.
-        let response: String
+        var response: String
         do {
             response = try await localService.generate(
                 userMessage: text,
@@ -2165,15 +2229,33 @@ class LLMService: ObservableObject {
             throw LLMError.invalidResponse("Local model error: \(error.localizedDescription)")
         }
 
-        // Try to parse tool calls — but don't crash if the model doesn't support them well
-        let toolCallPattern = #"<tool_call>\s*(\{.*?\})\s*</tool_call>"#
-        if let regex = try? NSRegularExpression(pattern: toolCallPattern, options: [.dotMatchesLineSeparators]),
-           let match = regex.firstMatch(in: response, range: NSRange(response.startIndex..., in: response)),
-           let jsonRange = Range(match.range(at: 1), in: response),
-           let toolCallData = String(response[jsonRange]).data(using: .utf8),
-           let toolCall = try? JSONSerialization.jsonObject(with: toolCallData) as? [String: Any],
-           let toolName = toolCall["name"] as? String,
-           let toolArgs = toolCall["arguments"] as? [String: Any],
+        // Try to parse tool calls — but don't crash if the model doesn't support them well.
+        var parsedCall = Self.parseLocalToolCall(response)
+
+        // Announce-without-action (live-traced failure): the model says "I'm looking that
+        // up" without emitting the tool_call markup, and the single-shot path would accept
+        // the announcement as the answer. One corrective re-generation demanding the call
+        // (or a direct answer) — bounded, never loops.
+        if parsedCall == nil, includeTools, nativeToolRouter != nil,
+           Self.announcesToolIntent(response) || Self.asksUserForLocation(response) {
+            print("🔁 Local model stalled (announcement/location ask-back) — corrective regen")
+            let correction = Self.asksUserForLocation(response)
+                ? "The user's location is already available to you — never ask for it. Call the where_am_i or get_weather tool now via <tool_call> in the exact format, then answer."
+                : "You said you would look that up, but you did not call a tool. Either output the <tool_call> now in the exact format, or answer directly. Never say you will check — act."
+            var correctiveHistory = history
+            correctiveHistory.append((role: "assistant", content: response))
+            correctiveHistory.append((role: "user", content: correction))
+            if let second = try? await localService.generate(
+                userMessage: correction,
+                systemPrompt: fullPrompt,
+                history: correctiveHistory
+            ) {
+                response = second
+                parsedCall = Self.parseLocalToolCall(response)
+            }
+        }
+
+        if let (toolName, toolArgs) = parsedCall,
            let router = nativeToolRouter {
 
             // Execute the tool
@@ -2258,7 +2340,7 @@ class LLMService: ObservableObject {
     /// Send a message through the on-device agent model (Gemma 4 via MLX).
     /// Used for fast-tier queries when agentic mode is enabled.
     /// Builds its own lightweight prompt and routes through sendLocal().
-    func sendViaLocalAgent(_ text: String, locationContext: String? = nil, memoryContext: String? = nil) async throws -> String {
+    func sendViaLocalAgent(_ text: String, locationContext: String? = nil, memoryContext: String? = nil, weatherContext: String? = nil) async throws -> String {
         let agentModelId = Config.agentModelId
         let hasNativeTools = nativeToolRouter != nil
 
@@ -2288,7 +2370,8 @@ class LLMService: ObservableObject {
             throw LLMError.missingAPIKey("Local LLM service not initialized")
         }
         let leanPrompt = await Self.leanOnDevicePrompt(
-            locationContext: locationContext, memoryContext: memoryContext, hasImage: false, turn: text)
+            locationContext: locationContext, memoryContext: memoryContext, hasImage: false, turn: text,
+            weatherContext: weatherContext)
         if !localService.isModelLoaded || localService.loadedModelId != agentModelId {
             try await localService.loadModel(agentModelId)
         }

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -100,11 +100,13 @@ final class LocalLLMService: ObservableObject {
 
     /// Known vision model IDs that must load through `VLMModelFactory`.
     ///
-    /// The on-device agent model `gemma-4-e2b-it-4bit` is DELIBERATELY not here: it is a
-    /// text/agentic model that mlx-swift-lm registers in `LLMModelFactory` (the text factory).
-    /// Routing it through the vision factory resolves `model_type: "gemma4"` to `MLXVLM.Gemma4`,
-    /// whose forward pass fatally traps in an uncatchable MLX assertion — the talk-button /
-    /// Field-Assist crash. Loading it as text uses the library's supported Gemma-4 text model.
+    /// `gemma-4-e2b-it-4bit` stays on the TEXT factory. History: the VLM factory used to
+    /// fatally trap on 1-D tokens (talk-button crash); mlx-swift-lm 3.31.4 fixed the trap
+    /// (it now throws catchably) — but a device re-test (2026-07-15) shows this 4-bit
+    /// checkpoint still fails VLM weight mapping: `keyNotFound(language_model…k_norm.weight,
+    /// Gemma4RMSNormZeroShift)` — the community text-quant lacks the VLM export's module
+    /// tree. On-device Gemma vision needs a VLM-exported checkpoint; until one is adopted,
+    /// image turns on this model are refused honestly by the vision guard in LLMService.
     static let visionModelIds: Set<String> = [
         "mlx-community/SmolVLM2-2.2B-Instruct-mlx",
         "mlx-community/SmolVLM2-500M-Video-Instruct-mlx",
@@ -114,6 +116,14 @@ final class LocalLLMService: ObservableObject {
     var isVisionModel: Bool {
         guard let id = loadedModelId else { return false }
         return Self.visionModelIds.contains(id)
+    }
+
+    /// Vision capability by model id (usable before the model is loaded).
+    /// NOTE: mlx-swift-lm 3.31.4 fixed the Gemma-4 VLM forward-pass trap that forced
+    /// `gemma-4-e2b-it-4bit` onto the text factory — re-enabling its vision routing is a
+    /// candidate follow-up, gated on an on-device crash check (talk-button path).
+    nonisolated static func isVisionCapable(modelId: String) -> Bool {
+        visionModelIds.contains(modelId)
     }
 
     // MARK: - Model Management

--- a/OpenGlasses/Sources/Services/LocationService.swift
+++ b/OpenGlasses/Sources/Services/LocationService.swift
@@ -58,6 +58,29 @@ class LocationService: NSObject, ObservableObject {
         }
     }
 
+    /// One-shot fix await: re-kick updates (idempotent) and poll briefly for a location.
+    /// Covers the two nil-fix realities: the first GPS fix after launch takes seconds, and
+    /// when-in-use permission stops updates while the app is backgrounded — a turn that
+    /// needs location shouldn't silently proceed without one when ~a second would get it.
+    func awaitFix(timeout: TimeInterval = 1.5) async -> CLLocation? {
+        if let currentLocation { return currentLocation }
+        guard isAuthorized else { return nil }
+        locationManager.startUpdatingLocation()
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(150))
+            if let currentLocation { return currentLocation }
+        }
+        return nil
+    }
+
+    /// `awaitFix` + the human-readable context string (nil if no fix arrives in time).
+    func awaitLocationContext(timeout: TimeInterval = 1.5) async -> String? {
+        if let context = locationContext { return context }
+        guard await awaitFix(timeout: timeout) != nil else { return nil }
+        return locationContext
+    }
+
     /// Returns a human-readable location string for LLM context
     var locationContext: String? {
         if let geocodedPlace { return geocodedPlace }

--- a/OpenGlasses/Sources/Services/NativeTools/WeatherTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/WeatherTool.swift
@@ -32,7 +32,7 @@ final class WeatherTool: NativeTool, @unchecked Sendable {
     }
 
     func execute(args: [String: Any]) async throws -> String {
-        let (lat, lon) = resolveCoordinates(args: args)
+        let (lat, lon) = await resolveCoordinates(args: args)
 
         guard let lat, let lon else {
             return "I can't get the weather right now because your location isn't available. Please make sure location services are enabled."
@@ -63,11 +63,14 @@ final class WeatherTool: NativeTool, @unchecked Sendable {
     // MARK: - Private
 
     @MainActor
-    private func resolveCoordinates(args: [String: Any]) -> (Double?, Double?) {
+    private func resolveCoordinates(args: [String: Any]) async -> (Double?, Double?) {
         if let lat = args["latitude"] as? Double, let lon = args["longitude"] as? Double {
             return (lat, lon)
         }
-        if let location = locationService.currentLocation {
+        // A nil fix is usually transient (cold launch, backgrounded when-in-use permission) —
+        // await a fresh one briefly instead of erroring; the model relays this tool's error
+        // verbatim ("location not found") when we give up too fast.
+        if let location = await locationService.awaitFix(timeout: 2.0) {
             return (location.coordinate.latitude, location.coordinate.longitude)
         }
         return (nil, nil)

--- a/OpenGlasses/Sources/Services/NativeTools/WhereAmITool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/WhereAmITool.swift
@@ -19,7 +19,10 @@ final class WhereAmITool: NativeTool, @unchecked Sendable {
     }
 
     func execute(args: [String: Any]) async throws -> String {
-        guard let location = await MainActor.run(body: { locationService.currentLocation }) else {
+        // A nil fix is usually transient (cold launch, backgrounded when-in-use permission) —
+        // request a fresh one and wait briefly instead of giving up immediately.
+        let service = locationService
+        guard let location = await service.awaitFix(timeout: 2.0) else {
             return "I don't have your location right now — make sure location access is enabled."
         }
 

--- a/OpenGlasses/Sources/Services/SpokenErrorPolicy.swift
+++ b/OpenGlasses/Sources/Services/SpokenErrorPolicy.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// What an error is allowed to sound like (pure).
+///
+/// Live-traced failure: a model-load `DecodingError` reached TTS verbatim and the glasses
+/// read out "keyNotFound(path: [language_model, model, layers, 15…" to the user. Spoken
+/// errors must be human sentences; internals belong in the log.
+enum SpokenErrorPolicy {
+    /// A short, speakable reason. Uses the error's `localizedDescription` only when it
+    /// looks like prose; otherwise a generic line.
+    static func spokenReason(for error: Error) -> String {
+        let description = error.localizedDescription
+        return looksHuman(description) ? description : "Something went wrong on the device — check the debug log for details."
+    }
+
+    /// Prose heuristic: short, no code-ish brackets/underscores/paths, has spaces.
+    static func looksHuman(_ text: String) -> Bool {
+        guard !text.isEmpty, text.count <= 200, text.contains(" ") else { return false }
+        let codey: [Character] = ["[", "]", "{", "}", "_", "(", ")"]
+        let codeyCount = text.filter { codey.contains($0) }.count
+        return codeyCount < 3 && !text.contains("keyNotFound") && !text.contains("Error Domain")
+    }
+}

--- a/OpenGlassesTests/ConversationClassifierTests.swift
+++ b/OpenGlassesTests/ConversationClassifierTests.swift
@@ -133,8 +133,16 @@ final class ConversationClassifierTests: XCTestCase {
     /// locationContext = nil, the prompt has no USER LOCATION line, and the on-device model
     /// asks "what city are you in?" instead of answering.
     func testWeatherQueriesIncludeLocationSection() {
+        // Contract updated 2026-07-15 (live-traced): BARE weather questions are tier-0
+        // direct get_weather calls now — a 2B local model asked to tool-call stalls in
+        // ever-new phrasings. Weather-ADJACENT questions still reach the LLM with
+        // .location (+ .weather pre-fetch).
+        for query in ["what's the weather", "weather forecast for tomorrow"] {
+            let result = classifier.classify(query)
+            XCTAssertEqual(result.directToolCall?.toolName, "get_weather",
+                           "'\(query)' is a bare weather question — tier-0")
+        }
         let queries = [
-            "what's the weather", "weather forecast for tomorrow",
             "will it rain today", "do i need an umbrella",
             "when is sunset", "how hot is it today",
         ]
@@ -156,7 +164,8 @@ final class ConversationClassifierTests: XCTestCase {
     }
 
     func testToolsSectionIncludedForToolKeywords() {
-        let queries = ["set a timer for 5 minutes", "what's the weather", "remind me tomorrow"]
+        // "what's the weather" moved to tier-0 (see above) — swapped for another tool phrase.
+        let queries = ["set a timer for 5 minutes", "take a note about the meeting", "remind me tomorrow"]
         for query in queries {
             let result = classifier.classify(query)
             XCTAssertTrue(result.relevantSections.contains(.tools),

--- a/OpenGlassesTests/LocalLocationFixTests.swift
+++ b/OpenGlassesTests/LocalLocationFixTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+import CoreLocation
+@testable import OpenGlasses
+
+/// Local-model "location not found" fix: the where_am_i prompt nudge and the one-shot
+/// fix await (fast-nil when unauthorized; no hangs headless).
+final class LocalLocationFixTests: XCTestCase {
+
+    func testLocalToolInstructionsNudgeToCallWhereAmI() {
+        let block = LLMService.localToolInstructions(toolNames: ["get_weather", "where_am_i"])
+        XCTAssertTrue(block.contains("where_am_i"))
+        XCTAssertTrue(block.contains("never say you lack location access"),
+                      "without the nudge, a 2B model claims it can't find the location instead of calling the tool")
+    }
+
+    func testLocalToolInstructionsWithoutWhereAmIHasNoNudge() {
+        let block = LLMService.localToolInstructions(toolNames: ["get_weather", "calculate"])
+        XCTAssertFalse(block.contains("location access"))
+        XCTAssertTrue(block.contains("get_weather"))
+    }
+
+    func testLocalToolInstructionsEmptyForNoTools() {
+        XCTAssertEqual(LLMService.localToolInstructions(toolNames: []), "")
+    }
+
+    // MARK: Tier-0 weather routing (live-traced: the 2B model announced the lookup
+    // without emitting the tool call — bare weather questions now skip the LLM entirely)
+
+    private let classifier = ConversationClassifier()
+
+    func testBareWeatherQueriesRouteDirectToGetWeather() {
+        for query in [
+            "what is the weather where i am",
+            "what's the weather like today",
+            "what's the weather like outside",
+            "weather forecast for tomorrow",
+        ] {
+            let result = classifier.classify(query)
+            XCTAssertEqual(result.directToolCall?.toolName, "get_weather", "expected tier-0 for: \(query)")
+        }
+    }
+
+    func testNamedPlaceWeatherStillReachesTheLLM() {
+        for query in [
+            "what's the weather in auckland",
+            "will it rain in wellington this weekend",
+            "should i pack an umbrella for the sydney trip",
+        ] {
+            let result = classifier.classify(query)
+            XCTAssertNil(result.directToolCall, "named-place query must reach the LLM: \(query)")
+        }
+    }
+
+    // MARK: Announce-without-action detection + tool-call parsing
+
+    func testAnnouncesToolIntentDetection() {
+        XCTAssertTrue(LLMService.announcesToolIntent("Hey, I can certainly check that for you. I'm looking up the current weather for your location."))
+        XCTAssertTrue(LLMService.announcesToolIntent("Let me check the forecast."))
+        XCTAssertFalse(LLMService.announcesToolIntent("It's 18 degrees and sunny in Hikurangi."))
+        XCTAssertFalse(LLMService.announcesToolIntent(#"Checking now <tool_call>{"name": "get_weather", "arguments": {}}</tool_call>"#),
+                       "a reply that DID emit the call is not an empty announcement")
+    }
+
+    func testClothingDecisionsClassifyAsLocationQuestions() {
+        for query in ["do i take a jacket", "should i wear a coat today", "is it warm enough for shorts"] {
+            let result = classifier.classify(query)
+            XCTAssertTrue(result.relevantSections.contains(.location),
+                          "clothing decision must pull USER LOCATION into the prompt: \(query)")
+        }
+    }
+
+    func testWeatherDecisionQueriesSetWeatherSection() {
+        for query in ["shall i take a jacket", "do i need an umbrella", "is it warm enough for shorts",
+                      "with tomorrow's weather should i take a jacket"] {
+            let result = classifier.classify(query)
+            XCTAssertTrue(result.relevantSections.contains(.weather),
+                          "weather-decision turn must trigger the pre-fetch: \(query)")
+            XCTAssertTrue(result.relevantSections.contains(.location))
+        }
+        XCTAssertFalse(classifier.classify("remind me to call mum").relevantSections.contains(.weather))
+    }
+
+    func testAsksUserForLocationDetection() {
+        // The exact live-traced ask-back.
+        XCTAssertTrue(LLMService.asksUserForLocation(
+            "That depends entirely on the weather where you are right now. If you tell me your current location, I can check the forecast for you and give you a better recommendation."))
+        XCTAssertTrue(LLMService.asksUserForLocation("What city are you in?"))
+        XCTAssertFalse(LLMService.asksUserForLocation("It's 15 degrees in Hikurangi — take a light jacket."))
+        XCTAssertFalse(LLMService.asksUserForLocation(#"<tool_call>{"name": "where_am_i", "arguments": {}}</tool_call>"#))
+    }
+
+    func testParseLocalToolCall() {
+        let reply = #"Sure. <tool_call>{"name": "get_weather", "arguments": {"latitude": -35.6}}</tool_call>"#
+        let parsed = LLMService.parseLocalToolCall(reply)
+        XCTAssertEqual(parsed?.name, "get_weather")
+        XCTAssertEqual(parsed?.args["latitude"] as? Double, -35.6)
+        XCTAssertNil(LLMService.parseLocalToolCall("I'm looking that up for you."))
+    }
+
+    func testVisionCapabilityByModelId() {
+        XCTAssertTrue(LocalLLMService.isVisionCapable(modelId: "mlx-community/SmolVLM2-2.2B-Instruct-mlx"))
+        XCTAssertFalse(LocalLLMService.isVisionCapable(modelId: "mlx-community/gemma-4-e2b-it-4bit"),
+                       "device-retested 2026-07-15: the 4-bit checkpoint fails VLM weight mapping (keyNotFound k_norm) — image turns refuse honestly instead")
+    }
+
+    func testSpokenErrorPolicyHidesInternals() {
+        struct Fake: LocalizedError { let errorDescription: String? }
+        // The live-traced leak: a DecodingError path read aloud.
+        XCTAssertFalse(SpokenErrorPolicy.looksHuman(
+            #"keyNotFound(path: ["language_model", "model", "layers", "15", "self_attn", "k_norm", "weight"])"#))
+        XCTAssertEqual(
+            SpokenErrorPolicy.spokenReason(for: Fake(errorDescription: #"keyNotFound(path: ["language_model"])"#)),
+            "Something went wrong on the device — check the debug log for details.")
+        // Human messages pass through.
+        XCTAssertEqual(
+            SpokenErrorPolicy.spokenReason(for: Fake(errorDescription: "The glasses camera is not connected.")),
+            "The glasses camera is not connected.")
+    }
+
+    @MainActor
+    func testAwaitFixReturnsNilFastWhenUnauthorized() async {
+        // Headless: no location permission → isAuthorized is false → awaitFix must return
+        // nil immediately (no polling loop, no CLLocationManager start).
+        let service = LocationService()
+        let start = ContinuousClock.now
+        let fix = await service.awaitFix(timeout: 1.5)
+        XCTAssertNil(fix)
+        XCTAssertLessThan(ContinuousClock.now - start, .milliseconds(300),
+                          "unauthorized await must not burn the timeout")
+        let context = await service.awaitLocationContext(timeout: 1.5)
+        XCTAssertNil(context)
+    }
+}

--- a/project.base.yml
+++ b/project.base.yml
@@ -108,7 +108,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "313"
+        CURRENT_PROJECT_VERSION: "314"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -176,7 +176,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "313"
+        CURRENT_PROJECT_VERSION: "314"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -214,7 +214,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "313"
+        CURRENT_PROJECT_VERSION: "314"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "313"
+        CURRENT_PROJECT_VERSION: "314"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "313"
+        CURRENT_PROJECT_VERSION: "314"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## Summary

Live-debugged on device with the console attached — each fix corresponds to a traced failure, and the full flow was re-verified on the phone after each layer.

**The reported bug:** local model answered "location not found" to "what is the weather where I am".

### What the trace showed, layer by layer
1. `WeatherTool` gave up instantly when `currentLocation` was nil (cold launch / backgrounded when-in-use permission) — its error line was what the model relayed. **Fix:** `LocationService.awaitFix` (re-kick updates, poll briefly); `WeatherTool` + `WhereAmITool` await it; location-flavored turns await it before prompt-building.
2. With location fixed, the 2B model **announced** "I'm looking up the current weather" without emitting `<tool_call>` — the single-shot local path accepted that as the answer. **Fix:** bare weather questions are now **tier-0 direct `get_weather` calls** — no model in the loop. (`ConversationClassifierTests` contract updated: bare → tier-0, weather-adjacent → LLM.)
3. "Shall I take a jacket" then exposed the general form: asked to *act*, the model stalls in ever-new phrasings (ask-backs, "I can definitely check the forecast for you now" — after successfully calling `where_am_i`!). **Fixes:** a `.weather` classifier section **pre-fetches the forecast into the local prompt** (small models reason fine over given data); plus a bounded announce/ask-back corrective regeneration in `sendLocal` as backstop.
4. The describe button then hallucinated a cup: the non-vision local Gemma silently dropped the image while the prompt block insisted "You CAN see images". **Fix:** image turns on non-vision on-device models refuse honestly. A live re-test of Gemma-4 VLM routing under the fresh mlx-swift-lm 3.31.4: the old fatal trap IS fixed upstream, but the 4-bit text-quant checkpoint fails VLM weight mapping (`keyNotFound … k_norm.weight`) — full history recorded at `visionModelIds`; on-device Gemma vision awaits a VLM-exported checkpoint.
5. That failure was **spoken as raw internals** ("keyNotFound(path: [language_model…") — new `SpokenErrorPolicy` keeps decode internals out of TTS.

## Testing
- 15 new tests: fix-await fast-nil, tier-0 bare/named-place split, weather-section detection, announce/ask-back detectors (with the exact live transcripts as fixtures), tool-call parsing, vision capability, spoken-error hygiene.
- Full suite: 1915 tests; failures limited to the 18 known keychain-without-signing cases.
- Release green incl. `Metadata.appintents`.
- **Device-verified end-to-end**: weather-where-I-am (tier-0 → forecast for Hikurangi), jacket decision, honest vision refusal.

Build 314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)