### PR TITLE
Fix silent encryption-key rotation and the MCP session-cache data race

### DIFF
--- a/OpenGlasses/Sources/Services/ConversationEncryptionService.swift
+++ b/OpenGlasses/Sources/Services/ConversationEncryptionService.swift
@@ -57,12 +57,20 @@ actor ConversationEncryptionService {
 
     // MARK: - Key Management
 
-    /// Get existing key or create a new one.
+    /// Get the existing key, or create one **only when the Keychain genuinely holds none**.
+    ///
+    /// The distinction matters: `retrieveKey()` reads a `.userPresence`-protected item, so it also
+    /// fails when the user cancels Face ID, is in biometric lockout, or the device is locked. Those
+    /// are not "no key exists" — swallowing them and falling through to `createAndStoreKey()` would
+    /// delete the live key and mint a new one, making every previously encrypted conversation
+    /// permanently unreadable. Only `.keyNotFound` may create; every other error propagates so the
+    /// caller aborts the save with the ciphertext on disk left intact.
     private func getOrCreateKey() throws -> SymmetricKey {
-        if let existing = try? retrieveKey() {
-            return existing
+        do {
+            return try retrieveKey()
+        } catch EncryptionError.keyNotFound {
+            return try createAndStoreKey()
         }
-        return try createAndStoreKey()
     }
 
     /// Create a new symmetric key and store it in Keychain with biometric protection.
@@ -88,8 +96,14 @@ actor ConversationEncryptionService {
             kSecAttrAccessControl as String: accessControl,
         ]
 
-        // Delete any existing key first
-        SecItemDelete(query as CFDictionary)
+        // Clear any stale item so the add can't fail with errSecDuplicateItem. Scoped to the
+        // identity attributes only — reusing the add query (which carries the key material and
+        // access control) is not a valid delete predicate.
+        SecItemDelete([
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: keychainAccount,
+            kSecAttrService as String: keychainService,
+        ] as CFDictionary)
 
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == errSecSuccess else {
@@ -98,6 +112,26 @@ actor ConversationEncryptionService {
 
         NSLog("[Encryption] Created new ChaCha20-Poly1305 key in Keychain")
         return key
+    }
+
+    /// Map a `SecItemCopyMatching` status onto the error the key path reacts to. Pure, so the
+    /// "which statuses may mint a new key" rule is unit-testable without a live Keychain.
+    ///
+    /// Only `errSecItemNotFound` is allowed to become `.keyNotFound` — that is the sole status
+    /// `getOrCreateKey` treats as licence to delete and regenerate. Presence failures map to
+    /// `.authenticationFailed` and everything else to `.keychainError`, both of which abort the
+    /// operation with the existing key and ciphertext untouched.
+    nonisolated static func retrievalError(for status: OSStatus) -> EncryptionError {
+        switch status {
+        case errSecItemNotFound:
+            return .keyNotFound
+        case errSecUserCanceled, errSecAuthFailed, errSecInteractionNotAllowed:
+            // The key exists but user presence couldn't be established (cancelled prompt,
+            // biometric lockout, locked device). Must never be mistaken for "no key".
+            return .authenticationFailed
+        default:
+            return .keychainError("Failed to retrieve key: \(status)")
+        }
     }
 
     /// Retrieve the symmetric key from Keychain. Triggers biometric prompt.
@@ -117,10 +151,7 @@ actor ConversationEncryptionService {
         let status = SecItemCopyMatching(query as CFDictionary, &result)
 
         guard status == errSecSuccess, let keyData = result as? Data else {
-            if status == errSecItemNotFound {
-                throw EncryptionError.keyNotFound
-            }
-            throw EncryptionError.keychainError("Failed to retrieve key: \(status)")
+            throw Self.retrievalError(for: status)
         }
 
         return SymmetricKey(data: keyData)
@@ -181,7 +212,7 @@ actor ConversationEncryptionService {
 
 // MARK: - Errors
 
-enum EncryptionError: LocalizedError {
+enum EncryptionError: LocalizedError, Equatable {
     case keyNotFound
     case keychainError(String)
     case invalidData

--- a/OpenGlasses/Sources/Services/ConversationStore.swift
+++ b/OpenGlasses/Sources/Services/ConversationStore.swift
@@ -481,7 +481,11 @@ class ConversationStore: ObservableObject {
                         output.append(encrypted)
                         try output.write(to: url, options: [.atomic, .completeFileProtection])
                     } catch {
-                        NSLog("[ConversationStore] Encrypted save failed: %@", error.localizedDescription)
+                        // The existing ciphertext on disk is untouched — `encrypt` throws before
+                        // the write, and a failed unlock no longer rotates the key out from under
+                        // it. This save is simply dropped; the next one retries.
+                        NSLog("[ConversationStore] Encrypted save skipped, history on disk intact: %@",
+                              error.localizedDescription)
                     }
                 }
             } else {

--- a/OpenGlasses/Sources/Services/MCP/MCPTransport.swift
+++ b/OpenGlasses/Sources/Services/MCP/MCPTransport.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os.lock
 
 /// The wire transport a server speaks. The catalogue and editor pick one; `MCPClient` selects the
 /// matching `MCPTransport` conformer at request time (`MCPTransportFactory`). Today only `.http`
@@ -89,32 +90,52 @@ struct HTTPTransport: MCPTransport {
     var session: URLSession = .shared
 
     /// Per-server MCP session IDs, `static` so they survive across the per-request instances that
-    /// `MCPTransportFactory` creates. Thread-safe in practice because every caller goes through
-    /// the `@MainActor` `MCPClient`. Empty string means "initialized, server doesn't use
+    /// `MCPTransportFactory` creates. Empty string means "initialized, server doesn't use
     /// sessions"; absent key means "not yet initialized".
-    nonisolated(unsafe) private static var sessions: [String: String] = [:]
+    ///
+    /// Lock-guarded, **not** actor-isolated: `MCPTransport.request` is a `nonisolated async`
+    /// requirement on a non-isolated struct, so it runs on the cooperative pool even though every
+    /// caller goes through the `@MainActor` `MCPClient` — an `async` call does not inherit the
+    /// caller's actor. Two turns with requests in flight (a voice tool call and a Settings-driven
+    /// `discoverAllTools`), or `MCPClient.updateServer` calling `resetSessions()` from the main
+    /// actor mid-request, would otherwise mutate the dictionary concurrently.
+    private static let sessionStore = OSAllocatedUnfairLock<[String: String]>(initialState: [:])
 
     /// Clear cached sessions (test support, and `MCPClient` calls it when a server's config
     /// changes so a rotated token re-handshakes).
-    static func resetSessions() { sessions.removeAll() }
+    static func resetSessions() { sessionStore.withLock { $0.removeAll() } }
+
+    /// The cached session ID for a server: `nil` = never initialized, `""` = initialized and the
+    /// server doesn't use sessions.
+    private static func session(for serverID: String) -> String? {
+        sessionStore.withLock { $0[serverID] }
+    }
+
+    private static func setSession(_ sessionID: String, for serverID: String) {
+        sessionStore.withLock { $0[serverID] = sessionID }
+    }
+
+    private static func clearSession(for serverID: String) {
+        sessionStore.withLock { $0.removeValue(forKey: serverID) }
+    }
 
     func request(_ payload: [String: Any], server: MCPServerConfig) async throws -> Data {
         // First contact with this server: run the MCP initialize handshake.
-        if Self.sessions[server.id] == nil {
+        if Self.session(for: server.id) == nil {
             await initializeSession(server: server)
         }
 
-        let sessionID = Self.sessions[server.id]
+        let sessionID = Self.session(for: server.id)
         let (data, response) = try await sendHTTP(payload, server: server, sessionID: sessionID)
         guard let httpResponse = response as? HTTPURLResponse else { return data }
 
         // 400/406 while we hold no real session → the server requires the MCP session
         // lifecycle (a previous handshake failed or expired). Re-initialize and retry once.
         if (httpResponse.statusCode == 400 || httpResponse.statusCode == 406), (sessionID ?? "").isEmpty {
-            Self.sessions.removeValue(forKey: server.id)
+            Self.clearSession(for: server.id)
             await initializeSession(server: server)
             let (retryData, retryResponse) = try await sendHTTP(payload, server: server,
-                                                                sessionID: Self.sessions[server.id])
+                                                                sessionID: Self.session(for: server.id))
             if let retryHTTP = retryResponse as? HTTPURLResponse, retryHTTP.statusCode >= 400 {
                 let body = String(data: retryData, encoding: .utf8) ?? ""
                 throw MCPTransportError.http(status: retryHTTP.statusCode, body: String(body.prefix(200)))
@@ -129,7 +150,7 @@ struct HTTPTransport: MCPTransport {
 
         // Capture a session ID from any successful response (a server may mint one late).
         if let newSessionID = httpResponse.value(forHTTPHeaderField: "mcp-session-id") {
-            Self.sessions[server.id] = newSessionID
+            Self.setSession(newSessionID, for: server.id)
         }
 
         return extractJSON(from: data, response: response, payload: payload)
@@ -153,14 +174,14 @@ struct HTTPTransport: MCPTransport {
         do {
             let (_, response) = try await sendHTTP(initPayload, server: server, sessionID: nil)
             let sessionID = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "mcp-session-id") ?? ""
-            Self.sessions[server.id] = sessionID   // "" = server doesn't use sessions
+            Self.setSession(sessionID, for: server.id)   // "" = server doesn't use sessions
 
             // Fire-and-forget; a server that returned a session expects this before real calls.
             let notifPayload: [String: Any] = ["jsonrpc": "2.0", "method": "notifications/initialized"]
             _ = try? await sendHTTP(notifPayload, server: server,
                                     sessionID: sessionID.isEmpty ? nil : sessionID)
         } catch {
-            Self.sessions[server.id] = ""
+            Self.setSession("", for: server.id)
             print("⚠️ MCP: session init failed for \(server.label), proceeding without session: \(error.localizedDescription)")
         }
     }

--- a/OpenGlassesTests/ConversationEncryptionKeyPolicyTests.swift
+++ b/OpenGlassesTests/ConversationEncryptionKeyPolicyTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+import Security
+@testable import OpenGlasses
+
+/// Guards the one rule that stands between a cancelled Face ID prompt and permanently unreadable
+/// conversation history: **only `errSecItemNotFound` may mint a new key.**
+///
+/// `getOrCreateKey` deletes the live Keychain item and generates a replacement whenever it decides
+/// no key exists. Because the item is `.userPresence`-protected, `SecItemCopyMatching` also fails
+/// when the user cancels the prompt, is in biometric lockout, or the device is locked. If any of
+/// those collapse into "no key", the old key is destroyed and every `OGENC1` file on disk becomes
+/// undecryptable. `retrievalError(for:)` is the pure seam that keeps them apart, so it can be
+/// exercised here without a live Keychain or a biometric prompt.
+final class ConversationEncryptionKeyPolicyTests: XCTestCase {
+
+    // MARK: - The one status that may create a key
+
+    func testItemNotFoundIsTheOnlyKeyNotFoundStatus() {
+        XCTAssertEqual(ConversationEncryptionService.retrievalError(for: errSecItemNotFound),
+                       .keyNotFound)
+    }
+
+    // MARK: - Presence failures must never read as "no key"
+
+    func testUserCancelledPromptDoesNotReportKeyMissing() {
+        XCTAssertEqual(ConversationEncryptionService.retrievalError(for: errSecUserCanceled),
+                       .authenticationFailed)
+    }
+
+    func testBiometricLockoutDoesNotReportKeyMissing() {
+        XCTAssertEqual(ConversationEncryptionService.retrievalError(for: errSecAuthFailed),
+                       .authenticationFailed)
+    }
+
+    /// The background-save case: device locked, so a `WhenUnlocked` item can't be read.
+    func testLockedDeviceDoesNotReportKeyMissing() {
+        XCTAssertEqual(ConversationEncryptionService.retrievalError(for: errSecInteractionNotAllowed),
+                       .authenticationFailed)
+    }
+
+    // MARK: - Everything else is a plain failure, not a licence to regenerate
+
+    func testUnexpectedStatusMapsToKeychainErrorNotKeyNotFound() {
+        let error = ConversationEncryptionService.retrievalError(for: errSecDecode)
+        guard case .keychainError = error else {
+            return XCTFail("Expected .keychainError, got \(error)")
+        }
+    }
+
+    /// The property that actually matters, stated once over the whole failure space: no status
+    /// other than `errSecItemNotFound` may ever produce `.keyNotFound`.
+    func testNoOtherStatusEverYieldsKeyNotFound() {
+        let statuses: [OSStatus] = [
+            errSecUserCanceled, errSecAuthFailed, errSecInteractionNotAllowed,
+            errSecDecode, errSecParam, errSecAllocate, errSecNotAvailable,
+            errSecDuplicateItem, errSecMissingEntitlement, errSecInvalidKeychain,
+            errSecIO, errSecUnimplemented, errSecBadReq, errSecInternalComponent,
+            0, -1, -25300 + 1,
+        ]
+        for status in statuses where status != errSecItemNotFound {
+            XCTAssertNotEqual(ConversationEncryptionService.retrievalError(for: status),
+                              .keyNotFound,
+                              "status \(status) must not be treated as a missing key — it would "
+                              + "destroy the existing key and orphan all encrypted history")
+        }
+    }
+}

--- a/OpenGlassesTests/MCPTransportConcurrencyTests.swift
+++ b/OpenGlassesTests/MCPTransportConcurrencyTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+import os.lock
+@testable import OpenGlasses
+
+/// Concurrency guards for `HTTPTransport`'s process-wide MCP session cache.
+///
+/// `MCPTransport.request` is a `nonisolated async` requirement on a non-isolated struct, so it runs
+/// on the cooperative pool even though every caller goes through the `@MainActor` `MCPClient` — an
+/// `async` call does not inherit its caller's actor. Concurrent turns (a voice tool call alongside a
+/// Settings-driven `discoverAllTools`), and `MCPClient.updateServer` calling `resetSessions()`
+/// mid-flight, therefore reach the cache from several threads at once.
+///
+/// These tests exercise that access pattern for real. The correctness assertion is per-server
+/// session attribution — a cache that tore under concurrent mutation would cross wires between
+/// servers or lose entries. Run under the Thread Sanitizer to also catch the raw data race.
+final class MCPTransportConcurrencyTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        SessionEchoURLProtocol.reset()
+        HTTPTransport.resetSessions()
+    }
+
+    override func tearDown() {
+        HTTPTransport.resetSessions()
+        super.tearDown()
+    }
+
+    private func server(_ index: Int) -> MCPServerConfig {
+        MCPServerConfig(id: "server-\(index)", label: "S\(index)",
+                        url: "http://s\(index).test/mcp", headers: [:], enabled: true)
+    }
+
+    // MARK: - Concurrent access
+
+    /// Many servers handshaking at once — the shape a parallel discovery or two overlapping turns
+    /// produce. Every server must end up with its *own* session ID.
+    func testConcurrentRequestsKeepPerServerSessionsDistinct() async throws {
+        let count = 16
+        let transport = HTTPTransport(session: SessionEchoURLProtocol.session())
+        let servers = (0..<count).map(server)
+
+        await withTaskGroup(of: Void.self) { group in
+            for config in servers {
+                group.addTask { _ = try? await transport.request(["id": 1], server: config) }
+            }
+        }
+
+        // Second round: sessions are cached now, so each request must carry the session its own
+        // server minted. A torn cache shows up here as a missing or cross-wired ID.
+        await withTaskGroup(of: Void.self) { group in
+            for config in servers {
+                group.addTask { _ = try? await transport.request(["id": 2], server: config) }
+            }
+        }
+
+        for index in 0..<count {
+            XCTAssertEqual(SessionEchoURLProtocol.lastSessionHeader(forHost: "s\(index).test"),
+                           "sid-s\(index).test",
+                           "server \(index) sent the wrong cached session ID")
+        }
+    }
+
+    /// `MCPClient.updateServer` resets the cache from the main actor while requests are in flight
+    /// off-actor. The interleaving is inherently racy in outcome — what must hold is that it stays
+    /// memory-safe and every request still completes.
+    func testResetSessionsDuringInFlightRequestsIsSafe() async {
+        let transport = HTTPTransport(session: SessionEchoURLProtocol.session())
+        let completed = OSAllocatedUnfairLock(initialState: 0)
+        // Four servers, three requests each — so the same cache entries are contended, not just
+        // disjoint keys.
+        let servers = (0..<12).map { server($0 % 4) }
+
+        await withTaskGroup(of: Void.self) { group in
+            for config in servers {
+                group.addTask {
+                    _ = try? await transport.request(["id": 1], server: config)
+                    completed.withLock { $0 += 1 }
+                }
+            }
+            for _ in 0..<8 {
+                group.addTask { HTTPTransport.resetSessions() }
+            }
+        }
+
+        XCTAssertEqual(completed.withLock { $0 }, 12, "every in-flight request should complete")
+    }
+
+    // MARK: - Attribution under sequential access (regression guard for the accessor refactor)
+
+    func testSessionIsScopedToItsOwnServer() async throws {
+        let transport = HTTPTransport(session: SessionEchoURLProtocol.session())
+
+        _ = try? await transport.request(["id": 1], server: server(1))
+        _ = try? await transport.request(["id": 1], server: server(2))
+        _ = try? await transport.request(["id": 2], server: server(1))
+
+        XCTAssertEqual(SessionEchoURLProtocol.lastSessionHeader(forHost: "s1.test"), "sid-s1.test")
+        XCTAssertEqual(SessionEchoURLProtocol.lastSessionHeader(forHost: "s2.test"), "sid-s2.test")
+    }
+
+    func testResetForcesAFreshHandshake() async throws {
+        let transport = HTTPTransport(session: SessionEchoURLProtocol.session())
+
+        _ = try? await transport.request(["id": 1], server: server(1))
+        let afterFirst = SessionEchoURLProtocol.requestCount(forHost: "s1.test")
+        XCTAssertGreaterThan(afterFirst, 1, "first contact should handshake before the real call")
+
+        // Cached: no second handshake.
+        _ = try? await transport.request(["id": 2], server: server(1))
+        let cachedCost = SessionEchoURLProtocol.requestCount(forHost: "s1.test") - afterFirst
+        XCTAssertEqual(cachedCost, 1, "a cached session should cost exactly one request")
+
+        // Rotated config: handshake again.
+        HTTPTransport.resetSessions()
+        _ = try? await transport.request(["id": 3], server: server(1))
+        let afterReset = SessionEchoURLProtocol.requestCount(forHost: "s1.test")
+        XCTAssertGreaterThan(afterReset - afterFirst - cachedCost, 1,
+                             "reset should force a fresh handshake")
+    }
+}
+
+// MARK: - Thread-safe URLProtocol stub
+
+/// Returns a per-host `mcp-session-id` and records what each host was sent, all behind a lock so
+/// the harness itself contributes no races to a concurrency test.
+final class SessionEchoURLProtocol: URLProtocol {
+
+    private struct State {
+        var lastSessionHeader: [String: String] = [:]
+        var requestCounts: [String: Int] = [:]
+    }
+
+    private static let state = OSAllocatedUnfairLock(initialState: State())
+
+    static func reset() { state.withLock { $0 = State() } }
+
+    static func lastSessionHeader(forHost host: String) -> String? {
+        state.withLock { $0.lastSessionHeader[host] }
+    }
+
+    static func requestCount(forHost host: String) -> Int {
+        state.withLock { $0.requestCounts[host] ?? 0 }
+    }
+
+    static func session() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SessionEchoURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let host = request.url?.host ?? "?"
+        let sent = request.value(forHTTPHeaderField: "mcp-session-id")
+        Self.state.withLock { state in
+            state.requestCounts[host, default: 0] += 1
+            // Only the real call carries a session; don't let the handshake's absent header
+            // overwrite what a previous round recorded.
+            if let sent { state.lastSessionHeader[host] = sent }
+        }
+
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: 200, httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json", "mcp-session-id": "sid-\(host)"])!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(#"{"jsonrpc":"2.0","id":1,"result":{}}"#.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
Two defects found in a security review of the app. Both are small, self-contained, and headless-testable.

## 1. A cancelled Face ID prompt could destroy the conversation encryption key

`ConversationEncryptionService.getOrCreateKey()` used `try? retrieveKey()`, collapsing every failure into "no key exists":

```swift
if let existing = try? retrieveKey() { return existing }
return try createAndStoreKey()      // SecItemDelete + SecItemAdd
```

The Keychain item is `.userPresence`-protected, so `retrieveKey()` also fails on a **cancelled Face ID prompt, biometric lockout, or a locked device** — none of which mean the key is absent. The fallback deletes the live key and mints a replacement, and every previously written `OGENC1` file becomes permanently undecryptable.

This is on the hot path: every encrypted save calls `encrypt` → `getOrCreateKey` (`ConversationStore.swift:479`). Compounding it, `retrieveKey()` builds a fresh `LAContext` per call, so a Face ID prompt fires on *every save* — which makes an accidental Cancel the likely case rather than the exotic one.

**Fix:** only `errSecItemNotFound` may create a key. Presence failures map to `.authenticationFailed`, everything else to `.keychainError`; both abort the save with the ciphertext on disk untouched (`encrypt` throws before the write). The status mapping is extracted as the pure `retrievalError(for:)` so the rule is unit-testable without a live Keychain or a biometric prompt.

Also scoped the `SecItemDelete` in `createAndStoreKey` to the identity attributes — it was being passed the *add* query, which carries the key material and access control and isn't a valid delete predicate.

## 2. `HTTPTransport.sessions` was mutated from several threads

```swift
nonisolated(unsafe) private static var sessions: [String: String] = [:]
```

The comment justified this as "thread-safe in practice because every caller goes through the `@MainActor` `MCPClient`" — that doesn't hold. `MCPTransport.request` is a `nonisolated async` protocol requirement on a non-isolated struct, so it runs on the cooperative pool; an `async` call does not inherit its caller's actor. Two reachable concurrent mutators:

- `MCPClient.updateServer` calls `resetSessions()` (`sessions.removeAll()`) from the main actor while a request is in flight off-actor.
- A voice-turn tool call and a Settings-driven `discoverAllTools()` can each have a request in flight at once.

Concurrent `Dictionary` mutation is heap corruption, not a stale read. The project builds in Swift 5.9 mode, so the compiler flags none of this.

**Fix:** a lock-guarded `OSAllocatedUnfairLock<[String: String]>` behind small accessors, matching the discipline already used by `WakeTapState` and `HostCollector`. The absent-key / empty-string semantics are unchanged.

## Tests

- `ConversationEncryptionKeyPolicyTests` — asserts `errSecItemNotFound` is the *only* status that may mint a key, swept over the failure space.
- `MCPTransportConcurrencyTests` — concurrent requests across servers, `resetSessions()` racing in-flight requests, and per-server session attribution. Uses its own lock-guarded `URLProtocol` stub so the harness contributes no races of its own. Run under TSan to also catch the raw race.

## Verification

- Full suite: **2181 tests, 0 failures**
- Release build: green
- Both via `DEVELOPER_DIR=/Applications/Xcode-beta.app/...` (stable 26.5 has no iOS platform components on this machine)

## Not included

The review turned up four other issues, left out to keep this PR focused — happy to file or fix separately:

- `NativeToolRouter.swift:99` — the agent-mode `.confirm` branch executes the tool when no `confirmationCoordinator` is wired, while the agent-mode-*off* floor 35 lines above explicitly fails closed. Latent today (one production wiring site).
- `code_agent` is absent from `PromptInjectionPolicy.highImpactTools` despite dispatching an arbitrary prompt to a remote coding agent — the same blast radius as `execute`, which is listed.
- `NativeToolRouter.executeWithTimeout` doesn't bound execution: `withTaskGroup` awaits all children, so a non-cancellable tool runs to completion after the model has been told it timed out.
- The `openglasses://` scheme does no caller validation; `action/photo` captures from the glasses camera and `listen/on` enables the mic, both invocable silently by any app on the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)