### PR TITLE
MCP session handshake, Gemini tool-call hardening, camera warm-up, high-res vision

### DIFF
--- a/OpenGlasses/Sources/Services/CameraService.swift
+++ b/OpenGlasses/Sources/Services/CameraService.swift
@@ -353,13 +353,22 @@ class CameraService: ObservableObject {
             session.start()  // DAT 0.8.0: Stream.start() is synchronous
         }
 
-        // Wait for streaming state
+        // Wait for streaming state. During a cold start the stream bounces through .stopped
+        // (device-traced: ~15-18s of .stopped/.waitingForDevice churn before .streaming), so a
+        // transient .stopped is NOT terminal — nudge start() again a few times before giving up.
+        var restartNudges = 0
         let deadline = ContinuousClock.now + .seconds(timeout)
         while ContinuousClock.now < deadline {
             if session.state == .streaming { break }
             if session.state == .stopped {
-                NSLog("[Camera] Session stopped unexpectedly while waiting for streaming")
-                throw CameraError.streamNotReady
+                if restartNudges < 3 {
+                    restartNudges += 1
+                    NSLog("[Camera] Stream stopped while warming up — restart nudge %d/3", restartNudges)
+                    session.start()
+                } else {
+                    NSLog("[Camera] Session stopped unexpectedly while waiting for streaming")
+                    throw CameraError.streamNotReady
+                }
             }
             try await Task.sleep(nanoseconds: 500_000_000)
         }
@@ -503,9 +512,10 @@ class CameraService: ObservableObject {
                 return
             }
 
-            // Timeout after 5 seconds — fall back to latest video frame
+            // Timeout after 8 seconds — fall back to latest video frame. (5s was too tight on
+            // a cold WiFi-transport capture; the photo often lands at 5-7s.)
             Task {
-                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                try? await Task.sleep(nanoseconds: 8_000_000_000)
                 if let cont = self.photoContinuation {
                     self.photoContinuation = nil
                     if let fallback = self.latestFrameAsJPEG() {

--- a/OpenGlasses/Sources/Services/LLM/HistoryHygiene.swift
+++ b/OpenGlasses/Sources/Services/LLM/HistoryHygiene.swift
@@ -83,27 +83,40 @@ enum HistoryHygiene {
         return out
     }
 
+    /// An image block in ANY of the three provider shapes the shared history can hold:
+    /// Anthropic (`type: image`), OpenAI-compatible (`type: image_url`), and Gemini
+    /// (`inlineData` inside a `parts` array). The prune runs for every provider now, so it
+    /// must recognise every shape or old photos silently keep re-uploading on that path.
+    private static func isImageBlock(_ block: [String: Any]) -> Bool {
+        if let type = block["type"] as? String, type == "image" || type == "image_url" { return true }
+        return block["inlineData"] != nil
+    }
+
     private static func messageHasImage(_ message: [String: Any]) -> Bool {
-        guard let blocks = message["content"] as? [[String: Any]] else { return false }
-        return blocks.contains { $0["type"] as? String == "image" }
+        let blocks = (message["content"] as? [[String: Any]]) ?? (message["parts"] as? [[String: Any]]) ?? []
+        return blocks.contains(where: isImageBlock)
     }
 
     private static func stripImages(from message: [String: Any]) -> [String: Any] {
-        guard let blocks = message["content"] as? [[String: Any]] else { return message }
+        let contentKey = message["content"] is [[String: Any]] ? "content"
+                       : message["parts"] is [[String: Any]] ? "parts" : nil
+        guard let key = contentKey, let blocks = message[key] as? [[String: Any]] else { return message }
         var newBlocks: [[String: Any]] = []
         var replacedAny = false
         for block in blocks {
-            if block["type"] as? String == "image" {
+            if isImageBlock(block) {
                 replacedAny = true
             } else {
                 newBlocks.append(block)
             }
         }
         if replacedAny {
-            newBlocks.append(["type": "text", "text": prunedImagePlaceholder])
+            // Gemini `parts` use `text` fields directly; content arrays use typed text blocks.
+            newBlocks.append(key == "parts" ? ["text": prunedImagePlaceholder]
+                                            : ["type": "text", "text": prunedImagePlaceholder])
         }
         var out = message
-        out["content"] = newBlocks
+        out[key] = newBlocks
         return out
     }
 

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -520,6 +520,12 @@ class LLMService: ObservableObject {
             print("🧭 Agent plan loop yielded no plan — falling back to single-shot")
         }
 
+        // Image hygiene for EVERY provider, not just Anthropic (where the request builder
+        // already prunes): stale images re-upload with every turn, and on the Gemini /
+        // OpenAI-compatible paths an unpruned photo history overflowed the context window
+        // outright. Prune here so all providers start the turn with at most one prior image.
+        conversationHistory = HistoryHygiene.pruneImages(conversationHistory, keepLast: 1)
+
         let rawResponse: String
         switch provider {
         case .anthropic:
@@ -1473,6 +1479,12 @@ class LLMService: ObservableObject {
         return nil
     }
 
+    /// A `.custom` endpoint that 400'd on a `tools` payload (some Ollama/LM Studio builds).
+    /// Remembered for the session so later turns skip tools instead of re-tripping the 400.
+    /// `static nonisolated(unsafe)` because it's flipped inside the nonisolated per-turn
+    /// closure; a bool flag with one realistic writer needs no stronger isolation.
+    nonisolated(unsafe) private static var customEndpointRejectsTools = false
+
     private func sendOpenAICompatible(_ text: String, systemPrompt: String, config: ModelConfig, includeTools: Bool, imageData: Data?, onToken: ((String) -> Void)? = nil, onStreamReset: (() -> Void)? = nil) async throws -> String {
         let provider = config.llmProvider
         let apiKey = config.apiKey
@@ -1564,8 +1576,11 @@ class LLMService: ObservableObject {
                 ]
 
                 // Only attach Tools if the provider reliably supports function calling.
-                // Custom endpoints (Ollama/LMStudio) often crash with 400 if `tools` array is in the payload.
+                // Custom endpoints get tools too (Gemini/vLLM/newer Ollama all speak OpenAI
+                // function calling); the ones that 400 on a `tools` payload are retried once
+                // without tools below and remembered for the rest of the session.
                 let providerSupportsTools = provider == .openai || provider == .groq || provider == .zai || provider == .qwen || provider == .openrouter
+                    || (provider == .custom && !Self.customEndpointRejectsTools)
 
                 if includeTools && providerSupportsTools {
                     let includeOpenClaw = Config.isOpenClawAgentActive && self.openClawBridge != nil
@@ -1595,19 +1610,42 @@ class LLMService: ObservableObject {
                 // Final-reply turns stream into the Chat tab when a streaming caller passes `onToken`;
                 // the reconstructed `message` (content + tool_calls) feeds the shared tool loop unchanged.
                 let message: [String: Any]
+                // Retry-without-tools for `.custom` (some Ollama/LM Studio builds 400 on the
+                // `tools` array): strip it, remember for the session, and re-send once.
+                func retryRequestWithoutTools() throws -> URLRequest {
+                    NSLog("[LLMService] custom endpoint rejected tools payload — retrying without tools")
+                    Self.customEndpointRejectsTools = true
+                    body.removeValue(forKey: "tools")
+                    var retried = request
+                    retried.httpBody = try JSONSerialization.data(withJSONObject: body)
+                    return retried
+                }
+                let toolsAttached = body["tools"] != nil
+
                 if let onToken {
                     // New tool-loop iteration: clear the caller's accumulated bubble first, so an
                     // intermediate tool turn's text never concatenates with the final reply (BM P9).
                     onStreamReset?()
                     let flag = TokenDeliveryFlag()
-                    message = try await self.withTransientSSERetries(tokenFlag: flag) {
-                        try await self.streamOpenAIMessage(request: request, provider: provider, model: config.model) { token in
-                            flag.mark()
-                            onToken(token)
+                    func streamTurn(_ req: URLRequest) async throws -> [String: Any] {
+                        try await self.withTransientSSERetries(tokenFlag: flag) {
+                            try await self.streamOpenAIMessage(request: req, provider: provider, model: config.model) { token in
+                                flag.mark()
+                                onToken(token)
+                            }
                         }
                     }
+                    do {
+                        message = try await streamTurn(request)
+                    } catch LLMError.apiError(_, 400, _) where provider == .custom && toolsAttached {
+                        message = try await streamTurn(try retryRequestWithoutTools())
+                    }
                 } else {
-                    let (data, response) = try await URLSession.shared.data(for: request)
+                    var (data, response) = try await URLSession.shared.data(for: request)
+                    if provider == .custom, toolsAttached,
+                       (response as? HTTPURLResponse)?.statusCode == 400 {
+                        (data, response) = try await URLSession.shared.data(for: try retryRequestWithoutTools())
+                    }
 
                     guard let httpResponse = response as? HTTPURLResponse,
                           httpResponse.statusCode == 200 else {
@@ -1639,17 +1677,30 @@ class LLMService: ObservableObject {
 
                 var toolCalls: [ToolInvocation] = []
                 if includeTools, let calls = message["tool_calls"] as? [[String: Any]] {
-                    for toolCall in calls {
-                        guard let callId = toolCall["id"] as? String,
-                              let function = toolCall["function"] as? [String: Any],
-                              let functionName = function["name"] as? String,
-                              let argsString = function["arguments"] as? String else { continue }
+                    for (index, toolCall) in calls.enumerated() {
+                        // Only `function.name` is truly required. Gemini's OpenAI-compatible
+                        // endpoint can omit `id` and `arguments` (no-arg tools) — the old strict
+                        // guard silently DROPPED such calls, so the loop finalized with an empty
+                        // reply while the server had returned a perfectly good tool_call.
+                        guard let function = toolCall["function"] as? [String: Any],
+                              let functionName = function["name"] as? String else {
+                            NSLog("[LLMService] Dropping malformed tool_call (no function.name): %@",
+                                  String(String(describing: toolCall).prefix(200)))
+                            continue
+                        }
+                        let callId = (toolCall["id"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? "call_\(index)"
+                        let argsString = function["arguments"] as? String ?? "{}"
                         // Malformed tool arguments (Plan BF): nil `arguments` → the dispatcher returns a
                         // correctable parse error instead of running the tool with empty args.
                         let parsedArgs = try? JSONSerialization.jsonObject(with: Data(argsString.utf8)) as? [String: Any]
                         toolCalls.append(ToolInvocation(id: callId, name: functionName,
                                                         arguments: parsedArgs, rawArguments: argsString))
                     }
+                    // One log line per turn: what was parsed vs what the server sent — the seam
+                    // where a "tool_call returned but nothing executed" bug is diagnosed.
+                    NSLog("[LLMService] %@ turn: %d/%d tool call(s) parsed%@", provider.displayName,
+                          toolCalls.count, calls.count,
+                          toolCalls.isEmpty ? "" : " → " + toolCalls.map(\.name).joined(separator: ", "))
                 }
                 let text = message["content"] as? String ?? ""
                 return AssistantTurn(text: text, toolCalls: toolCalls, payload: message)
@@ -1678,10 +1729,11 @@ class LLMService: ObservableObject {
             },
             finalize: { [weak self] turn in
                 guard let self else { throw LLMError.invalidResponse(provider.displayName) }
-                guard let message = turn.payload as? [String: Any],
-                      let responseText = message["content"] as? String else {
-                    throw LLMError.invalidResponse(provider.displayName)
-                }
+                // Gemini's OpenAI-compatible endpoint omits `content` on tool-call turns — a
+                // hard guard here 400-equivalent-failed the whole conversation after a
+                // successful tool run. Fall back to the accumulated turn text (may be empty).
+                let message = turn.payload as? [String: Any]
+                let responseText = (message?["content"] as? String) ?? turn.text
                 self.conversationHistory.append(["role": "assistant", "content": responseText])
                 return responseText
             }

--- a/OpenGlasses/Sources/Services/MCP/MCPTransport.swift
+++ b/OpenGlasses/Sources/Services/MCP/MCPTransport.swift
@@ -74,20 +74,112 @@ enum MCPTransportError: LocalizedError, Equatable {
     }
 }
 
-/// The shipped transport: one JSON-RPC request over an HTTP POST (Streamable HTTP). This is a
-/// byte-for-byte lift of the original inline `MCPClient.mcpRequest` — same method, headers, 15s
-/// timeout, and ≥400 → throw — so extracting it is a pure refactor with no behaviour change. The
-/// `session` is injectable purely so tests can stub `URLProtocol`; production uses `.shared`.
+/// The shipped transport: Streamable HTTP (JSON-RPC over HTTP POST) with the MCP session
+/// lifecycle. On first contact with a server it performs the MCP handshake (`initialize` →
+/// `notifications/initialized`) and captures the `mcp-session-id` header; subsequent requests
+/// carry that header. Responses may arrive as plain JSON (`application/json`) or SSE-framed
+/// (`text/event-stream` — FastMCP and the official TS server always frame POST responses this
+/// way), so the JSON-RPC payload is unwrapped via `SSEEventParser` before it's returned; callers
+/// always receive raw JSON `Data`. Servers that implement neither (bare single-POST endpoints,
+/// e.g. Home Assistant's) still work: a failed handshake marks the server "no session" and the
+/// request proceeds exactly as before.
+///
+/// The `session` is injectable purely so tests can stub `URLProtocol`; production uses `.shared`.
 struct HTTPTransport: MCPTransport {
     var session: URLSession = .shared
 
+    /// Per-server MCP session IDs, `static` so they survive across the per-request instances that
+    /// `MCPTransportFactory` creates. Thread-safe in practice because every caller goes through
+    /// the `@MainActor` `MCPClient`. Empty string means "initialized, server doesn't use
+    /// sessions"; absent key means "not yet initialized".
+    nonisolated(unsafe) private static var sessions: [String: String] = [:]
+
+    /// Clear cached sessions (test support, and `MCPClient` calls it when a server's config
+    /// changes so a rotated token re-handshakes).
+    static func resetSessions() { sessions.removeAll() }
+
     func request(_ payload: [String: Any], server: MCPServerConfig) async throws -> Data {
-        guard let url = URL(string: server.url) else {
+        // First contact with this server: run the MCP initialize handshake.
+        if Self.sessions[server.id] == nil {
+            await initializeSession(server: server)
+        }
+
+        let sessionID = Self.sessions[server.id]
+        let (data, response) = try await sendHTTP(payload, server: server, sessionID: sessionID)
+        guard let httpResponse = response as? HTTPURLResponse else { return data }
+
+        // 400/406 while we hold no real session → the server requires the MCP session
+        // lifecycle (a previous handshake failed or expired). Re-initialize and retry once.
+        if (httpResponse.statusCode == 400 || httpResponse.statusCode == 406), (sessionID ?? "").isEmpty {
+            Self.sessions.removeValue(forKey: server.id)
+            await initializeSession(server: server)
+            let (retryData, retryResponse) = try await sendHTTP(payload, server: server,
+                                                                sessionID: Self.sessions[server.id])
+            if let retryHTTP = retryResponse as? HTTPURLResponse, retryHTTP.statusCode >= 400 {
+                let body = String(data: retryData, encoding: .utf8) ?? ""
+                throw MCPTransportError.http(status: retryHTTP.statusCode, body: String(body.prefix(200)))
+            }
+            return extractJSON(from: retryData, response: retryResponse, payload: payload)
+        }
+
+        if httpResponse.statusCode >= 400 {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw MCPTransportError.http(status: httpResponse.statusCode, body: String(body.prefix(200)))
+        }
+
+        // Capture a session ID from any successful response (a server may mint one late).
+        if let newSessionID = httpResponse.value(forHTTPHeaderField: "mcp-session-id") {
+            Self.sessions[server.id] = newSessionID
+        }
+
+        return extractJSON(from: data, response: response, payload: payload)
+    }
+
+    // MARK: - MCP session handshake
+
+    /// `initialize` → `notifications/initialized`. On failure the server is marked "no session
+    /// needed" so the real request still goes through — simple MCP servers skip the lifecycle.
+    private func initializeSession(server: MCPServerConfig) async {
+        let initPayload: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": [
+                "protocolVersion": "2024-11-05",
+                "capabilities": [:] as [String: Any],
+                "clientInfo": ["name": "OpenGlasses", "version": "1.0"] as [String: Any],
+            ] as [String: Any],
+        ]
+        do {
+            let (_, response) = try await sendHTTP(initPayload, server: server, sessionID: nil)
+            let sessionID = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "mcp-session-id") ?? ""
+            Self.sessions[server.id] = sessionID   // "" = server doesn't use sessions
+
+            // Fire-and-forget; a server that returned a session expects this before real calls.
+            let notifPayload: [String: Any] = ["jsonrpc": "2.0", "method": "notifications/initialized"]
+            _ = try? await sendHTTP(notifPayload, server: server,
+                                    sessionID: sessionID.isEmpty ? nil : sessionID)
+        } catch {
+            Self.sessions[server.id] = ""
+            print("⚠️ MCP: session init failed for \(server.label), proceeding without session: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - HTTP
+
+    private func sendHTTP(_ payload: [String: Any], server: MCPServerConfig,
+                          sessionID: String?) async throws -> (Data, URLResponse) {
+        guard !server.url.isEmpty, let url = URL(string: server.url) else {
             throw MCPTransportError.badURL
         }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        // MCP Streamable HTTP requires the client to accept both response framings.
+        request.setValue("application/json, text/event-stream", forHTTPHeaderField: "Accept")
+        if let sessionID, !sessionID.isEmpty {
+            request.setValue(sessionID, forHTTPHeaderField: "mcp-session-id")
+        }
 
         // Auth headers (e.g. Authorization: Bearer …) are applied identically for every transport.
         for (key, value) in server.headers {
@@ -96,11 +188,25 @@ struct HTTPTransport: MCPTransport {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: payload)
         request.timeoutInterval = 15
+        return try await session.data(for: request)
+    }
 
-        let (data, response) = try await session.data(for: request)
-        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
-            let body = String(data: data, encoding: .utf8) ?? ""
-            throw MCPTransportError.http(status: httpResponse.statusCode, body: String(body.prefix(200)))
+    // MARK: - SSE response unwrapping
+
+    /// If the server answered in `text/event-stream` framing, pull the JSON-RPC response out of
+    /// the SSE events — matched to the request's `id` where possible (a stream can interleave
+    /// notifications before the response), else the first event. Plain JSON passes through.
+    private func extractJSON(from data: Data, response: URLResponse, payload: [String: Any]) -> Data {
+        let contentType = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Type") ?? ""
+        guard contentType.contains("text/event-stream"),
+              let body = String(data: data, encoding: .utf8) else { return data }
+        let events = SSEEventParser.parse(body)
+        if let rpcID = payload["id"] as? Int,
+           let matched = SSEEventParser.jsonRPCResponse(in: events, id: rpcID) {
+            return matched
+        }
+        if let first = events.first, let jsonData = first.data.data(using: .utf8) {
+            return jsonData
         }
         return data
     }

--- a/OpenGlasses/Sources/Services/MCPClient.swift
+++ b/OpenGlasses/Sources/Services/MCPClient.swift
@@ -163,6 +163,7 @@ final class MCPClient: ObservableObject {
         servers.removeAll { $0.id == id }
         discoveredTools.removeAll { $0.serverId == id }
         Config.setMCPServers(servers)
+        HTTPTransport.resetSessions()
     }
 
     func updateServer(_ server: MCPServerConfig) {
@@ -179,6 +180,9 @@ final class MCPClient: ObservableObject {
             || old.transport != server.transport || old.enabled != server.enabled
         guard materialChange else { return }
         discoveredTools.removeAll { $0.serverId == server.id }
+        // The MCP session was minted under the old config — a rotated token or new URL must
+        // re-handshake, not reuse the stale mcp-session-id.
+        HTTPTransport.resetSessions()
         if server.enabled {
             Task { [weak self] in
                 guard let self else { return }

--- a/OpenGlasses/Sources/Services/OpenClawBridge.swift
+++ b/OpenGlasses/Sources/Services/OpenClawBridge.swift
@@ -212,6 +212,23 @@ class OpenClawBridge: ObservableObject {
         disconnectWebSocket()
     }
 
+    /// Consecutive WebSocket failures since the last successful connect. The resolved endpoint
+    /// is cached forever on success, so a candidate that later dies (left the LAN, tunnel
+    /// restarted) would otherwise be hammered until app restart — "persistent gateway offline".
+    /// After a few failures in a row, drop the cache so the next attempt re-probes all
+    /// candidates (LAN → tunnel failover).
+    private var consecutiveWSFailures = 0
+    private static let maxWSFailuresBeforeEndpointReset = 3
+
+    private func noteWSFailure() {
+        consecutiveWSFailures += 1
+        guard consecutiveWSFailures >= Self.maxWSFailuresBeforeEndpointReset else { return }
+        NSLog("[OpenClaw] %d consecutive WS failures — dropping cached endpoint to re-probe", consecutiveWSFailures)
+        consecutiveWSFailures = 0
+        cachedEndpoint = nil
+        resolvedConnection = nil
+    }
+
     /// The active gateway's token, or the legacy token.
     var activeToken: String {
         activeGateway?.token ?? Config.openClawGatewayToken
@@ -372,6 +389,7 @@ class OpenClawBridge: ObservableObject {
            let ok = json["ok"] as? Bool, ok {
             wsConnected = true
             sessionCompacted = false
+            consecutiveWSFailures = 0
             NSLog("[OpenClaw] WS connected as node with capabilities")
             startReceiveLoop()
 
@@ -380,6 +398,7 @@ class OpenClawBridge: ObservableObject {
             onGatewayConnected?()
         } else {
             NSLog("[OpenClaw] WS connect failed: %@", String(response.prefix(300)))
+            noteWSFailure()
             throw NSError(domain: "OpenClaw", code: -2, userInfo: [NSLocalizedDescriptionKey: "WebSocket auth failed: \(String(response.prefix(200)))"])
         }
     }

--- a/OpenGlasses/Sources/Utils/LLMImagePreparer.swift
+++ b/OpenGlasses/Sources/Utils/LLMImagePreparer.swift
@@ -4,8 +4,8 @@ import UIKit
 /// base64-encoded into a request.
 ///
 /// Anthropic's Messages API rejects an inline image larger than **5 MB** with a 400
-/// (`image exceeds 5 MB maximum`) and downsamples anything over ~1568 px on the long edge
-/// anyway. Ray-Ban glasses frames arrive small (the DAT stream is already downscaled), so
+/// (`image exceeds 5 MB maximum`) and downsamples anything over the model's long-edge
+/// ceiling anyway. Ray-Ban glasses frames arrive small (the DAT stream is already downscaled), so
 /// this never bites on the glasses path — but the iPhone-camera fallback
 /// (`PhoneCameraSource`) and the photo tools capture at full sensor resolution, where a
 /// 12 MP JPEG can clear 5 MB and fail the request on *exactly* the no-glasses path we rely
@@ -15,8 +15,13 @@ import UIKit
 /// (Lesson cribbed from the `glassbridge` project's LEARNINGS.md, which hit this 400 with
 /// native iPhone JPEGs.)
 enum LLMImagePreparer {
-    /// Longest edge (in pixels) we allow before downscaling — Anthropic's recommended ceiling.
-    static let maxLongEdge: CGFloat = 1568
+    /// Longest edge (in pixels) we allow before downscaling. Current Claude models
+    /// (Sonnet 5 / Opus 4.7+, incl. our default) support high-resolution vision up to
+    /// 2576 px on the long edge; older models just downscale server-side, so this is safe
+    /// across providers. Costs more image tokens than the old 1568 ceiling, but history
+    /// pruning keeps only the latest image so the spend is bounded — and the extra fidelity
+    /// is exactly what instrument_reading / text-in-scene captures need.
+    static let maxLongEdge: CGFloat = 2576
     /// Byte ceiling for the encoded JPEG, kept comfortably under Anthropic's 5 MB hard limit.
     static let maxBytes = 4_500_000
     /// Frames below this long edge carry no usable content (the 1×1 placeholder failure mode).

--- a/OpenGlassesTests/HistoryHygieneTests.swift
+++ b/OpenGlassesTests/HistoryHygieneTests.swift
@@ -96,6 +96,46 @@ final class HistoryHygieneTests: XCTestCase {
         XCTAssertTrue(blocks?.contains { $0["type"] as? String == "image" } ?? false)
     }
 
+    /// The prune now runs for every provider, so it must recognise the OpenAI-compatible
+    /// `image_url` block shape — an unpruned photo history overflowed Gemini-via-OpenAI context.
+    func testPruneRecognisesOpenAIImageURLBlocks() {
+        func openAIImageMessage(_ text: String) -> [String: Any] {
+            ["role": "user", "content": [
+                ["type": "image_url", "image_url": ["url": "data:image/jpeg;base64,AAAA"]],
+                ["type": "text", "text": text],
+            ]]
+        }
+        let pruned = HistoryHygiene.pruneImages(
+            [openAIImageMessage("first"), openAIImageMessage("second")], keepLast: 1)
+        let firstBlocks = pruned[0]["content"] as? [[String: Any]]
+        XCTAssertFalse(firstBlocks?.contains { $0["type"] as? String == "image_url" } ?? true,
+                       "old OpenAI-format image should be pruned")
+        XCTAssertTrue(firstBlocks?.contains { ($0["text"] as? String) == HistoryHygiene.prunedImagePlaceholder } ?? false)
+        let secondBlocks = pruned[1]["content"] as? [[String: Any]]
+        XCTAssertTrue(secondBlocks?.contains { $0["type"] as? String == "image_url" } ?? false,
+                      "newest image must be kept")
+    }
+
+    /// Gemini native turns store images as `inlineData` inside a `parts` array.
+    func testPruneRecognisesGeminiInlineDataParts() {
+        func geminiImageMessage(_ text: String) -> [String: Any] {
+            ["role": "user", "parts": [
+                ["inlineData": ["mimeType": "image/jpeg", "data": "AAAA"]],
+                ["text": text],
+            ]]
+        }
+        let pruned = HistoryHygiene.pruneImages(
+            [geminiImageMessage("first"), geminiImageMessage("second")], keepLast: 1)
+        let firstParts = pruned[0]["parts"] as? [[String: Any]]
+        XCTAssertFalse(firstParts?.contains { $0["inlineData"] != nil } ?? true,
+                       "old Gemini inlineData should be pruned")
+        XCTAssertTrue(firstParts?.contains { ($0["text"] as? String) == HistoryHygiene.prunedImagePlaceholder } ?? false,
+                      "placeholder lands as a bare-text part, not a typed block")
+        let secondParts = pruned[1]["parts"] as? [[String: Any]]
+        XCTAssertTrue(secondParts?.contains { $0["inlineData"] != nil } ?? false,
+                      "newest image must be kept")
+    }
+
     // MARK: - Token estimation
 
     func testImageBlockCountsMoreThanTheFloor() {

--- a/OpenGlassesTests/LLMImagePreparerTests.swift
+++ b/OpenGlassesTests/LLMImagePreparerTests.swift
@@ -3,7 +3,7 @@ import UIKit
 @testable import OpenGlasses
 
 /// Verifies the outgoing-image guard that keeps cloud vision requests under Anthropic's
-/// 5 MB inline-image cap (and ~1568 px long-edge ceiling). This matters specifically on
+/// 5 MB inline-image cap (and the high-res 2576 px long-edge ceiling). This matters specifically on
 /// the iPhone-camera fallback / photo-tool paths, which capture at full sensor resolution
 /// — the one place a 12 MP JPEG can blow past 5 MB and 400 the request.
 final class LLMImagePreparerTests: XCTestCase {
@@ -33,7 +33,7 @@ final class LLMImagePreparerTests: XCTestCase {
         let out = LLMImagePreparer.prepared(input)
         XCTAssertLessThanOrEqual(longEdge(of: out), Int(LLMImagePreparer.maxLongEdge))
         XCTAssertLessThanOrEqual(out.count, LLMImagePreparer.maxBytes)
-        // Aspect ratio preserved (3:2 → long edge 1568, short edge ~1045).
+        // Aspect ratio preserved (3:2 → long edge 2576, short edge ~1717).
         if let cg = UIImage(data: out)?.cgImage {
             XCTAssertEqual(Double(cg.width) / Double(cg.height), 3.0 / 2.0, accuracy: 0.02)
         }

--- a/OpenGlassesTests/MCPTransportTests.swift
+++ b/OpenGlassesTests/MCPTransportTests.swift
@@ -105,6 +105,60 @@ final class MCPTransportTests: XCTestCase {
         }
     }
 
+    // MARK: - MCP session handshake + SSE framing (Streamable HTTP)
+
+    func testFirstRequestPerformsInitializeHandshake() async throws {
+        MockURLProtocol.reset()
+        MockURLProtocol.responseBody = Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.utf8)
+
+        let server = MCPServerConfig(id: "hs", label: "FastMCP", url: "https://example.test/mcp",
+                                     headers: [:], enabled: true)
+        let transport = HTTPTransport(session: MockURLProtocol.session())
+        _ = try await transport.request(["jsonrpc": "2.0", "id": 1, "method": "tools/list"], server: server)
+
+        // initialize + notifications/initialized + the real payload.
+        XCTAssertEqual(MockURLProtocol.requestCount, 3)
+        // Streamable HTTP requires accepting both response framings on every request.
+        let captured = try XCTUnwrap(MockURLProtocol.lastRequest)
+        XCTAssertEqual(captured.value(forHTTPHeaderField: "Accept"), "application/json, text/event-stream")
+
+        // Second request on the same server reuses the session — no re-handshake.
+        _ = try await transport.request(["jsonrpc": "2.0", "id": 2, "method": "tools/list"], server: server)
+        XCTAssertEqual(MockURLProtocol.requestCount, 4)
+    }
+
+    func testSessionIDFromInitializeIsSentOnSubsequentRequests() async throws {
+        MockURLProtocol.reset()
+        MockURLProtocol.responseBody = Data(#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#.utf8)
+        MockURLProtocol.responseHeaders = ["mcp-session-id": "sess-123"]
+
+        let server = MCPServerConfig(id: "sid", label: "Sessioned", url: "https://example.test/mcp",
+                                     headers: [:], enabled: true)
+        let transport = HTTPTransport(session: MockURLProtocol.session())
+        _ = try await transport.request(["jsonrpc": "2.0", "id": 1, "method": "tools/list"], server: server)
+
+        let captured = try XCTUnwrap(MockURLProtocol.lastRequest)
+        XCTAssertEqual(captured.value(forHTTPHeaderField: "mcp-session-id"), "sess-123",
+                       "the session minted at initialize rides every later request")
+    }
+
+    func testSSEFramedResponseIsUnwrappedToJSON() async throws {
+        MockURLProtocol.reset()
+        // FastMCP frames POST responses as SSE even for a single JSON-RPC reply.
+        MockURLProtocol.responseHeaders = ["Content-Type": "text/event-stream"]
+        MockURLProtocol.responseBody = Data(
+            "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":7,\"result\":{\"tools\":[]}}\n\n".utf8)
+
+        let server = MCPServerConfig(id: "sse-framed", label: "FastMCP", url: "https://example.test/mcp",
+                                     headers: [:], enabled: true)
+        let transport = HTTPTransport(session: MockURLProtocol.session())
+        let data = try await transport.request(["jsonrpc": "2.0", "id": 7, "method": "tools/list"], server: server)
+
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["id"] as? Int, 7, "caller receives the unwrapped JSON-RPC payload, not SSE framing")
+        XCTAssertNotNil((json["result"] as? [String: Any])?["tools"])
+    }
+
     func testHTTPTransportThrowsOnHTTPError() async {
         MockURLProtocol.reset()
         MockURLProtocol.statusCode = 503
@@ -135,12 +189,17 @@ final class MockURLProtocol: URLProtocol {
     nonisolated(unsafe) static var lastBody: Data?
     nonisolated(unsafe) static var responseBody = Data("{}".utf8)
     nonisolated(unsafe) static var statusCode = 200
+    nonisolated(unsafe) static var responseHeaders: [String: String] = [:]
+    nonisolated(unsafe) static var requestCount = 0
 
     static func reset() {
         lastRequest = nil
         lastBody = nil
         responseBody = Data("{}".utf8)
         statusCode = 200
+        responseHeaders = [:]
+        requestCount = 0
+        HTTPTransport.resetSessions()   // the session cache is static — isolate tests
     }
 
     static func session() -> URLSession {
@@ -155,10 +214,13 @@ final class MockURLProtocol: URLProtocol {
     override func startLoading() {
         MockURLProtocol.lastRequest = request
         MockURLProtocol.lastBody = Self.readBody(from: request)
+        MockURLProtocol.requestCount += 1
 
+        var headers = ["Content-Type": "application/json"]
+        headers.merge(MockURLProtocol.responseHeaders) { _, new in new }
         let response = HTTPURLResponse(
             url: request.url!, statusCode: MockURLProtocol.statusCode,
-            httpVersion: "HTTP/1.1", headerFields: ["Content-Type": "application/json"])!
+            httpVersion: "HTTP/1.1", headerFields: headers)!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: MockURLProtocol.responseBody)
         client?.urlProtocolDidFinishLoading(self)

--- a/project.base.yml
+++ b/project.base.yml
@@ -108,7 +108,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "318"
+        CURRENT_PROJECT_VERSION: "319"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -176,7 +176,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "318"
+        CURRENT_PROJECT_VERSION: "319"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -214,7 +214,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "318"
+        CURRENT_PROJECT_VERSION: "319"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "318"
+        CURRENT_PROJECT_VERSION: "319"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "318"
+        CURRENT_PROJECT_VERSION: "319"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## Summary

Fixes across the MCP transport, the OpenAI-compatible LLM path, camera capture, and vision image sizing.

### MCP: Streamable HTTP session lifecycle (`MCPTransport`)
- `initialize` → `notifications/initialized` handshake on first contact; `mcp-session-id` carried on every later request; 400/406-without-session triggers one re-handshake retry.
- SSE-framed POST responses (`text/event-stream` — how FastMCP and the official TS server always answer) are unwrapped via the existing `SSEEventParser`, correlated to the JSON-RPC request id rather than blindly taking the first event.
- Servers that implement neither still work — a failed handshake marks "no session" and the request proceeds as before.
- Session cache invalidated on server config changes (a rotated token re-handshakes) — composes with the #246 edit-in-place work.

### LLM: Gemini tool-call hardening (`LLMService`)
- The tool_call parser required `id` and `arguments` and silently dropped calls missing either — Gemini's OpenAI-compat endpoint omits both on no-arg tools, so a perfectly good tool_call produced an empty spoken reply and no execution. Now only `function.name` is required; missing id is synthesized, missing arguments defaults to `{}`; one per-turn log line shows parsed-vs-sent.
- `finalize` tolerates tool-call turns where Gemini omits `content` (previously failed the whole conversation after a successful tool run).
- `.custom` endpoints now get tools (Gemini/vLLM/new Ollama all speak OpenAI function calling), with a safety net: a 400 on the tools payload retries once without tools and remembers for the session — old Ollama builds keep working.
- Image pruning (`keepLast: 1`) hoisted from the Anthropic request builder into `sendMessage`, so Gemini/OpenAI paths stop re-uploading stale photos (context-overflow fix); `HistoryHygiene` extended to recognise OpenAI `image_url` and Gemini `parts`/`inlineData` shapes, not just Anthropic blocks.

### Camera (`CameraService`)
- Transient `.stopped` during stream warm-up gets up to 3 `start()` nudges instead of aborting the capture (cold start bounces through `.stopped` for ~15–18s).
- Photo continuation timeout 5s → 8s (cold WiFi-transport captures often land at 5–7s).

### Vision (`LLMImagePreparer`)
- Long-edge ceiling 1568 → 2576 px — current Claude models (incl. our default `claude-sonnet-5`) support high-res vision at 2576; older models downscale server-side. More image tokens per photo, bounded by the history pruning above, and the fidelity directly helps instrument-reading / text-in-scene captures. 5 MB byte guard unchanged.

### Gateway (`OpenClawBridge`)
- Cached endpoint is dropped after 3 consecutive WebSocket failures so `resolve` re-probes LAN → tunnel (previously a stale cached endpoint made the gateway look permanently offline).

### Tests
- MCP handshake (3 requests on first contact, session reuse), session-id propagation, SSE-framed response unwrapping; `MockURLProtocol` gains response headers + request counting + static-session isolation.
- Multi-format image pruning (OpenAI + Gemini shapes).

### Verification
Release gate green at the 13-failure environmental baseline (unsigned-runner keychain tests). Build 319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)