### PR TITLE
Pin mlx-swift-lm 3.31.3 — restore Gemma 4 on-device vision

### DIFF
--- a/ci_scripts/Package.resolved
+++ b/ci_scripts/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
-        "version" : "3.31.4"
+        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
+        "version" : "3.31.3"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
-        "version" : "603.0.2"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {

--- a/project.base.yml
+++ b/project.base.yml
@@ -64,7 +64,7 @@ packages:
     from: "2.2.5"
   mlx-swift-lm:
     url: https://github.com/ml-explore/mlx-swift-lm.git
-    version: "3.31.4"
+    version: "3.31.3"
   swift-huggingface:
     url: https://github.com/huggingface/swift-huggingface.git
     from: "0.1.0"
@@ -108,7 +108,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "322"
+        CURRENT_PROJECT_VERSION: "323"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -176,7 +176,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "322"
+        CURRENT_PROJECT_VERSION: "323"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -214,7 +214,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "322"
+        CURRENT_PROJECT_VERSION: "323"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "322"
+        CURRENT_PROJECT_VERSION: "323"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "322"
+        CURRENT_PROJECT_VERSION: "323"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## Summary

Pins `mlx-swift-lm` from 3.31.4 to **3.31.3**, restoring the native Gemma 4 VLM load — which makes Gemma 4 a real on-device *vision* model in OpenGlasses instead of demoting to text-only.

### Why
Under our 3.31.4 pin, loading `mlx-community/gemma-4-E2B-it-4bit` (and E4B) through `VLMModelFactory` fails at `model.update(parameters:verify:)` with `keyNotFound(language_model…k_norm.weight)`. Root cause from our earlier investigation: Gemma 4's KV-shared layers own no `k_proj`/`v_proj`/`k_norm` tensors, and when `num_kv_shared_layers` doesn't decode from the checkpoint's config, 3.31.4 builds those module slots anyway while the checkpoint (correctly) omits them. The same checkpoint loads cleanly on 3.31.3 — a version-linked regression, not a broken checkpoint.

### Safety
- **Attempt-and-demote is unchanged** — if the VLM load fails anywhere, behaviour is exactly today's (Gemma 4 runs as text-only). The pin can only improve the outcome.
- Full test suite green against 3.31.3 (13-failure environmental baseline) — all MLX call sites (token-shape handling, hub download, generation) compile and pass unchanged.
- `ci_scripts/Package.resolved` refreshed so Xcode Cloud resolves the same pin.

### Pending — on-device verification
MLX doesn't run on the simulator, so the discriminating test is on the phone: load Gemma 4 E2B, ask a photo question, and confirm (a) the VLM-factory load succeeds with no `k_norm` keyNotFound, and (b) no jetsam during image encode — our 896² image cap plus the memory budget should hold it. A device build including this pin is queued.

Build 323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)