### PR TITLE
Video recording: storage guard + stream-death auto-stop

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -744,6 +744,14 @@ class AppState: ObservableObject, AppStateProtocol {
         memoryRewind.wakeWordService = wakeWordService
         videoRecorder.wakeWordService = wakeWordService
         videoRecorder.ambientCaptionService = ambientCaptions
+        // Stream-death auto-stop: announce it — the user can't tell from inside a pocket that
+        // the glasses died and the recording was ended and saved.
+        videoRecorder.onAutoStopped = { [weak self] message in
+            guard let self else { return }
+            Task { @MainActor in
+                await self.speechService.speak(message)
+            }
+        }
         videoRecorder.hipaaService = hipaaService
         videoRecorder.meetingAssistant = meetingAssistant
         videoRecorder.llmClosure = { [weak self] prompt in

--- a/OpenGlasses/Sources/Services/NativeTools/VideoRecordingTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/VideoRecordingTool.swift
@@ -86,6 +86,10 @@ struct VideoRecordingTool: NativeTool {
                     response += " Live transcription is running — a text transcript will be saved alongside the video."
                 }
                 response += " Say 'stop recording' when you're done — there is no time limit."
+                // Low (but sufficient) disk: lead with the warning so it's actually heard.
+                if let warning = await MainActor.run(body: { recorder.lowStorageWarning }) {
+                    response = warning + " " + response
+                }
                 return response
             } catch {
                 return "Could not start recording: \(error.localizedDescription)"

--- a/OpenGlasses/Sources/Services/VideoRecordingService.swift
+++ b/OpenGlasses/Sources/Services/VideoRecordingService.swift
@@ -78,6 +78,70 @@ class VideoRecordingService: ObservableObject {
         return String(format: "%02d:%02d", mins, secs)
     }
 
+    // MARK: - Storage guard
+
+    /// Recording refuses to start below this free-disk floor (a dying write corrupts the MP4).
+    static let minimumFreeBytes: Int64 = 200 * 1_000_000
+    /// Below this, recording still starts but the caller should warn with the estimated headroom.
+    static let lowStorageBytes: Int64 = 2_000 * 1_000_000
+
+    enum StorageVerdict: Equatable {
+        case ok
+        /// Enough to record, but low — carries the estimated minutes of recording left.
+        case low(minutesRemaining: Int)
+        case insufficient
+    }
+
+    /// Pure storage decision (testable): free bytes + the actual encode bitrates → verdict.
+    static func storageVerdict(freeBytes: Int64, videoBitrate: Int, audioBitrate: Int = 64_000) -> StorageVerdict {
+        if freeBytes < minimumFreeBytes { return .insufficient }
+        guard freeBytes < lowStorageBytes else { return .ok }
+        let bytesPerSecond = max(Double(videoBitrate + audioBitrate) / 8, 1)
+        let minutes = Int(Double(freeBytes) / bytesPerSecond / 60)
+        return .low(minutesRemaining: minutes)
+    }
+
+    /// Free disk space usable for a recording (importantUsage — iOS may free purgeable space).
+    static func freeDiskBytes() -> Int64? {
+        let values = try? URL(fileURLWithPath: NSHomeDirectory())
+            .resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        return values?.volumeAvailableCapacityForImportantUsage
+    }
+
+    /// Thrown when there isn't enough disk left to record safely.
+    struct InsufficientStorageError: LocalizedError {
+        var errorDescription: String? {
+            "Not enough storage to record — free up some space and try again."
+        }
+    }
+
+    /// Non-nil right after a recording starts with low (but sufficient) storage: a spoken-style
+    /// warning with the estimated minutes remaining. The caller announces it once.
+    private(set) var lowStorageWarning: String?
+
+    // MARK: - Stream-death auto-stop
+
+    /// Called when recording auto-stops because frames stopped arriving (glasses died: battery,
+    /// thermal shutdown, out of range). Carries a spoken-style message; the file up to the stall
+    /// is saved normally first.
+    var onAutoStopped: ((String) -> Void)?
+
+    /// Seconds without a frame (after at least one arrived) before recording auto-stops.
+    static let frameStallSeconds: TimeInterval = 15
+
+    /// Wall-clock of the most recent appended frame (nil until the first frame arrives).
+    /// Written from the background frame queue, read by the main-actor watchdog tick.
+    private nonisolated(unsafe) var lastFrameAt: Date?
+
+    /// Pure watchdog decision (testable): stop only when recording, at least one frame has ever
+    /// arrived, and the stream has been silent past the stall threshold. A recording that never
+    /// received a frame is left alone — the user may still be waiting for the stream to warm up.
+    static func shouldAutoStop(isRecording: Bool, lastFrameAt: Date?, now: Date,
+                               stallSeconds: TimeInterval = frameStallSeconds) -> Bool {
+        guard isRecording, let lastFrameAt else { return false }
+        return now.timeIntervalSince(lastFrameAt) >= stallSeconds
+    }
+
     /// Start recording video + audio.
     /// - Parameters:
     ///   - publisher: Video frame publisher from CameraService
@@ -89,6 +153,19 @@ class VideoRecordingService: ObservableObject {
         outputSize: CGSize? = nil
     ) throws {
         guard !isRecording else { return }
+
+        // Storage guard: refuse when a write-out would die mid-file; warn when it's just low.
+        lowStorageWarning = nil
+        if let free = Self.freeDiskBytes() {
+            switch Self.storageVerdict(freeBytes: free, videoBitrate: bitrate) {
+            case .insufficient:
+                throw InsufficientStorageError()
+            case .low(let minutes):
+                lowStorageWarning = "Heads up — storage is low. About \(minutes) minutes of recording space left."
+            case .ok:
+                break
+            }
+        }
 
         let tempDir = FileManager.default.temporaryDirectory
         let fileName = "OpenGlasses_\(Int(Date().timeIntervalSince1970)).mp4"
@@ -158,6 +235,7 @@ class VideoRecordingService: ObservableObject {
         self.poolHeight = 0
         self.recordingDuration = 0
         self.recordingStartDate = Date()
+        self.lastFrameAt = nil
         self.recordingTranscript = ""
         self.transcriptEntries = []
         self.isRecording = true
@@ -197,12 +275,29 @@ class VideoRecordingService: ObservableObject {
                 if self.autoTranscribe {
                     self.collectCaptions()
                 }
+                // Stream-death watchdog: if the glasses died (battery/thermal/range), stop and
+                // SAVE rather than idling forever on a stalled stream.
+                if Self.shouldAutoStop(isRecording: self.isRecording, lastFrameAt: self.lastFrameAt, now: Date()) {
+                    await self.autoStopForStalledStream()
+                }
             }
         }
 
         NSLog("[Recording] Started (video+audio) → %@ (%dx%d @ %d bps)",
               url.lastPathComponent, encodedWidth, encodedHeight, bitrate)
         hipaaService?.log(action: "RECORDING_STARTED", detail: "Video+audio recording started")
+    }
+
+    /// Stream-death auto-stop: finish and save the recording normally (everything captured up
+    /// to the stall is kept), then tell the caller so it can be announced.
+    private func autoStopForStalledStream() async {
+        let duration = formattedDuration
+        NSLog("[Recording] No frames for %.0fs — auto-stopping (glasses stream died)", Self.frameStallSeconds)
+        let url = await stopRecording()
+        let saved = url != nil
+        onAutoStopped?(saved
+            ? "The glasses stopped sending video, so I've ended the recording and saved the \(duration) captured so far."
+            : "The glasses stopped sending video and the recording could not be saved.")
     }
 
     /// Stop recording and return the URL of the finished .mp4.
@@ -419,6 +514,7 @@ class VideoRecordingService: ObservableObject {
     // MARK: - Frame Appending
 
     private nonisolated func appendFrame(_ image: UIImage) {
+        lastFrameAt = Date()   // feeds the stream-death watchdog
         guard let cgImage = image.cgImage else { return }
 
         let width = cgImage.width

--- a/OpenGlassesTests/VideoRecordingGuardTests.swift
+++ b/OpenGlassesTests/VideoRecordingGuardTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Pure-decision coverage for the recording guards: the storage verdict (refuse / warn-with-
+/// estimate / ok) and the stream-death watchdog (auto-stop only after frames have flowed and
+/// then stalled). The I/O edges (disk query, AVAssetWriter, timers) stay untested by design.
+@MainActor
+final class VideoRecordingGuardTests: XCTestCase {
+
+    // MARK: - Storage verdict
+
+    func testInsufficientBelowHardFloor() {
+        XCTAssertEqual(
+            VideoRecordingService.storageVerdict(freeBytes: 150_000_000, videoBitrate: 1_500_000),
+            .insufficient)
+    }
+
+    func testLowStorageCarriesMinutesEstimate() {
+        // 1 GB free at 1.5 Mbps video + 64 kbps audio ≈ 195.5 KB/s → ~85 minutes.
+        let verdict = VideoRecordingService.storageVerdict(freeBytes: 1_000_000_000, videoBitrate: 1_500_000)
+        guard case .low(let minutes) = verdict else {
+            return XCTFail("1 GB free should be low, got \(verdict)")
+        }
+        XCTAssertEqual(minutes, 85)
+    }
+
+    func testPlentyOfStorageIsOK() {
+        XCTAssertEqual(
+            VideoRecordingService.storageVerdict(freeBytes: 50_000_000_000, videoBitrate: 1_500_000),
+            .ok)
+    }
+
+    func testHigherBitrateShrinksTheEstimate() {
+        guard case .low(let slow) = VideoRecordingService.storageVerdict(freeBytes: 1_000_000_000, videoBitrate: 1_500_000),
+              case .low(let fast) = VideoRecordingService.storageVerdict(freeBytes: 1_000_000_000, videoBitrate: 6_000_000) else {
+            return XCTFail("both should be low")
+        }
+        XCTAssertGreaterThan(slow, fast, "a higher bitrate must estimate fewer minutes")
+    }
+
+    // MARK: - Stream-death watchdog
+
+    func testNoAutoStopBeforeFirstFrame() {
+        // Waiting for the stream to warm up is not a stall — never stop a frameless recording.
+        XCTAssertFalse(VideoRecordingService.shouldAutoStop(
+            isRecording: true, lastFrameAt: nil, now: Date()))
+    }
+
+    func testNoAutoStopWhileFramesFlow() {
+        let now = Date()
+        XCTAssertFalse(VideoRecordingService.shouldAutoStop(
+            isRecording: true, lastFrameAt: now.addingTimeInterval(-2), now: now))
+    }
+
+    func testAutoStopAfterStall() {
+        let now = Date()
+        XCTAssertTrue(VideoRecordingService.shouldAutoStop(
+            isRecording: true,
+            lastFrameAt: now.addingTimeInterval(-VideoRecordingService.frameStallSeconds - 1),
+            now: now))
+    }
+
+    func testNoAutoStopWhenNotRecording() {
+        let now = Date()
+        XCTAssertFalse(VideoRecordingService.shouldAutoStop(
+            isRecording: false, lastFrameAt: now.addingTimeInterval(-600), now: now))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ The agentic path is hardened against **prompt injection** — untrusted content 
 - **Voice-Activated Photo Capture** — "take a picture" or "what's this?"
 - **QR/Barcode Scanner** — "scan this code" (Vision framework, works offline)
 - **Live Camera Preview** — real-time view of glasses POV
-- **Video Recording** — MP4 with configurable bitrate
+- **Video Recording** — MP4 with configurable bitrate, glasses-mic audio muxed in, optional live transcription. **No recording time limit** — say "record a video" and it runs until you say "stop recording" (built for meetings and long sessions; the practical limits are glasses battery/thermals and phone storage, not the app). If storage is low it warns with the estimated minutes left, and if the glasses stop mid-recording (battery, thermal shutdown, out of range) it automatically stops, saves everything captured, and tells you.
 - **RTMP Broadcasting** — live stream to YouTube, Twitch, Kick
 - **WebRTC Browser Streaming** — shareable URL for peer-to-peer viewing
 - **Privacy Filter** — auto-blurs bystander faces

--- a/project.base.yml
+++ b/project.base.yml
@@ -108,7 +108,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "323"
+        CURRENT_PROJECT_VERSION: "325"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -176,7 +176,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "323"
+        CURRENT_PROJECT_VERSION: "325"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -214,7 +214,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "323"
+        CURRENT_PROJECT_VERSION: "325"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "323"
+        CURRENT_PROJECT_VERSION: "325"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "323"
+        CURRENT_PROJECT_VERSION: "325"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## Video recording hardening

Makes long, hands-free recordings survive the two failure modes the wearer can't see coming: running out of disk mid-write, and the glasses dying mid-recording.

### What's in it
- **Storage guard at `startRecording`** — a pure, testable `storageVerdict(freeBytes:videoBitrate:audioBitrate:)`:
  - **refuses** below a 200 MB hard floor (a write that dies mid-file corrupts the MP4);
  - **warns but proceeds** below 2 GB, leading the spoken start response with the estimated minutes of recording space left (derived from the actual encode bitrate);
  - free space measured via `volumeAvailableCapacityForImportantUsage` so iOS can free purgeable space.
- **15s frame-stall watchdog** — `shouldAutoStop(isRecording:lastFrameAt:now:)` auto-stops when frames stop arriving after at least one has flowed (glasses battery/thermal/range death). It **saves** everything captured up to the stall, then announces via TTS ("The glasses stopped sending video, so I've ended the recording and saved the … captured so far") — the wearer can't tell from inside a pocket that the stream died. A recording that never received a frame is left alone (still warming up).
- **README note** clarifying recording has no app-side time limit.

### Tests
`VideoRecordingGuardTests` — pure-decision coverage of the storage verdict (refuse / warn-with-estimate / ok, plus bitrate sensitivity) and the watchdog (no-stop before first frame, no-stop while frames flow, no-stop when idle, stop after stall). I/O edges (disk query, AVAssetWriter, timers) are untested by design.

### Gate
Release `xcodebuild test` (unsigned simulator runner): green — `VideoRecordingGuardTests` all pass; only the 13 environmental keychain/config baseline failures remain, no product-code failures.

### Note
Branched from and merged with current main (build 325, sequential after #255).
