### PR TITLE
Home screen redesign, Settings hub, local vision + Gemma 4, photo pipeline overhaul

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -185,10 +185,7 @@ struct OpenGlassesApp: App {
                         Task { @MainActor in
                             if let persona = Config.enabledPersonas.first(where: { $0.id == personaId }) {
                                 // Activate this persona's model + prompt
-                                appState.activePersona = persona
-                                Config.setActiveModelId(persona.modelId)
-                                Config.setActivePresetId(persona.presetId)
-                                appState.llmService.refreshActiveModel()
+                                appState.applyPersonaRouting(persona)
                                 // Start listening immediately — skip wake word
                                 appState.wakeWordService.stopListening()
                                 try? await Task.sleep(nanoseconds: 100_000_000)
@@ -1322,11 +1319,8 @@ class AppState: ObservableObject, AppStateProtocol {
                 }
                 // Route to the persona that owns this wake phrase
                 if let persona = Config.persona(forPhrase: matchedPhrase) {
-                    self.activePersona = persona
-                    Config.setActiveModelId(persona.modelId)
-                    Config.setActivePresetId(persona.presetId)
-                    self.llmService.refreshActiveModel()
-                    print("🎭 Persona activated: \(persona.name) (model: \(persona.modelId))")
+                    self.applyPersonaRouting(persona)
+                    print("🎭 Persona activated: \(persona.name) (model: \(persona.modelId.isEmpty ? "user's current" : persona.modelId))")
                 }
                 await self.handleWakeWordDetected()
             }
@@ -1886,7 +1880,6 @@ class AppState: ObservableObject, AppStateProtocol {
             if currentMode == .direct {
                 cameraService.restoreAudioForWakeWord()
             }
-            cameraService.saveToPhotoLibrary(photoData)
             print("📸 Photo + prompt: \(prompt)")
 
             let rawResponse = try await llmService.sendMessage(
@@ -1989,8 +1982,18 @@ class AppState: ObservableObject, AppStateProtocol {
     }
 
     func captureAndAnalyzePhoto() async {
+        if !isConnected {
+            // Recheck before surrendering to the phone camera: the flag can be stale (auto-
+            // sleep fired, a Disconnect tap, a dropped link) while the glasses sit on the
+            // user's face. One bounded reconnect attempt — the same path the hero capsule uses.
+            NSLog("[Photo] Glasses flagged disconnected — rechecking before phone fallback")
+            await glassesService.connect()
+            for _ in 0..<20 where !isConnected {   // up to 5s
+                try? await Task.sleep(nanoseconds: 250_000_000)
+            }
+        }
         guard isConnected else {
-            // No glasses — fall back to the phone camera.
+            // Genuinely no glasses — fall back to the phone camera (explicit UI).
             presentPhoneCamera(prompt: "Describe what you see in this image.", userLog: "[Phone photo]")
             return
         }
@@ -2001,7 +2004,6 @@ class AppState: ObservableObject, AppStateProtocol {
             if currentMode == .direct {
                 cameraService.restoreAudioForWakeWord()
             }
-            cameraService.saveToPhotoLibrary(photoData)
             print("📸 Manual photo captured, sending to LLM for analysis")
 
             let prompt = "Describe what you see in this image."
@@ -2011,7 +2013,12 @@ class AppState: ObservableObject, AppStateProtocol {
                 imageData: photoData,
                 memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? prompt : nil) : nil
             )
-            let response = Config.userMemoryEnabled ? userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse
+            var response = Config.userMemoryEnabled ? userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse
+            // A phone-camera capture must SAY so — the phone sees the desk, not what the
+            // glasses are pointed at, and an unannounced camera swap reads as hallucination.
+            if cameraService.lastCaptureSource == .phone {
+                response = "From the phone camera — the glasses weren't available. " + response
+            }
             lastResponse = response
             if Config.conversationPersistenceEnabled {
                 conversationStore.appendMessage(role: "user", content: "[Photo taken manually]")
@@ -2126,7 +2133,6 @@ class AppState: ObservableObject, AppStateProtocol {
             if currentMode == .direct {
                 cameraService.restoreAudioForWakeWord()
             }
-            cameraService.saveToPhotoLibrary(photoData)
             let generator = UINotificationFeedbackGenerator()
             generator.notificationOccurred(.success)
             lastResponse = "Photo saved to camera roll"
@@ -2486,7 +2492,6 @@ class AppState: ObservableObject, AppStateProtocol {
                             try Task.checkCancellation()
                             // Restore audio for wake word after camera capture (camera reconfigures for Bluetooth)
                             self.cameraService.restoreAudioForWakeWord()
-                            self.cameraService.saveToPhotoLibrary(photoData)
                             print("📸 Photo captured, sending to LLM with prompt: \(query)")
 
                             return try await self.llmService.sendMessage(
@@ -2497,7 +2502,12 @@ class AppState: ObservableObject, AppStateProtocol {
                             )
                         },
                         postProcess: { rawResponse in
-                            Config.userMemoryEnabled ? self.userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse
+                            var response = Config.userMemoryEnabled ? self.userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse
+                            // Phone-camera captures must announce themselves (see captureAndAnalyzePhoto).
+                            if self.cameraService.lastCaptureSource == .phone {
+                                response = "From the phone camera — the glasses weren't available. " + response
+                            }
+                            return response
                         },
                         accept: { response in
                             self.lastResponse = response
@@ -2687,18 +2697,20 @@ class AppState: ObservableObject, AppStateProtocol {
         // Check for persona names in the transcription (for Action Button / push-to-talk mode)
         // e.g. "Hey Claude, what's the weather" → activate Claude persona, strip prefix.
         // Recognition + stripping is pure (VoiceCommandParser); AppState applies the match.
-        if activePersona == nil {
+        // Runs even with a persona active so "hey travel" can switch away from another persona
+        // mid-session (wake-word mode always could); re-matching the ACTIVE persona's own
+        // phrase just strips the prefix without re-applying routing.
+        do {
             let personas = Config.enabledPersonas
             let personaPhrases = personas.map {
                 VoiceCommandParser.PersonaPhrases(id: $0.id, phrases: $0.allPhrases)
             }
             if let match = voiceCommandParser.detectPersona(in: text, personas: personaPhrases),
                let persona = personas.first(where: { $0.id == match.personaId }) {
-                activePersona = persona
-                Config.setActiveModelId(persona.modelId)
-                Config.setActivePresetId(persona.presetId)
-                llmService.refreshActiveModel()
-                print("🎭 Persona detected in transcription: \(persona.name)")
+                if persona.id != activePersona?.id {
+                    applyPersonaRouting(persona)
+                    print("🎭 Persona detected in transcription: \(persona.name)")
+                }
                 query = match.query
             }
         }
@@ -3072,15 +3084,50 @@ class AppState: ObservableObject, AppStateProtocol {
         let prevPresetId = Config.activePresetId
         let prevPersona = activePersona
 
-        activePersona = persona
-        Config.setActiveModelId(persona.modelId)
-        Config.setActivePresetId(persona.presetId)
+        applyPersonaRouting(persona)
 
         await sendTextMessage(question, speakResponse: false)
 
         Config.setActiveModelId(prevModelId)
         Config.setActivePresetId(prevPresetId)
         activePersona = prevPersona
+        llmService.refreshActiveModel()
+    }
+
+    /// Single owner of the push-to-talk switch (Settings toggle + home-screen BarButton both
+    /// call this): persists the flag and stops/starts the always-on wake-word mic to match.
+    func setPushToTalk(_ enabled: Bool) {
+        Config.setSilentMode(enabled)
+        if enabled {
+            wakeWordService.stopListening()
+            isListening = false
+        } else {
+            Task { try? await wakeWordService.startListening() }
+        }
+    }
+
+    /// Restart the wake-word listener after settings changes that affect it (Direct mode only).
+    func restartWakeWordIfDirect() {
+        guard currentMode == .direct else { return }
+        Task {
+            wakeWordService.stopListening()
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            try? await wakeWordService.startListening()
+        }
+    }
+
+    /// Apply a persona's routing: persona + prompt preset, and its model ONLY when it names one.
+    /// All built-in mode templates ship `modelId: ""` meaning "keep the user's current model" —
+    /// setting that blindly hit `activeModelId`'s empty-id fallback and silently reset the
+    /// active model to the FIRST saved model (live-traced: "hey travel" kicked the user off
+    /// their selected local model).
+    func applyPersonaRouting(_ persona: Persona) {
+        activePersona = persona
+        if !persona.modelId.isEmpty {
+            Config.setActiveModelId(persona.modelId)
+        }
+        Config.setActivePresetId(persona.presetId)
+        llmService.refreshActiveModel()
     }
 
     /// Start wake word listener in "stop detection" mode during TTS playback.
@@ -3124,7 +3171,6 @@ class AppState: ObservableObject, AppStateProtocol {
                 guard let self else { throw RemoteInvokeError.unavailable }
                 let data = try await self.cameraService.capturePhoto()
                 self.cameraService.restoreAudioForWakeWord()
-                self.cameraService.saveToPhotoLibrary(data)
             },
             startAudioRecording: { [weak self] in
                 guard let self else { throw RemoteInvokeError.unavailable }

--- a/OpenGlasses/Sources/App/Views/AgenticFeaturesView.swift
+++ b/OpenGlasses/Sources/App/Views/AgenticFeaturesView.swift
@@ -275,7 +275,7 @@ struct AgenticFeaturesView: View {
                             Label("Start Onboarding", systemImage: "person.crop.circle.badge.questionmark")
                         }
                     } footer: {
-                        Text("The agent will ask you questions to learn about you and customize its personality. Say \"Hey OpenGlasses\" to begin.")
+                        Text("The agent will ask you questions to learn about you and customize its personality. Say \"OpenGlasses\" to begin.")
                     }
                 }
 

--- a/OpenGlasses/Sources/App/Views/BottomControlBar.swift
+++ b/OpenGlasses/Sources/App/Views/BottomControlBar.swift
@@ -1,14 +1,17 @@
 import SwiftUI
 import PhotosUI
 
-/// Bottom control bar — ergonomic layout for thumb and index finger use.
+/// The control dock — ONE floating glass panel above the tab bar holding every control in a
+/// single visual language (previously four stacked bands in four styles: full-width model bar,
+/// glass quick-action tiles, hero capsule, plain utility buttons).
 ///
-/// Layout: Two rows.
-///   Row 1 (primary):  Wide mic/action capsule — the main touch target.
-///   Row 2 (secondary): [Settings] [Camera] [Preview] [Model] [Keyboard]
+/// Layout inside the panel:
+///   Row 1 (primary):  wide mic/action capsule — the only large element, the main touch target.
+///   Row 2 (utility):  one horizontally-scrolling row of identical tiles — local-model chip
+///                     first (contextual), then the user's quick actions, then system utilities.
 ///
-/// The mic capsule is large enough to hit easily with a thumb from either hand.
-/// Secondary buttons are spaced for index finger taps.
+/// The PANEL is the glass; tiles are flat on it. One blur layer instead of a stack of
+/// per-tile blurs — deliberately cheaper to composite over the animating ambience.
 struct BottomControlBar: View {
     @EnvironmentObject var appState: AppState
     @ObservedObject var session: GeminiLiveSessionManager
@@ -31,13 +34,17 @@ struct BottomControlBar: View {
 
     private var previewVisible: Bool { appState.isConnected }
 
+    /// Observes the same UserDefaults key `Config.silentMode` writes, so the push-to-talk
+    /// BarButton re-renders on toggle AND stays live-synced with the Settings switch.
+    @AppStorage("silentMode") private var pushToTalk = false
+
     private var photoDisabledForLocalModel: Bool {
         guard let model = Config.activeModel, model.llmProvider == .local else { return false }
         return !model.visionEnabled
     }
 
     var body: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: 12) {
             // Primary: wide action capsule
             heroCapsule
                 .simultaneousGesture(
@@ -47,59 +54,81 @@ struct BottomControlBar: View {
                         }
                 )
 
-            // Secondary: utility row
-            HStack(spacing: 0) {
-                cameraButton
-                    .frame(maxWidth: .infinity)
+            // Utility row: everything else, one tile idiom, scrolls when it outgrows the width.
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 4) {
+                    // Contextual: on-device model chip (was a full-width band above the bar).
+                    if let local = appState.llmService.localLLMService,
+                       let active = Config.activeModel, active.llmProvider == .local {
+                        LocalModelTile(service: local, modelConfig: active)
+                    }
 
-                if previewVisible {
+                    // Model picker rides next to the load chip — the two model controls
+                    // read as one group.
                     BarButton(
-                        icon: "eye",
-                        label: "Preview",
-                        isActive: appState.videoRecorder.isRecording
+                        icon: "brain",
+                        label: appState.llmService.activeModelName,
+                        truncateLabel: true
                     ) {
-                        showPreview = true
+                        showModelPicker = true
                     }
-                    .frame(maxWidth: .infinity)
-                }
 
-                BarButton(
-                    icon: "brain",
-                    label: appState.llmService.activeModelName,
-                    truncateLabel: true
-                ) {
-                    showModelPicker = true
-                }
-                .frame(maxWidth: .infinity)
-
-                if let chatBinding = showChatInput {
-                    BarButton(icon: "keyboard", label: "Type") {
-                        chatBinding.wrappedValue = true
+                    // The user's quick actions (was its own band of glass tiles).
+                    if appState.isConnected && appState.currentMode == .direct {
+                        QuickActionTiles()
                     }
-                    .frame(maxWidth: .infinity)
-                }
 
-                if Config.accessibilityModeEnabled {
+                    cameraButton
+
+                    if previewVisible {
+                        BarButton(
+                            icon: "eye",
+                            label: "Preview",
+                            isActive: appState.videoRecorder.isRecording
+                        ) {
+                            showPreview = true
+                        }
+                    }
+
+                    if let chatBinding = showChatInput {
+                        BarButton(icon: "keyboard", label: "Type") {
+                            chatBinding.wrappedValue = true
+                        }
+                    }
+
+                    // Push-to-talk toggle — same switch as Settings (one owner: AppState.setPushToTalk).
                     BarButton(
-                        icon: assistive.isActive ? "eye.fill" : "eye",
-                        label: assistive.isActive ? "Assistive On" : "Assistive",
-                        isActive: assistive.isActive
+                        icon: pushToTalk ? "hand.tap.fill" : "waveform",
+                        label: pushToTalk ? "Push-Talk" : "Wake Word",
+                        isActive: pushToTalk
                     ) {
-                        appState.toggleAssistiveMode()
+                        appState.setPushToTalk(!pushToTalk)
                     }
-                    .frame(maxWidth: .infinity)
-                }
 
-                if appState.isConnected {
-                    BarButton(icon: "moon.fill", label: "Sleep") {
-                        appState.disconnectGlasses()
+                    if Config.accessibilityModeEnabled {
+                        BarButton(
+                            icon: assistive.isActive ? "eye.fill" : "eye",
+                            label: assistive.isActive ? "Assistive On" : "Assistive",
+                            isActive: assistive.isActive
+                        ) {
+                            appState.toggleAssistiveMode()
+                        }
                     }
-                    .frame(maxWidth: .infinity)
+
+                    if appState.isConnected {
+                        // "Sleep" undersold what this does — it disconnects the glasses
+                        // session outright (stops speech, wake word, camera, live sessions).
+                        BarButton(icon: "moon.fill", label: "Disconnect") {
+                            appState.disconnectGlasses()
+                        }
+                    }
                 }
+                .padding(.horizontal, 4)
             }
-            .padding(.horizontal, 8)
         }
-        .padding(.horizontal, 16)
+        .padding(14)
+        .glassEffect(in: .rect(cornerRadius: 28))
+        .padding(.horizontal, 12)
         .padding(.top, 8)
         .padding(.bottom, 8)
     }
@@ -268,20 +297,24 @@ private struct ActionCapsule: View {
     }
 }
 
-// MARK: - Bar Button (secondary actions)
+// MARK: - Bar Button (the dock's single tile idiom)
 
-/// Compact button for the secondary utility row.
+/// The dock tile — every control in the utility row uses this one idiom. Flat on the dock's
+/// glass (no per-tile blur); active state = a soft tint wash behind the tile.
 private struct BarButton: View {
     let icon: String
     var label: String = ""
     var isActive: Bool = false
     var isDisabled: Bool = false
+    var isBusy: Bool = false
     var badge: String? = nil
+    var tint: Color? = nil
     var truncateLabel: Bool = false
     var action: () -> Void = {}
 
     private var foreground: Color {
         if isDisabled { return .secondary }
+        if let tint, isActive { return tint }
         return .primary
     }
 
@@ -289,7 +322,10 @@ private struct BarButton: View {
         Button(action: action) {
             VStack(spacing: 3) {
                 ZStack {
-                    if icon == "OpenGlassesLogo" {
+                    if isBusy {
+                        ProgressView()
+                            .scaleEffect(0.7)
+                    } else if icon == "OpenGlassesLogo" {
                         LogoIcon(size: 18)
                             .foregroundStyle(foreground)
                     } else {
@@ -312,18 +348,85 @@ private struct BarButton: View {
 
                 if !label.isEmpty {
                     Text(label)
-                        .font(.system(size: 9, weight: .medium))
-                        .foregroundStyle(.secondary)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(foreground)   // .secondary was illegible over the ambience tint
                         .lineLimit(1)
                         .truncationMode(truncateLabel ? .middle : .tail)
                 }
             }
-            .frame(minWidth: 44, minHeight: 44)
+            .frame(minWidth: 58, minHeight: 48)
+            .padding(.horizontal, 2)
+            .background(
+                (tint ?? Color.primary).opacity(isActive ? 0.12 : 0),
+                in: RoundedRectangle(cornerRadius: 12)
+            )
             .contentShape(Rectangle())
         }
-        .disabled(isDisabled)
+        .disabled(isDisabled || isBusy)
         .opacity(isDisabled ? 0.4 : 1)
         .accessibilityLabel(label.isEmpty ? icon.replacingOccurrences(of: ".fill", with: "").replacingOccurrences(of: ".", with: " ") : label)
         .accessibilityAddTraits(isActive ? .isSelected : [])
+    }
+}
+
+// MARK: - Local model tile (was the full-width LocalModelBar band)
+
+/// On-device model control as a dock tile: Load (accent) → Loading (spinner) → Loaded
+/// (green, tap to unload). Shown only when the active model is local.
+private struct LocalModelTile: View {
+    @ObservedObject var service: LocalLLMService
+    let modelConfig: ModelConfig
+    @Environment(\.appAccent) private var accent
+
+    var body: some View {
+        let isLoaded = service.isModelLoaded && service.loadedModelId == modelConfig.model
+        BarButton(
+            icon: isLoaded ? "checkmark.circle.fill" : "cpu",
+            label: service.isLoadingModel ? "Loading…" : (isLoaded ? "Unload" : "Load \(modelConfig.name)"),
+            isActive: !service.isLoadingModel,   // tinted whenever idle: accent invites Load, green marks Loaded
+            isBusy: service.isLoadingModel,
+            tint: isLoaded ? .green : accent,
+            truncateLabel: true
+        ) {
+            if isLoaded {
+                service.unloadModel()
+            } else {
+                Task { try? await service.loadModel(modelConfig.model) }
+            }
+        }
+        .accessibilityLabel(isLoaded ? "\(modelConfig.name) loaded. Tap to unload."
+                                     : "Load on-device model \(modelConfig.name)")
+    }
+}
+
+// MARK: - Quick action tiles (was QuickActionsGrid, its own band of glass tiles)
+
+/// The user's configured quick actions as dock tiles — same idiom as every other control.
+private struct QuickActionTiles: View {
+    @EnvironmentObject var appState: AppState
+    @State private var executingActionId: String?
+
+    private var actions: [QuickAction] {
+        let all = Config.quickActions
+        return Config.showAllQuickActions ? all : Array(all.prefix(4))
+    }
+
+    var body: some View {
+        ForEach(actions) { action in
+            BarButton(
+                icon: action.icon,
+                label: action.label,
+                isBusy: executingActionId == action.id
+            ) {
+                guard executingActionId == nil else { return }
+                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                executingActionId = action.id
+                Task {
+                    await appState.executeQuickAction(action)
+                    executingActionId = nil
+                }
+            }
+            .accessibilityHint(executingActionId == action.id ? "Running" : "Double-tap to execute")
+        }
     }
 }

--- a/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
+++ b/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
@@ -152,21 +152,18 @@ struct LocalModelManagerView: View {
                             if downloadedIds.contains(model.id) {
                                 Image(systemName: "checkmark.circle.fill")
                                     .foregroundStyle(.green)
-                            } else if downloadingModelId == model.id {
-                                HStack(spacing: 8) {
-                                    ProgressView(value: localService?.downloadProgress ?? 0)
-                                        .frame(width: 60)
-                                    // BK P5: a real Cancel — routes through the service so the
-                                    // in-flight download is actually stopped, not just hidden.
-                                    Button("Cancel") {
-                                        localService?.cancelDownload()
-                                        downloadingModelId = nil
-                                    }
-                                    .buttonStyle(.borderless)
-                                    .controlSize(.small)
+                            } else if downloadingModelId == model.id, let service = localService {
+                                // Own subview so the service's @Published progress actually
+                                // re-renders it — read through the computed optional above,
+                                // nothing observed the service and the bar never moved.
+                                DownloadProgressRow(service: service) {
+                                    service.cancelDownload()
+                                    downloadingModelId = nil
                                 }
                             } else if !model.isCompatibleWithDevice {
-                                Label("Needs 8 GB", systemImage: "memorychip")
+                                // The model's OWN requirement — this badge was hardcoded
+                                // "Needs 8 GB" and misreported every other tier.
+                                Label("Needs \(Int(model.minimumRAMGB)) GB", systemImage: "memorychip")
                                     .font(.caption)
                                     .foregroundStyle(.orange)
                             } else {
@@ -188,7 +185,7 @@ struct LocalModelManagerView: View {
             } header: {
                 Text("Recommended")
             } footer: {
-                Text("These models are tested on iPhone and optimized for size. Larger models need more RAM.")
+                Text("These models are tested on iPhone and optimized for size. Larger models need more RAM. Keep the app open while downloading — the screen stays awake automatically.")
             }
 
             // MARK: Custom Model
@@ -333,5 +330,34 @@ struct LocalModelManagerView: View {
         if bytes < 1024 * 1024 { return String(format: "%.0f KB", Double(bytes) / 1024) }
         if bytes < 1024 * 1024 * 1024 { return String(format: "%.1f MB", Double(bytes) / (1024 * 1024)) }
         return String(format: "%.1f GB", Double(bytes) / (1024 * 1024 * 1024))
+    }
+}
+
+/// Observes the service so the download progress actually updates — with a live percentage,
+/// because a multi-GB pull with no numbers reads as a hang. A compact spinner + percent, not a
+/// linear bar: the bar-plus-Cancel cluster was wide enough to crush the model name and its
+/// Vision/Tools badges in the same row.
+private struct DownloadProgressRow: View {
+    @ObservedObject var service: LocalLLMService
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.small)
+            if service.downloadProgress > 0 {
+                Text("\(Int(service.downloadProgress * 100))%")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            // BK P5: a real Cancel — routes through the service so the in-flight
+            // download is actually stopped, not just hidden.
+            Button(action: onCancel) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel("Cancel download")
+        }
     }
 }

--- a/OpenGlasses/Sources/App/Views/OnboardingOverlay.swift
+++ b/OpenGlasses/Sources/App/Views/OnboardingOverlay.swift
@@ -45,7 +45,7 @@ struct OnboardingOverlay: View {
                         number: 3,
                         icon: "mic",
                         title: "Say Your Wake Word",
-                        subtitle: "Say \"Hey OpenGlasses\" to start a conversation."
+                        subtitle: "Say \"OpenGlasses\" to start a conversation."
                     )
                 }
                 .padding(.horizontal, 24)

--- a/OpenGlasses/Sources/App/Views/OnboardingView.swift
+++ b/OpenGlasses/Sources/App/Views/OnboardingView.swift
@@ -903,7 +903,7 @@ struct OnboardingView: View {
                     .font(.title.weight(.bold))
                     .foregroundStyle(.white)
 
-                Text("Say \"Hey OpenGlasses\" or tap the mic to start a conversation.")
+                Text("Say \"OpenGlasses\" or tap the mic to start a conversation.")
                     .font(.subheadline)
                     .foregroundStyle(.white.opacity(0.6))
                     .multilineTextAlignment(.center)

--- a/OpenGlasses/Sources/App/Views/PersonasView.swift
+++ b/OpenGlasses/Sources/App/Views/PersonasView.swift
@@ -170,14 +170,14 @@ struct PersonaEditorView: View {
     let onSave: (Persona) -> Void
 
     @State private var name = ""
-    @State private var wakePhrase = "hey openglasses"
+    @State private var wakePhrase = "openglasses"
     @State private var wakeAlts = ""
     @State private var selectedModelId = ""
     @State private var selectedPresetId = "preset-default"
     @State private var enabled = true
 
     private let wakePhrasePresets = [
-        "hey openglasses", "hey claude", "hey jarvis", "hey rayban",
+        "openglasses", "hey openglasses", "hey claude", "hey jarvis", "hey rayban",
         "hey computer", "hey assistant", "hey gemini", "hey gpt"
     ]
 

--- a/OpenGlasses/Sources/App/Views/SettingsScreens.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsScreens.swift
@@ -1,0 +1,686 @@
+import SwiftUI
+
+// MARK: - Voice & Triggers
+
+/// Wake word + hands-free trigger settings (always visible, including Simple Mode).
+struct VoiceTriggersSettingsScreen: View {
+    @ObservedObject var appState: AppState
+
+    var body: some View {
+        Form {
+            // MARK: Wake Word
+            Section {
+                Picker("Wake Phrase", selection: Binding(
+                    get: { Config.wakePhrase },
+                    set: { newValue in
+                        Config.setWakePhrase(newValue)
+                        Config.setAlternativeWakePhrases(Config.defaultAlternativesForPhrase(newValue))
+                    }
+                )) {
+                    Text("OpenGlasses").tag("openglasses")
+                    Text("Hey OpenGlasses").tag("hey openglasses")
+                    Text("Hey Claude").tag("hey claude")
+                    Text("Hey Jarvis").tag("hey jarvis")
+                    Text("Hey Computer").tag("hey computer")
+                    Text("Hey Assistant").tag("hey assistant")
+                    Text("Hey Rayban").tag("hey rayban")
+                }
+
+                InfoToggle(
+                    title: "Push-to-Talk Mode",
+                    isOn: Binding(
+                        get: { Config.silentMode },
+                        set: { appState.setPushToTalk($0) }
+                    ),
+                    info: "Turns off the always-on wake-word listener so the mic isn't held in the background — fixes conflicts with music/podcasts playing at the same time. Start a conversation on demand instead: the iPhone Action Button (\"Ask OpenGlasses\"), Siri, the home screen widget, the Apple Watch, or a manual mic tap."
+                )
+
+                InfoToggle(
+                    title: "Open App for Siri Questions",
+                    isOn: Binding(
+                        get: { Config.siriAskOpensApp },
+                        set: { Config.setSiriAskOpensApp($0) }
+                    ),
+                    info: "When you say \"Hey Siri, ask OpenGlasses…\", the answer is normally spoken hands-free without opening the app. Turn this on if Siri says OpenGlasses isn't running — it launches the app first so the question always goes through, at the cost of bringing the app to the foreground."
+                )
+            } header: {
+                Text("Voice")
+            } footer: {
+                Text("The phrase that starts a conversation. Push-to-Talk Mode stops the always-listening mic (so it won't fight other audio) — trigger on demand via the Action Button, Siri, widget, or watch.")
+            }
+
+            // MARK: Hands-Free Triggers
+            Section {
+                ForEach(AlternativeTrigger.allCases) { trigger in
+                    InfoToggle(
+                        title: trigger.displayName,
+                        isOn: Binding(
+                            get: { Config.alternativeTriggerEnabled(trigger) },
+                            set: { newValue in
+                                Config.setAlternativeTriggerEnabled(trigger, newValue)
+                                appState.alternativeTriggers.refresh()
+                            }
+                        ),
+                        info: trigger.detail
+                    )
+                }
+            } header: {
+                Text("Hands-Free Triggers")
+            } footer: {
+                Text("Alternative ways to start the assistant without the wake word — for noisy, silent, or no-speech situations. All are off by default. The Volume Button trigger can interfere with normal volume control.")
+            }
+        }
+        .navigationTitle("Voice & Triggers")
+    }
+}
+
+// MARK: - AI & Personality
+
+/// Models, personas, system prompt, and behaviour settings (owner-only; hidden in Simple Mode).
+struct AIPersonalitySettingsScreen: View {
+    @ObservedObject var appState: AppState
+
+    // Model configs editing
+    @State private var modelConfigs: [ModelConfig] = Config.savedModels
+    @State private var editingModel: ModelConfig? = nil
+    @State private var showAddModel = false
+
+    // Intelligence settings
+    @State private var intentClassifierEnabled = Config.intentClassifierEnabled
+    @State private var userMemoryEnabled = Config.userMemoryEnabled
+    @State private var memoryNudgesEnabled = Config.memoryNudgesEnabled
+    @State private var conversationPersistenceEnabled = Config.conversationPersistenceEnabled
+    @State private var autoModelRoutingEnabled = Config.autoModelRoutingEnabled
+
+    var body: some View {
+        Form {
+            // MARK: AI Models
+            Section {
+                ForEach(modelConfigs) { model in
+                    Button {
+                        editingModel = model
+                    } label: {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(model.name)
+                                    .foregroundStyle(Color(.label))
+                                    .lineLimit(1)
+                                HStack(spacing: 4) {
+                                    Text(model.llmProvider.displayName)
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                    if model.visionEnabled {
+                                        Image(systemName: "eye")
+                                            .font(.caption2)
+                                            .foregroundStyle(Color(.label))
+                                            .accessibilityLabel("Vision enabled")
+                                    }
+                                    if !model.apiKey.isEmpty {
+                                        Image(systemName: "checkmark.circle.fill")
+                                            .font(.caption2)
+                                            .foregroundStyle(.green)
+                                            .accessibilityLabel("API key set")
+                                    } else {
+                                        Image(systemName: "exclamationmark.circle")
+                                            .font(.caption2)
+                                            .foregroundStyle(.orange)
+                                            .accessibilityLabel("API key missing")
+                                    }
+                                }
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .accessibilityHidden(true)
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(model.name), \(model.llmProvider.displayName)\(!model.apiKey.isEmpty ? "" : ", API key missing")\(model.visionEnabled ? ", vision enabled" : "")")
+                    .accessibilityHint("Double-tap to edit")
+                }
+                .onDelete { indexSet in
+                    modelConfigs.remove(atOffsets: indexSet)
+                }
+
+                Button {
+                    showAddModel = true
+                } label: {
+                    Label("Add Model", systemImage: "plus.circle.fill")
+                }
+            } header: {
+                Text("AI Models")
+            } footer: {
+                Text("Models are the AI you talk to. Add a key for any provider you want — you can switch between them anytime from the main screen.")
+            }
+
+            // MARK: Personality
+            Section {
+                NavigationLink {
+                    PersonasView()
+                } label: {
+                    HStack {
+                        Label("Personas", systemImage: "person.2")
+                        Spacer()
+                        Text("\(Config.enabledPersonas.count) active")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                NavigationLink {
+                    PromptPresetsView()
+                } label: {
+                    HStack {
+                        Label("System Prompt", systemImage: "text.quote")
+                        Spacer()
+                        Text(Config.activePreset?.name ?? "Default")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } header: {
+                Text("Personality")
+            } footer: {
+                Text("Personas are different characters with their own model + prompt (e.g. a museum docent, a fitness coach). System Prompt tweaks the default voice and behaviour.")
+            }
+
+            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+            // MARK: — Intelligence
+            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+            Section {
+                InfoToggle(
+                    title: "Intent Classifier",
+                    isOn: $intentClassifierEnabled,
+                    info: "Uses a lightweight on-device model to determine if speech is directed at the assistant or is just background conversation. Prevents the AI from responding to nearby chatter, TV audio, or other people talking."
+                )
+                InfoToggle(
+                    title: "User Memory",
+                    isOn: $userMemoryEnabled,
+                    info: "Remembers facts you share across conversations — your name, preferences, routines, dietary needs, etc. This context is included in future conversations so the AI can personalise responses. Memory is stored locally on your device."
+                )
+                InfoToggle(
+                    title: "Conversation History",
+                    isOn: $conversationPersistenceEnabled,
+                    info: "Saves conversation transcripts so you can review them later in the History tab. Also provides context for follow-up questions within a session. When off, conversations are ephemeral and discarded after each session."
+                )
+                InfoToggle(
+                    title: "Memory Suggestions",
+                    isOn: $memoryNudgesEnabled,
+                    info: "After you state a durable fact (\"my daughter's name is Mia\") or repeat a multi-step request, the assistant offers a spoken nudge to remember it or save it as a skill — you confirm by voice. With Agentic Features on, these are saved automatically instead of nudged. Off by default."
+                )
+
+                NavigationLink {
+                    SmartRoutingView(
+                        autoModelRoutingEnabled: $autoModelRoutingEnabled,
+                        modelConfigs: modelConfigs
+                    )
+                } label: {
+                    HStack {
+                        Label("Smart Routing", systemImage: "arrow.triangle.branch")
+                        Spacer()
+                        Text(autoModelRoutingEnabled ? "On" : "Off")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                NavigationLink {
+                    AgenticFeaturesView(agentDocs: appState.agentDocs, localLLM: appState.localLLMService)
+                        .environmentObject(appState)
+                } label: {
+                    HStack {
+                        Label("Agentic Features", systemImage: "bolt.badge.automatic")
+                        Spacer()
+                        if Config.agentModeEnabled {
+                            Text("On")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            } header: {
+                Text("How It Behaves")
+            } footer: {
+                Text("Intent Classifier ignores nearby chatter so the AI only responds when you're talking to it. Memory and History let the AI remember who you are across sessions. Smart Routing picks the right model for the task; Agentic Features let the AI take multi-step actions on its own.")
+            }
+        }
+        .navigationTitle("AI & Personality")
+        .sheet(item: $editingModel) { model in
+            ModelEditorView(model: model) { updated in
+                if let idx = modelConfigs.firstIndex(where: { $0.id == updated.id }) {
+                    modelConfigs[idx] = updated
+                    Config.setSavedModels(modelConfigs)
+                }
+            }
+        }
+        .sheet(isPresented: $showAddModel) {
+            AddModelView { newModel in
+                modelConfigs.append(newModel)
+                Config.setSavedModels(modelConfigs)
+            }
+        }
+        .onDisappear {
+            saveSettings()
+        }
+    }
+
+    // MARK: - Save Settings
+
+    private func saveSettings() {
+        Config.setSavedModels(modelConfigs)
+
+        if !modelConfigs.contains(where: { $0.id == Config.activeModelId }) {
+            if let first = modelConfigs.first {
+                Config.setActiveModelId(first.id)
+            }
+        }
+        appState.llmService.refreshActiveModel()
+
+        Config.setIntentClassifierEnabled(intentClassifierEnabled)
+        Config.setUserMemoryEnabled(userMemoryEnabled)
+        Config.setMemoryNudgesEnabled(memoryNudgesEnabled)
+        Config.setConversationPersistenceEnabled(conversationPersistenceEnabled)
+
+        appState.restartWakeWordIfDirect()
+    }
+}
+
+// MARK: - Tools & Actions
+
+/// Tools the AI can use (owner-only; hidden in Simple Mode).
+struct ToolsActionsSettingsScreen: View {
+    @ObservedObject var appState: AppState
+
+    var body: some View {
+        Form {
+            Section {
+                NavigationLink {
+                    QuickActionsSettingsView()
+                } label: {
+                    Label("Quick Actions", systemImage: "dial.high")
+                }
+
+                NavigationLink {
+                    ToolsSettingsView(appState: appState)
+                } label: {
+                    Label("Tools", systemImage: "wrench.and.screwdriver")
+                }
+
+                NavigationLink {
+                    FieldAssistSettingsView()
+                } label: {
+                    HStack {
+                        Label("Field Assist", systemImage: "wrench.adjustable")
+                        Spacer()
+                        if Config.fieldAssistEnabled {
+                            Text("On").foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                NavigationLink {
+                    VaultManagerView()
+                } label: {
+                    Label("Custom Vaults", systemImage: "tray.full")
+                }
+
+                NavigationLink {
+                    VaultFilesEditorView(vaultId: "notes", title: "Personal Notes")
+                } label: {
+                    Label("Personal Notes", systemImage: "note.text")
+                }
+
+                NavigationLink {
+                    DeckListView()
+                } label: {
+                    Label("Study Mode", systemImage: "graduationcap")
+                }
+
+                NavigationLink {
+                    ReadingStatsView()
+                } label: {
+                    Label("Reading", systemImage: "book")
+                }
+
+                NavigationLink {
+                    HealthVaultEditorView()
+                } label: {
+                    HStack {
+                        Label("Health Vault", systemImage: "heart.text.square")
+                        Spacer()
+                        if VaultRegistry.shared.isUnlocked("health") {
+                            Text("Unlocked").foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                NavigationLink {
+                    AccessibilitySettingsView()
+                        .environmentObject(appState)
+                } label: {
+                    HStack {
+                        Label("Accessibility", systemImage: "accessibility")
+                        Spacer()
+                        if Config.accessibilityModeEnabled {
+                            Text("On").foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                NavigationLink {
+                    CustomToolsView()
+                        .environmentObject(appState)
+                } label: {
+                    Label("Custom Tools", systemImage: "hammer")
+                }
+
+                NavigationLink {
+                    SiriExposureView()
+                } label: {
+                    Label("Siri & Search", systemImage: "mic.badge.plus")
+                }
+
+                if Config.agentModeEnabled {
+                    NavigationLink {
+                        MCPServerSettingsView()
+                            .environmentObject(appState)
+                    } label: {
+                        HStack {
+                            Label("MCP Server", systemImage: "macbook.and.iphone")
+                            Spacer()
+                            if MCPGlassesServer.shared.isRunning {
+                                Text("Running").foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+
+                NavigationLink {
+                    PlaybooksSettingsView(store: appState.playbookStore)
+                } label: {
+                    Label("Playbooks", systemImage: "list.clipboard")
+                }
+
+                NavigationLink {
+                    ClawHubBrowserView()
+                } label: {
+                    HStack {
+                        Label("Skill Store", systemImage: "square.grid.3x3.square")
+                        Spacer()
+                        let count = InstalledSkillStore.shared.installedSkills.filter(\.enabled).count
+                        if count > 0 {
+                            Text("\(count) active")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                NavigationLink {
+                    VoiceSkillsManagerView()
+                } label: {
+                    Label("Voice Skills", systemImage: "waveform")
+                }
+
+                if Config.agentModeEnabled {
+                    NavigationLink {
+                        SuggestedSkillsView()
+                    } label: {
+                        HStack {
+                            Label("Suggested Skills", systemImage: "lightbulb.max")
+                            Spacer()
+                            let count = EvolvedSkillStore.shared.pending().count
+                            if count > 0 {
+                                Text("\(count)")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(.white)
+                                    .padding(.horizontal, 7).padding(.vertical, 2)
+                                    .background(Capsule().fill(.red))
+                            }
+                        }
+                    }
+                }
+            } header: {
+                Text("Tools the AI Can Use")
+            } footer: {
+                Text("Quick Actions are shortcuts you can tap from the widget. Tools are built-in capabilities (camera, search, HomeKit, music…). Custom Tools and Playbooks let you script your own. The Skill Store adds community-built skills.")
+            }
+        }
+        .navigationTitle("Tools & Actions")
+    }
+}
+
+// MARK: - Connections
+
+/// Connected apps & services (owner-only; hidden in Simple Mode).
+struct ConnectionsSettingsScreen: View {
+    @ObservedObject var appState: AppState
+
+    var body: some View {
+        Form {
+            Section {
+                NavigationLink {
+                    ServicesSettingsView(appState: appState)
+                } label: {
+                    Label("Services & Integrations", systemImage: "square.grid.2x2")
+                }
+
+                NavigationLink {
+                    GatewaySettingsView(appState: appState)
+                } label: {
+                    HStack {
+                        Label("Gateways", systemImage: "server.rack")
+                        Spacer()
+                        let count = Config.enabledGateways.count
+                        if count > 0 {
+                            Text("\(count) active")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+
+                NavigationLink {
+                    MCPServersView()
+                        .environmentObject(appState)
+                } label: {
+                    Label("MCP Servers", systemImage: "point.3.connected.trianglepath.dotted")
+                }
+            } header: {
+                Text("Connected Apps & Services")
+            } footer: {
+                Text("ElevenLabs voices, Perplexity search, broadcast targets, and live-streaming live under Services. Gateways are OpenClaw bridges to your devices (smart home, automations). MCP Servers expose external tool servers the AI can call.")
+            }
+        }
+        .navigationTitle("Connections")
+    }
+}
+
+// MARK: - Glasses & Privacy
+
+/// Hardware, privacy, and medical compliance (always visible, including Simple Mode).
+struct GlassesPrivacySettingsScreen: View {
+    @ObservedObject var appState: AppState
+
+    // Privacy filter
+    @State private var privacyFilterEnabled = Config.privacyFilterEnabled
+    @State private var useGlassesMicForWakeWord = Config.useGlassesMicForWakeWord
+
+    // Security
+    @State private var conversationEncryptionEnabled = Config.conversationEncryptionEnabled
+    @State private var isTogglingEncryption = false
+
+    var body: some View {
+        Form {
+            Section {
+                NavigationLink {
+                    HardwarePrivacyView(
+                        appState: appState,
+                        useGlassesMicForWakeWord: $useGlassesMicForWakeWord,
+                        privacyFilterEnabled: $privacyFilterEnabled,
+                        conversationEncryptionEnabled: $conversationEncryptionEnabled,
+                        isTogglingEncryption: $isTogglingEncryption
+                    )
+                } label: {
+                    Label("Hardware & Privacy", systemImage: "lock.shield")
+                }
+
+                NavigationLink {
+                    MedicalCompliancePaywallView(
+                        hipaaService: appState.hipaaService,
+                        exportService: appState.medicalExportService
+                    )
+                } label: {
+                    HStack {
+                        Label("Medical Compliance", systemImage: "cross.case.fill")
+                        Spacer()
+                        if StoreKitService.shared.canAccessMedicalCompliance && Config.hipaaMode {
+                            Image(systemName: "cross.case.fill")
+                                .font(.caption)
+                                .foregroundStyle(AppAccent.aiCoral)
+                                .accessibilityHidden(true)
+                            Image(systemName: "checkmark.circle.fill")
+                                .font(.caption)
+                                .foregroundStyle(.green)
+                                .accessibilityLabel("Active")
+                        } else if !StoreKitService.shared.canAccessMedicalCompliance {
+                            Image(systemName: "cross.case.fill")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .accessibilityHidden(true)
+                        }
+                    }
+                }
+            } header: {
+                Text("Glasses & Privacy")
+            } footer: {
+                Text("Mic source, on-device bystander-face blurring, and encrypted conversations live in Hardware & Privacy. Medical Compliance enables HIPAA-grade encryption and exports for clinical use (separate subscription).")
+            }
+        }
+        .navigationTitle("Glasses & Privacy")
+        .onDisappear {
+            saveSettings()
+        }
+    }
+
+    // MARK: - Save Settings
+
+    private func saveSettings() {
+        Config.setPrivacyFilterEnabled(privacyFilterEnabled)
+        appState.privacyFilter.isEnabled = privacyFilterEnabled
+        Config.setUseGlassesMicForWakeWord(useGlassesMicForWakeWord)
+
+        appState.restartWakeWordIfDirect()
+    }
+}
+
+// MARK: - Look & Feel
+
+/// Theme, accent colour, and languages (always visible, including Simple Mode).
+struct LookFeelSettingsScreen: View {
+    @AppStorage("accentColorName") private var accentColorName: String = "violet"
+
+    var body: some View {
+        Form {
+            Section {
+                Picker("Theme", selection: Binding(
+                    get: { UserDefaults.standard.string(forKey: "appAppearance") ?? "dark" },
+                    set: { UserDefaults.standard.set($0, forKey: "appAppearance") }
+                )) {
+                    Text("Dark").tag("dark")
+                    Text("Light").tag("light")
+                    Text("System").tag("system")
+                }
+                .pickerStyle(.segmented)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Accent Colour")
+                        .font(.subheadline)
+                    HStack(spacing: 12) {
+                        ForEach(AppAccent.presets) { preset in
+                            Button {
+                                accentColorName = preset.id
+                                Config.setAccentColorName(preset.id)
+                            } label: {
+                                Circle()
+                                    .fill(preset.color)
+                                    .frame(width: 30, height: 30)
+                                    .overlay(
+                                        Circle()
+                                            .strokeBorder(.white, lineWidth: accentColorName == preset.id ? 2.5 : 0)
+                                    )
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("\(preset.name) accent colour\(accentColorName == preset.id ? ", selected" : "")")
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+
+                NavigationLink {
+                    LanguageSettingsView()
+                } label: {
+                    HStack {
+                        Label("Languages", systemImage: "globe")
+                        Spacer()
+                        let downloaded = LocalizationManager.shared.downloadableLanguages.filter(\.isDownloaded).count
+                        let bundled = LocalizationManager.bundledLanguages.count
+                        Text("\(bundled + downloaded) available")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            } header: {
+                Text("Look & Feel")
+            } footer: {
+                Text("Theme, accent colour, and which languages the assistant speaks and understands.")
+            }
+        }
+        .navigationTitle("Look & Feel")
+    }
+}
+
+// MARK: - Advanced
+
+/// Diagnostic / power-user tools (owner-only; hidden in Simple Mode).
+struct AdvancedSettingsScreen: View {
+    @ObservedObject var appState: AppState
+
+    var body: some View {
+        Form {
+            Section {
+                NavigationLink {
+                    PromptInspectorView(appState: appState)
+                } label: {
+                    Label("Prompt Inspector", systemImage: "doc.text.magnifyingglass")
+                }
+
+                NavigationLink {
+                    NetworkMonitorView()
+                } label: {
+                    Label("Network Activity", systemImage: "antenna.radiowaves.left.and.right")
+                }
+
+                NavigationLink {
+                    LiveVisionSettingsView()
+                } label: {
+                    Label("Live Vision", systemImage: "camera.metering.matrix")
+                }
+
+                NavigationLink {
+                    DocumentsView()
+                } label: {
+                    Label("Documents", systemImage: "doc.text.magnifyingglass")
+                }
+
+                NavigationLink {
+                    CaptureFlowAuthorView()
+                } label: {
+                    Label("Author Capture-Flow", systemImage: "list.bullet.rectangle")
+                }
+            } header: {
+                Text("Advanced")
+            } footer: {
+                Text("Diagnostic tools for power users — inspect the prompts being sent to the AI and watch live network requests. Useful for debugging or building your own integrations.")
+            }
+        }
+        .navigationTitle("Advanced")
+    }
+}

--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -4,9 +4,7 @@ import AVFoundation
 struct SettingsView: View {
     @ObservedObject var appState: AppState
     @Environment(\.appAccent) private var accent
-    @AppStorage("accentColorName") private var accentColorName: String = "violet"
 
-    // Model configs editing
     @State private var simpleModeEnabled = Config.simpleModeEnabled
 
     // Owner gate (BM P10): Simple-Mode exit always asks; Settings entry asks when the flag is on.
@@ -14,606 +12,95 @@ struct SettingsView: View {
     @State private var settingsLocked = Config.settingsOwnerGateEnabled
     @State private var exitGate = OwnerGateMachine()
     @State private var entryGate = OwnerGateMachine()
-    @State private var modelConfigs: [ModelConfig] = Config.savedModels
-    @State private var editingModel: ModelConfig? = nil
-    @State private var showAddModel = false
 
-    // Intelligence settings
-    @State private var intentClassifierEnabled = Config.intentClassifierEnabled
-    @State private var userMemoryEnabled = Config.userMemoryEnabled
-    @State private var memoryNudgesEnabled = Config.memoryNudgesEnabled
-    @State private var conversationPersistenceEnabled = Config.conversationPersistenceEnabled
-    @State private var autoModelRoutingEnabled = Config.autoModelRoutingEnabled
-
-    // Privacy filter
-    @State private var privacyFilterEnabled = Config.privacyFilterEnabled
-    @State private var useGlassesMicForWakeWord = Config.useGlassesMicForWakeWord
-
-    // Security
-    @State private var conversationEncryptionEnabled = Config.conversationEncryptionEnabled
-    @State private var isTogglingEncryption = false
-
-    // Service settings (owned here, bound to ServicesSettingsView)
-    // ElevenLabs / TTS voice, web-search keys, and live-streaming config are owned
-    // by ServicesSettingsView (self-contained, persists to Config on change).
+    // The individual settings sections live in per-category screens (SettingsScreens.swift);
+    // this view is the hub: a short list of categories plus the always-visible
+    // Simple Mode and About sections.
 
     var body: some View {
         Form {
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-            // MARK: — Core
+            // MARK: — Categories (hub)
             // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-            // MARK: Wake Word
-            Section {
-                Picker("Wake Phrase", selection: Binding(
-                    get: { Config.wakePhrase },
-                    set: { newValue in
-                        Config.setWakePhrase(newValue)
-                        Config.setAlternativeWakePhrases(Config.defaultAlternativesForPhrase(newValue))
-                    }
-                )) {
-                    Text("Hey OpenGlasses").tag("hey openglasses")
-                    Text("Hey Claude").tag("hey claude")
-                    Text("Hey Jarvis").tag("hey jarvis")
-                    Text("Hey Computer").tag("hey computer")
-                    Text("Hey Assistant").tag("hey assistant")
-                    Text("Hey Rayban").tag("hey rayban")
-                }
-
-                InfoToggle(
-                    title: "Push-to-Talk Mode",
-                    isOn: Binding(
-                        get: { Config.silentMode },
-                        set: { newValue in
-                            Config.setSilentMode(newValue)
-                            if newValue {
-                                appState.wakeWordService.stopListening()
-                                appState.isListening = false
-                            } else {
-                                Task { try? await appState.wakeWordService.startListening() }
-                            }
-                        }
-                    ),
-                    info: "Turns off the always-on wake-word listener so the mic isn't held in the background — fixes conflicts with music/podcasts playing at the same time. Start a conversation on demand instead: the iPhone Action Button (\"Ask OpenGlasses\"), Siri, the home screen widget, the Apple Watch, or a manual mic tap."
-                )
-
-                InfoToggle(
-                    title: "Open App for Siri Questions",
-                    isOn: Binding(
-                        get: { Config.siriAskOpensApp },
-                        set: { Config.setSiriAskOpensApp($0) }
-                    ),
-                    info: "When you say \"Hey Siri, ask OpenGlasses…\", the answer is normally spoken hands-free without opening the app. Turn this on if Siri says OpenGlasses isn't running — it launches the app first so the question always goes through, at the cost of bringing the app to the foreground."
-                )
-            } header: {
-                Text("Voice")
-            } footer: {
-                Text("The phrase that starts a conversation. Push-to-Talk Mode stops the always-listening mic (so it won't fight other audio) — trigger on demand via the Action Button, Siri, widget, or watch.")
-            }
-
-            // MARK: Hands-Free Triggers
-            Section {
-                ForEach(AlternativeTrigger.allCases) { trigger in
-                    InfoToggle(
-                        title: trigger.displayName,
-                        isOn: Binding(
-                            get: { Config.alternativeTriggerEnabled(trigger) },
-                            set: { newValue in
-                                Config.setAlternativeTriggerEnabled(trigger, newValue)
-                                appState.alternativeTriggers.refresh()
-                            }
-                        ),
-                        info: trigger.detail
-                    )
-                }
-            } header: {
-                Text("Hands-Free Triggers")
-            } footer: {
-                Text("Alternative ways to start the assistant without the wake word — for noisy, silent, or no-speech situations. All are off by default. The Volume Button trigger can interfere with normal volume control.")
-            }
-
+            // Each row pushes a screen in SettingsScreens.swift holding the full sections.
             // Simple Mode hides the owner-only configuration surface (models, personas,
             // behavior, tools, integrations, advanced) — the device keeps working exactly
-            // as configured; the sections below just stop being visible/editable.
-            if !simpleModeEnabled {
-            // MARK: AI Models
-            Section {
-                ForEach(modelConfigs) { model in
-                    Button {
-                        editingModel = model
-                    } label: {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(model.name)
-                                    .foregroundStyle(Color(.label))
-                                    .lineLimit(1)
-                                HStack(spacing: 4) {
-                                    Text(model.llmProvider.displayName)
-                                        .font(.footnote)
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(1)
-                                    if model.visionEnabled {
-                                        Image(systemName: "eye")
-                                            .font(.caption2)
-                                            .foregroundStyle(Color(.label))
-                                            .accessibilityLabel("Vision enabled")
-                                    }
-                                    if !model.apiKey.isEmpty {
-                                        Image(systemName: "checkmark.circle.fill")
-                                            .font(.caption2)
-                                            .foregroundStyle(.green)
-                                            .accessibilityLabel("API key set")
-                                    } else {
-                                        Image(systemName: "exclamationmark.circle")
-                                            .font(.caption2)
-                                            .foregroundStyle(.orange)
-                                            .accessibilityLabel("API key missing")
-                                    }
-                                }
-                            }
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                                .accessibilityHidden(true)
-                        }
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityElement(children: .combine)
-                    .accessibilityLabel("\(model.name), \(model.llmProvider.displayName)\(!model.apiKey.isEmpty ? "" : ", API key missing")\(model.visionEnabled ? ", vision enabled" : "")")
-                    .accessibilityHint("Double-tap to edit")
-                }
-                .onDelete { indexSet in
-                    modelConfigs.remove(atOffsets: indexSet)
-                }
-
-                Button {
-                    showAddModel = true
-                } label: {
-                    Label("Add Model", systemImage: "plus.circle.fill")
-                }
-            } header: {
-                Text("AI Models")
-            } footer: {
-                Text("Models are the AI you talk to. Add a key for any provider you want — you can switch between them anytime from the main screen.")
-            }
-
-            // MARK: Personality
-            Section {
-                NavigationLink {
-                    PersonasView()
-                } label: {
-                    HStack {
-                        Label("Personas", systemImage: "person.2")
-                        Spacer()
-                        Text("\(Config.enabledPersonas.count) active")
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                NavigationLink {
-                    PromptPresetsView()
-                } label: {
-                    HStack {
-                        Label("System Prompt", systemImage: "text.quote")
-                        Spacer()
-                        Text(Config.activePreset?.name ?? "Default")
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            } header: {
-                Text("Personality")
-            } footer: {
-                Text("Personas are different characters with their own model + prompt (e.g. a museum docent, a fitness coach). System Prompt tweaks the default voice and behaviour.")
-            }
-
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-            // MARK: — Intelligence
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+            // as configured; those categories just stop being visible/editable.
 
             Section {
-                InfoToggle(
-                    title: "Intent Classifier",
-                    isOn: $intentClassifierEnabled,
-                    info: "Uses a lightweight on-device model to determine if speech is directed at the assistant or is just background conversation. Prevents the AI from responding to nearby chatter, TV audio, or other people talking."
-                )
-                InfoToggle(
-                    title: "User Memory",
-                    isOn: $userMemoryEnabled,
-                    info: "Remembers facts you share across conversations — your name, preferences, routines, dietary needs, etc. This context is included in future conversations so the AI can personalise responses. Memory is stored locally on your device."
-                )
-                InfoToggle(
-                    title: "Conversation History",
-                    isOn: $conversationPersistenceEnabled,
-                    info: "Saves conversation transcripts so you can review them later in the History tab. Also provides context for follow-up questions within a session. When off, conversations are ephemeral and discarded after each session."
-                )
-                InfoToggle(
-                    title: "Memory Suggestions",
-                    isOn: $memoryNudgesEnabled,
-                    info: "After you state a durable fact (\"my daughter's name is Mia\") or repeat a multi-step request, the assistant offers a spoken nudge to remember it or save it as a skill — you confirm by voice. With Agentic Features on, these are saved automatically instead of nudged. Off by default."
-                )
-
                 NavigationLink {
-                    SmartRoutingView(
-                        autoModelRoutingEnabled: $autoModelRoutingEnabled,
-                        modelConfigs: modelConfigs
+                    VoiceTriggersSettingsScreen(appState: appState)
+                } label: {
+                    categoryRow(
+                        "Voice & Triggers",
+                        systemImage: "waveform",
+                        description: "Wake phrase, push-to-talk, hands-free triggers"
                     )
-                } label: {
-                    HStack {
-                        Label("Smart Routing", systemImage: "arrow.triangle.branch")
-                        Spacer()
-                        Text(autoModelRoutingEnabled ? "On" : "Off")
-                            .foregroundStyle(.secondary)
-                    }
                 }
 
-                NavigationLink {
-                    AgenticFeaturesView(agentDocs: appState.agentDocs, localLLM: appState.localLLMService)
-                        .environmentObject(appState)
-                } label: {
-                    HStack {
-                        Label("Agentic Features", systemImage: "bolt.badge.automatic")
-                        Spacer()
-                        if Config.agentModeEnabled {
-                            Text("On")
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-            } header: {
-                Text("How It Behaves")
-            } footer: {
-                Text("Intent Classifier ignores nearby chatter so the AI only responds when you're talking to it. Memory and History let the AI remember who you are across sessions. Smart Routing picks the right model for the task; Agentic Features let the AI take multi-step actions on its own.")
-            }
-
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-            // MARK: — Privacy & Compliance
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-            // (Medical Compliance moved into "Glasses & Privacy" below.)
-
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-            // MARK: — Tools & Actions
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-            Section {
-                NavigationLink {
-                    QuickActionsSettingsView()
-                } label: {
-                    Label("Quick Actions", systemImage: "dial.high")
-                }
-
-                NavigationLink {
-                    ToolsSettingsView(appState: appState)
-                } label: {
-                    Label("Tools", systemImage: "wrench.and.screwdriver")
-                }
-
-                NavigationLink {
-                    FieldAssistSettingsView()
-                } label: {
-                    HStack {
-                        Label("Field Assist", systemImage: "wrench.adjustable")
-                        Spacer()
-                        if Config.fieldAssistEnabled {
-                            Text("On").foregroundStyle(.secondary)
-                        }
-                    }
-                }
-
-                NavigationLink {
-                    VaultManagerView()
-                } label: {
-                    Label("Custom Vaults", systemImage: "tray.full")
-                }
-
-                NavigationLink {
-                    VaultFilesEditorView(vaultId: "notes", title: "Personal Notes")
-                } label: {
-                    Label("Personal Notes", systemImage: "note.text")
-                }
-
-                NavigationLink {
-                    DeckListView()
-                } label: {
-                    Label("Study Mode", systemImage: "graduationcap")
-                }
-
-                NavigationLink {
-                    ReadingStatsView()
-                } label: {
-                    Label("Reading", systemImage: "book")
-                }
-
-                NavigationLink {
-                    HealthVaultEditorView()
-                } label: {
-                    HStack {
-                        Label("Health Vault", systemImage: "heart.text.square")
-                        Spacer()
-                        if VaultRegistry.shared.isUnlocked("health") {
-                            Text("Unlocked").foregroundStyle(.secondary)
-                        }
-                    }
-                }
-
-                NavigationLink {
-                    AccessibilitySettingsView()
-                        .environmentObject(appState)
-                } label: {
-                    HStack {
-                        Label("Accessibility", systemImage: "accessibility")
-                        Spacer()
-                        if Config.accessibilityModeEnabled {
-                            Text("On").foregroundStyle(.secondary)
-                        }
-                    }
-                }
-
-                NavigationLink {
-                    CustomToolsView()
-                        .environmentObject(appState)
-                } label: {
-                    Label("Custom Tools", systemImage: "hammer")
-                }
-
-                NavigationLink {
-                    SiriExposureView()
-                } label: {
-                    Label("Siri & Search", systemImage: "mic.badge.plus")
-                }
-
-                if Config.agentModeEnabled {
+                if !simpleModeEnabled {
                     NavigationLink {
-                        MCPServerSettingsView()
-                            .environmentObject(appState)
+                        AIPersonalitySettingsScreen(appState: appState)
                     } label: {
-                        HStack {
-                            Label("MCP Server", systemImage: "macbook.and.iphone")
-                            Spacer()
-                            if MCPGlassesServer.shared.isRunning {
-                                Text("Running").foregroundStyle(.secondary)
-                            }
-                        }
+                        categoryRow(
+                            "AI & Personality",
+                            systemImage: "brain.head.profile",
+                            description: "Models, personas, prompt, and behaviour"
+                        )
                     }
-                }
 
-                NavigationLink {
-                    PlaybooksSettingsView(store: appState.playbookStore)
-                } label: {
-                    Label("Playbooks", systemImage: "list.clipboard")
-                }
-
-                NavigationLink {
-                    ClawHubBrowserView()
-                } label: {
-                    HStack {
-                        Label("Skill Store", systemImage: "square.grid.3x3.square")
-                        Spacer()
-                        let count = InstalledSkillStore.shared.installedSkills.filter(\.enabled).count
-                        if count > 0 {
-                            Text("\(count) active")
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-
-                NavigationLink {
-                    VoiceSkillsManagerView()
-                } label: {
-                    Label("Voice Skills", systemImage: "waveform")
-                }
-
-                if Config.agentModeEnabled {
                     NavigationLink {
-                        SuggestedSkillsView()
+                        ToolsActionsSettingsScreen(appState: appState)
                     } label: {
-                        HStack {
-                            Label("Suggested Skills", systemImage: "lightbulb.max")
-                            Spacer()
-                            let count = EvolvedSkillStore.shared.pending().count
-                            if count > 0 {
-                                Text("\(count)")
-                                    .font(.caption.weight(.semibold))
-                                    .foregroundStyle(.white)
-                                    .padding(.horizontal, 7).padding(.vertical, 2)
-                                    .background(Capsule().fill(.red))
-                            }
-                        }
+                        categoryRow(
+                            "Tools & Actions",
+                            systemImage: "wrench.and.screwdriver",
+                            description: "Quick actions, tools, skills, and playbooks"
+                        )
                     }
-                }
-            } header: {
-                Text("Tools the AI Can Use")
-            } footer: {
-                Text("Quick Actions are shortcuts you can tap from the widget. Tools are built-in capabilities (camera, search, HomeKit, music…). Custom Tools and Playbooks let you script your own. The Skill Store adds community-built skills.")
-            }
 
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-            // MARK: — Connections
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-            Section {
-                NavigationLink {
-                    ServicesSettingsView(appState: appState)
-                } label: {
-                    Label("Services & Integrations", systemImage: "square.grid.2x2")
-                }
-
-                NavigationLink {
-                    GatewaySettingsView(appState: appState)
-                } label: {
-                    HStack {
-                        Label("Gateways", systemImage: "server.rack")
-                        Spacer()
-                        let count = Config.enabledGateways.count
-                        if count > 0 {
-                            Text("\(count) active")
-                                .foregroundStyle(.secondary)
-                        }
+                    NavigationLink {
+                        ConnectionsSettingsScreen(appState: appState)
+                    } label: {
+                        categoryRow(
+                            "Connections",
+                            systemImage: "point.3.connected.trianglepath.dotted",
+                            description: "Services, gateways, and MCP servers"
+                        )
                     }
                 }
 
                 NavigationLink {
-                    MCPServersView()
-                        .environmentObject(appState)
+                    GlassesPrivacySettingsScreen(appState: appState)
                 } label: {
-                    Label("MCP Servers", systemImage: "point.3.connected.trianglepath.dotted")
-                }
-            } header: {
-                Text("Connected Apps & Services")
-            } footer: {
-                Text("ElevenLabs voices, Perplexity search, broadcast targets, and live-streaming live under Services. Gateways are OpenClaw bridges to your devices (smart home, automations). MCP Servers expose external tool servers the AI can call.")
-            }
-
-            }
-
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-            // MARK: — Glasses & Privacy
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-            Section {
-                NavigationLink {
-                    HardwarePrivacyView(
-                        appState: appState,
-                        useGlassesMicForWakeWord: $useGlassesMicForWakeWord,
-                        privacyFilterEnabled: $privacyFilterEnabled,
-                        conversationEncryptionEnabled: $conversationEncryptionEnabled,
-                        isTogglingEncryption: $isTogglingEncryption
+                    categoryRow(
+                        "Glasses & Privacy",
+                        systemImage: "lock.shield",
+                        description: "Hardware, privacy, and medical compliance"
                     )
-                } label: {
-                    Label("Hardware & Privacy", systemImage: "lock.shield")
                 }
 
                 NavigationLink {
-                    MedicalCompliancePaywallView(
-                        hipaaService: appState.hipaaService,
-                        exportService: appState.medicalExportService
+                    LookFeelSettingsScreen()
+                } label: {
+                    categoryRow(
+                        "Look & Feel",
+                        systemImage: "paintbrush",
+                        description: "Theme, accent colour, and languages"
                     )
-                } label: {
-                    HStack {
-                        Label("Medical Compliance", systemImage: "cross.case.fill")
-                        Spacer()
-                        if StoreKitService.shared.canAccessMedicalCompliance && Config.hipaaMode {
-                            Image(systemName: "cross.case.fill")
-                                .font(.caption)
-                                .foregroundStyle(AppAccent.aiCoral)
-                                .accessibilityHidden(true)
-                            Image(systemName: "checkmark.circle.fill")
-                                .font(.caption)
-                                .foregroundStyle(.green)
-                                .accessibilityLabel("Active")
-                        } else if !StoreKitService.shared.canAccessMedicalCompliance {
-                            Image(systemName: "cross.case.fill")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .accessibilityHidden(true)
-                        }
+                }
+
+                if !simpleModeEnabled {
+                    NavigationLink {
+                        AdvancedSettingsScreen(appState: appState)
+                    } label: {
+                        categoryRow(
+                            "Advanced",
+                            systemImage: "gearshape.2",
+                            description: "Diagnostics and power-user tools"
+                        )
                     }
                 }
-            } header: {
-                Text("Glasses & Privacy")
-            } footer: {
-                Text("Mic source, on-device bystander-face blurring, and encrypted conversations live in Hardware & Privacy. Medical Compliance enables HIPAA-grade encryption and exports for clinical use (separate subscription).")
-            }
-
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-            // MARK: — Appearance
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-            Section {
-                Picker("Theme", selection: Binding(
-                    get: { UserDefaults.standard.string(forKey: "appAppearance") ?? "dark" },
-                    set: { UserDefaults.standard.set($0, forKey: "appAppearance") }
-                )) {
-                    Text("Dark").tag("dark")
-                    Text("Light").tag("light")
-                    Text("System").tag("system")
-                }
-                .pickerStyle(.segmented)
-
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Accent Colour")
-                        .font(.subheadline)
-                    HStack(spacing: 12) {
-                        ForEach(AppAccent.presets) { preset in
-                            Button {
-                                accentColorName = preset.id
-                                Config.setAccentColorName(preset.id)
-                            } label: {
-                                Circle()
-                                    .fill(preset.color)
-                                    .frame(width: 30, height: 30)
-                                    .overlay(
-                                        Circle()
-                                            .strokeBorder(.white, lineWidth: accentColorName == preset.id ? 2.5 : 0)
-                                    )
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("\(preset.name) accent colour\(accentColorName == preset.id ? ", selected" : "")")
-                        }
-                    }
-                }
-                .padding(.vertical, 4)
-
-                NavigationLink {
-                    LanguageSettingsView()
-                } label: {
-                    HStack {
-                        Label("Languages", systemImage: "globe")
-                        Spacer()
-                        let downloaded = LocalizationManager.shared.downloadableLanguages.filter(\.isDownloaded).count
-                        let bundled = LocalizationManager.bundledLanguages.count
-                        Text("\(bundled + downloaded) available")
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            } header: {
-                Text("Look & Feel")
-            } footer: {
-                Text("Theme, accent colour, and which languages the assistant speaks and understands.")
-            }
-
-            if !simpleModeEnabled {
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-            // MARK: — Advanced
-            // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-            Section {
-                NavigationLink {
-                    PromptInspectorView(appState: appState)
-                } label: {
-                    Label("Prompt Inspector", systemImage: "doc.text.magnifyingglass")
-                }
-
-                NavigationLink {
-                    NetworkMonitorView()
-                } label: {
-                    Label("Network Activity", systemImage: "antenna.radiowaves.left.and.right")
-                }
-
-                NavigationLink {
-                    LiveVisionSettingsView()
-                } label: {
-                    Label("Live Vision", systemImage: "camera.metering.matrix")
-                }
-
-                NavigationLink {
-                    DocumentsView()
-                } label: {
-                    Label("Documents", systemImage: "doc.text.magnifyingglass")
-                }
-
-                NavigationLink {
-                    CaptureFlowAuthorView()
-                } label: {
-                    Label("Author Capture-Flow", systemImage: "list.bullet.rectangle")
-                }
-            } header: {
-                Text("Advanced")
-            } footer: {
-                Text("Diagnostic tools for power users — inspect the prompts being sent to the AI and watch live network requests. Useful for debugging or building your own integrations.")
-            }
-
             }
 
             // MARK: Simple Mode (always visible so the owner can leave it — behind the owner gate)
@@ -679,23 +166,6 @@ struct SettingsView: View {
         }
         .navigationTitle("Settings")
         .tint(accent)
-        .sheet(item: $editingModel) { model in
-            ModelEditorView(model: model) { updated in
-                if let idx = modelConfigs.firstIndex(where: { $0.id == updated.id }) {
-                    modelConfigs[idx] = updated
-                    Config.setSavedModels(modelConfigs)
-                }
-            }
-        }
-        .sheet(isPresented: $showAddModel) {
-            AddModelView { newModel in
-                modelConfigs.append(newModel)
-                Config.setSavedModels(modelConfigs)
-            }
-        }
-        .onDisappear {
-            saveSettings()
-        }
         // Owner gate on Settings entry (BM P10, opt-in): an opaque cover — never a blur that
         // leaks decrypted key fields — until device-owner auth grants entry.
         .overlay {
@@ -704,6 +174,25 @@ struct SettingsView: View {
         .onAppear {
             if settingsLocked { authenticateSettingsEntry() }
         }
+    }
+
+    // MARK: - Category Row
+
+    /// A hub row: category label plus a one-line description of what lives inside.
+    /// The description lives INSIDE the Label's title so it aligns with the title text —
+    /// as a sibling of the Label it started at the leading edge, colliding with the icon.
+    private func categoryRow(_ title: String, systemImage: String, description: String) -> some View {
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                Text(description)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        } icon: {
+            Image(systemName: systemImage)
+        }
+        .padding(.vertical, 2)
     }
 
     // MARK: - Owner gate (BM P10)
@@ -778,36 +267,6 @@ struct SettingsView: View {
 
     private static var buildNumber: String {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "–"
-    }
-
-    // MARK: - Save Settings
-
-    private func saveSettings() {
-        Config.setSavedModels(modelConfigs)
-
-        if !modelConfigs.contains(where: { $0.id == Config.activeModelId }) {
-            if let first = modelConfigs.first {
-                Config.setActiveModelId(first.id)
-            }
-        }
-        appState.llmService.refreshActiveModel()
-
-        Config.setPrivacyFilterEnabled(privacyFilterEnabled)
-        appState.privacyFilter.isEnabled = privacyFilterEnabled
-        Config.setUseGlassesMicForWakeWord(useGlassesMicForWakeWord)
-
-        Config.setIntentClassifierEnabled(intentClassifierEnabled)
-        Config.setUserMemoryEnabled(userMemoryEnabled)
-        Config.setMemoryNudgesEnabled(memoryNudgesEnabled)
-        Config.setConversationPersistenceEnabled(conversationPersistenceEnabled)
-
-        if appState.currentMode == .direct {
-            Task {
-                appState.wakeWordService.stopListening()
-                try? await Task.sleep(nanoseconds: 300_000_000)
-                try? await appState.wakeWordService.startListening()
-            }
-        }
     }
 }
 

--- a/OpenGlasses/Sources/App/Views/StatusIndicator.swift
+++ b/OpenGlasses/Sources/App/Views/StatusIndicator.swift
@@ -9,7 +9,9 @@ struct StatusIndicator: View {
     @EnvironmentObject var appState: AppState
     @ObservedObject var session: GeminiLiveSessionManager
     @ObservedObject var openAISession: OpenAIRealtimeSessionManager
+    @ObservedObject var openClawBridge: OpenClawBridge
     @Environment(\.appAccent) private var accent
+    @State private var showDisconnectConfirm = false
 
     private var isGemini: Bool { appState.currentMode == .geminiLive }
     private var isOpenAI: Bool { appState.currentMode == .openaiRealtime }
@@ -38,7 +40,7 @@ struct StatusIndicator: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(statusLabel)
-                        .font(.system(size: 17, weight: .medium))
+                        .font(.system(size: 17, weight: .semibold, design: .rounded))
                         .foregroundStyle(Color(.label))
                         .lineLimit(1)
 
@@ -82,14 +84,82 @@ struct StatusIndicator: View {
                 reconnectingLabel.padding(.bottom, 10)
             }
 
-            // Active mode indicator
-            activeModeBadge
-                .padding(.bottom, 12)
+            // Bottom row: active mode + the connection pills (formerly a separate band above
+            // the card — merged here so the home screen is one status surface, not two).
+            HStack(spacing: 8) {
+                activeModeBadge
+                Spacer()
+                glassesPill
+                if Config.isOpenClawConfigured {
+                    openClawPill
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 12)
         }
         .glassEffect(in: .rect(cornerRadius: 16))
         .padding(.horizontal, 20)
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
         .accessibilityLabel("\(statusLabel). \(modeLabel). \(appState.isConnected ? "Connected" : "Disconnected")")
+    }
+
+    // MARK: - Connection pills (merged from the old StatusPillsRow)
+
+    private var glassesPill: some View {
+        let connected = appState.isConnected
+        let color: Color = connected ? .green : .red.opacity(0.7)
+        let label = connected ? (appState.glassesService.deviceName ?? "Glasses") : "Disconnected"
+
+        return Button {
+            if connected {
+                showDisconnectConfirm = true
+            } else {
+                Task { await appState.glassesService.connect() }
+            }
+        } label: {
+            HStack(spacing: 5) {
+                LogoIcon(size: 13)
+                    .foregroundStyle(color)
+                if connected {
+                    Circle().fill(color).frame(width: 5, height: 5)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .glassEffect(in: .capsule)
+        }
+        .buttonStyle(.plain)
+        .confirmationDialog("Disconnect Glasses", isPresented: $showDisconnectConfirm) {
+            Button("Disconnect", role: .destructive) {
+                appState.disconnectGlasses()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Stop mic, camera, and TTS. Gateway tasks keep running.")
+        }
+        .accessibilityLabel("Glasses: \(label)")
+    }
+
+    private var openClawPill: some View {
+        let (color, label): (Color, String) = {
+            switch openClawBridge.connectionState {
+            case .connected: return (.green, "Connected")
+            case .checking: return (.orange, "Checking")
+            case .unreachable: return (.red, "Unreachable")
+            case .notConfigured: return (.gray, "Not Set Up")
+            }
+        }()
+
+        return HStack(spacing: 5) {
+            Circle().fill(color).frame(width: 5, height: 5)
+            Text("OpenClaw")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Color(.label))
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .glassEffect(in: .capsule)
+        .accessibilityLabel("OpenClaw: \(label)")
     }
 
     // MARK: - Active Mode Badge
@@ -261,90 +331,3 @@ struct StatusIndicator: View {
 
 }
 
-// MARK: - Quick Actions Grid (standalone)
-
-/// Horizontal grid of quick action buttons, shown above the hero capsule.
-struct QuickActionsGrid: View {
-    @EnvironmentObject var appState: AppState
-    @State private var executingActionId: String?
-
-    private var allActions: [QuickAction] { Config.quickActions }
-
-    /// Show top 4 or all, based on user preference.
-    private var actions: [QuickAction] {
-        let all = allActions
-        if Config.showAllQuickActions {
-            return all
-        }
-        return Array(all.prefix(4))
-    }
-
-    private var isExecutingAction: Bool { executingActionId != nil }
-
-    private var visible: Bool {
-        guard appState.isConnected && appState.currentMode == .direct && !actions.isEmpty else { return false }
-        // Stay visible while an action is executing (shows spinner)
-        if isExecutingAction { return true }
-        // Otherwise hide when busy
-        return !appState.isProcessing
-            && !appState.isListening
-            && !appState.speechService.isSpeaking
-            && !appState.cameraService.isCaptureInProgress
-    }
-
-    var body: some View {
-        if appState.isConnected && appState.currentMode == .direct && !allActions.isEmpty {
-            let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 4)
-
-            LazyVGrid(columns: columns, spacing: 10) {
-                ForEach(actions) { action in
-                    quickActionButton(action)
-                }
-            }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 8)
-            .opacity(visible ? 1 : 0)
-            .allowsHitTesting(visible)
-            .animation(.easeInOut(duration: 0.2), value: visible)
-        }
-    }
-
-    private func quickActionButton(_ action: QuickAction) -> some View {
-        let isExecuting = executingActionId == action.id
-
-        return Button {
-            guard !isExecuting else { return }
-            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-            executingActionId = action.id
-            Task {
-                await appState.executeQuickAction(action)
-                executingActionId = nil
-            }
-        } label: {
-            VStack(spacing: 5) {
-                ZStack {
-                    if isExecuting {
-                        ProgressView()
-                            .scaleEffect(0.7)
-                    } else {
-                        Image(systemName: action.icon)
-                            .font(.system(size: 17, weight: .medium))
-                            .foregroundStyle(Color(.label))
-                    }
-                }
-                .frame(maxWidth: .infinity)
-                .frame(height: 42)
-                .glassEffect(in: .rect(cornerRadius: 12))
-
-                Text(action.label)
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-        }
-        .buttonStyle(.plain)
-        .disabled(isExecuting)
-        .accessibilityLabel(action.label)
-        .accessibilityHint(isExecuting ? "Running" : "Double-tap to execute")
-    }
-}

--- a/OpenGlasses/Sources/App/Views/VoiceTab.swift
+++ b/OpenGlasses/Sources/App/Views/VoiceTab.swift
@@ -1,13 +1,11 @@
 import SwiftUI
 
-/// Voice tab — the primary interaction screen.
+/// Voice tab — the primary interaction screen, kept to three zones:
 ///
-/// Layout (top to bottom):
-///   1. Two status pills (Glasses + OpenClaw) at top
-///   2. StatusIndicator (center, with quick actions)
-///   3. Transcript overlay
-///   4. Chat input bar (text + image attach) or hero capsule
-///   5. Hero capsule + floating action buttons (bottom)
+///   1. Status (top): one StatusIndicator card — state, mode, persona, and the
+///      glasses/OpenClaw connection pills merged into its footer row
+///   2. Conversation (center): the coral voice waveline, ambient captions, transcript
+///   3. Controls (bottom): quick-action row, chat input or hero capsule + actions
 struct VoiceTab: View {
     @EnvironmentObject var appState: AppState
     @State private var showPreview = false
@@ -21,8 +19,12 @@ struct VoiceTab: View {
     private var isRealtime: Bool { appState.currentMode.isRealtime }
 
     var body: some View {
+        // One observation point derives the voice state; the ambience (background radiance) and
+        // the waveline express it together — a single motion system, not scattered effects.
+        VoiceStateProvider(session: session, openAISession: openAISession,
+                           speech: appState.speechService) { voiceState in
         ZStack {
-            Color(.systemBackground).ignoresSafeArea()
+            VoiceAmbience(state: voiceState).ignoresSafeArea()
 
             VStack(spacing: 0) {
                 // Recording indicator
@@ -31,15 +33,18 @@ struct VoiceTab: View {
                         .padding(.top, 8)
                 }
 
-                // Status pills row
-                StatusPillsRow(
-                    openClawBridge: appState.openClawBridge
-                )
-                .padding(.top, 8)
-
-                // Status card
-                StatusIndicator(session: session, openAISession: openAISession)
+                // Status card — one status surface: state, mode, persona, and the connection
+                // pills (formerly their own band above the card).
+                StatusIndicator(session: session, openAISession: openAISession,
+                                openClawBridge: appState.openClawBridge)
                     .padding(.top, 12)
+
+                Spacer()
+
+                // Voice-state waveline — the assistant's presence. Decorative and additive:
+                // StatusIndicator stays the source of truth for connection/mode state.
+                VoiceWaveline(state: voiceState)
+                    .padding(.horizontal, 24)
 
                 Spacer()
 
@@ -53,20 +58,8 @@ struct VoiceTab: View {
                 TranscriptOverlay(session: session, openAISession: openAISession)
                     .padding(.bottom, 8)
 
-                // Load the on-device model on demand — only shown when the active
-                // model is local, so it's not lazy-loaded (slowly) on first query.
-                if let local = appState.llmService.localLLMService {
-                    LocalModelBar(service: local)
-                        .padding(.horizontal, 16)
-                        .padding(.bottom, 8)
-                }
-
-                // Quick actions (above hero capsule)
-                if !showChatInput {
-                    QuickActionsGrid()
-                }
-
-                // Chat input bar (when active) or voice controls
+                // Chat input bar (when active) or voice controls. The control dock
+                // (BottomControlBar) owns the model chip and quick actions as tiles.
                 if showChatInput && !isRealtime {
                     ChatInputBar(showChatInput: $showChatInput)
                 } else {
@@ -79,6 +72,7 @@ struct VoiceTab: View {
                     )
                 }
             }
+        }
         }
         .fullScreenCover(isPresented: $showPreview) {
             LivePreviewView()
@@ -114,73 +108,6 @@ struct VoiceTab: View {
     }
 }
 
-// MARK: - Local Model Bar (home-screen load/unload)
-
-/// Home-screen control to load/unload the on-device model on demand. Shown only when
-/// the active model is a local (MLX) model, so the user isn't waiting on a lazy load
-/// at first query — and can free memory when done.
-private struct LocalModelBar: View {
-    @ObservedObject var service: LocalLLMService
-    @Environment(\.appAccent) private var accent
-
-    var body: some View {
-        if let active = Config.activeModel, active.llmProvider == .local {
-            content(active)
-        }
-    }
-
-    @ViewBuilder
-    private func content(_ active: ModelConfig) -> some View {
-        let modelId = active.model
-        let isLoaded = service.isModelLoaded && service.loadedModelId == modelId
-
-        if service.isLoadingModel {
-            HStack(spacing: 8) {
-                ProgressView().controlSize(.small)
-                Text("Loading \(active.name)…")
-                    .font(.footnote.weight(.medium))
-                    .foregroundStyle(.secondary)
-                if service.downloadProgress > 0, service.downloadProgress < 1 {
-                    Text("\(Int(service.downloadProgress * 100))%")
-                        .font(.caption).foregroundStyle(.secondary)
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 10)
-            .background(.quaternary.opacity(0.4), in: Capsule())
-        } else if isLoaded {
-            Button { service.unloadModel() } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "checkmark.circle.fill").foregroundStyle(.green)
-                    Text("\(active.name) loaded")
-                        .font(.footnote.weight(.medium))
-                        .foregroundStyle(Color(.label))
-                    Text("· Unload").font(.caption).foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 10)
-                .background(.green.opacity(0.12), in: Capsule())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("\(active.name) loaded. Tap to unload.")
-        } else {
-            Button { Task { try? await service.loadModel(modelId) } } label: {
-                HStack(spacing: 7) {
-                    Image(systemName: "cpu")
-                    Text("Load \(active.name)")
-                }
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.white)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-                .background(accent, in: Capsule())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Load on-device model \(active.name)")
-        }
-    }
-}
-
 // MARK: - Voice Tab Controls (hero capsule + secondary buttons)
 
 /// Bottom controls for the Voice tab — reuses the original BottomControlBar patterns.
@@ -205,83 +132,6 @@ private struct VoiceTabControls: View {
     }
 }
 
-// MARK: - Status Pills Row
-
-struct StatusPillsRow: View {
-    @EnvironmentObject var appState: AppState
-    @ObservedObject var openClawBridge: OpenClawBridge
-
-    var body: some View {
-        HStack {
-            glassesPill
-            Spacer()
-            if Config.isOpenClawConfigured {
-                openClawPill
-            }
-        }
-        .padding(.horizontal, 16)
-    }
-
-    @State private var showDisconnectConfirm = false
-
-    private var glassesPill: some View {
-        let connected = appState.isConnected
-        let color: Color = connected ? .green : .red.opacity(0.7)
-        let label = connected ? (appState.glassesService.deviceName ?? "Glasses") : "Disconnected"
-
-        return Button {
-            if connected {
-                showDisconnectConfirm = true
-            } else {
-                Task { await appState.glassesService.connect() }
-            }
-        } label: {
-            HStack(spacing: 6) {
-                LogoIcon(size: 15)
-                    .foregroundStyle(color)
-                if connected {
-                    Circle().fill(color).frame(width: 6, height: 6)
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .glassEffect(in: .capsule)
-        }
-        .buttonStyle(.plain)
-        .confirmationDialog("Disconnect Glasses", isPresented: $showDisconnectConfirm) {
-            Button("Disconnect", role: .destructive) {
-                appState.disconnectGlasses()
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("Stop mic, camera, and TTS. Gateway tasks keep running.")
-        }
-        .accessibilityLabel("Glasses: \(label)")
-    }
-
-    private var openClawPill: some View {
-        let (color, label): (Color, String) = {
-            switch openClawBridge.connectionState {
-            case .connected: return (.green, "Connected")
-            case .checking: return (.orange, "Checking")
-            case .unreachable: return (.red, "Unreachable")
-            case .notConfigured: return (.gray, "Not Set Up")
-            }
-        }()
-
-        return HStack(spacing: 6) {
-            Circle().fill(color).frame(width: 6, height: 6)
-            Text("OpenClaw")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(Color(.label))
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .glassEffect(in: .capsule)
-        .accessibilityLabel("OpenClaw: \(label)")
-    }
-}
-
 // MARK: - Chat Input Bar
 
 /// Voice-tab inline chat input — the hero capsule's typed-message alternative.
@@ -298,3 +148,22 @@ struct ChatInputBar: View {
     }
 }
 
+
+/// Observes exactly the signals the voice visuals fuse — the ambience and waveline re-render on
+/// their changes without widening what VoiceTab itself watches — and hands the derived state to
+/// its content.
+private struct VoiceStateProvider<Content: View>: View {
+    @EnvironmentObject var appState: AppState
+    @ObservedObject var session: GeminiLiveSessionManager
+    @ObservedObject var openAISession: OpenAIRealtimeSessionManager
+    @ObservedObject var speech: TextToSpeechService
+    @ViewBuilder var content: (VoiceVisualState) -> Content
+
+    var body: some View {
+        content(VoiceVisualState.from(
+            isSpeaking: speech.isSpeaking || session.isModelSpeaking || openAISession.isModelSpeaking,
+            isProcessing: appState.isProcessing,
+            isListening: appState.isListening,
+            realtimeActive: session.isActive || openAISession.isActive))
+    }
+}

--- a/OpenGlasses/Sources/App/Views/VoiceWaveline.swift
+++ b/OpenGlasses/Sources/App/Views/VoiceWaveline.swift
@@ -1,0 +1,215 @@
+import SwiftUI
+
+/// The assistant's voice-state visual: a ribbon of distinct wave strands (the Siri-style idiom)
+/// in the app's warm coral family — several lines that weave and cross, not one line with a glow.
+///
+/// Motion design: three FIXED sine harmonics whose per-state *amplitudes* are blended with eased
+/// transitions — frequencies and phases never change, so a state switch morphs the wave instead of
+/// jumping it. (Changing a frequency mid-animation jumps the sine phase; that discontinuity is
+/// what makes cheap voice visuals twitch.) Each strand adds only CONSTANT phase offsets and a
+/// constant speed detune, so the phase-continuity contract holds per strand too.
+///
+///   • idle      — calm, slowly interweaving threads: present, not busy
+///   • listening — tight, quick, low ripple: attentive stillness
+///   • thinking  — a slow swell with a fast shimmer riding it: working
+///   • speaking  — tall, lively, flowing: talking
+struct VoiceWaveline: View {
+
+    var state: VoiceVisualState = .idle
+    var height: CGFloat = 76
+
+    /// A sunset spectrum around the app's AI accent — four clearly DISTINCT hues (orange, gold,
+    /// pink, red), because near-identical corals blur back into one thick line. Stays off
+    /// violet/cyan per the brand rule.
+    static let coral = AppAccent.aiCoral
+    static let gold  = Color(red: 0.96, green: 0.76, blue: 0.23)   // golden yellow
+    static let rose  = Color(red: 0.91, green: 0.36, blue: 0.54)   // warm pink
+    static let ember = Color(red: 0.85, green: 0.27, blue: 0.23)   // deep red
+
+    /// The ribbon, back to front. Offsets/detunes are constants (phase-continuous); the negative
+    /// ampScale mirrors a strand so it *must* cross the others — that guaranteed crossing is what
+    /// makes the eye read "several threads" instead of "one thick line".
+    static let strands: [WavelineStrand] = [
+        WavelineStrand(phaseShift: 2.1, timeScale: 0.82, ampScale:  0.90,
+                       color: gold,  lineWidth: 1.8, opacity: 0.75),
+        WavelineStrand(phaseShift: 4.4, timeScale: 1.18, ampScale:  0.78,
+                       color: ember, lineWidth: 1.8, opacity: 0.70),
+        WavelineStrand(phaseShift: 1.1, timeScale: 0.94, ampScale: -0.75,
+                       color: rose,  lineWidth: 1.6, opacity: 0.75),
+        WavelineStrand(phaseShift: 0.0, timeScale: 1.00, ampScale:  1.00,
+                       color: coral, lineWidth: 2.4, opacity: 1.00),
+    ]
+
+    @State private var amplitudes = WavelineParams.params(for: .idle)
+
+    var body: some View {
+        // Capped at 60fps: the glow's 6px blur is an offscreen Gaussian pass per frame, and on
+        // ProMotion an uncapped .animation runs it at 120Hz — twice the GPU/battery for motion
+        // this slow-moving, with no visible difference.
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { timeline in
+            let t = timeline.date.timeIntervalSinceReferenceDate
+            Canvas { context, size in
+                // Soft glow underlay traces the primary strand, then the ribbon on top.
+                if let primary = Self.strands.last {
+                    var glow = context
+                    glow.addFilter(.blur(radius: 6))
+                    glow.stroke(strandPath(primary, time: t, size: size),
+                                with: shading(for: primary, opacityScale: 0.30, width: size.width),
+                                style: StrokeStyle(lineWidth: 6, lineCap: .round))
+                }
+                for strand in Self.strands {
+                    context.stroke(strandPath(strand, time: t, size: size),
+                                   with: shading(for: strand, width: size.width),
+                                   style: StrokeStyle(lineWidth: strand.lineWidth, lineCap: .round))
+                }
+            }
+        }
+        .frame(height: height)
+        .onChange(of: state) { _, newState in
+            withAnimation(.easeInOut(duration: 0.6)) {
+                amplitudes = WavelineParams.params(for: newState)
+            }
+        }
+        .onAppear { amplitudes = WavelineParams.params(for: state) }
+        .accessibilityHidden(true)   // decorative; state is announced elsewhere
+        .animation(.easeInOut(duration: 0.6), value: amplitudes)
+    }
+
+    private func strandPath(_ strand: WavelineStrand, time: Double, size: CGSize) -> Path {
+        let midY = size.height / 2
+        var path = Path()
+        let steps = max(48, Int(size.width / 4))
+        for i in 0...steps {
+            let x = size.width * CGFloat(i) / CGFloat(steps)
+            let y = midY + WavelineParams.displacement(
+                phase: Double(i) / Double(steps),
+                time: time,
+                amplitudes: amplitudes,
+                phaseShift: strand.phaseShift,
+                timeScale: strand.timeScale) * midY * 0.85 * strand.ampScale
+            if i == 0 { path.move(to: CGPoint(x: x, y: y)) }
+            else { path.addLine(to: CGPoint(x: x, y: y)) }
+        }
+        return path
+    }
+
+    /// Edge-faded stroke gradient in the strand's own colour.
+    private func shading(for strand: WavelineStrand, opacityScale: Double = 1, width: CGFloat) -> GraphicsContext.Shading {
+        let peak = strand.opacity * opacityScale
+        return .linearGradient(
+            Gradient(colors: [strand.color.opacity(0.0),
+                              strand.color.opacity(peak),
+                              strand.color.opacity(peak),
+                              strand.color.opacity(0.0)]),
+            startPoint: .zero,
+            endPoint: CGPoint(x: width, y: 0))
+    }
+}
+
+/// One thread of the ribbon: constant phase offset + constant speed detune (so each strand is
+/// individually phase-continuous), its own coral-family colour, weight, and amplitude scale.
+struct WavelineStrand {
+    let phaseShift: Double
+    let timeScale: Double
+    let ampScale: Double
+    let color: Color
+    let lineWidth: CGFloat
+    let opacity: Double
+}
+
+/// The home screen's atmosphere: a faint coral radiance behind the conversation zone that
+/// breathes with the same voice state as the waveline — one motion system, two expressions.
+/// Deliberately near-subliminal (single-digit opacities): the screen should feel lit by the
+/// assistant's presence, never painted with it. Sits over the system background, so light and
+/// dark mode both keep their character.
+struct VoiceAmbience: View {
+    var state: VoiceVisualState = .idle
+
+    private var glow: Double {
+        switch state {
+        case .idle: return 0.04
+        case .listening: return 0.06
+        case .thinking: return 0.07
+        case .speaking: return 0.11
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Color(.systemBackground)
+            RadialGradient(
+                colors: [VoiceWaveline.coral.opacity(glow), .clear],
+                center: UnitPoint(x: 0.5, y: 0.42),   // behind the waveline zone
+                startRadius: 0,
+                endRadius: 420)
+            // A whisper of depth toward the controls, so the bottom zone reads grounded.
+            LinearGradient(
+                colors: [.clear, Color.primary.opacity(0.03)],
+                startPoint: UnitPoint(x: 0.5, y: 0.55),
+                endPoint: .bottom)
+        }
+        .animation(.easeInOut(duration: 0.9), value: glow)
+        .accessibilityHidden(true)
+    }
+}
+
+/// What the assistant is doing, as the waveline sees it.
+enum VoiceVisualState: Equatable {
+    case idle, listening, thinking, speaking
+
+    /// Fuse the app's observable signals into one visual state. Pure — precedence is
+    /// speaking > thinking > listening > idle, because the *most active* thing happening is what
+    /// the eye should confirm. In a realtime session the mic is always open, so an active session
+    /// that isn't speaking reads as listening.
+    static func from(isSpeaking: Bool, isProcessing: Bool, isListening: Bool,
+                     realtimeActive: Bool = false) -> VoiceVisualState {
+        if isSpeaking { return .speaking }
+        if isProcessing { return .thinking }
+        if isListening || realtimeActive { return .listening }
+        return .idle
+    }
+}
+
+/// The waveline's motion parameters — pure and headless-testable.
+///
+/// Three fixed harmonics (a slow travelling swell, a mid flow, a fast shimmer); states blend
+/// their amplitudes. An envelope pins both ends of the line to the midline so the wave lives in
+/// the middle, like speech.
+struct WavelineParams: Equatable, Animatable {
+    var slow: Double
+    var mid: Double
+    var fast: Double
+
+    var animatableData: AnimatablePair<Double, AnimatablePair<Double, Double>> {
+        get { AnimatablePair(slow, AnimatablePair(mid, fast)) }
+        set { slow = newValue.first; mid = newValue.second.first; fast = newValue.second.second }
+    }
+
+    /// Fixed frequencies: spatial (cycles across the width) and temporal (radians/second).
+    /// Never state-dependent — see the phase-continuity note on `VoiceWaveline`.
+    static let spatial: (slow: Double, mid: Double, fast: Double) = (1.1, 2.3, 4.7)
+    static let temporal: (slow: Double, mid: Double, fast: Double) = (1.4, 2.2, 5.6)
+
+    static func params(for state: VoiceVisualState) -> WavelineParams {
+        switch state {
+        case .idle:      return WavelineParams(slow: 0.18, mid: 0.06, fast: 0.00)
+        case .listening: return WavelineParams(slow: 0.08, mid: 0.12, fast: 0.22)
+        case .thinking:  return WavelineParams(slow: 0.30, mid: 0.08, fast: 0.14)
+        case .speaking:  return WavelineParams(slow: 0.50, mid: 0.32, fast: 0.18)
+        }
+    }
+
+    /// Normalized displacement (−1…1 scale) at `phase` ∈ 0…1 across the width, at `time`.
+    /// Waves *travel* (time enters as phase offset), and the end-pin envelope keeps the line
+    /// anchored at both edges. `phaseShift`/`timeScale` are a strand's constant offsets — the
+    /// shift is decorrelated per harmonic (×1, ×1.7, ×2.3) so strands separate instead of
+    /// running parallel; being constants, they preserve phase continuity.
+    static func displacement(phase: Double, time: Double, amplitudes: WavelineParams,
+                             phaseShift: Double = 0, timeScale: Double = 1) -> Double {
+        let envelope = sin(phase * .pi)   // 0 at both ends, 1 in the middle
+        let s = sin(phase * spatial.slow * 2 * .pi + time * temporal.slow * timeScale + phaseShift) * amplitudes.slow
+        let m = sin(phase * spatial.mid * 2 * .pi - time * temporal.mid * timeScale + phaseShift * 1.7) * amplitudes.mid
+        let f = sin(phase * spatial.fast * 2 * .pi + time * temporal.fast * timeScale + phaseShift * 2.3) * amplitudes.fast
+        return (s + m + f) * envelope
+    }
+}

--- a/OpenGlasses/Sources/Services/CameraService.swift
+++ b/OpenGlasses/Sources/Services/CameraService.swift
@@ -90,7 +90,18 @@ class CameraService: ObservableObject {
     }
 
     func ensurePermission() async throws {
-        if permissionGranted { return }
+        // The cached flag is only a fast path PAST the iOS prompt + registration wait — the
+        // Meta permission itself is re-verified live every time. Live-traced: the user revoked
+        // the app in the Meta AI app mid-session, and the stale flag sailed straight past the
+        // permission step instead of re-asking.
+        if permissionGranted {
+            if let status = try? await Wearables.shared.checkPermissionStatus(.camera),
+               status == .granted {
+                return
+            }
+            NSLog("[Camera] Cached permission no longer granted — re-running the permission flow")
+            permissionGranted = false
+        }
 
         let regState = Wearables.shared.registrationState
         NSLog("[Camera] SDK state: %d (need 3 for camera permissions)", regState.rawValue)
@@ -151,9 +162,24 @@ class CameraService: ObservableObject {
 
     // MARK: - Persistent Session
 
+    /// Last device id seen on the SDK's devices stream — lets the session bind to THE known
+    /// device (`SpecificDeviceSelector`) instead of asking `AutoDeviceSelector` for any
+    /// "eligible" device, which throws `noEligibleDevice` during the discovery/wake window.
+    private var knownDeviceId: String?
+    private var devicesListenerToken: Any?
+
     /// Ensure the persistent stream session exists. Creates it on first call.
     private func ensureSession() async throws {
         guard streamSession == nil else { return }
+
+        // First call: start tracking the devices list, and give the listener a beat to
+        // deliver the current snapshot before we pick a selector.
+        if devicesListenerToken == nil {
+            devicesListenerToken = Wearables.shared.addDevicesListener { [weak self] deviceIds in
+                Task { @MainActor in self?.knownDeviceId = deviceIds.first }
+            }
+            try? await Task.sleep(nanoseconds: 200_000_000)
+        }
 
         // DAT 0.7: DeviceSession owns the connection; Streams hang off it.
         if deviceSession?.state == .stopped {
@@ -161,10 +187,23 @@ class CameraService: ObservableObject {
         }
 
         if deviceSession == nil {
-            deviceSession = try Wearables.shared.createSession(deviceSelector: deviceSelector)
+            // Bind to the specific discovered device when we know it — field-proven more
+            // reliable than AutoDeviceSelector for a device whose link is mid-wake.
+            if let id = knownDeviceId {
+                NSLog("[Camera] Creating session bound to device %@", id)
+                deviceSession = try Wearables.shared.createSession(
+                    deviceSelector: SpecificDeviceSelector(device: id))
+            } else {
+                deviceSession = try Wearables.shared.createSession(deviceSelector: deviceSelector)
+            }
         }
 
         guard let deviceSession else { throw CameraError.captureFailed }
+
+        // Watch the session's error stream BEFORE starting it — the reason a session dies
+        // during startup (update-required refusal, device drop) arrives there, and attaching
+        // after the state check meant every early stop was an unexplained "stream not ready".
+        watchSessionErrors(on: deviceSession)
 
         if deviceSession.state != .started {
             do {
@@ -179,14 +218,19 @@ class CameraService: ObservableObject {
                 throw error
             }
             let deadline = ContinuousClock.now + .seconds(20)
+            let stoppedGraceEnd = ContinuousClock.now + .seconds(2)
             while ContinuousClock.now < deadline {
                 if deviceSession.state == .started { break }
-                if deviceSession.state == .stopped { break }
+                // .stopped inside the first moments can be the pre-transition resting state;
+                // only treat it as terminal once the state machine has had time to move.
+                if deviceSession.state == .stopped && ContinuousClock.now > stoppedGraceEnd { break }
                 try await Task.sleep(nanoseconds: 300_000_000)
             }
         }
 
         guard deviceSession.state == .started else {
+            NSLog("[Camera] Session never reached .started (state: %@)",
+                  String(describing: deviceSession.state))
             throw CameraError.streamNotReady
         }
 
@@ -209,7 +253,7 @@ class CameraService: ObservableObject {
         }
         streamSession = stream
         attachListeners(to: stream)
-        watchSessionErrors(on: deviceSession)
+        // (session error watcher already attached above, before start)
         NSLog("[Camera] Created persistent Stream (.\(Config.cameraResolution), \(fps)fps)")
     }
 
@@ -340,22 +384,35 @@ class CameraService: ObservableObject {
 
     /// Capture a photo from the glasses camera. Returns JPEG data.
     /// Reuses the persistent session — starts it if needed, does NOT stop it after capture.
+    /// EVERY captured image is saved to the photo library ("Glasses" album) for later review —
+    /// centralized here so no capture path can forget it.
     func capturePhoto() async throws -> Data {
         // Glasses are usable for the camera only once fully registered (state 3). When
         // they're offline / not connected / not registered, capture from the iPhone back
         // camera instead so the vision tools keep working without glasses.
+        //
+        // But when glasses ARE registered, a failed glasses capture must FAIL — not silently
+        // swap to the phone camera. Live-traced: the phone was on the desk, every "photo"
+        // showed the desk, and the assistant confidently described it while the user pointed
+        // their glasses at something else. A wrong-camera photo is worse than an error.
+        let data: Data
         if Wearables.shared.registrationState.rawValue < 3 {
             NSLog("[Camera] Glasses not registered (state < 3) — capturing from iPhone back camera")
-            return try await phoneSource.capturePhoto()
+            data = try await phoneSource.capturePhoto()
+            lastCaptureSource = .phone
+        } else {
+            data = try await captureFromGlasses()
+            lastCaptureSource = .glasses
         }
-        do {
-            return try await captureFromGlasses()
-        } catch {
-            NSLog("[Camera] Glasses capture failed (%@) — falling back to iPhone back camera",
-                  error.localizedDescription)
-            return try await phoneSource.capturePhoto()
-        }
+        saveToPhotoLibrary(data)
+        return data
     }
+
+    /// Which camera actually served the last successful `capturePhoto()`. Callers use this to
+    /// ANNOUNCE a phone-camera capture — a silently swapped camera made the assistant describe
+    /// the desk the phone was lying on while the user pointed their glasses elsewhere.
+    enum CaptureSource { case glasses, phone }
+    private(set) var lastCaptureSource: CaptureSource = .glasses
 
     /// Capture a photo from the glasses camera. Returns JPEG data.
     private func captureFromGlasses() async throws -> Data {
@@ -363,7 +420,28 @@ class CameraService: ObservableObject {
         defer { isCaptureInProgress = false }
 
         try await ensurePermission()
-        try await ensureSession()
+
+        // The DAT link drops when the glasses idle (battery saving) and discovery lags app
+        // launch by seconds — a session created in that window throws noEligibleDevice
+        // ("all discovered devices are powered off or disconnected") even though the glasses
+        // are registered and on the user's face. Live-traced: discovery failed at +0.3s after
+        // launch, link up at +4.7s. Retry with backoff (~12s window) while the link returns.
+        var sessionError: Error?
+        for attempt in 1...4 {
+            do {
+                try await ensureSession()
+                sessionError = nil
+                break
+            } catch {
+                sessionError = error
+                NSLog("[Camera] ensureSession attempt %d/4 failed: %@", attempt, error.localizedDescription)
+                await resetSession()
+                if attempt < 4 {
+                    try? await Task.sleep(nanoseconds: UInt64(attempt) * 2_000_000_000)
+                }
+            }
+        }
+        if let sessionError { throw sessionError }
 
         // Wait for stream to be ready (start if needed)
         var lastError: Error?
@@ -444,9 +522,23 @@ class CameraService: ObservableObject {
         continuation.resume(returning: photoData.data)
     }
 
-    /// Convert the latest video frame to JPEG data for use as a photo fallback.
+    /// How old a video frame may be and still stand in for a failed photo capture. Beyond
+    /// this, the frame shows where the camera pointed SECONDS AGO — live-traced: repeated
+    /// capture failures kept donating one stale frame, and the assistant confidently
+    /// described the same scene while the user pointed the glasses at different things.
+    private static let frameFallbackMaxAge: TimeInterval = 10
+
+    /// Convert the latest video frame to JPEG data for use as a photo fallback — but ONLY if
+    /// it's fresh. A stale frame is worse than an honest failure: it hallucinates a scene.
     private func latestFrameAsJPEG(quality: CGFloat = 0.85) -> Data? {
-        guard let frame = latestFrame else { return nil }
+        guard let frame = latestFrame,
+              Date().timeIntervalSince(lastFrameTime) < Self.frameFallbackMaxAge else {
+            if latestFrame != nil {
+                NSLog("[Camera] Latest frame is stale (%.0fs old) — refusing frame fallback",
+                      Date().timeIntervalSince(lastFrameTime))
+            }
+            return nil
+        }
         return frame.jpegData(compressionQuality: quality)
     }
 
@@ -569,6 +661,10 @@ class CameraService: ObservableObject {
         errorListenerToken = nil
         streamSession = nil
         deviceSession = nil
+        // A torn-down session's frames must not survive to serve as "photos" for the next
+        // capture — the staleness gate is belt, this is braces.
+        latestFrame = nil
+        lastFrameTime = .distantPast
         latestFrame = nil
         NSLog("[Camera] Session reset")
     }

--- a/OpenGlasses/Sources/Services/ConversationClassifier.swift
+++ b/OpenGlasses/Sources/Services/ConversationClassifier.swift
@@ -153,7 +153,39 @@ struct ConversationClassifier {
             return DirectToolCall(toolName: "get_weather", arguments: [:])
         }
 
+        // Calendar lookups — deterministic action selection (live-traced: the 2B model only
+        // ever called calendar with the default "today", interrogated the user for a date it
+        // couldn't use, then denied having calendar access). Create/add flows still reach the
+        // LLM — they need title/time extraction.
+        if let action = matchCalendarQuery(text) {
+            return DirectToolCall(toolName: "calendar", arguments: ["action": action])
+        }
+
         return nil
+    }
+
+    /// Match an informational calendar question and pick the tool action for it, or nil.
+    /// Three gates: names a calendar-ish noun, is NOT a creation command, and has an
+    /// inspection shape ("do I have…", "what's on…"). Then the day words choose the action.
+    private func matchCalendarQuery(_ text: String) -> String? {
+        let calendarNouns = ["calendar", "schedule", "agenda", "appointments", "meetings", "meeting"]
+        guard calendarNouns.contains(where: text.contains) else { return nil }
+        let createVerbs = ["add", "create", "schedule a", "schedule an", "put ", "book", "set up",
+                           "new event", "move ", "cancel", "delete", "remind"]
+        guard !createVerbs.contains(where: text.contains) else { return nil }
+        let inspectionShapes = ["do i have", "have i got", "anything in", "anything on", "anything for",
+                                "what's in", "whats in", "what's on", "whats on", "what is on",
+                                "what do i have", "check my", "show my", "am i free", "any meetings",
+                                "any events", "any appointments", "next meeting", "next event",
+                                "next appointment", "what's my", "whats my"]
+        guard inspectionShapes.contains(where: text.contains) else { return nil }
+
+        if text.contains("next meeting") || text.contains("next event") || text.contains("next appointment") {
+            return "next"
+        }
+        if text.contains("tomorrow") { return "tomorrow" }
+        if text.contains("week") || text.contains("upcoming") || text.contains("coming up") { return "upcoming" }
+        return "today"
     }
 
     private let weatherDirectPatterns = ["weather forecast", "forecast", "weather"]

--- a/OpenGlasses/Sources/Services/LLM/UncertaintyDetector.swift
+++ b/OpenGlasses/Sources/Services/LLM/UncertaintyDetector.swift
@@ -24,6 +24,12 @@ struct UncertaintyVerdict: Equatable {
 enum UncertaintyDetector {
 
     static func assess(question: String, answer: String) -> UncertaintyVerdict {
+        // The web can never answer a question about the user's own data — a re-ask there
+        // produces the worst possible reply ("Checked the web — I don't have access to your
+        // personal calendar", live-traced). Personal-data questions are the tools' job.
+        if isPersonalDataQuestion(normalize(question)) {
+            return .confident
+        }
         // Freshness wins the reported reason when both signals trip.
         if asksForVolatileData(normalize(question)) {
             return UncertaintyVerdict(shouldSearch: true, reason: .freshnessRequested)
@@ -33,6 +39,23 @@ enum UncertaintyDetector {
         }
         return .confident
     }
+
+    /// True when the question is about the user's own on-device data — calendar, reminders,
+    /// alarms, health, battery — which no web search can see.
+    static func isPersonalDataQuestion(_ question: String) -> Bool {
+        personalDataPatterns.contains { pattern in
+            question.range(of: pattern, options: .regularExpression) != nil
+        }
+    }
+
+    private static let personalDataPatterns: [String] = [
+        #"\bmy (calendar|schedule|agenda|appointments?|meetings?|events?)\b"#,
+        #"\b(in|on) the calendar\b"#,
+        #"\bmy (reminders?|alarms?|timers?)\b"#,
+        #"\bmy (steps?|step count|heart rate|workouts?)\b"#,
+        #"\bmy (battery|phone|device)\b"#,
+        #"\bam i free\b"#,
+    ]
 
     // MARK: - Signals
 

--- a/OpenGlasses/Sources/Services/LLM/UncertaintyReask.swift
+++ b/OpenGlasses/Sources/Services/LLM/UncertaintyReask.swift
@@ -5,32 +5,92 @@ import Foundation
 /// empty search, search throw, regenerate throw, empty regeneration — falls back to the
 /// original answer, so the gate is never worse than doing nothing.
 ///
+/// Conversation-aware (field-traced failure): a follow-up like "what about the other semi
+/// final?" is a useless literal search query — no tournament, no sport — and a grounding prompt
+/// that never shows the model what was already said can't reconcile the new results with its
+/// earlier (possibly incomplete) answer. So: context-dependent questions are first rewritten
+/// into a self-contained query via the caller's model, and the grounding prompt carries the
+/// recent exchanges.
+///
 /// The transparency prefix means a re-grounded answer is never silently swapped in for the
 /// model's own — consistent with the project's no-silent-fallback stance.
 enum UncertaintyReask {
 
     static let transparencyPrefix = "Checked the web for that — "
 
+    /// A question that can't stand alone as a search query: too short to name its subject, or
+    /// leaning on anaphora ("the other one", "what about them"). Pure heuristic, cheap, testable.
+    /// The length trigger is ≤2 words — a 3-word question can carry its own subject ("who won
+    /// Wimbledon") and must NOT be rewritten against possibly-unrelated history, while
+    /// elliptical stubs ("who won?", "and tomorrow?") must be.
+    static func isContextDependent(_ question: String) -> Bool {
+        let lowered = question.lowercased()
+        let words = lowered
+            .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+            .map(String.init)
+        if words.count <= 2 { return true }
+        if lowered.contains("what about") || lowered.contains("how about") { return true }
+        let anaphors: Set<String> = ["other", "that", "it", "they", "them", "this", "those",
+                                     "he", "she", "him", "her", "its", "their", "else", "again"]
+        return words.contains { anaphors.contains($0) }
+    }
+
+    /// Compact recent-conversation block for prompts (last `maxTurns` turns, each clipped) —
+    /// enough for the model to resolve "the other one", small enough not to crowd the budget.
+    static func conversationBlock(history: [(role: String, content: String)],
+                                  maxTurns: Int = 4, clipTo: Int = 300) -> String {
+        history.suffix(maxTurns).map { turn in
+            "\(turn.role == "assistant" ? "Assistant" : "User"): \(String(turn.content.prefix(clipTo)))"
+        }.joined(separator: "\n")
+    }
+
+    /// Normalize a model-rewritten search query: first line only, surrounding quotes and a
+    /// "query:"-style prefix stripped. Returns nil when the result is empty or implausibly long
+    /// (the model answered instead of rewriting) — callers then fall back to the raw question.
+    static func cleanedRewrittenQuery(_ raw: String?) -> String? {
+        guard var q = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !q.isEmpty else { return nil }
+        q = String(q.split(separator: "\n", omittingEmptySubsequences: true).first ?? "")
+            .trimmingCharacters(in: .whitespaces)
+        if let colon = q.range(of: "query:", options: [.caseInsensitive, .anchored]) {
+            q = String(q[colon.upperBound...]).trimmingCharacters(in: .whitespaces)
+        }
+        q = q.trimmingCharacters(in: CharacterSet(charactersIn: "\"'“”‘’"))
+        guard !q.isEmpty, q.count <= 120 else { return nil }
+        return q
+    }
+
     static func answer(
         question: String,
         originalAnswer: String,
+        history: [(role: String, content: String)] = [],
         search: (String) async throws -> String?,
+        rewriteQuery: ((String) async throws -> String)? = nil,
         regenerate: (String) async throws -> String
     ) async -> String {
+        // Contextualize the search query when the question leans on the conversation. Any
+        // rewrite failure (throw, empty, rambling) falls back to the raw question — the gate
+        // never gets worse than the old behaviour.
+        var searchQuery = question
+        if !history.isEmpty, isContextDependent(question), let rewriteQuery,
+           let rewritten = cleanedRewrittenQuery(try? await rewriteQuery(question)) {
+            searchQuery = rewritten
+        }
+
         // Search failed, threw, or came back empty → the original answer stands.
-        let searched = (try? await search(question)) ?? nil
+        let searched = (try? await search(searchQuery)) ?? nil
         guard let results = searched?.trimmingCharacters(in: .whitespacesAndNewlines),
               !results.isEmpty else {
             return originalAnswer
         }
 
+        let convo = conversationBlock(history: history)
         let grounding = """
-        Web search results for "\(question)":
+        \(convo.isEmpty ? "" : "Recent conversation:\n\(convo)\n\n")Web search results for "\(searchQuery)":
 
         \(results)
 
-        Using these results where they are relevant, answer the user's question concisely. \
-        If the results don't actually answer it, say so briefly.
+        Using these results where they are relevant\(convo.isEmpty ? "" : " — and staying consistent with the recent conversation above (correct it if the results show it was incomplete or wrong)"), \
+        answer the user's question concisely. If the results don't actually answer it, say so briefly.
         Question: \(question)
         """
 

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -475,9 +475,18 @@ class LLMService: ObservableObject {
         // Vision honesty: a non-vision on-device model silently DROPS the image while the
         // vision prompt block insists "You CAN see images" — the model then invents a scene
         // (live-traced: described a cup that was never photographed). Refuse instead.
+        // Demotion-aware when the service is in hand: a Gemma whose VLM load fell back to the
+        // text factory would silently drop the image despite its architectural vision claim.
         if isOnDevice, imageData != nil,
-           provider == .appleOnDevice || !LocalLLMService.isVisionCapable(modelId: modelConfig.model) {
-            return "I can't look at photos with the current on-device model. Switch to a vision-capable local model like SmolVLM, or a cloud model, and try again."
+           provider == .appleOnDevice
+               || !(localLLMService?.isVisionUsable(modelId: modelConfig.model)
+                    ?? LocalLLMService.isVisionCapable(modelId: modelConfig.model)) {
+            // Don't recommend the very model being refused: a demoted Gemma is architecturally
+            // vision-capable but this build's vision weights wouldn't load on this device.
+            if provider != .appleOnDevice, LocalLLMService.isVisionCapable(modelId: modelConfig.model) {
+                return LocalLLMService.visionWeightsUnavailableMessage
+            }
+            return "I can't look at photos with the current on-device model. Switch to a vision-capable local model like SmolVLM2, or a cloud model, and try again."
         }
 
         let fullPrompt: String
@@ -2092,10 +2101,18 @@ class LLMService: ObservableObject {
         var answer = response.content
         if Config.localWebSearchFallbackEnabled,
            UncertaintyDetector.assess(question: text, answer: answer).shouldSearch {
+            // The Apple session is stateful (it holds its own transcript), so its rewrite is
+            // context-aware without an explicit history block; the shared conversationHistory
+            // still feeds the grounding prompt for cross-answer reconciliation.
+            let recent = recentTupleHistory(6, stripToolMarkup: false)
             answer = await UncertaintyReask.answer(
                 question: text,
                 originalAnswer: answer,
+                history: recent,
                 search: { query in try await WebSearchTool().execute(args: ["query": query]) },
+                rewriteQuery: { q in
+                    try await session.respond(to: "Rewrite this follow-up as ONE self-contained web search query, using our conversation for context. If it already stands alone, output it unchanged. Output only the query, nothing else: \(q)").content
+                },
                 regenerate: { grounding in try await session.respond(to: grounding).content }
             )
         }
@@ -2150,13 +2167,38 @@ class LLMService: ObservableObject {
 
     /// True when the reply narrates an intention to fetch/check something without any
     /// tool markup — the shape a small model produces instead of acting.
+    /// The last `n` history entries as (role, content) tuples — the shape the local paths and
+    /// UncertaintyReask consume. Optionally strips `<tool_call>` markup (local path keeps its
+    /// context clean; the Apple path's transcript never contains markup).
+    private func recentTupleHistory(_ n: Int, stripToolMarkup: Bool) -> [(role: String, content: String)] {
+        conversationHistory.suffix(n).compactMap { turn in
+            guard let role = turn["role"] as? String, var content = turn["content"] as? String else { return nil }
+            if stripToolMarkup {
+                content = content
+                    .replacingOccurrences(of: #"<tool_call>.*?</tool_call>"#, with: "", options: .regularExpression)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            return content.isEmpty ? nil : (role: role, content: content)
+        }
+    }
+
     nonisolated static func announcesToolIntent(_ response: String) -> Bool {
         let lowered = response.lowercased()
         guard !lowered.contains("<tool_call>") else { return false }
+        // A promise-instead-of-action reply is SHORT (a sentence or two). A long answer that
+        // merely contains "searching for"/"let me check" mid-prose is an answer, not a stall —
+        // without this gate the never-speak-a-promise net could discard valid replies.
+        guard lowered.count < 280 else { return false }
         let intentPhrases = [
             "looking up", "look that up", "look it up", "let me check", "i'll check",
             "i will check", "checking the", "let me get", "i'll get", "i'm getting",
             "fetching", "one moment", "just a moment", "i'm looking",
+            // Search-flavoured announcements (live-traced: "I will now search for popular
+            // tourist destinations in Samoa for you" — then silence). Anchored to first-person
+            // intent so an answer that merely mentions searching doesn't match.
+            "i will now search", "i will search", "i'll search", "let me search",
+            "i'm searching", "searching for", "i should have used a tool",
+            "i will use a tool", "using a tool to",
         ]
         return intentPhrases.contains { lowered.contains($0) }
     }
@@ -2190,6 +2232,11 @@ class LLMService: ObservableObject {
         if toolNames.contains("where_am_i") {
             block += "\nIf you need the user's location and it isn't given above, call where_am_i — never say you lack location access and never ask the user where they are."
         }
+        if toolNames.contains("calendar") {
+            // Live-traced: without the argument schema the model only ever got the default
+            // ("today"), asked the user for dates it couldn't use, then denied having access.
+            block += "\ncalendar arguments: {\"action\": \"today\" | \"tomorrow\" | \"next\" | \"upcoming\"} — pick the one matching the day asked about. You DO have the user's calendar through this tool; never claim you lack calendar access and never ask for a date when one of these actions fits."
+        }
         return block
     }
 
@@ -2218,19 +2265,7 @@ class LLMService: ObservableObject {
         // Build history — last 3 exchanges for local models (context is precious; the
         // LocalModelBudget cap still guards the ceiling). Was 2 — too short for a
         // follow-up that references the answer before last.
-        let recentHistory = conversationHistory.suffix(6)
-        var history: [(role: String, content: String)] = []
-        for turn in recentHistory {
-            if let role = turn["role"] as? String, let content = turn["content"] as? String {
-                // Strip any tool call markup from history to keep context clean
-                let clean = content
-                    .replacingOccurrences(of: #"<tool_call>.*?</tool_call>"#, with: "", options: .regularExpression)
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                if !clean.isEmpty {
-                    history.append((role: role, content: clean))
-                }
-            }
-        }
+        let history = recentTupleHistory(6, stripToolMarkup: true)
 
         // Add user message to history
         conversationHistory.append(["role": "user", "content": text])
@@ -2242,10 +2277,13 @@ class LLMService: ObservableObject {
         // common no-tool path, which streams cleanly.
         var response: String
         do {
+            // The image rides only the FIRST generation of the turn — tool-result follow-up
+            // regenerations below re-answer over text, which is correct and far cheaper.
             response = try await localService.generate(
                 userMessage: text,
                 systemPrompt: fullPrompt,
                 history: history,
+                imageData: imageData,
                 onToken: onToken
             )
         } catch is CancellationError {
@@ -2345,13 +2383,33 @@ class LLMService: ObservableObject {
         // Uncertainty gate (Plan BI): the local path can't reach `web_search` through a tool
         // loop, so a hedged or freshness-sensitive answer gets one transparent web-grounded
         // re-ask. Off-flag or confident answers pass straight through.
+        //
+        // An intent announcement that survived the corrective regen ("I will now search for…")
+        // is treated as uncertainty too: the promised search actually happens here. And a
+        // promise must NEVER be the spoken answer — if the re-ask can't improve on it (search
+        // failed, flag off), an honest failure line replaces it rather than dead air after
+        // "I'll look that up".
+        let announcedIntent = Self.announcesToolIntent(cleanResponse)
+        // Personal-data questions must never reach the web, even via the announced-intent
+        // branch — "let me check your reminders" + web search = "I don't have access to your
+        // personal reminders", the exact reply the detector's guard exists to prevent.
+        let isPersonalData = UncertaintyDetector.isPersonalDataQuestion(text.lowercased())
         var finalAnswer = cleanResponse
-        if Config.localWebSearchFallbackEnabled,
-           UncertaintyDetector.assess(question: text, answer: cleanResponse).shouldSearch {
+        if Config.localWebSearchFallbackEnabled, !isPersonalData,
+           announcedIntent || UncertaintyDetector.assess(question: text, answer: cleanResponse).shouldSearch {
             finalAnswer = await UncertaintyReask.answer(
                 question: text,
                 originalAnswer: cleanResponse,
+                history: history,
                 search: { query in try await WebSearchTool().execute(args: ["query": query]) },
+                rewriteQuery: { q in
+                    // A follow-up leaning on the conversation ("the other semi final?") is a
+                    // junk literal query — one tiny generation makes it self-contained.
+                    try await localService.generate(
+                        userMessage: "Conversation:\n\(UncertaintyReask.conversationBlock(history: history))\n\nRewrite this follow-up as ONE self-contained web search query. If it already stands alone, output it unchanged. Output only the query, nothing else: \(q)",
+                        systemPrompt: "You rewrite follow-up questions into standalone web search queries. Output only the query."
+                    )
+                },
                 regenerate: { grounding in
                     try await localService.generate(
                         userMessage: grounding,
@@ -2360,6 +2418,12 @@ class LLMService: ObservableObject {
                     )
                 }
             )
+        }
+
+        // The never-speak-a-promise net: if the answer still announces an action (re-ask failed
+        // or the fallback flag is off), replace it with an honest miss.
+        if announcedIntent && finalAnswer == cleanResponse {
+            finalAnswer = "I couldn't get that information just now — please ask me again."
         }
 
         // BK P3: reject an empty local completion (immediate EOS / all-markup) instead of

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -36,9 +36,36 @@ final class LocalLLMService: ObservableObject {
     /// HubClient configured to store models in Application Support (persistent, not purgeable).
     private let hub: HubClient = {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        let modelsDir = appSupport.appendingPathComponent("LocalModels", isDirectory: true)
+        var modelsDir = appSupport.appendingPathComponent("LocalModels", isDirectory: true)
         try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
+
+        // Multi-GB re-downloadable weights must not ride along in iCloud backups (they bloat the
+        // user's backup and iOS review flags re-fetchable data that isn't excluded).
+        var noBackup = URLResourceValues()
+        noBackup.isExcludedFromBackup = true
+        try? modelsDir.setResourceValues(noBackup)
+
+        // Once per process, never per instance: throwaway LocalLLMService() constructions
+        // (e.g. a view listing downloaded models) must not re-run the sweep while the primary
+        // service has a download in flight — its live safetensors IS a CFNetworkDownload temp.
+        _ = LocalLLMService.sweepOrphanedDownloadTempsOnce
+
         return HubClient(cache: HubCache(cacheDirectory: modelsDir))
+    }()
+
+    /// Sweep orphaned download temps: an interrupted multi-GB pull strands its
+    /// CFNetworkDownload_*.tmp in the sandbox tmp dir (several GB observed in the field).
+    /// Static-once: at FIRST touch in a process no download can be in flight, so everything
+    /// matching is garbage; later touches (new instances) are no-ops.
+    private static let sweepOrphanedDownloadTempsOnce: Void = {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+        guard let items = try? FileManager.default.contentsOfDirectory(at: tmp, includingPropertiesForKeys: [.fileSizeKey]) else { return }
+        var freed: Int64 = 0
+        for item in items where item.lastPathComponent.hasPrefix("CFNetworkDownload_") {
+            freed += Int64((try? item.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0)
+            try? FileManager.default.removeItem(at: item)
+        }
+        if freed > 0 { NSLog("🧹 LocalLLM: swept %lld MB of orphaned download temps", freed / 1_048_576) }
     }()
 
     // MARK: - Recommended Models
@@ -51,8 +78,17 @@ final class LocalLLMService: ObservableObject {
             estimatedSize: "3.6 GB",
             hasVision: true,
             hasToolCalling: true,
-            notes: "Best on-device agent — vision, tool calling, 140+ languages. Uses ~4 GB while running; close other apps if it refuses to load.",
+            notes: "Best on-device agent — tool calling, 140+ languages. Vision-ready architecture, but this build's vision weights don't load in the current MLX runtime (device-verified 2026-07-16) — photo questions answer text-only until a fixed build lands, then vision enables automatically. Uses ~4 GB while running.",
             minimumRAMGB: 8
+        ),
+        RecommendedModel(
+            id: "mlx-community/gemma-4-e4b-it-4bit",
+            name: "Gemma 4 E4B (Agent+)",
+            estimatedSize: "5.1 GB",
+            hasVision: true,
+            hasToolCalling: true,
+            notes: "Bigger Gemma 4 — highest-quality on-device agent. Same vision caveat as E2B (text-only until an MLX runtime fix). Needs a high-memory device (12 GB).",
+            minimumRAMGB: 12
         ),
         // Vision models (can see photos from glasses)
         RecommendedModel(
@@ -80,14 +116,9 @@ final class LocalLLMService: ObservableObject {
             hasToolCalling: true,
             notes: "Strong reasoning and tool use"
         ),
-        RecommendedModel(
-            id: "mlx-community/gemma-2-2b-it-4bit",
-            name: "Gemma 2 2B",
-            estimatedSize: "1.5 GB",
-            hasVision: false,
-            hasToolCalling: true,
-            notes: "Good balance of size and quality"
-        ),
+        // (Gemma 2 2B was retired from this list in favor of the Gemma 4 pair above —
+        // vision + tools at comparable footprints. Already-downloaded copies keep working:
+        // loading is by id, and its LocalModelBudget entry remains.)
         RecommendedModel(
             id: "mlx-community/Qwen2.5-0.5B-Instruct-4bit",
             name: "Qwen 2.5 0.5B",
@@ -98,32 +129,48 @@ final class LocalLLMService: ObservableObject {
         ),
     ]
 
-    /// Known vision model IDs that must load through `VLMModelFactory`.
+    /// Model IDs whose checkpoints declare a vision tree, attempted through `VLMModelFactory`.
     ///
-    /// `gemma-4-e2b-it-4bit` stays on the TEXT factory. History: the VLM factory used to
-    /// fatally trap on 1-D tokens (talk-button crash); mlx-swift-lm 3.31.4 fixed the trap
-    /// (it now throws catchably) — but a device re-test (2026-07-15) shows this 4-bit
-    /// checkpoint still fails VLM weight mapping: `keyNotFound(language_model…k_norm.weight,
-    /// Gemma4RMSNormZeroShift)` — the community text-quant lacks the VLM export's module
-    /// tree. On-device Gemma vision needs a VLM-exported checkpoint; until one is adopted,
-    /// image turns on this model are refused honestly by the vision guard in LLMService.
+    /// Gemma 4 history: the VLM factory used to fatally trap on 1-D tokens (talk-button
+    /// crash); mlx-swift-lm 3.31.4 made that catchable — but a device test (2026-07-15)
+    /// showed the e2b 4-bit quant failing VLM weight mapping (`keyNotFound(language_model…
+    /// k_norm.weight, Gemma4RMSNormZeroShift)`). The hub configs for all three Gemma 4
+    /// checkpoints declare `Gemma4ForConditionalGeneration` with a `vision_config`
+    /// (verified 2026-07-16), so vision is *attempted* — and a mapping failure now demotes
+    /// gracefully to the text factory (`loadModel`), with image turns refused honestly by
+    /// the vision guard in LLMService. Nothing regresses if a checkpoint doesn't cooperate.
     static let visionModelIds: Set<String> = [
         "mlx-community/SmolVLM2-2.2B-Instruct-mlx",
         "mlx-community/SmolVLM2-500M-Video-Instruct-mlx",
+        "mlx-community/gemma-4-e2b-it-4bit",
+        "mlx-community/gemma-4-E2B-it-4bit",
+        "mlx-community/gemma-4-e4b-it-4bit",
     ]
 
-    /// Whether the currently loaded model supports vision.
-    var isVisionModel: Bool {
-        guard let id = loadedModelId else { return false }
-        return Self.visionModelIds.contains(id)
-    }
+    /// Models whose VLM load failed weight mapping this run and were demoted to the text
+    /// factory. In-memory: a re-uploaded checkpoint gets a fresh chance next launch.
+    private(set) var visionDemotedModelIds: Set<String> = []
 
-    /// Vision capability by model id (usable before the model is loaded).
-    /// NOTE: mlx-swift-lm 3.31.4 fixed the Gemma-4 VLM forward-pass trap that forced
-    /// `gemma-4-e2b-it-4bit` onto the text factory — re-enabling its vision routing is a
-    /// candidate follow-up, gated on an on-device crash check (talk-button path).
+    /// True when the LOADED model went through `VLMModelFactory` — the single source of
+    /// truth for everything factory-dependent (token batch shape, image input). Must track
+    /// the factory that actually succeeded, not the id's nominal capability: a demoted
+    /// Gemma fed a (1, L) batch dies in the text factory's chunked prefill (uncatchable).
+    private(set) var loadedViaVLMFactory = false
+
+    /// Whether the currently loaded model supports vision (as actually loaded).
+    var isVisionModel: Bool { isModelLoaded && loadedViaVLMFactory }
+
+    /// Vision capability by model id — architectural claim, usable before load.
     nonisolated static func isVisionCapable(modelId: String) -> Bool {
         visionModelIds.contains(modelId)
+    }
+
+    /// Vision usability by model id, demotion-aware. Prefer this over the static check
+    /// when a service instance is in hand: after a VLM→text demotion the architectural
+    /// claim is true but images would be silently dropped.
+    func isVisionUsable(modelId: String) -> Bool {
+        if loadedModelId == modelId, isModelLoaded { return loadedViaVLMFactory }
+        return Self.visionModelIds.contains(modelId) && !visionDemotedModelIds.contains(modelId)
     }
 
     // MARK: - Model Management
@@ -139,11 +186,36 @@ final class LocalLLMService: ObservableObject {
         isDownloading = true
         downloadingModelId = modelId
         downloadProgress = 0
+        // A multi-GB pull dies when iOS auto-locks the screen (the app suspends and the transfer
+        // is torn down), so keep the display awake for the duration. Restored in the defer on
+        // every exit path — completion, cancel, or error. No other feature owns this flag.
+        UIApplication.shared.isIdleTimerDisabled = true
         defer {
+            UIApplication.shared.isIdleTimerDisabled = false
             isDownloading = false
             downloadingModelId = nil
             activeDownloadTask = nil
         }
+
+        // The hub's progress callback is per-FILE (a fresh 0→1 fraction each file), and a model
+        // is mostly one giant safetensors — so the fraction sits at 0 for the whole pull, then
+        // jumps to done. For catalog models (known expected size) poll the bytes actually on
+        // disk instead, as the SINGLE progress writer; unknown/custom ids keep the hub fraction.
+        let expectedBytes = Self.expectedDownloadBytes(for: modelId)
+        let downloadStart = Date()
+        var progressPoller: Task<Void, Never>?
+        if let expectedBytes, expectedBytes > 0 {
+            progressPoller = Task { [weak self] in
+                while !Task.isCancelled {
+                    guard let self else { return }
+                    let bytes = self.onDiskDownloadBytes(for: modelId, since: downloadStart)
+                    let est = min(0.99, Double(bytes) / Double(expectedBytes))
+                    if est > self.downloadProgress { self.downloadProgress = est }   // monotonic
+                    try? await Task.sleep(nanoseconds: 700_000_000)
+                }
+            }
+        }
+        defer { progressPoller?.cancel() }
 
         // BK P5: own the cancellable unit. Before, the real Task lived in the caller and
         // `activeDownloadTask` was permanently nil, so `cancelDownload()` cancelled nothing and
@@ -158,7 +230,9 @@ final class LocalLLMService: ObservableObject {
                     throw LocalLLMError.generationFailed("Invalid model id: \(modelId)")
                 }
                 _ = try await self.hub.downloadSnapshot(of: repoID) { @MainActor progress in
-                    self.downloadProgress = progress.fractionCompleted
+                    // Single-writer rule: when the byte poller runs, the per-file fraction is
+                    // noise (it thrashes 1%↔99%); only unknown-size models use it.
+                    if expectedBytes == nil { self.downloadProgress = progress.fractionCompleted }
                 }
             }
         }
@@ -182,6 +256,7 @@ final class LocalLLMService: ObservableObject {
         isDownloading = false
         downloadingModelId = nil
         downloadProgress = 0
+        UIApplication.shared.isIdleTimerDisabled = false   // belt-and-braces with downloadModel's defer
     }
 
     /// Load an already-downloaded model into memory.
@@ -234,23 +309,44 @@ final class LocalLLMService: ObservableObject {
         Memory.cacheLimit = 20 * 1024 * 1024
 
         let config = ModelConfiguration(id: modelId)
-        let factory: any ModelFactory = Self.visionModelIds.contains(modelId)
-            ? VLMModelFactory.shared
-            : LLMModelFactory.shared
-
-        modelContainer = try await factory.loadContainer(
-            from: #hubDownloader(hub),
-            using: #huggingFaceTokenizerLoader(),
-            configuration: config
-        ) { progress in
-            Task { @MainActor in
-                self.downloadProgress = progress.fractionCompleted
+        func load(with factory: any ModelFactory) async throws -> ModelContainer {
+            try await factory.loadContainer(
+                from: #hubDownloader(hub),
+                using: #huggingFaceTokenizerLoader(),
+                configuration: config
+            ) { progress in
+                Task { @MainActor in
+                    self.downloadProgress = progress.fractionCompleted
+                }
             }
+        }
+
+        let wantsVision = Self.visionModelIds.contains(modelId)
+            && !visionDemotedModelIds.contains(modelId)
+        if wantsVision {
+            do {
+                modelContainer = try await load(with: VLMModelFactory.shared)
+                loadedViaVLMFactory = true
+            } catch {
+                // The known shape of this failure is a quant whose weight tree doesn't
+                // match the VLM export (keyNotFound …k_norm.weight — device trace
+                // 2026-07-15). Whatever the cause, the model is still a perfectly good
+                // text model: demote for this run and load through the text factory.
+                // Image turns then get the honest refusal instead of a broken load.
+                NSLog("[LocalLLM] VLM load failed for %@ — demoting to text factory: %@",
+                      modelId, error.localizedDescription)
+                visionDemotedModelIds.insert(modelId)
+                modelContainer = try await load(with: LLMModelFactory.shared)
+                loadedViaVLMFactory = false
+            }
+        } else {
+            modelContainer = try await load(with: LLMModelFactory.shared)
+            loadedViaVLMFactory = false
         }
 
         loadedModelId = modelId
         isModelLoaded = true
-        print("✅ Local model loaded: \(modelId) (vision: \(Self.visionModelIds.contains(modelId)))")
+        print("✅ Local model loaded: \(modelId) (vision: \(loadedViaVLMFactory))")
     }
 
     /// Unload model from memory.
@@ -259,6 +355,7 @@ final class LocalLLMService: ObservableObject {
         modelContainer = nil
         loadedModelId = nil
         isModelLoaded = false
+        loadedViaVLMFactory = false
         if hadModel {
             // Return MLX's recycled evaluation buffers to the OS — without this, Unload
             // frees the weights but leaves the buffer cache resident. Guarded so a
@@ -271,10 +368,15 @@ final class LocalLLMService: ObservableObject {
     // MARK: - Generation
 
     /// Generate a text response from the local model.
+    /// - Parameter imageData: an image for the turn (VLM models only). Honored only when the
+    ///   loaded model actually went through the VLM factory; the vision guard in LLMService
+    ///   refuses image turns upstream otherwise, so a non-nil image here with a text-factory
+    ///   model is a caller bug — logged and ignored rather than crashed on.
     func generate(
         userMessage: String,
         systemPrompt: String,
         history: [(role: String, content: String)] = [],
+        imageData: Data? = nil,
         onToken: ((String) -> Void)? = nil
     ) async throws -> String {
         // On-device inference runs on the GPU via Metal, which iOS forbids in the
@@ -298,6 +400,25 @@ final class LocalLLMService: ObservableObject {
 
         isGenerating = true
         defer { isGenerating = false }
+
+        // Image turn (P: local vision): route through the VLM processor, which owns the
+        // model's own chat template and image tokenization — the manual tokenize path below
+        // has no way to interleave image tokens.
+        if let imageData {
+            if loadedViaVLMFactory {
+                return try await generateVisionTurn(
+                    userMessage: userMessage, systemPrompt: systemPrompt,
+                    history: history, imageData: imageData,
+                    container: container, onToken: onToken)
+            }
+            // Reachable despite the upstream guard: the first-ever photo question loads the
+            // model DURING the turn, and the VLM→text demotion happens after the guard already
+            // passed. Refuse honestly — silently answering text-only about an image the model
+            // never saw is the exact hallucination the vision guard exists to prevent.
+            NSLog("[LocalLLM] Image supplied to a text-factory model (%@) — refusing honestly",
+                  loadedModelId ?? "?")
+            return Self.visionWeightsUnavailableMessage
+        }
 
         // Tokenize a candidate history exactly as the model will — chat template, with the
         // no-system-role fallback some small models need. Used both to measure truncation
@@ -347,7 +468,9 @@ final class LocalLLMService: ObservableObject {
         // - Vision models (VLMModelFactory, e.g. SmolVLM2/Idefics3) skip that chunked
         //   prepare and feed the tokens to the language model in one shot, so they need the
         //   explicit (1, L) batch axis (their forward pass indexes dim(2)).
-        let tokenIDs = Self.tokenBatch(tokens, isVisionModel: Self.visionModelIds.contains(loadedModelId ?? ""))
+        // Keyed off the factory that ACTUALLY loaded the model, never the id's nominal
+        // capability — after a VLM→text demotion, a (1, L) batch here is the fatal crash.
+        let tokenIDs = Self.tokenBatch(tokens, isVisionModel: loadedViaVLMFactory)
         // NSLog (not print) so it survives a fatal MLX crash in the unified log,
         // confirming what shape reaches the model.
         NSLog("🔬 LocalLLM.generate model=%@ tokenIDs.shape=%@ count=%d", loadedModelId ?? "?", "\(tokenIDs.shape)", tokens.count)
@@ -394,6 +517,68 @@ final class LocalLLMService: ObservableObject {
         NSLog("🔬 LocalLLM.generate done — mlx active=%dMB cache=%dMB, app footprint=%dMB",
               Memory.activeMemory / 1_048_576, Memory.cacheMemory / 1_048_576,
               Int(MemoryHeadroom.appFootprintBytes() / 1_048_576))
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// One image turn through a VLM-factory model. The processor owns the chat template and
+    /// image tokenization; history is kept short (image tokens are big) and un-budgeted — the
+    /// processor's own encoding is the authority on how many tokens the image costs.
+    private func generateVisionTurn(
+        userMessage: String,
+        systemPrompt: String,
+        history: [(role: String, content: String)],
+        imageData: Data,
+        container: ModelContainer,
+        onToken: ((String) -> Void)?
+    ) async throws -> String {
+        guard let ciImage = CIImage(data: imageData) else {
+            throw LocalLLMError.generationFailed("Couldn't decode the photo.")
+        }
+
+        var chat: [Chat.Message] = [.system(systemPrompt)]
+        for turn in history.suffix(4) {
+            chat.append(turn.role == "assistant" ? .assistant(turn.content) : .user(turn.content))
+        }
+        chat.append(.user(userMessage, images: [.ciImage(ciImage)]))
+        // 896² is Gemma's native vision resolution and a sane cap for every supported VLM —
+        // a full-resolution glasses photo through the image pipeline is a pure memory spike.
+        let userInput = UserInput(chat: chat,
+                                  processing: .init(resize: CGSize(width: 896, height: 896)))
+        let parameters = GenerateParameters(maxTokens: 512, temperature: 0.7, topP: 0.9)
+
+        // Same mid-generation backgrounding watch as the text path (Metal in the background
+        // is an uncatchable kill) — but the drain runs inside `container.perform`, OFF the
+        // main actor, so the flag must be a lock-guarded box rather than this actor's
+        // property (and UIApplication can't be re-read there; the entry pre-check plus the
+        // notification cover it).
+        let backgroundedFlag = LockedFlag()
+        let bgObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            backgroundedFlag.set()
+        }
+        defer { NotificationCenter.default.removeObserver(bgObserver) }
+
+        NSLog("🔬 LocalLLM.generateVisionTurn model=%@ image=%dKB", loadedModelId ?? "?", imageData.count / 1024)
+        let output = try await container.perform { context -> String in
+            let lmInput = try await context.processor.prepare(input: userInput)
+            let stream = try MLXLMCommon.generate(input: lmInput, parameters: parameters, context: context)
+            var iterator = stream.makeAsyncIterator()
+            return try await Self.drainTokenStream(
+                nextChunk: {
+                    while let generation = await iterator.next() {
+                        if case .chunk(let text) = generation { return text }
+                    }
+                    return nil
+                },
+                isBackgrounded: { backgroundedFlag.isSet },
+                onToken: onToken
+            )
+        }
+        NSLog("🔬 LocalLLM.generateVisionTurn done — mlx active=%dMB cache=%dMB",
+              Memory.activeMemory / 1_048_576, Memory.cacheMemory / 1_048_576)
         return output.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
@@ -459,6 +644,40 @@ final class LocalLLMService: ObservableObject {
     /// Get size of a downloaded model on disk.
     func modelSizeOnDisk(_ modelId: String) -> Int64 {
         directorySize(modelPath(modelId))
+    }
+
+    /// Spoken/shown when an image reaches a model whose VLM load was demoted to text-only.
+    /// Single source — LLMService's pre-flight guard and the in-generation net both return it.
+    static let visionWeightsUnavailableMessage =
+        "This model's vision weights couldn't load on this device, so it's running text-only. For photos, switch to SmolVLM2 or a cloud model."
+
+    /// Expected full-snapshot size for a catalog model (parsed from its `estimatedSize`), or nil
+    /// for custom/unknown ids. Drives the byte-based download progress estimate.
+    static func expectedDownloadBytes(for modelId: String) -> Int64? {
+        guard let est = recommendedModels.first(where: { $0.id == modelId })?.estimatedSize else { return nil }
+        let cleaned = est.uppercased()
+            .replacingOccurrences(of: "GB", with: "")
+            .trimmingCharacters(in: .whitespaces)
+        guard let gb = Double(cleaned), gb > 0 else { return nil }
+        return Int64(gb * 1_073_741_824)
+    }
+
+    /// Bytes on disk attributable to an in-progress download: the partial snapshot plus
+    /// CFNetwork's in-flight temp files (where the big safetensors grows until completion).
+    /// Only temps created after `start` count — a stale orphan would jump the bar to 99%.
+    private func onDiskDownloadBytes(for modelId: String, since start: Date) -> Int64 {
+        var total = modelSizeOnDisk(modelId)
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+        if let items = try? FileManager.default.contentsOfDirectory(
+            at: tmp, includingPropertiesForKeys: [.creationDateKey, .fileSizeKey]
+        ) {
+            for item in items where item.lastPathComponent.hasPrefix("CFNetworkDownload_") {
+                let values = try? item.resourceValues(forKeys: [.creationDateKey, .fileSizeKey])
+                let created = values?.creationDate ?? .distantPast
+                if created >= start { total += Int64(values?.fileSize ?? 0) }
+            }
+        }
+        return total
     }
 
     /// Delete a downloaded model.
@@ -562,16 +781,45 @@ struct RecommendedModel: Identifiable {
         self.minimumRAMGB = minimumRAMGB
     }
 
-    /// Whether the current device has enough RAM to run this model.
+    /// Whether the current device has enough RAM to run this model. Compared against the
+    /// *marketing* RAM size, not raw `physicalMemory`: a 12 GB device reports ~11.5 GB
+    /// (carve-outs), so a raw `>= 12` check blocked exactly the hardware it was meant to
+    /// allow.
     var isCompatibleWithDevice: Bool {
         guard minimumRAMGB > 0 else { return true }
-        return LocalLLMService.deviceRAMGB >= minimumRAMGB
+        return LocalLLMService.marketingRAMGB >= minimumRAMGB
     }
 }
 
 extension LocalLLMService {
-    /// Physical RAM of this device in GB.
+    /// Physical RAM of this device in GB, as reported (always a little under the marketing
+    /// number).
     nonisolated static var deviceRAMGB: Double {
         Double(ProcessInfo.processInfo.physicalMemory) / 1_073_741_824
+    }
+
+    /// The device's nominal RAM size: reported physical memory rounded UP to the next whole
+    /// GB. Physical always underreports marketing by under a gigabyte, so the ceiling
+    /// recovers the number on the box (11.5 → 12, 7.4 → 8) without ever inflating a smaller
+    /// device into a larger tier.
+    nonisolated static var marketingRAMGB: Double {
+        deviceRAMGB.rounded(.up)
+    }
+}
+
+/// A lock-guarded one-way boolean, settable from any thread — the mid-generation backgrounding
+/// signal for vision turns, whose token drain runs off the main actor inside `container.perform`.
+final class LockedFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = false
+
+    var isSet: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return value
+    }
+
+    func set() {
+        lock.lock(); defer { lock.unlock() }
+        value = true
     }
 }

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -108,7 +108,9 @@ struct Config {
         if let phrase = UserDefaults.standard.string(forKey: "wakePhrase"), !phrase.isEmpty {
             return phrase.lowercased()
         }
-        return "hey openglasses"
+        // No "hey" prefix: matching is substring-based, so the bare name also catches anyone
+        // who still says "hey openglasses" — one default covers both habits.
+        return "openglasses"
     }
 
     static func setWakePhrase(_ phrase: String) {
@@ -142,6 +144,11 @@ struct Config {
             return ["hey ray ban", "hey ray-ban", "hey raven", "hey rayben", "hey ray band"]
         case "hey openglasses":
             return ["hey open glasses", "hey open glass", "hey openclass", "hey open class", "hey openglass"]
+        case "openglasses":
+            // Hey-less default. Alternates cover the recognizer splitting the compound; the
+            // riskier "open class(es)" misrecognitions are NOT included here — without the
+            // "hey" anchor they'd false-trigger on ordinary speech.
+            return ["open glasses", "openglass", "open glass"]
         default:
             return []
         }
@@ -471,7 +478,7 @@ struct Config {
     // MARK: - Custom System Prompt
 
     static let defaultSystemPrompt = """
-    You are OpenGlasses, a voice assistant running on Ray-Ban Meta smart glasses. Your responses will be spoken aloud via text-to-speech. Your name is OpenGlasses and the user activates you by saying "Hey OpenGlasses".
+    You are OpenGlasses, a voice assistant running on Ray-Ban Meta smart glasses. Your responses will be spoken aloud via text-to-speech. Your name is OpenGlasses and the user activates you by saying "OpenGlasses".
 
     RESPONSE STYLE:
     - Keep responses CONCISE but COMPLETE — typically 2-4 sentences, longer for complex topics.

--- a/OpenGlassesTests/ConversationClassifierTests.swift
+++ b/OpenGlassesTests/ConversationClassifierTests.swift
@@ -38,6 +38,37 @@ final class ConversationClassifierTests: XCTestCase {
         }
     }
 
+    /// Live-traced (calendar-for-tomorrow): the 2B local model only ever called calendar with
+    /// the default "today", then interrogated the user for a date, then denied having access.
+    /// Informational calendar questions now route deterministically with the right action.
+    func testCalendarLookupsMatchDirectlyWithDayAction() {
+        let cases: [(String, String)] = [
+            ("do i have anything in my calendar for tomorrow", "tomorrow"),
+            ("have i got anything on my calendar tomorrow", "tomorrow"),
+            ("what's on my schedule today", "today"),
+            ("do i have any meetings this week", "upcoming"),
+            ("what's my next meeting", "next"),
+            ("am i free tomorrow according to my calendar", "tomorrow"),
+        ]
+        for (query, action) in cases {
+            let result = classifier.classify(query)
+            XCTAssertEqual(result.directToolCall?.toolName, "calendar",
+                           "'\(query)' should directly call calendar")
+            XCTAssertEqual(result.directToolCall?.arguments["action"] as? String, action,
+                           "'\(query)' should pick action '\(action)'")
+        }
+    }
+
+    /// Creation and modification must still reach the LLM — they need title/time extraction.
+    func testCalendarMutationsDoNotMatchDirectly() {
+        for query in ["add a meeting to my calendar tomorrow at 3pm",
+                      "schedule a dentist appointment for tomorrow",
+                      "cancel my meeting tomorrow"] {
+            XCTAssertNil(classifier.classify(query).directToolCall,
+                         "'\(query)' must reach the LLM for extraction")
+        }
+    }
+
     func testMusicPauseMatchesDirectly() {
         let result = classifier.classify("pause")
         XCTAssertEqual(result.directToolCall?.toolName, "music_control")

--- a/OpenGlassesTests/LocalLocationFixTests.swift
+++ b/OpenGlassesTests/LocalLocationFixTests.swift
@@ -61,6 +61,18 @@ final class LocalLocationFixTests: XCTestCase {
                        "a reply that DID emit the call is not an empty announcement")
     }
 
+    /// Live-traced (Samoa/travel-guide): a search-flavoured announcement — "I will now search
+    /// for popular tourist destinations in Samoa for you" — matched no intent phrase, so the
+    /// corrective regen never fired and the promise was spoken as the final answer.
+    func testSearchAnnouncementsDetected() {
+        XCTAssertTrue(LLMService.announcesToolIntent(
+            "I apologize, I should have used a tool to get that information. I will now search for popular tourist destinations in Samoa for you."))
+        XCTAssertTrue(LLMService.announcesToolIntent("Let me search for that."))
+        XCTAssertTrue(LLMService.announcesToolIntent("Searching for current exchange rates now."))
+        XCTAssertFalse(LLMService.announcesToolIntent("You can search for cheap flights on several comparison sites."),
+                       "mentioning that the USER can search is an answer, not an announcement")
+    }
+
     func testClothingDecisionsClassifyAsLocationQuestions() {
         for query in ["do i take a jacket", "should i wear a coat today", "is it warm enough for shorts"] {
             let result = classifier.classify(query)
@@ -99,8 +111,11 @@ final class LocalLocationFixTests: XCTestCase {
 
     func testVisionCapabilityByModelId() {
         XCTAssertTrue(LocalLLMService.isVisionCapable(modelId: "mlx-community/SmolVLM2-2.2B-Instruct-mlx"))
-        XCTAssertFalse(LocalLLMService.isVisionCapable(modelId: "mlx-community/gemma-4-e2b-it-4bit"),
-                       "device-retested 2026-07-15: the 4-bit checkpoint fails VLM weight mapping (keyNotFound k_norm) — image turns refuse honestly instead")
+        // Attempt-and-demote (2026-07-16): Gemma 4 is nominally vision-capable and ATTEMPTS the
+        // VLM factory; if this build's weights fail VLM mapping it demotes to text at runtime
+        // (`isVisionUsable` is the demotion-aware truth, and image turns refuse honestly).
+        XCTAssertTrue(LocalLLMService.isVisionCapable(modelId: "mlx-community/gemma-4-e2b-it-4bit"),
+                      "nominal capability — runtime demotion (visionDemotedModelIds) handles load failure")
     }
 
     func testCurrentDateTimeLineFormat() {

--- a/OpenGlassesTests/LocalModelBudgetTests.swift
+++ b/OpenGlassesTests/LocalModelBudgetTests.swift
@@ -75,4 +75,26 @@ final class LocalModelBudgetTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Download size parsing (drives the byte-based progress bar)
+
+    @MainActor
+    func testExpectedDownloadBytesParsesCatalogSizes() {
+        // Every catalog entry must parse — a nil here silently reverts that model's download
+        // bar to the useless per-file hub fraction.
+        for model in LocalLLMService.recommendedModels {
+            let bytes = LocalLLMService.expectedDownloadBytes(for: model.id)
+            XCTAssertNotNil(bytes, "catalog size failed to parse: \(model.id) (\(model.estimatedSize))")
+            XCTAssertGreaterThan(bytes ?? 0, 100_000_000, "implausibly small for \(model.id)")
+        }
+        // Spot-check the arithmetic: "5.1 GB" → 5.1 × 2^30.
+        XCTAssertEqual(LocalLLMService.expectedDownloadBytes(for: "mlx-community/gemma-4-e4b-it-4bit"),
+                       Int64(5.1 * 1_073_741_824))
+    }
+
+    @MainActor
+    func testExpectedDownloadBytesNilForUnknownModel() {
+        XCTAssertNil(LocalLLMService.expectedDownloadBytes(for: "someone/custom-model-4bit"),
+                     "custom ids have no expected size — hub fraction is the fallback")
+    }
 }

--- a/OpenGlassesTests/LocalModelRoutingTests.swift
+++ b/OpenGlassesTests/LocalModelRoutingTests.swift
@@ -8,18 +8,16 @@ import XCTest
 @MainActor
 final class LocalModelRoutingTests: XCTestCase {
 
-    func testAgentModelDoesNotLoadThroughTheVisionFactory() {
-        XCTAssertFalse(
-            LocalLLMService.visionModelIds.contains(Config.defaultAgentModelId),
-            "the on-device agent model must load as text; listing it as a vision model routes it "
-            + "to the crashing MLXVLM.Gemma4 forward pass")
-    }
-
-    func testGemma4IsTreatedAsTextNotVision() {
-        // Any gemma-4 id is a text/agentic model here; the vision set is SmolVLM only.
-        XCTAssertFalse(LocalLLMService.visionModelIds.contains { $0.contains("gemma-4") })
-        XCTAssertTrue(LocalLLMService.visionModelIds.allSatisfy { $0.contains("SmolVLM") },
-                      "only genuine VLMs belong in the vision factory route")
+    /// Attempt-and-demote (2026-07-16): Gemma 4 models ATTEMPT the VLM factory (they are
+    /// architecturally VLMs) and demote to the text factory at runtime if the checkpoint's
+    /// vision weights fail mapping. The old crash this test feared (wrong token shape through
+    /// the VLM forward pass) is prevented by keying the shape off `loadedViaVLMFactory` — the
+    /// factory that ACTUALLY loaded — not off nominal membership in `visionModelIds`.
+    func testGemma4AttemptsVisionFactoryWithRuntimeDemotion() {
+        XCTAssertTrue(LocalLLMService.visionModelIds.contains { $0.contains("gemma-4") },
+                      "Gemma 4 must attempt the VLM factory so vision self-enables on a fixed runtime")
+        XCTAssertTrue(LocalLLMService.visionModelIds.contains { $0.contains("SmolVLM") },
+                      "the proven vision models stay on the VLM route")
     }
 
     /// The on-device prompt budget (BK P2) must sit below the observed OOM point (an ~8.2k-token

--- a/OpenGlassesTests/LocalTokenShapeTests.swift
+++ b/OpenGlassesTests/LocalTokenShapeTests.swift
@@ -15,21 +15,25 @@ import XCTest
 /// routing input that decides the shape.
 final class LocalTokenShapeTests: XCTestCase {
 
-    func testGemma4AgentModelIsNotRoutedAsVision() {
-        // gemma-4-e2b is a text/agentic model: it must load through LLMModelFactory and
-        // therefore take the 1D path. If someone adds it to visionModelIds, prompts over
-        // the prefill step size fatally crash on device.
-        XCTAssertFalse(LocalLLMService.visionModelIds.contains("mlx-community/gemma-4-e2b-it-4bit"))
+    func testGemma4AttemptsVLMFactory() {
+        // Attempt-and-demote (2026-07-16): gemma-4 IS routed to VLMModelFactory first. The 1D-
+        // vs-(1,L) token shape that used to make this membership dangerous is now keyed off
+        // `loadedViaVLMFactory` — the factory that ACTUALLY loaded — so a demoted Gemma takes
+        // the 1D path automatically and the fatal shape mismatch cannot recur.
+        XCTAssertTrue(LocalLLMService.visionModelIds.contains("mlx-community/gemma-4-e2b-it-4bit"))
     }
 
     func testVisionModelIdsAreVLMFactoryModels() {
-        // Only the SmolVLM2 checkpoints load through VLMModelFactory and take the
-        // batched (1, L) token path; everything else must stay 1D.
+        // The VLM-factory attempt set: proven SmolVLM2 checkpoints plus the Gemma 4 family
+        // (both hub casings of e2b — the catalog uses lowercase, the community page capital).
         XCTAssertEqual(
             LocalLLMService.visionModelIds,
             [
                 "mlx-community/SmolVLM2-2.2B-Instruct-mlx",
                 "mlx-community/SmolVLM2-500M-Video-Instruct-mlx",
+                "mlx-community/gemma-4-e2b-it-4bit",
+                "mlx-community/gemma-4-E2B-it-4bit",
+                "mlx-community/gemma-4-e4b-it-4bit",
             ]
         )
     }

--- a/OpenGlassesTests/UncertaintyDetectorTests.swift
+++ b/OpenGlassesTests/UncertaintyDetectorTests.swift
@@ -47,6 +47,36 @@ final class UncertaintyDetectorTests: XCTestCase {
         XCTAssertEqual(verdict, .confident)
     }
 
+    // MARK: - Personal-data questions never reach the web
+
+    /// Live-traced: "do I have anything in my calendar for Friday" hedged ("I don't have
+    /// access…") and the gate sent it to WEB SEARCH — "Checked the web — I don't have access
+    /// to your personal calendar" is the worst possible reply. The user's own data is the
+    /// tools' job; the gate must stand down even when freshness words ("today") appear.
+    func testPersonalDataQuestionsNeverSearch() {
+        let questions = [
+            "do i have anything in my calendar for tomorrow",
+            "what's on my schedule today",
+            "do i have anything on the calendar this week",
+            "what are my reminders",
+            "how's my battery today",
+            "am i free tomorrow",
+        ]
+        for question in questions {
+            let verdict = UncertaintyDetector.assess(
+                question: question,
+                answer: "I don't have access to your personal calendar.")
+            XCTAssertFalse(verdict.shouldSearch, "the web can't see the user's own data: \(question)")
+        }
+    }
+
+    func testNonPersonalQuestionsStillTrip() {
+        let verdict = UncertaintyDetector.assess(
+            question: "what's the exchange rate today",
+            answer: "It's definitely X.")
+        XCTAssertTrue(verdict.shouldSearch, "the personal-data guard must not over-block")
+    }
+
     // MARK: - Freshness-sensitive questions
 
     func testFreshQuestionsTripEvenWithConfidentAnswers() {

--- a/OpenGlassesTests/UncertaintyReaskTests.swift
+++ b/OpenGlassesTests/UncertaintyReaskTests.swift
@@ -75,4 +75,81 @@ final class UncertaintyReaskTests: XCTestCase {
         )
         XCTAssertEqual(result, "original")
     }
+
+    // MARK: - Conversation-aware follow-ups
+
+    private let semiFinalHistory: [(role: String, content: String)] = [
+        (role: "user", content: "Who's playing in the world cup semi finals?"),
+        (role: "assistant", content: "Argentina play France on Tuesday."),
+    ]
+
+    func testContextDependentHeuristic() {
+        XCTAssertTrue(UncertaintyReask.isContextDependent("what about the other semi final?"),
+                      "anaphor 'other' leans on the conversation")
+        XCTAssertTrue(UncertaintyReask.isContextDependent("who won?"), "too short to name its subject")
+        XCTAssertTrue(UncertaintyReask.isContextDependent("when do they play again?"))
+        XCTAssertFalse(UncertaintyReask.isContextDependent("who is playing in the world cup semi finals tomorrow"),
+                       "a self-contained question needs no rewrite")
+    }
+
+    func testFollowUpSearchesRewrittenQueryAndGroundsWithConversation() async {
+        let searchedQuery = Box<[String]>([])
+        let groundings = Box<[String]>([])
+        let result = await UncertaintyReask.answer(
+            question: "what about the other semi final?",
+            originalAnswer: "I'm not sure.",
+            history: semiFinalHistory,
+            search: { query in
+                searchedQuery.value.append(query)
+                return "England play Spain on Wednesday."
+            },
+            rewriteQuery: { _ in "world cup 2026 second semi final teams" },
+            regenerate: { grounding in
+                groundings.value.append(grounding)
+                return "The other semi final is England v Spain on Wednesday."
+            }
+        )
+        XCTAssertEqual(searchedQuery.value, ["world cup 2026 second semi final teams"],
+                       "the rewritten self-contained query is searched, not the raw follow-up")
+        XCTAssertTrue(groundings.value[0].contains("Argentina play France"),
+                      "the grounding prompt carries the recent conversation for reconciliation")
+        XCTAssertTrue(result.hasPrefix(UncertaintyReask.transparencyPrefix))
+    }
+
+    func testRewriteFailureFallsBackToRawQuestion() async {
+        let searchedQuery = Box<[String]>([])
+        _ = await UncertaintyReask.answer(
+            question: "what about the other semi final?",
+            originalAnswer: "original",
+            history: semiFinalHistory,
+            search: { query in searchedQuery.value.append(query); return nil },
+            rewriteQuery: { _ in throw TestError() },
+            regenerate: { _ in "unused" }
+        )
+        XCTAssertEqual(searchedQuery.value, ["what about the other semi final?"],
+                       "a failed rewrite must never block the search — raw question is used")
+    }
+
+    func testSelfContainedQuestionSkipsRewrite() async {
+        let rewriteCalls = Box<[String]>([])
+        _ = await UncertaintyReask.answer(
+            question: "who is playing in the world cup semi finals tomorrow",
+            originalAnswer: "original",
+            history: semiFinalHistory,
+            search: { _ in nil },
+            rewriteQuery: { q in rewriteCalls.value.append(q); return "unused" },
+            regenerate: { _ in "unused" }
+        )
+        XCTAssertTrue(rewriteCalls.value.isEmpty, "no rewrite generation spent on a standalone question")
+    }
+
+    func testCleanedRewrittenQuery() {
+        XCTAssertEqual(UncertaintyReask.cleanedRewrittenQuery("\"world cup semi finals\""), "world cup semi finals")
+        XCTAssertEqual(UncertaintyReask.cleanedRewrittenQuery("Query: fifa semi final schedule\nExtra line"),
+                       "fifa semi final schedule")
+        XCTAssertNil(UncertaintyReask.cleanedRewrittenQuery("  \n"), "empty rewrite → fall back")
+        XCTAssertNil(UncertaintyReask.cleanedRewrittenQuery(String(repeating: "a", count: 200)),
+                     "an answer-length blob is not a query → fall back")
+        XCTAssertNil(UncertaintyReask.cleanedRewrittenQuery(nil))
+    }
 }

--- a/OpenGlassesTests/VoiceWavelineTests.swift
+++ b/OpenGlassesTests/VoiceWavelineTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Tests the waveline's pure core: state fusion precedence and the motion math's invariants.
+/// The rendering is decorative; what must not regress is which state wins and that the wave
+/// stays anchored and phase-continuous. Headless.
+final class VoiceWavelineTests: XCTestCase {
+
+    // MARK: - State fusion
+
+    /// Precedence: speaking > thinking > listening > idle — the most active thing wins the eye.
+    func testFusionPrecedence() {
+        XCTAssertEqual(VoiceVisualState.from(isSpeaking: true, isProcessing: true, isListening: true,
+                                             realtimeActive: true), .speaking)
+        XCTAssertEqual(VoiceVisualState.from(isSpeaking: false, isProcessing: true, isListening: true,
+                                             realtimeActive: true), .thinking)
+        XCTAssertEqual(VoiceVisualState.from(isSpeaking: false, isProcessing: false, isListening: true,
+                                             realtimeActive: false), .listening)
+        XCTAssertEqual(VoiceVisualState.from(isSpeaking: false, isProcessing: false, isListening: false,
+                                             realtimeActive: false), .idle)
+    }
+
+    /// A realtime session's mic is always open — an active session that isn't speaking listens.
+    func testRealtimeSessionReadsAsListening() {
+        XCTAssertEqual(VoiceVisualState.from(isSpeaking: false, isProcessing: false, isListening: false,
+                                             realtimeActive: true), .listening)
+    }
+
+    // MARK: - Motion math
+
+    /// The end-pin envelope: the line is anchored at both edges at every time and in every state.
+    func testDisplacementIsZeroAtBothEnds() {
+        for state in [VoiceVisualState.idle, .listening, .thinking, .speaking] {
+            let params = WavelineParams.params(for: state)
+            for t in stride(from: 0.0, through: 10.0, by: 0.7) {
+                XCTAssertEqual(WavelineParams.displacement(phase: 0, time: t, amplitudes: params), 0,
+                               accuracy: 1e-9)
+                XCTAssertEqual(WavelineParams.displacement(phase: 1, time: t, amplitudes: params), 0,
+                               accuracy: 1e-9)
+            }
+        }
+    }
+
+    /// Displacement stays within the sum of amplitudes — the wave can't escape its lane.
+    func testDisplacementIsBounded() {
+        for state in [VoiceVisualState.idle, .listening, .thinking, .speaking] {
+            let params = WavelineParams.params(for: state)
+            let bound = params.slow + params.mid + params.fast + 1e-9
+            for phase in stride(from: 0.0, through: 1.0, by: 0.02) {
+                for t in stride(from: 0.0, through: 5.0, by: 0.3) {
+                    let d = WavelineParams.displacement(phase: phase, time: t, amplitudes: params)
+                    XCTAssertLessThanOrEqual(abs(d), bound, "escaped at phase \(phase), t \(t), \(state)")
+                }
+            }
+        }
+    }
+
+    /// Every state has a distinct parameter set, ordered by energy: idle is the quietest,
+    /// speaking the tallest — so the states are visually distinguishable by construction.
+    func testStatesAreDistinctAndEnergyOrdered() {
+        let energy: (VoiceVisualState) -> Double = { state in
+            let p = WavelineParams.params(for: state)
+            return p.slow + p.mid + p.fast
+        }
+        XCTAssertLessThan(energy(.idle), energy(.thinking))
+        XCTAssertLessThan(energy(.thinking), energy(.speaking))
+        let all = [VoiceVisualState.idle, .listening, .thinking, .speaking].map(WavelineParams.params(for:))
+        XCTAssertEqual(Set(all.map { "\($0.slow)-\($0.mid)-\($0.fast)" }).count, 4, "no two states share params")
+    }
+
+    /// Strand offsets (constant phase shift + speed detune) never break the end-pin envelope:
+    /// every thread of the ribbon stays anchored at both edges, whatever its offsets.
+    func testStrandOffsetsStayAnchoredAndBounded() {
+        let params = WavelineParams.params(for: .speaking)
+        let bound = params.slow + params.mid + params.fast + 1e-9
+        for shift in [0.0, 1.1, 2.1, 4.4] {
+            for scale in [0.82, 0.94, 1.0, 1.18] {
+                XCTAssertEqual(WavelineParams.displacement(phase: 0, time: 2.7, amplitudes: params,
+                                                           phaseShift: shift, timeScale: scale), 0, accuracy: 1e-9)
+                XCTAssertEqual(WavelineParams.displacement(phase: 1, time: 2.7, amplitudes: params,
+                                                           phaseShift: shift, timeScale: scale), 0, accuracy: 1e-9)
+                for phase in stride(from: 0.0, through: 1.0, by: 0.05) {
+                    XCTAssertLessThanOrEqual(
+                        abs(WavelineParams.displacement(phase: phase, time: 2.7, amplitudes: params,
+                                                        phaseShift: shift, timeScale: scale)), bound)
+                }
+            }
+        }
+    }
+
+    /// Phase continuity is structural: frequencies are static properties the states can't touch —
+    /// blending amplitudes at fixed frequency can never jump the wave. This test documents the
+    /// contract: a mid-transition blend of two states' params still respects the same bound.
+    func testMidTransitionBlendStaysBoundedAndAnchored() {
+        let a = WavelineParams.params(for: .idle)
+        let b = WavelineParams.params(for: .speaking)
+        let blended = WavelineParams(slow: (a.slow + b.slow) / 2,
+                                     mid: (a.mid + b.mid) / 2,
+                                     fast: (a.fast + b.fast) / 2)
+        XCTAssertEqual(WavelineParams.displacement(phase: 0, time: 3.3, amplitudes: blended), 0, accuracy: 1e-9)
+        let bound = blended.slow + blended.mid + blended.fast + 1e-9
+        for phase in stride(from: 0.0, through: 1.0, by: 0.05) {
+            XCTAssertLessThanOrEqual(abs(WavelineParams.displacement(phase: phase, time: 3.3, amplitudes: blended)), bound)
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A source-available voice-powered AI assistant for Ray-Ban and Oakley Meta smart 
 2. **Build on your iPhone** from Xcode (⌘R) — set signing team if prompted
 3. Add an AI model in **Settings → AI Models** (Anthropic, OpenAI, Gemini, or a local model)
 4. Pair your Ray-Ban or Oakley Meta glasses via the Meta AI app
-5. Say **"Hey OpenGlasses"** and ask anything
+5. Say **"OpenGlasses"** and ask anything
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 1. 构建并安装到你的 iPhone 上（参见[从源码构建](#从源码构建)）
 2. 在 **设置 → AI 模型** 中添加 AI 模型（Anthropic、OpenAI、Gemini 或本地模型）
 3. 通过 Meta AI 应用配对你的 Ray-Ban 或 Oakley Meta 眼镜
-4. 说 **"Hey OpenGlasses"** 然后提问
+4. 说 **"OpenGlasses"** 然后提问
 
 ---
 

--- a/project.base.yml
+++ b/project.base.yml
@@ -108,7 +108,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "315"
+        CURRENT_PROJECT_VERSION: "316"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -176,7 +176,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "315"
+        CURRENT_PROJECT_VERSION: "316"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -214,7 +214,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "315"
+        CURRENT_PROJECT_VERSION: "316"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "315"
+        CURRENT_PROJECT_VERSION: "316"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "315"
+        CURRENT_PROJECT_VERSION: "316"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
One device-iterated round covering the home screen, Settings, local models, conversation quality, and a root-caused photo-pipeline overhaul. Every fix in here was driven by live testing on a physical iPhone + Ray-Ban Metas, most with on-device traces attached to the diagnosis.

## Home screen & UI
- **Voice waveline**: multi-strand ribbon (coral/gold/rose/ember) with per-strand constant phase offsets and speed detunes — phase-continuous by construction, one mirrored strand guarantees visible crossings. Glow blur capped at 60fps. `VoiceAmbience` radiance breathes with the voice state.
- **Control dock**: one floating glass panel replaces four mismatched bands (full-width model bar, quick-action tiles, capsule, utility buttons). Hero capsule + a single scrollable tile row: model chip, model picker, quick actions, camera, preview, type, push-to-talk toggle, disconnect. The panel is the only blur layer.
- **Settings hub**: 7 parent categories replace the long flat scroll; push-to-talk has a single owner (`AppState.setPushToTalk`) live-synced between Settings and the dock.
- **Wake word**: bare "OpenGlasses" (substring matching keeps "Hey OpenGlasses" working).

## Local models
- **Vision plumbing** for MLX vision turns (896px cap, backgrounding guard); **Gemma 4 e2b/e4b attempt-and-demote** — try the VLM factory, fall back to text on the device-verified weight-mapping failure, token shape keyed off the factory that actually loaded. Honest refusal messages. Policy tests updated to pin the new contract.
- **Downloads**: byte-based progress (the hub's per-file fraction is useless for one-big-safetensors models), screen kept awake during pulls, iCloud backup exclusion, once-per-process orphan temp sweep, compact spinner row. Gemma 2 2B retired; E4B added; RAM gate uses marketing size.

## Conversation quality (all live-traced)
- Follow-ups get context: query rewrite for context-dependent questions + grounding prompts that carry recent exchanges ("what about the other semi final?" now searches for the right thing and reconciles its earlier answer).
- Personal-data questions never reach web search; announce-without-action promises are detected (incl. search-flavoured), acted on, and never spoken as the final answer.
- Calendar questions route deterministically with the right action (the 2B model only ever managed "today").
- Persona activation no longer stomps the active model (empty template modelId hit the first-saved fallback — "hey travel" silently kicked the user off the local model).

## Photo pipeline (root-caused end to end)
- Every capture saves to the Glasses album in Photos.
- Stale-frame fallback freshness-gated (a minutes-old frame was being described repeatedly as a live "photo"); frames cleared on teardown.
- No silent phone-camera fallback while glasses are registered — and any legitimate phone capture announces itself in the spoken answer (the phone on the desk was the "hallucination").
- Stale disconnected-flag recheck (one bounded reconnect) before any phone fallback; live Meta permission recheck (mid-session revocation re-runs the grant flow).
- `noEligibleDevice` root cause: session now binds to the *specific* discovered device + bounded session retries (~12s) cover the glasses' BT idle-wake and discovery lag; session error stream watched from creation so stop reasons (incl. update-required) surface.

## Verification
- Release `xcodebuild test`: 2,062 tests, failures exactly on the unsigned-runner keychain baseline (13 in the 4 known classes), 0 unexpected.
- Multi-agent review pass (correctness / simplification / perf / conventions) with all verified findings applied — includes two fixes where new guards contradicted each other, a temp-sweep that could delete a live download, and a 120Hz blur cost.
- Localization catalog churn deliberately excluded per repo policy. Build bumped to 316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)