### PR TITLE
Local model: date/time in every prompt + tier-0 follow-up continuity

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2722,6 +2722,11 @@ class AppState: ObservableObject, AppStateProtocol {
                 lastResponse = result
                 print("⚡ Direct tool call: \(directCall.toolName) → \(result)")
 
+                // Follow-up continuity: the LLM never saw this exchange (tier-0 bypasses
+                // it) — record it in the model's history so "what about tomorrow?" can
+                // refer back to the forecast just spoken.
+                llmService.recordExternalExchange(user: query, assistant: result)
+
                 if Config.conversationPersistenceEnabled {
                     conversationStore.appendMessage(role: "assistant", content: result)
                 }

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -353,6 +353,11 @@ class LLMService: ObservableObject {
         if let playbook = playbookContext {
             prompt += "\n\n\(playbook)"
         }
+        // Models have no clock — without this one ~15-token line they answer date/time
+        // reasoning from their training cutoff, confidently wrong ("local LLM doesn't
+        // know day or time"). Unconditional: cheap enough for every turn, both paths.
+        prompt += "\n\nCURRENT DATE & TIME: \(Self.currentDateTimeLine())"
+
         if let location = locationContext {
             prompt += "\n\nUSER LOCATION: \(location)"
         }
@@ -2099,6 +2104,25 @@ class LLMService: ObservableObject {
         "where_am_i"
     ]
 
+    /// Record an exchange the LLM didn't produce — tier-0 direct tool answers — so
+    /// follow-up turns can see it. Without this, "what about tomorrow?" after a direct
+    /// weather answer reached the model with no forecast anywhere in its history (the
+    /// direct path bypasses the LLM entirely; it only wrote to the UI transcript).
+    func recordExternalExchange(user: String, assistant: String) {
+        conversationHistory.append(["role": "user", "content": user])
+        conversationHistory.append(["role": "assistant", "content": assistant])
+        trimHistory()
+    }
+
+    /// "Tuesday, 15 July 2026, 6:41 pm (Pacific/Auckland)" — injected into every system
+    /// prompt. Pure and injectable for tests.
+    nonisolated static func currentDateTimeLine(now: Date = Date(), timeZone: TimeZone = .current) -> String {
+        let formatter = DateFormatter()
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "EEEE, d MMMM yyyy, h:mm a"
+        return "\(formatter.string(from: now)) (\(timeZone.identifier))"
+    }
+
     /// Parse the local model's `<tool_call>` markup. Extracted (pure) from `sendLocal` so
     /// the announce-without-action retry can re-parse the corrective generation.
     nonisolated static func parseLocalToolCall(_ response: String) -> (name: String, args: [String: Any])? {
@@ -2182,8 +2206,10 @@ class LLMService: ObservableObject {
             fullPrompt += Self.localToolInstructions(toolNames: toolNames)
         }
 
-        // Build history — keep only last 2 exchanges for local models (context is precious)
-        let recentHistory = conversationHistory.suffix(4)
+        // Build history — last 3 exchanges for local models (context is precious; the
+        // LocalModelBudget cap still guards the ceiling). Was 2 — too short for a
+        // follow-up that references the answer before last.
+        let recentHistory = conversationHistory.suffix(6)
         var history: [(role: String, content: String)] = []
         for turn in recentHistory {
             if let role = turn["role"] as? String, let content = turn["content"] as? String {

--- a/OpenGlassesTests/LocalLocationFixTests.swift
+++ b/OpenGlassesTests/LocalLocationFixTests.swift
@@ -103,6 +103,19 @@ final class LocalLocationFixTests: XCTestCase {
                        "device-retested 2026-07-15: the 4-bit checkpoint fails VLM weight mapping (keyNotFound k_norm) — image turns refuse honestly instead")
     }
 
+    func testCurrentDateTimeLineFormat() {
+        let tz = TimeZone(identifier: "Pacific/Auckland")!
+        var components = DateComponents()
+        (components.year, components.month, components.day, components.hour, components.minute) = (2026, 7, 15, 18, 41)
+        components.timeZone = tz
+        let date = Calendar(identifier: .gregorian).date(from: components)!
+        let line = LLMService.currentDateTimeLine(now: date, timeZone: tz)
+        XCTAssertTrue(line.contains("2026"), line)
+        XCTAssertTrue(line.contains("July"), line)
+        XCTAssertTrue(line.lowercased().contains("wednesday"), "15 July 2026 is a Wednesday: \(line)")
+        XCTAssertTrue(line.contains("Pacific/Auckland"), line)
+    }
+
     func testSpokenErrorPolicyHidesInternals() {
         struct Fake: LocalizedError { let errorDescription: String? }
         // The live-traced leak: a DecodingError path read aloud.

--- a/project.base.yml
+++ b/project.base.yml
@@ -108,7 +108,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "314"
+        CURRENT_PROJECT_VERSION: "315"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -176,7 +176,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "314"
+        CURRENT_PROJECT_VERSION: "315"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -214,7 +214,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "314"
+        CURRENT_PROJECT_VERSION: "315"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "314"
+        CURRENT_PROJECT_VERSION: "315"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "314"
+        CURRENT_PROJECT_VERSION: "315"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
Follow-up to [#239](https://github.com/straff2002/OpenGlasses/pull/239) — two more live-reported gaps, same debugging session:

**"The local LLM doesn't know day or time."** No prompt (lean or cloud) carried any date/time — tier-0 answers the bare asks, but anything *reasoning* with time got training-cutoff guesses. One unconditional ~15-token `CURRENT DATE & TIME:` line in the system prompt fixes both paths (pure `currentDateTimeLine`, tested).

**"When I ask the weather tomorrow, it doesn't look back in the conversation."** Two causes: tier-0 direct answers bypassed `LLMService` entirely, so the forecast was never in the model's history at all (`recordExternalExchange` now records them); and the local history window was 2 exchanges — now 3, with the BK-P2 token budget still capping the ceiling.

Gates: full suite (1916 tests, keychain-only failures) + Release incl. `Metadata.appintents`, both run on exactly this tree; device build smoke-checked live.

Build 315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)