### PR TITLE
DAT field hardening: stall/pause discipline, capability-release waits, HUD blank-before-stop, playback resurrection, non-blocking Gemini tools (flagged)

### DIFF
--- a/OpenGlasses/Sources/Services/Audio/RealtimeAudioEngine.swift
+++ b/OpenGlasses/Sources/Services/Audio/RealtimeAudioEngine.swift
@@ -308,7 +308,22 @@ final class RealtimeAudioEngine {
     }
 
     private func playAudioOnQueue(data: Data) {
-        guard isCapturing, isPlayerNodeAttached, audioEngine.isRunning, !data.isEmpty else { return }
+        guard isCapturing, isPlayerNodeAttached, !data.isEmpty else { return }
+
+        // An AVAudioSession deactivation (sleep, another owner's session cycle) can leave
+        // the engine non-nil but silently dead: `isRunning == false` while the graph looks
+        // intact, and every scheduled buffer is swallowed without an error. Resurrect the
+        // engine before scheduling instead of dropping the response into the void.
+        if !audioEngine.isRunning {
+            do {
+                try audioEngine.start()
+                NSLog("%@ Playback engine was dead — restarted before scheduling", config.logPrefix)
+            } catch {
+                NSLog("%@ Playback engine restart failed (%@) — dropping %d bytes",
+                      config.logPrefix, error.localizedDescription, data.count)
+                return
+            }
+        }
 
         guard let playerFormat = try? AudioFormatFactory.pcm(
             .pcmFormatFloat32,

--- a/OpenGlasses/Sources/Services/CameraService.swift
+++ b/OpenGlasses/Sources/Services/CameraService.swift
@@ -168,6 +168,14 @@ class CameraService: ObservableObject {
     private var knownDeviceId: String?
     private var devicesListenerToken: Any?
 
+    /// True while `startStreaming()`'s continuous mode owns the stream (live voice modes
+    /// put the mic on the glasses concurrently) — drives the low-res contention floor in
+    /// `ensureSession`. Discrete photo sessions leave it false.
+    private var continuousStreamingIntent = false
+    /// Resolution tier the current stream was actually built at (post-policy), so
+    /// `startStreaming` can rebuild a photo-era low-res stream that would starve voice.
+    private var activeStreamResolution: String?
+
     /// Ensure the persistent stream session exists. Creates it on first call.
     private func ensureSession() async throws {
         guard streamSession == nil else { return }
@@ -234,8 +242,19 @@ class CameraService: ObservableObject {
             throw CameraError.streamNotReady
         }
 
+        // Continuous streaming in the live voice modes runs alongside glasses-mic audio;
+        // the policy floors "low" to "medium" there so video can't starve the voice link
+        // off the shared Bluetooth radio (see `StreamConfigPolicy`).
+        let effectiveResolution = StreamConfigPolicy.effectiveResolution(
+            requested: Config.cameraResolution,
+            concurrentGlassesVoice: continuousStreamingIntent
+        )
+        if effectiveResolution != Config.cameraResolution {
+            NSLog("[Camera] Resolution floored to %@ for streaming with glasses voice", effectiveResolution)
+            onDebugEvent?("Camera: low-res floored to medium while voice is on the glasses")
+        }
         let resolution: StreamingResolution = {
-            switch Config.cameraResolution {
+            switch effectiveResolution {
             case "low": return .low
             case "medium": return .medium
             default: return .high
@@ -252,9 +271,10 @@ class CameraService: ObservableObject {
             throw CameraError.streamNotReady
         }
         streamSession = stream
+        activeStreamResolution = effectiveResolution
         attachListeners(to: stream)
         // (session error watcher already attached above, before start)
-        NSLog("[Camera] Created persistent Stream (.\(Config.cameraResolution), \(fps)fps)")
+        NSLog("[Camera] Created persistent Stream (.\(effectiveResolution), \(fps)fps)")
     }
 
     /// BR P2: device-level errors (incl. `.datAppOnTheGlassesUpdateRequired`) arrive on the
@@ -424,6 +444,13 @@ class CameraService: ObservableObject {
     private(set) var lastCaptureSource: CaptureSource = .glasses
 
     /// Capture a photo from the glasses camera. Returns JPEG data.
+    ///
+    /// NOTE (device-reported, unverified here): `capturePhoto` also works on a stream that
+    /// was added but never `start()`ed, and capturing on a *streaming* stream has been
+    /// reported to race the frame flow and trip the glasses-side frame-stall watchdog.
+    /// Our start-then-capture path is field-traced and carries the frame fallback, so it
+    /// stays; if captures ever start stalling the stream, try the no-start discrete path
+    /// before reaching for bigger hammers.
     private func captureFromGlasses() async throws -> Data {
         isCaptureInProgress = true
         defer { isCaptureInProgress = false }
@@ -606,10 +633,26 @@ class CameraService: ObservableObject {
     func startStreaming() async throws {
         guard !isStreaming else { return }
         idleTeardownTask?.cancel()   // explicit streaming owns the session now
+        continuousStreamingIntent = true
 
-        try await ensurePermission()
-        try await ensureSession()
-        try await waitForStreaming()
+        // A stream left behind by the discrete photo path may sit at the user's "low"
+        // tier; continuous streaming with glasses-mic voice needs the contention floor
+        // (see `StreamConfigPolicy`), so rebuild it at the effective tier first.
+        if let active = activeStreamResolution,
+           StreamConfigPolicy.effectiveResolution(
+               requested: Config.cameraResolution,
+               concurrentGlassesVoice: true) != active {
+            await teardownStreamOnly()
+        }
+
+        do {
+            try await ensurePermission()
+            try await ensureSession()
+            try await waitForStreaming()
+        } catch {
+            continuousStreamingIntent = false
+            throw error
+        }
 
         isStreaming = true
         startStallDetection()
@@ -618,6 +661,7 @@ class CameraService: ObservableObject {
 
     /// Stop continuous video streaming. Session is kept alive for reuse.
     func stopStreaming() async {
+        continuousStreamingIntent = false
         guard isStreaming else { return }
         stopStallDetection()
         if let session = streamSession {
@@ -640,6 +684,15 @@ class CameraService: ObservableObject {
                 try? await Task.sleep(nanoseconds: 500_000_000) // Check every 0.5s
                 guard !Task.isCancelled, let self else { break }
                 guard self.isStreaming, !self.isRecoveringFromStall else { continue }
+
+                // Temple-tap pause is a system hold: no frames is expected, there is no
+                // app-callable resume, and tearing down collapses the channel the next
+                // tap would resume. Sit it out (and keep the clock fresh so recovery
+                // doesn't fire the instant the tap resumes the stream).
+                if !StreamRecoveryPolicy.shouldRecoverFromStall(state: self.streamSession?.state) {
+                    self.lastFrameTime = Date()
+                    continue
+                }
 
                 let elapsed = Date().timeIntervalSince(self.lastFrameTime)
                 if elapsed > 1.5 {
@@ -669,7 +722,7 @@ class CameraService: ObservableObject {
 
         switch action {
         case .rebuildStream:
-            teardownStreamOnly()
+            await teardownStreamOnly()
         case .resetSession:
             await resetSession()
         }
@@ -696,22 +749,43 @@ class CameraService: ObservableObject {
     /// BR P2: drop the Stream and its listeners but keep the DeviceSession alive — a failed
     /// stream must not strand a half-open session (`ensureSession` re-adds the stream on
     /// the retained session).
-    private func teardownStreamOnly() {
-        streamSession?.stop()
+    private func teardownStreamOnly() async {
+        if let stream = streamSession {
+            stream.stop()
+            await awaitStreamStopped(stream)
+        }
         stateListenerToken = nil
         videoFrameListenerToken = nil
         photoListenerToken = nil
         errorListenerToken = nil
         streamSession = nil
+        activeStreamResolution = nil
         NSLog("[Camera] Stream torn down (session retained)")
+    }
+
+    /// Bounded wait for a stopped stream to actually reach `.stopped`. The camera
+    /// capability is process-wide and is freed when the stream finishes stopping — not
+    /// when the session is torn down — so arming a replacement stream before then throws
+    /// `capabilityAlreadyActive`. `stop()` is synchronous but the state transition isn't.
+    private func awaitStreamStopped(_ stream: MWDATCamera.Stream, timeout: Duration = .seconds(2)) async {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if stream.state == .stopped { return }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        NSLog("[Camera] Stream did not reach .stopped within %.0fs — proceeding",
+              Double(timeout.components.seconds))
     }
 
     /// Reset the session completely (for error recovery).
     private func resetSession() async {
         sessionErrorTask?.cancel()
         sessionErrorTask = nil
-        if let session = streamSession {
-            session.stop()
+        if let stream = streamSession {
+            stream.stop()
+            // Wait for the capability to actually free (see `awaitStreamStopped`) so the
+            // retry loop's next `ensureSession` doesn't collide with the dying stream.
+            await awaitStreamStopped(stream)
         }
         deviceSession?.stop()
         stateListenerToken = nil
@@ -719,12 +793,12 @@ class CameraService: ObservableObject {
         photoListenerToken = nil
         errorListenerToken = nil
         streamSession = nil
+        activeStreamResolution = nil
         deviceSession = nil
         // A torn-down session's frames must not survive to serve as "photos" for the next
         // capture — the staleness gate is belt, this is braces.
         latestFrame = nil
         lastFrameTime = .distantPast
-        latestFrame = nil
         NSLog("[Camera] Session reset")
     }
 

--- a/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveService.swift
+++ b/OpenGlasses/Sources/Services/GeminiLive/GeminiLiveService.swift
@@ -318,7 +318,17 @@ class GeminiLiveService: ObservableObject {
     private func sendSetupMessage() {
         var toolsArray: [[String: Any]] = []
         if !toolDeclarations.isEmpty {
-            toolsArray = [["functionDeclarations": toolDeclarations]]
+            // Flag-gated: NON_BLOCKING lets the model keep the conversation going while a
+            // tool runs; the router then acks slow calls and defers results WHEN_IDLE
+            // (`ToolCallRouter.toolResponse(phase:)`). Off by default — shape change.
+            let declarations = Config.geminiNonBlockingToolsEnabled
+                ? toolDeclarations.map { decl -> [String: Any] in
+                    var d = decl
+                    d["behavior"] = "NON_BLOCKING"
+                    return d
+                }
+                : toolDeclarations
+            toolsArray = [["functionDeclarations": declarations]]
         }
 
         let setup: [String: Any] = [

--- a/OpenGlasses/Sources/Services/GlassesDisplayService.swift
+++ b/OpenGlasses/Sources/Services/GlassesDisplayService.swift
@@ -469,6 +469,12 @@ final class GlassesDisplayService: ObservableObject {
 
     private func teardownDisplay() async {
         if let display {
+            // Blank the waveguide BEFORE stopping, and give the clear a beat to land —
+            // stopping with content still up can surface the system home screen on the
+            // lens instead of going dark (device-traced ordering; iOS DAT has no
+            // `removeDisplay`, so clear → settle → stop is the whole discipline).
+            try? await display.clearDisplay()
+            try? await Task.sleep(nanoseconds: 200_000_000)
             display.stop()  // DAT 0.8.0: Display.stop() is synchronous
         }
         display = nil

--- a/OpenGlasses/Sources/Services/StreamRecoveryPolicy.swift
+++ b/OpenGlasses/Sources/Services/StreamRecoveryPolicy.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MWDATCore
+import MWDATCamera
 
 /// Plan BR P2 — tiered camera-stream recovery + DAT compatibility messaging (pure).
 ///
@@ -20,6 +21,30 @@ enum StreamRecoveryPolicy {
     /// Consecutive failed recoveries (0 on the first attempt after healthy streaming).
     static func action(consecutiveFailures: Int) -> Action {
         consecutiveFailures < 2 ? .rebuildStream : .resetSession
+    }
+
+    /// Whether a frame-flow stall should trigger recovery at all, given the stream's
+    /// current state. `.paused` is the temple-tap system hold: frames stopping is the
+    /// EXPECTED behavior, there is no app-callable resume, and tearing the stream down
+    /// collapses the media channel the tap would otherwise resume. Recovery must wait
+    /// it out, not "fix" it.
+    static func shouldRecoverFromStall(state: StreamState?) -> Bool {
+        state != .paused
+    }
+}
+
+/// Chooses the effective stream configuration for a capture session (pure).
+///
+/// Device-traced: at low resolution the video stream can ride the *Bluetooth* radio
+/// instead of WiFi, starving the concurrent HFP/LE voice link — the glasses mic goes
+/// silent while frames keep flowing. Medium and above keep video on the WiFi transport.
+/// So when continuous streaming will run alongside glasses-mic audio (live voice modes),
+/// the configured "low" tier is floored to "medium"; discrete photo sessions keep the
+/// user's setting untouched.
+enum StreamConfigPolicy {
+    static func effectiveResolution(requested: String, concurrentGlassesVoice: Bool) -> String {
+        if concurrentGlassesVoice && requested == "low" { return "medium" }
+        return requested
     }
 }
 

--- a/OpenGlasses/Sources/Services/ToolCallRouter.swift
+++ b/OpenGlasses/Sources/Services/ToolCallRouter.swift
@@ -8,6 +8,15 @@ class ToolCallRouter {
     var nativeToolRouter: NativeToolRouter?
     private var inFlightTasks: [String: Task<Void, Never>] = [:]
 
+    /// Two-phase response support (`Config.geminiNonBlockingToolsEnabled`): calls still
+    /// running at `ackDelay` get an immediate ack (`willContinue` + SILENT scheduling) so
+    /// the model's open transaction closes fast; their final result is then delivered
+    /// WHEN_IDLE so the announcement never barges into the user. Fast calls keep the
+    /// plain single-response shape.
+    private var ackTimers: [String: Task<Void, Never>] = [:]
+    private var ackedCallIds: Set<String> = []
+    static let ackDelay: Duration = .seconds(1)
+
     /// Plan BR P1: per-session circuit breaker — bounds runaway tool loops. The session
     /// manager resets its user-turn window and reads `suspendedToolNames` when re-declaring
     /// tools on reconnect.
@@ -47,6 +56,19 @@ class ToolCallRouter {
 
         // Pause camera/audio streaming during tool execution to prevent instability
         onToolExecutionStarted?()
+
+        if Config.geminiNonBlockingToolsEnabled {
+            ackTimers[callId] = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: Self.ackDelay)
+                guard let self, !Task.isCancelled, self.inFlightTasks[callId] != nil else { return }
+                self.ackedCallIds.insert(callId)
+                NSLog("[ToolCall] %@ (id: %@) still running — sending non-blocking ack", callName, callId)
+                sendResponse(Self.toolResponse(
+                    callId: callId, name: callName,
+                    payload: ["result": "Still working — the result will follow."],
+                    phase: .ack))
+            }
+        }
 
         let argsKey = ToolCallBreaker.argsKey(call.args)
         let task = Task { @MainActor in
@@ -89,6 +111,7 @@ class ToolCallRouter {
             sendResponse(response)
 
             self.inFlightTasks.removeValue(forKey: callId)
+            self.ackTimers.removeValue(forKey: callId)?.cancel()
         }
 
         inFlightTasks[callId] = task
@@ -101,6 +124,8 @@ class ToolCallRouter {
                 task.cancel()
                 inFlightTasks.removeValue(forKey: id)
             }
+            ackTimers.removeValue(forKey: id)?.cancel()
+            ackedCallIds.remove(id)
         }
         bridge.lastToolCallStatus = .cancelled(ids.first ?? "unknown")
     }
@@ -111,6 +136,9 @@ class ToolCallRouter {
             task.cancel()
         }
         inFlightTasks.removeAll()
+        for (_, timer) in ackTimers { timer.cancel() }
+        ackTimers.removeAll()
+        ackedCallIds.removeAll()
     }
 
     // MARK: - Private
@@ -133,15 +161,50 @@ class ToolCallRouter {
         case .failure(let error):
             responseValue = ["error": error]
         }
+        let phase: ResponsePhase = ackedCallIds.remove(callId) != nil ? .finalAfterAck : .direct
+        return Self.toolResponse(callId: callId, name: name, payload: responseValue, phase: phase)
+    }
+
+    // MARK: - Response shape (pure, testable)
+
+    /// Which leg of the (possibly two-phase) exchange a response is.
+    enum ResponsePhase {
+        /// The only response for a call that finished fast — plain shape, model handles
+        /// delivery normally. Also used whenever the non-blocking flag is off.
+        case direct
+        /// Early ack for a still-running NON_BLOCKING call: `willContinue` keeps the call
+        /// open, SILENT scheduling stops the model narrating the ack.
+        case ack
+        /// The real result after an ack: WHEN_IDLE scheduling so the announcement waits
+        /// for the user's turn to finish instead of interrupting.
+        case finalAfterAck
+    }
+
+    /// Build the wire shape for one function response. Static + value-in/value-out so
+    /// tests can pin the exact payload per phase.
+    nonisolated static func toolResponse(
+        callId: String,
+        name: String,
+        payload: [String: Any],
+        phase: ResponsePhase
+    ) -> [String: Any] {
+        var functionResponse: [String: Any] = [
+            "id": callId,
+            "name": name,
+            "response": payload
+        ]
+        switch phase {
+        case .direct:
+            break
+        case .ack:
+            functionResponse["willContinue"] = true
+            functionResponse["scheduling"] = "SILENT"
+        case .finalAfterAck:
+            functionResponse["scheduling"] = "WHEN_IDLE"
+        }
         return [
             "toolResponse": [
-                "functionResponses": [
-                    [
-                        "id": callId,
-                        "name": name,
-                        "response": responseValue
-                    ]
-                ]
+                "functionResponses": [functionResponse]
             ]
         ]
     }

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -1711,6 +1711,19 @@ struct Config {
         !geminiLiveAPIKey.isEmpty
     }
 
+    /// Two-phase tool responses for Gemini Live: declare functions NON_BLOCKING, ack a
+    /// slow call fast (`willContinue` + SILENT) so the model's open transaction closes,
+    /// then deliver the real result WHEN_IDLE so it never barges into the user's turn.
+    /// Default OFF until validated against the live endpoint on device — the setup and
+    /// response payload shapes change when enabled.
+    static var geminiNonBlockingToolsEnabled: Bool {
+        UserDefaults.standard.object(forKey: "geminiNonBlockingToolsEnabled") as? Bool ?? false
+    }
+
+    static func setGeminiNonBlockingToolsEnabled(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: "geminiNonBlockingToolsEnabled")
+    }
+
     // MARK: - OpenAI Realtime Configuration
 
     /// Find the best OpenAI model config for Realtime mode.

--- a/OpenGlassesTests/DATFieldHardeningTests.swift
+++ b/OpenGlassesTests/DATFieldHardeningTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+import MWDATCamera
+@testable import OpenGlasses
+
+/// Field-hardening sweep: paused-aware stall recovery, the low-res/voice contention
+/// floor, and the flag-gated two-phase Gemini Live tool-response shapes.
+final class DATFieldHardeningTests: XCTestCase {
+
+    // MARK: - Stall recovery vs temple-tap pause
+
+    func testStallRecoverySkipsPausedStream() {
+        XCTAssertFalse(StreamRecoveryPolicy.shouldRecoverFromStall(state: .paused),
+                       "temple-tap pause is a system hold — recovery must wait it out")
+    }
+
+    func testStallRecoveryProceedsForActiveOrUnknownStates() {
+        XCTAssertTrue(StreamRecoveryPolicy.shouldRecoverFromStall(state: .streaming))
+        XCTAssertTrue(StreamRecoveryPolicy.shouldRecoverFromStall(state: .stopped))
+        XCTAssertTrue(StreamRecoveryPolicy.shouldRecoverFromStall(state: .waitingForDevice))
+        XCTAssertTrue(StreamRecoveryPolicy.shouldRecoverFromStall(state: nil),
+                      "no stream reference must not suppress recovery")
+    }
+
+    // MARK: - Stream resolution contention floor
+
+    func testLowResolutionFlooredWhenVoiceRidesGlasses() {
+        XCTAssertEqual(
+            StreamConfigPolicy.effectiveResolution(requested: "low", concurrentGlassesVoice: true),
+            "medium",
+            "low-res streaming shares the Bluetooth radio with the voice link")
+    }
+
+    func testResolutionUntouchedWithoutConcurrentVoice() {
+        XCTAssertEqual(
+            StreamConfigPolicy.effectiveResolution(requested: "low", concurrentGlassesVoice: false),
+            "low")
+    }
+
+    func testHigherTiersNeverRemapped() {
+        XCTAssertEqual(
+            StreamConfigPolicy.effectiveResolution(requested: "medium", concurrentGlassesVoice: true),
+            "medium")
+        XCTAssertEqual(
+            StreamConfigPolicy.effectiveResolution(requested: "high", concurrentGlassesVoice: true),
+            "high")
+    }
+
+    // MARK: - Two-phase tool-response shapes
+
+    private func functionResponse(in envelope: [String: Any]) -> [String: Any]? {
+        ((envelope["toolResponse"] as? [String: Any])?["functionResponses"]
+            as? [[String: Any]])?.first
+    }
+
+    func testDirectResponseKeepsPlainShape() {
+        let envelope = ToolCallRouter.toolResponse(
+            callId: "c1", name: "weather", payload: ["result": "sunny"], phase: .direct)
+        let fr = functionResponse(in: envelope)
+        XCTAssertEqual(fr?["id"] as? String, "c1")
+        XCTAssertEqual(fr?["name"] as? String, "weather")
+        XCTAssertEqual((fr?["response"] as? [String: Any])?["result"] as? String, "sunny")
+        XCTAssertNil(fr?["willContinue"], "plain responses must not carry non-blocking fields")
+        XCTAssertNil(fr?["scheduling"])
+    }
+
+    func testAckResponseKeepsCallOpenSilently() {
+        let envelope = ToolCallRouter.toolResponse(
+            callId: "c2", name: "slow_tool", payload: ["result": "working"], phase: .ack)
+        let fr = functionResponse(in: envelope)
+        XCTAssertEqual(fr?["willContinue"] as? Bool, true)
+        XCTAssertEqual(fr?["scheduling"] as? String, "SILENT")
+    }
+
+    func testFinalAfterAckDefersDelivery() {
+        let envelope = ToolCallRouter.toolResponse(
+            callId: "c3", name: "slow_tool", payload: ["result": "done"], phase: .finalAfterAck)
+        let fr = functionResponse(in: envelope)
+        XCTAssertNil(fr?["willContinue"], "the final leg closes the call")
+        XCTAssertEqual(fr?["scheduling"] as? String, "WHEN_IDLE",
+                       "the result must wait for the user's turn, not interrupt it")
+    }
+
+    func testNonBlockingFlagDefaultsOff() {
+        UserDefaults.standard.removeObject(forKey: "geminiNonBlockingToolsEnabled")
+        XCTAssertFalse(Config.geminiNonBlockingToolsEnabled,
+                       "payload-shape change must be opt-in until validated live")
+    }
+}

--- a/project.base.yml
+++ b/project.base.yml
@@ -108,7 +108,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "325"
+        CURRENT_PROJECT_VERSION: "326"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -176,7 +176,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "325"
+        CURRENT_PROJECT_VERSION: "326"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -214,7 +214,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "325"
+        CURRENT_PROJECT_VERSION: "326"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "325"
+        CURRENT_PROJECT_VERSION: "326"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.7"
-        CURRENT_PROJECT_VERSION: "325"
+        CURRENT_PROJECT_VERSION: "326"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## What

A hardening sweep of the camera/session, HUD, and realtime-audio paths against device-traced DAT 0.8 behaviors, plus a flag-gated two-phase tool-response mode for Gemini Live.

### Camera / stream
- **Temple-tap pause no longer triggers stall recovery.** `.paused` is a system hold with no app-callable resume; frames stopping is expected, and tearing the stream down collapses the media channel the next tap would resume. `StreamRecoveryPolicy.shouldRecoverFromStall` (pure) + the stall loop now sit it out and keep the stall clock fresh for the resume.
- **Bounded wait for `.stopped` before re-arming a stream.** The camera capability is process-wide and frees when the *stream* finishes stopping — not on session teardown — so premature re-arm throws `capabilityAlreadyActive`. `awaitStreamStopped` (2s bound) now runs in both teardown paths.
- **Low-res contention floor.** Continuous streaming alongside glasses-mic voice floors a configured "low" tier to "medium" (`StreamConfigPolicy`, pure): low-res video can ride the shared Bluetooth radio and starve the HFP/LE voice link — the mic goes silent. Discrete photo sessions keep the user's setting; `startStreaming` rebuilds a photo-era low stream when needed.
- Documented (comment-only) the no-start discrete capture alternative for future stall debugging; removed a duplicated reset line.

### HUD
- **Blank before stop.** `teardownDisplay` now clears the waveguide, lets the clear settle (~200ms), then stops — stopping with content up can surface the system home screen on-lens. (iOS DAT has no `removeDisplay`; clear → settle → stop is the whole discipline.)

### Realtime audio
- **Playback engine resurrection.** An `AVAudioSession` deactivation can leave the engine non-nil but silently dead (`isRunning == false`), swallowing every scheduled buffer. `playAudioOnQueue` now restarts the engine before scheduling instead of dropping response audio into the void. Covers both Gemini Live and OpenAI Realtime (shared engine).

### Gemini Live tools — flag-gated, default OFF
`Config.geminiNonBlockingToolsEnabled`: declares functions `NON_BLOCKING`, acks a still-running call at 1s (`willContinue` + `SILENT` scheduling) so the model's open transaction closes fast, then delivers the real result `WHEN_IDLE` so the announcement never barges into the user's turn. Payload shapes are pinned by tests; OFF until validated against the live endpoint on device.

### Housekeeping
- Build 326 (specs kept in sync).

## Tests
- New `DATFieldHardeningTests` (9 tests): paused-skip policy, resolution floor matrix, all three tool-response phase shapes, flag default.
- Full suite: **2118 tests, 0 failures** (sim, via Xcode-beta toolchain — stable 26.5 lacks iOS platform components).
- **Release build green** (`-configuration Release`, sim, unsigned).

## Device-pending
Pause-resume behavior, capability-release timing, HUD teardown ordering, and the non-blocking flag all want an on-device pass — everything here is either behavior-preserving by construction, bounded, or flag-gated off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)