### PR TITLE
Fix #246: MCP server editing + live-client sync, diagnosable connect errors, fork link-back docs

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -3526,7 +3526,9 @@ class AppState: ObservableObject, AppStateProtocol {
         }
 
         guard isConnected else {
-            errorMessage = "Could not connect to glasses"
+            let stateRaw = Wearables.shared.registrationState.rawValue
+            errorMessage = RegistrationFlow.connectFailureMessage(stateRaw: stateRaw)
+            addDebugEvent("connectAndListen gave up: registrationState=\(stateRaw)")
             return
         }
 

--- a/OpenGlasses/Sources/App/Views/MCPServersView.swift
+++ b/OpenGlasses/Sources/App/Views/MCPServersView.swift
@@ -1,13 +1,40 @@
 import SwiftUI
 
 /// Manage MCP (Model Context Protocol) server connections.
-/// Add servers by URL, discover their tools, enable/disable.
+/// Add servers by URL, edit them in place, discover their tools, enable/disable.
+///
+/// All mutations go through the LIVE `appState.mcpClient` — issue #246: this view used to edit a
+/// private copy and write UserDefaults directly, so the running client kept using the old config
+/// (deleted servers stayed callable, a rotated token wasn't sent until force-quit).
 struct MCPServersView: View {
     @EnvironmentObject var appState: AppState
-    @State private var servers: [MCPServerConfig] = Config.mcpServers
     @State private var showAddSheet = false
+    @State private var editingServer: MCPServerConfig?
     @State private var discoveredCount: Int = 0
     @State private var isDiscovering = false
+
+    var body: some View {
+        // Nested ObservableObjects don't propagate through @EnvironmentObject — observe the
+        // client directly so the list re-renders on add/edit/delete.
+        MCPServersList(
+            mcpClient: appState.mcpClient,
+            showAddSheet: $showAddSheet,
+            editingServer: $editingServer,
+            discoveredCount: $discoveredCount,
+            isDiscovering: $isDiscovering
+        )
+    }
+}
+
+private struct MCPServersList: View {
+    @EnvironmentObject var appState: AppState
+    @ObservedObject var mcpClient: MCPClient
+    @Binding var showAddSheet: Bool
+    @Binding var editingServer: MCPServerConfig?
+    @Binding var discoveredCount: Int
+    @Binding var isDiscovering: Bool
+
+    private var servers: [MCPServerConfig] { mcpClient.servers }
 
     var body: some View {
         List {
@@ -20,39 +47,46 @@ struct MCPServersView: View {
                 } else {
                     ForEach(servers) { server in
                         HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                HStack(spacing: 6) {
-                                    Text(server.label)
-                                        .foregroundStyle(Color(.label))
+                            // Tap the row to EDIT (issue #246: rotating a token used to require
+                            // delete + re-add).
+                            Button {
+                                editingServer = server
+                            } label: {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    HStack(spacing: 6) {
+                                        Text(server.label)
+                                            .foregroundStyle(Color(.label))
+                                            .lineLimit(1)
+                                        Circle()
+                                            .fill(server.enabled ? .green : .gray)
+                                            .frame(width: 8, height: 8)
+                                            .accessibilityHidden(true)
+                                    }
+                                    Text(server.url)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
                                         .lineLimit(1)
-                                    Circle()
-                                        .fill(server.enabled ? .green : .gray)
-                                        .frame(width: 8, height: 8)
-                                        .accessibilityHidden(true)
                                 }
-                                Text(server.url)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(1)
+                                .contentShape(Rectangle())
                             }
+                            .buttonStyle(.plain)
                             Spacer()
                             Toggle("Enable \(server.label)", isOn: Binding(
                                 get: { server.enabled },
                                 set: { enabled in
-                                    if let idx = servers.firstIndex(where: { $0.id == server.id }) {
-                                        servers[idx].enabled = enabled
-                                        Config.setMCPServers(servers)
-                                    }
+                                    var updated = server
+                                    updated.enabled = enabled
+                                    mcpClient.updateServer(updated)
                                 }
                             ))
                             .labelsHidden()
                         }
                         .accessibilityElement(children: .combine)
                         .accessibilityLabel("\(server.label), \(server.enabled ? "enabled" : "disabled"). \(server.url)")
+                        .accessibilityHint("Double-tap to edit")
                         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                             Button(role: .destructive) {
-                                servers.removeAll { $0.id == server.id }
-                                Config.setMCPServers(servers)
+                                mcpClient.removeServer(id: server.id)
                             } label: {
                                 Label("Delete", systemImage: "trash")
                             }
@@ -62,15 +96,14 @@ struct MCPServersView: View {
             } header: {
                 Text("MCP Servers")
             } footer: {
-                Text("MCP servers expose tools the AI can call. Popular servers: Home Assistant, Notion, GitHub, Slack, and more.")
+                Text("MCP servers expose tools the AI can call. Tap a server to edit it (URL, token, transport). Popular servers: Home Assistant, Notion, GitHub, Slack, and more.")
             }
 
             // MARK: Catalogue (Plan V) — one-tap install of vetted servers
             Section {
                 NavigationLink {
                     MCPCatalogView { newServer in
-                        servers.append(newServer)
-                        Config.setMCPServers(servers)
+                        mcpClient.addServer(newServer)
                     }
                 } label: {
                     Label("Browse catalogue", systemImage: "square.grid.2x2")
@@ -147,8 +180,12 @@ struct MCPServersView: View {
         }
         .sheet(isPresented: $showAddSheet) {
             MCPServerEditorView { newServer in
-                servers.append(newServer)
-                Config.setMCPServers(servers)
+                mcpClient.addServer(newServer)
+            }
+        }
+        .sheet(item: $editingServer) { server in
+            MCPServerEditorView(prefill: server, isEditing: true) { updated in
+                mcpClient.updateServer(updated)
             }
         }
     }
@@ -156,8 +193,8 @@ struct MCPServersView: View {
     private func discover() {
         isDiscovering = true
         Task {
-            await appState.mcpClient.discoverAllTools()
-            discoveredCount = appState.mcpClient.discoveredTools.count
+            await mcpClient.discoverAllTools()
+            discoveredCount = mcpClient.discoveredTools.count
             isDiscovering = false
         }
     }
@@ -177,17 +214,25 @@ struct MCPServerEditorView: View {
     @State private var transport: MCPTransportKind
     @State private var authKind: MCPAuthKind
 
+    /// Edit mode (issue #246): preserves the server's identity/enabled/policy so a token rotation
+    /// or URL fix is an in-place update, not a delete-and-re-add.
+    private let isEditing: Bool
+    private let existing: MCPServerConfig?
+
     /// `prefill` seeds the form (catalogue one-tap install lands here with label/url/transport/auth
     /// already set); the user can still edit anything before saving. Defaults to a blank manual add.
-    init(prefill: MCPServerConfig? = nil, onSave: @escaping (MCPServerConfig) -> Void) {
+    /// With `isEditing: true`, saving keeps the prefilled server's id (and enabled/policy).
+    init(prefill: MCPServerConfig? = nil, isEditing: Bool = false, onSave: @escaping (MCPServerConfig) -> Void) {
         self.onSave = onSave
+        self.isEditing = isEditing
+        self.existing = prefill
         _label      = State(initialValue: prefill?.label ?? "")
         _url        = State(initialValue: prefill?.url ?? "")
         _transport  = State(initialValue: prefill?.transport ?? .http)
         _authKind   = State(initialValue: prefill?.authKind ?? .bearer)
-        let existing = prefill?.headers.first
-        _authHeader = State(initialValue: existing?.key ?? "Authorization")
-        _authValue  = State(initialValue: existing?.value ?? "")
+        let existingHeader = prefill?.headers.first
+        _authHeader = State(initialValue: existingHeader?.key ?? "Authorization")
+        _authValue  = State(initialValue: existingHeader?.value ?? "")
     }
 
     var body: some View {
@@ -229,25 +274,26 @@ struct MCPServerEditorView: View {
                     }
                 }
             }
-            .navigationTitle(label.isEmpty ? "Add MCP Server" : "Add \(label)")
+            .navigationTitle(isEditing ? "Edit \(existing?.label ?? "Server")"
+                                       : (label.isEmpty ? "Add MCP Server" : "Add \(label)"))
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
                 }
                 ToolbarItem(placement: .confirmationAction) {
-                    Button("Add") {
+                    Button(isEditing ? "Save" : "Add") {
                         var headers: [String: String] = [:]
                         if !authHeader.isEmpty && !authValue.isEmpty {
                             headers[authHeader] = authValue
                         }
                         let server = MCPServerConfig(
-                            id: UUID().uuidString,
+                            id: (isEditing ? existing?.id : nil) ?? UUID().uuidString,
                             label: label.trimmingCharacters(in: .whitespaces),
                             url: url.trimmingCharacters(in: .whitespaces),
                             headers: headers,
-                            enabled: true,
-                            policy: .redact,          // safe default (Plan R) — same as a catalogue install
+                            enabled: (isEditing ? existing?.enabled : nil) ?? true,
+                            policy: (isEditing ? existing?.policy : nil) ?? .redact,   // safe default (Plan R)
                             transport: transport,
                             authKind: authKind
                         )

--- a/OpenGlasses/Sources/Services/MCPClient.swift
+++ b/OpenGlasses/Sources/Services/MCPClient.swift
@@ -166,9 +166,25 @@ final class MCPClient: ObservableObject {
     }
 
     func updateServer(_ server: MCPServerConfig) {
-        if let idx = servers.firstIndex(where: { $0.id == server.id }) {
-            servers[idx] = server
-            Config.setMCPServers(servers)
+        guard let idx = servers.firstIndex(where: { $0.id == server.id }) else { return }
+        let old = servers[idx]
+        servers[idx] = server
+        Config.setMCPServers(servers)
+
+        // Issue #246: config changes must invalidate what was discovered under the OLD config —
+        // a rotated token or changed URL otherwise keeps serving stale tool definitions (and a
+        // disabled server's tools stayed callable). Re-discover live when the server remains
+        // enabled and something material changed, so the catalogue heals without a manual tap.
+        let materialChange = old.url != server.url || old.headers != server.headers
+            || old.transport != server.transport || old.enabled != server.enabled
+        guard materialChange else { return }
+        discoveredTools.removeAll { $0.serverId == server.id }
+        if server.enabled {
+            Task { [weak self] in
+                guard let self else { return }
+                let tools = await self.discoverTools(from: server)
+                self.discoveredTools.append(contentsOf: tools)
+            }
         }
     }
 

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
@@ -122,7 +122,8 @@ final class NativeToolRouter {
         // 2. Check MCP servers for the tool (matched on its fully-qualified, namespace-isolated
         //    name so a server can't shadow a native tool). Blocked (tool-poisoned) tools are
         //    never matched here, so the model can't reach them.
-        if let mcp = mcpClient, let tool = mcp.offeredTool(matching: name), let server = mcp.server(id: tool.serverId) {
+        if let mcp = mcpClient, let tool = mcp.offeredTool(matching: name),
+           let server = mcp.server(id: tool.serverId), server.enabled {
             // Outbound egress screen (Plan R): secrets/PII never leave the device for a
             // third-party server. A `.block` verdict is treated like a declined confirmation —
             // no network call, and a failure the model is told not to retry.

--- a/OpenGlasses/Sources/Services/RegistrationFlow.swift
+++ b/OpenGlasses/Sources/Services/RegistrationFlow.swift
@@ -22,4 +22,14 @@ enum RegistrationFlow {
             ? "Waiting for device…"
             : "Approve OpenGlasses in the Meta AI app to continue…"
     }
+
+    /// Diagnostic failure message for a connect that gave up — names the stalled layer instead of
+    /// a bare "Could not connect to glasses" (issue #246: that string hid a broken registration
+    /// link-back for an entire debugging evening). Still actionable, now also diagnosable.
+    static func connectFailureMessage(stateRaw: Int) -> String {
+        if isRegistered(stateRaw: stateRaw) {
+            return "Glasses registered but no device appeared (state \(stateRaw)). Make sure the glasses are on, nearby, and connected in the Meta AI app, then try again."
+        }
+        return "Glasses registration didn't complete (state \(stateRaw)). If you approved OpenGlasses in the Meta AI app and this persists, the approval link-back may not be reaching this app — on a custom build, verify the AppLink domain and associated-domains entitlement match your bundle ID."
+    }
 }

--- a/OpenGlassesTests/MCPTransportTests.swift
+++ b/OpenGlassesTests/MCPTransportTests.swift
@@ -182,3 +182,75 @@ final class MockURLProtocol: URLProtocol {
         return data
     }
 }
+
+// MARK: - Server config lifecycle (issue #246)
+
+/// A config change must invalidate what was discovered under the OLD config — a rotated token
+/// otherwise kept serving stale tool definitions until force-quit, and a disabled server's
+/// tools stayed callable.
+final class MCPServerLifecycleTests: XCTestCase {
+
+    /// Hermetic transport: every request answers an empty tools/list, so updateServer's
+    /// re-discovery Task never touches the network.
+    private struct EmptyToolsTransport: MCPTransport {
+        func request(_ payload: [String: Any], server: MCPServerConfig) async throws -> Data {
+            Data(#"{"jsonrpc":"2.0","id":1,"result":{"tools":[]}}"#.utf8)
+        }
+    }
+
+    @MainActor
+    private func makeClient() -> (MCPClient, MCPServerConfig, MCPServerConfig) {
+        let client = MCPClient()
+        client.transportOverride = EmptyToolsTransport()
+        let a = MCPServerConfig(id: "a", label: "Alpha", url: "http://a/mcp",
+                                headers: ["Authorization": "Bearer old-token"], enabled: true)
+        let b = MCPServerConfig(id: "b", label: "Beta", url: "http://b/mcp", headers: [:], enabled: true)
+        client.servers = [a, b]
+        client.discoveredTools = [
+            MCPTool(name: "t1", description: "d", inputSchema: [:], serverId: "a", serverLabel: "Alpha"),
+            MCPTool(name: "t2", description: "d", inputSchema: [:], serverId: "b", serverLabel: "Beta"),
+        ]
+        return (client, a, b)
+    }
+
+    @MainActor
+    func testTokenRotationDropsThatServersToolsOnly() {
+        let (client, a, _) = makeClient()
+        var updated = a
+        updated.headers = ["Authorization": "Bearer new-token"]
+        client.updateServer(updated)
+        XCTAssertFalse(client.discoveredTools.contains { $0.serverId == "a" },
+                       "tools discovered under the old token must not survive a rotation")
+        XCTAssertTrue(client.discoveredTools.contains { $0.serverId == "b" },
+                      "other servers' tools are untouched")
+        XCTAssertEqual(client.servers.first { $0.id == "a" }?.headers["Authorization"], "Bearer new-token")
+    }
+
+    @MainActor
+    func testDisablingDropsToolsSoTheyAreNoLongerCallable() {
+        let (client, a, _) = makeClient()
+        var updated = a
+        updated.enabled = false
+        client.updateServer(updated)
+        XCTAssertFalse(client.discoveredTools.contains { $0.serverId == "a" },
+                       "a disabled server's tools must leave the offered set")
+    }
+
+    @MainActor
+    func testLabelOnlyChangeKeepsDiscoveredTools() {
+        let (client, a, _) = makeClient()
+        var updated = a
+        updated.label = "Alpha Renamed"
+        client.updateServer(updated)
+        XCTAssertTrue(client.discoveredTools.contains { $0.serverId == "a" },
+                      "a cosmetic rename must not force re-discovery")
+    }
+
+    @MainActor
+    func testRemoveServerDropsItsTools() {
+        let (client, _, _) = makeClient()
+        client.removeServer(id: "a")
+        XCTAssertFalse(client.discoveredTools.contains { $0.serverId == "a" })
+        XCTAssertNil(client.server(id: "a"))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -417,6 +417,20 @@ Host an `apple-app-site-association` file at `https://YOUR-DOMAIN/.well-known/ap
 }
 ```
 
+**Both ends must match your build, or registration silently never completes** (#246):
+
+- The AASA `appID` must be **your** Team ID + bundle ID — a copied AASA still declaring the upstream app makes iOS refuse the domain association.
+- Your entitlements file must contain the **associated-domains** entitlement for the same domain (`applinks:YOUR-DOMAIN`). Without it, iOS never even attempts the link-back. If you use a personal entitlements overlay, check it has:
+
+```xml
+<key>com.apple.developer.associated-domains</key>
+<array>
+    <string>applinks:YOUR-DOMAIN</string>
+</array>
+```
+
+The failure mode when either end is wrong: approval completes in the Meta AI app, but the approval callback (a Universal Link) never reaches OpenGlasses — registration never finalises, the devices listener never fires, and connecting fails. The in-app error names the stalled registration state and points here.
+
 ### 5. Enable Developer Mode
 
 On iPhone: Meta AI app → Settings → About → tap version number **5 times** → toggle Developer Mode on.

--- a/project.base.yml
+++ b/project.base.yml
@@ -108,7 +108,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "317"
+        CURRENT_PROJECT_VERSION: "318"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -176,7 +176,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "317"
+        CURRENT_PROJECT_VERSION: "318"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -214,7 +214,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "317"
+        CURRENT_PROJECT_VERSION: "318"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "317"
+        CURRENT_PROJECT_VERSION: "318"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "317"
+        CURRENT_PROJECT_VERSION: "318"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
Fixes the two app bugs and the UX gap reported in #246, plus documents the fork-configuration trap that caused the reporter's main issue.

## MCP: edit-in-place + live-client sync
- **Tap a server row to edit it** (label, URL, token, transport). The editor preserves identity/enabled/policy — token rotation is an in-place update, not delete-and-re-add.
- **The stale-token root cause**: `MCPServersView` mutated a private `@State` copy and wrote UserDefaults directly, so the *live* `MCPClient` (which reads config once at init) kept serving the old config — deleted servers stayed callable and a rotated token wasn't sent until force-quit, exactly as verified server-side in the report. All mutations now go through the live client; `updateServer` invalidates that server's discovered tools on any material change (URL/headers/transport/enabled) and re-discovers automatically.
- **Latent fix**: a disabled server's tools stayed in the offered set and remained callable — the router now checks `enabled` at call time, and disabling removes the tools immediately.
- Four hermetic tests (stubbed transport) pin the contract: rotation drops only that server's tools; disable removes them from the callable set; renames don't force re-discovery; removal cleans up.

## Connect diagnosability
"Could not connect to glasses" hid everything for an entire debugging evening. It now names the stalled layer:
- Registration incomplete → message includes the raw state and points at the Meta AI approval **link-back** (AASA + associated-domains on custom builds) — the reporter's exact root cause.
- Registered but no device → says that, with the actionable next steps.
- Raw state also lands in the persistent `debug-events.log` (shipped in #248) for post-hoc diagnosis.

## Fork setup docs
README's Universal Links section now documents both ends that must match a custom bundle ID — the AASA `appID` **and** the `com.apple.developer.associated-domains` entitlement — plus the silent failure mode when either is wrong.

## Verification
Release `xcodebuild test`: 2,066 tests (4 new), failures exactly on the unsigned-runner keychain baseline (13, 4 known classes), 0 unexpected. Build 318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)