### PR TITLE
Hands-free "new topic": voice-cleared conversation context

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -876,6 +876,20 @@ class AppState: ObservableObject, AppStateProtocol {
             }
         }
 
+        // Hands-free "new topic" — the new_topic tool posts this; clear the LLM's context
+        // (deferred-safe when a turn is in flight) and start a fresh persistence thread so the
+        // conversation history view also breaks here.
+        NotificationCenter.default.addObserver(forName: .ogNewTopicRequested, object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                self.llmService.requestHistoryClear()
+                if Config.conversationPersistenceEnabled {
+                    self.conversationStore.startThread(mode: self.currentMode.rawValue, personaId: self.activePersona?.id)
+                }
+                NSLog("[AppState] New topic — conversation context cleared")
+            }
+        }
+
         // Wire camera frames for realtime sessions:
         // Direct push: CameraService streams frames to whichever session is active
         cameraService.onVideoFrame = { [weak self] image in

--- a/OpenGlasses/Sources/Services/ConversationClassifier.swift
+++ b/OpenGlasses/Sources/Services/ConversationClassifier.swift
@@ -161,8 +161,21 @@ struct ConversationClassifier {
             return DirectToolCall(toolName: "calendar", arguments: ["action": action])
         }
 
+        // "New topic" — a bare conversation-reset command clears context without an LLM turn.
+        // Bare-query gated: "new topic" inside a longer sentence ("write about a new topic for
+        // my essay") must reach the LLM as content, not wipe the conversation.
+        if let matched = matchedPattern(text, patterns: newTopicPatterns), isBareQuery(text, matched: matched) {
+            return DirectToolCall(toolName: "new_topic", arguments: [:])
+        }
+
         return nil
     }
+
+    private let newTopicPatterns = [
+        "new topic", "new conversation", "start over", "start fresh", "start again",
+        "clear the conversation", "clear conversation", "clear our conversation",
+        "forget this conversation", "forget that", "reset the conversation", "fresh start"
+    ]
 
     /// Match an informational calendar question and pick the tool action for it, or nil.
     /// Three gates: names a calendar-ish noun, is NOT a creation command, and has an
@@ -219,7 +232,9 @@ struct ConversationClassifier {
         // Weather tier-0 ("what is the weather where I am", "what's the weather like
         // outside"). Additions only widen what counts as bare; anything with real content
         // words still reaches the LLM.
-        "what", "where", "am", "like", "outside", "here", "tomorrow", "for"
+        "what", "where", "am", "like", "outside", "here", "tomorrow", "for",
+        // New-topic tier-0 ("let's start a new topic", "can we start over", "okay new topic").
+        "let", "lets", "a", "we", "can", "okay", "ok", "just", "start"
     ]
 
     // MARK: - Tier 1: Prompt Section Detection

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -451,7 +451,17 @@ class LLMService: ObservableObject {
     ///   concatenate with the final reply (BM P9).
     func sendMessage(_ text: String, locationContext: String? = nil, imageData: Data? = nil, memoryContext: String? = nil, agentContext: String? = nil, playbookContext: String? = nil, nowPlayingContext: String? = nil, shortcutsContext: String? = nil, promptSections: ConversationClassifier.PromptSections? = nil, onToken: ((String) -> Void)? = nil, onStreamReset: (() -> Void)? = nil) async throws -> String {
         isProcessing = true
-        defer { isProcessing = false }
+        defer {
+            isProcessing = false
+            // A "new topic" requested DURING this turn (the model called the new_topic tool)
+            // applies now that the turn is complete — clearing mid-loop would orphan the
+            // pending tool_result and 400 the next request.
+            if pendingHistoryClear {
+                pendingHistoryClear = false
+                clearHistory()
+                NSLog("[LLMService] History cleared (deferred new-topic request)")
+            }
+        }
 
         // Compress context window if conversation history has grown too large
         // Use LLM summarization in agentic mode, heuristic fallback otherwise
@@ -687,6 +697,20 @@ class LLMService: ObservableObject {
     }
 
     /// Clear conversation history (e.g. when starting fresh or switching providers)
+    /// Set when a "new topic" arrives while a turn is in flight; applied in `sendMessage`'s defer.
+    private var pendingHistoryClear = false
+
+    /// Clear the conversation history — immediately when idle, or after the in-flight turn
+    /// completes when the model itself requested it via the `new_topic` tool (a mid-loop wipe
+    /// would orphan the pending tool_result).
+    func requestHistoryClear() {
+        if isProcessing {
+            pendingHistoryClear = true
+        } else {
+            clearHistory()
+        }
+    }
+
     func clearHistory() {
         conversationHistory.removeAll()
     }

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
@@ -23,6 +23,7 @@ final class NativeToolRegistry {
         register(weatherTool)
         register(dateTimeTool)
         register(CalculatorTool())
+        register(NewTopicTool())
         register(UnitConversionTool())
         register(TimerTool())
         register(SaveNoteTool())

--- a/OpenGlasses/Sources/Services/NativeTools/NewTopicTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NewTopicTool.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+extension Notification.Name {
+    /// Posted when the user asks for a fresh conversation ("new topic", "start over"). AppState
+    /// observes it and clears the LLM history + starts a new persistence thread — the tool stays
+    /// decoupled from those services, matching how the registry is wired before AppState finishes
+    /// building.
+    static let ogNewTopicRequested = Notification.Name("OGNewTopicRequested")
+}
+
+/// Hands-free conversation reset. Reachable two ways: the classifier's Tier-0 deterministic route
+/// (a bare "new topic" never burns an LLM turn) and normal tool-calling for phrasings the
+/// classifier doesn't match ("please forget everything we just talked about").
+///
+/// The actual clearing is deferred-safe: `LLMService.requestHistoryClear()` clears immediately when
+/// idle, but waits for the in-flight turn to finish when the LLM itself invoked this tool —
+/// wiping history mid-loop would orphan the pending tool_result and 400 the next request.
+@MainActor
+final class NewTopicTool: NativeTool {
+    let name = "new_topic"
+    let description = """
+    Start a fresh conversation: clears the assistant's memory of the current chat so the next \
+    question starts with a clean slate. Use when the user says "new topic", "start over", "start \
+    fresh", "clear the conversation", or "forget this conversation". Takes no parameters. Saved \
+    notes, memories, and settings are NOT affected — only the current chat context.
+    """
+    let parametersSchema: [String: Any] = [
+        "type": "object",
+        "properties": [:] as [String: Any]
+    ]
+
+    func execute(args: [String: Any]) async throws -> String {
+        NotificationCenter.default.post(name: .ogNewTopicRequested, object: nil)
+        return "Okay — fresh start. What would you like to talk about?"
+    }
+}

--- a/OpenGlassesTests/ConversationClassifierTests.swift
+++ b/OpenGlassesTests/ConversationClassifierTests.swift
@@ -59,6 +59,33 @@ final class ConversationClassifierTests: XCTestCase {
         }
     }
 
+    // MARK: - New topic (hands-free context clear)
+
+    func testNewTopicCommandsMatchDirectly() {
+        for query in ["new topic",
+                      "let's start a new topic",
+                      "start over",
+                      "can we start fresh",
+                      "clear the conversation",
+                      "okay new conversation",
+                      "forget this conversation"] {
+            XCTAssertEqual(classifier.classify(query).directToolCall?.toolName, "new_topic",
+                           "'\(query)' should directly clear context")
+        }
+    }
+
+    /// "New topic" as CONTENT (not a command) must reach the LLM — a substring match here
+    /// would wipe the user's conversation mid-thought.
+    func testNewTopicInsideContentDoesNotMatch() {
+        for query in ["suggest a new topic for my essay",
+                      "write about a new topic in quantum computing",
+                      "when we start over in january what changes",
+                      "help me start over with this recipe from step three"] {
+            XCTAssertNil(classifier.classify(query).directToolCall,
+                         "'\(query)' is content, not a reset command")
+        }
+    }
+
     /// Creation and modification must still reach the LLM — they need title/time extraction.
     func testCalendarMutationsDoNotMatchDirectly() {
         for query in ["add a meeting to my calendar tomorrow at 3pm",

--- a/project.base.yml
+++ b/project.base.yml
@@ -108,7 +108,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "323"
+        CURRENT_PROJECT_VERSION: "324"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -176,7 +176,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "323"
+        CURRENT_PROJECT_VERSION: "324"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -214,7 +214,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "323"
+        CURRENT_PROJECT_VERSION: "324"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "323"
+        CURRENT_PROJECT_VERSION: "324"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "323"
+        CURRENT_PROJECT_VERSION: "324"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## Hands-free "new topic"

Adds a voice-driven conversation reset so the wearer can start a fresh chat without touching the phone.

### What's in it
- **`NewTopicTool`** (`new_topic`) — a no-argument native tool that posts a `.ogNewTopicRequested` notification. Reachable two ways:
  - the classifier's **Tier-0 deterministic route** for bare commands ("new topic", "start over", "start fresh", "clear the conversation", "forget this conversation") — these never burn an LLM turn;
  - normal tool-calling for phrasings the classifier doesn't match ("please forget everything we just talked about").
- **Bare-query gating** in `ConversationClassifier` — "new topic" inside a longer sentence ("write about a new topic for my essay") still reaches the LLM as content instead of wiping the conversation.
- **Deferred-safe clear** — `LLMService.requestHistoryClear()` clears immediately when idle, but when the model itself invoked `new_topic` mid-turn it defers the wipe to `sendMessage`'s `defer`, so a pending `tool_result` is never orphaned (which would 400 the next request).
- **AppState observer** clears LLM history and starts a fresh persistence thread, so the conversation-history view also breaks at the reset point. Saved notes, memories, and settings are untouched — only the current chat context.

### Tests
`ConversationClassifierTests` cover both the command matches **and** the content non-matches (bare-query gating).

### Gate
Release `xcodebuild test` (unsigned simulator runner): green — only the 13 environmental keychain/config baseline failures, no product-code failures.
