### PR TITLE
Close the four remaining gaps from the security review

### DIFF
--- a/GlassesActivityWidget/GlassesActivityWidget.swift
+++ b/GlassesActivityWidget/GlassesActivityWidget.swift
@@ -47,7 +47,7 @@ struct GlassesActivityWidget: Widget {
                         if context.state.isConnected {
                             actionButtons(for: context.state, compact: true)
                         } else {
-                            Link(destination: URL(string: "openglasses://connect")!) {
+                            Link(destination: DeepLinkTrust.signedURL("openglasses://connect")!) {
                                 Label {
                                     Text("Connect")
                                 } icon: {
@@ -139,7 +139,7 @@ struct GlassesActivityWidget: Widget {
             if !context.state.isConnected {
                 chunkyLink(label: "Connect Glasses",
                            icon: "antenna.radiowaves.left.and.right",
-                           url: URL(string: "openglasses://connect")!,
+                           url: DeepLinkTrust.signedURL("openglasses://connect")!,
                            tint: .green, strong: true)
             }
         }
@@ -164,20 +164,20 @@ struct GlassesActivityWidget: Widget {
         if !state.quickActionButtons.isEmpty {
             return state.quickActionButtons.prefix(4).map {
                 ActionItem(id: $0.id, label: $0.label, icon: $0.icon,
-                           url: URL(string: "openglasses://quickaction/\($0.id)")!,
+                           url: DeepLinkTrust.signedURL("openglasses://quickaction/\($0.id)")!,
                            accent: $0.id == "field-assist")
             }
         } else if !state.personaButtons.isEmpty {
             return state.personaButtons.prefix(4).map {
                 ActionItem(id: $0.id, label: $0.name, icon: "person.fill",
-                           url: URL(string: "openglasses://persona/\($0.id)")!, accent: false)
+                           url: DeepLinkTrust.signedURL("openglasses://persona/\($0.id)")!, accent: false)
             }
         } else {
             return [
                 ActionItem(id: "ask", label: "Ask", icon: "mic.fill",
-                           url: URL(string: "openglasses://action/ask")!, accent: true),
+                           url: DeepLinkTrust.signedURL("openglasses://action/ask")!, accent: true),
                 ActionItem(id: "photo", label: "Photo", icon: "camera.fill",
-                           url: URL(string: "openglasses://action/photo")!, accent: false),
+                           url: DeepLinkTrust.signedURL("openglasses://action/photo")!, accent: false),
             ]
         }
     }

--- a/GlassesActivityWidget/HomeScreenWidget.swift
+++ b/GlassesActivityWidget/HomeScreenWidget.swift
@@ -130,7 +130,7 @@ struct HomeWidgetView: View {
                     .background(accent.opacity(0.85), in: RoundedRectangle(cornerRadius: 16))
                 }
                 .buttonStyle(.plain)
-                Link(destination: URL(string: "openglasses://action/photo")!) {
+                Link(destination: DeepLinkTrust.signedURL("openglasses://action/photo")!) {
                     HStack(spacing: 4) {
                         Image(systemName: "camera.fill")
                         Text("Photo")
@@ -181,7 +181,7 @@ struct HomeWidgetView: View {
     }
 
     private func quickActionLink(url: String, icon: String, label: String) -> some View {
-        Link(destination: URL(string: url)!) {
+        Link(destination: DeepLinkTrust.signedURL(url)!) {
             VStack(spacing: 4) {
                 Image(systemName: icon)
                     .font(.title3)

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -136,6 +136,9 @@ struct OpenGlassesApp: App {
         // Move any plaintext provider secrets out of UserDefaults and into the
         // Keychain. Must run before anything reads a secret (AppState, LLM, TTS…).
         Config.migrateSecretsToKeychainIfNeeded()
+        // Mint the deep-link trust token before any URL can be delivered, so a first-party link
+        // is never rejected because the app hadn't got round to creating one.
+        DeepLinkTrust.ensureToken()
         // Defer Wearables SDK (Bluetooth permission) until after onboarding
         if Config.hasCompletedOnboarding {
             configureWearables()
@@ -176,6 +179,18 @@ struct OpenGlassesApp: App {
                     if url.scheme == "openglasses",
                        ["shortcut-result", "shortcut-cancel", "shortcut-error"].contains(url.host) {
                         ShortcutCallbackManager.shared.handleCallback(url: url)
+                        return
+                    }
+
+                    // A custom URL scheme is an open door: any app on the device can call it, with
+                    // no prompt and no caller identity. Links that act — capture a frame from the
+                    // glasses, open the mic, run a quick action — are honoured only when they carry
+                    // the app-group token the first-party widgets stamp on. See [[DeepLinkTrust]].
+                    if url.scheme == "openglasses",
+                       DeepLinkTrust.requiresTrustedCaller(host: url.host, action: url.lastPathComponent),
+                       !DeepLinkTrust.isTrusted(url) {
+                        NSLog("[OpenGlasses] Ignored untrusted deep link: %@/%@",
+                              url.host ?? "?", url.lastPathComponent)
                         return
                     }
 

--- a/OpenGlasses/Sources/Services/Agent/SafetySupervisor.swift
+++ b/OpenGlasses/Sources/Services/Agent/SafetySupervisor.swift
@@ -65,7 +65,8 @@ enum SafetySupervisor {
     static func evaluate(tool: String, args: [String: Any], context: SafetyContext) -> SafetyVerdict {
         var best: SafetyVerdict = .allow
         for rule in SafetyRuleKind.allCases where context.enabledRules.contains(rule) {
-            if let verdict = apply(rule, tool: tool, context: context), verdict.severity > best.severity {
+            if let verdict = apply(rule, tool: tool, args: args, context: context),
+               verdict.severity > best.severity {
                 best = verdict
             }
         }
@@ -73,7 +74,8 @@ enum SafetySupervisor {
         // tool must not run autonomously: `.recommend` requires explicit human confirmation, `.paused`
         // blocks it outright. Read-only tools are untouched (reading is fine while idle), and this
         // only ever *raises* severity — it never overrides a stricter rule verdict.
-        if let ceiling = autonomyCeiling(tool: tool, autonomy: context.autonomy), ceiling.severity > best.severity {
+        if let ceiling = autonomyCeiling(tool: tool, args: args, autonomy: context.autonomy),
+           ceiling.severity > best.severity {
             best = ceiling
         }
         return best
@@ -84,8 +86,9 @@ enum SafetySupervisor {
     /// rather than `.confirm`: a disengaged user can't answer a spoken prompt (and
     /// `requestConfirmation` would suspend the agent loop indefinitely), so the action is held — not
     /// run, not prompted — and surfaced on re-engagement via the held-recommendation store.
-    private static func autonomyCeiling(tool: String, autonomy: Autonomy) -> SafetyVerdict? {
-        guard PromptInjectionPolicy.isHighImpact(toolName: tool) else { return nil }
+    private static func autonomyCeiling(tool: String, args: [String: Any],
+                                        autonomy: Autonomy) -> SafetyVerdict? {
+        guard PromptInjectionPolicy.isHighImpact(toolName: tool, args: args) else { return nil }
         switch autonomy {
         case .autoAct:   return nil
         case .recommend: return .block(reason: "held — you've been idle, so ‘\(tool)’ wasn't run automatically")
@@ -93,10 +96,11 @@ enum SafetySupervisor {
         }
     }
 
-    private static func apply(_ rule: SafetyRuleKind, tool: String, context: SafetyContext) -> SafetyVerdict? {
+    private static func apply(_ rule: SafetyRuleKind, tool: String, args: [String: Any],
+                              context: SafetyContext) -> SafetyVerdict? {
         switch rule {
         case .needsVoiceApproval:
-            return PromptInjectionPolicy.isHighImpact(toolName: tool)
+            return PromptInjectionPolicy.isHighImpact(toolName: tool, args: args)
                 ? .confirm(reason: "‘\(tool)’ can take a real action — confirm first")
                 : nil
 

--- a/OpenGlasses/Sources/Services/MCP/MCPTransport.swift
+++ b/OpenGlasses/Sources/Services/MCP/MCPTransport.swift
@@ -116,7 +116,7 @@ struct HTTPTransport: MCPTransport {
     }
 
     private static func clearSession(for serverID: String) {
-        sessionStore.withLock { $0.removeValue(forKey: serverID) }
+        sessionStore.withLock { $0[serverID] = nil }
     }
 
     func request(_ payload: [String: Any], server: MCPServerConfig) async throws -> Data {

--- a/OpenGlasses/Sources/Services/NativeTools/CustomToolWrapper.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/CustomToolWrapper.swift
@@ -56,10 +56,16 @@ struct CustomToolWrapper: NativeTool {
             }
         }
 
-        // Callback URLs — the shortcut will redirect back to OpenGlasses with results
-        urlString += "&x-success=openglasses://shortcut-result"
-        urlString += "&x-cancel=openglasses://shortcut-cancel"
-        urlString += "&x-error=openglasses://shortcut-error"
+        // Callback URLs — the shortcut will redirect back to OpenGlasses with results. Each
+        // carries a one-shot token so another app can't answer this call with output of its own
+        // (the return leg is an openglasses:// link anyone can open). The token rides unencoded,
+        // as these callback values already do: `?` and `=` are legal inside a query value, and the
+        // token's base64url alphabet contains no `&` to break out of it.
+        let callbackToken = ShortcutCallbackManager.makeCallbackToken()
+        let cb = "\(ShortcutCallbackManager.queryName)=\(callbackToken)"
+        urlString += "&x-success=openglasses://shortcut-result?\(cb)"
+        urlString += "&x-cancel=openglasses://shortcut-cancel?\(cb)"
+        urlString += "&x-error=openglasses://shortcut-error?\(cb)"
 
         guard let url = URL(string: urlString) else {
             return "Couldn't build URL for shortcut '\(shortcutName)'."
@@ -74,7 +80,7 @@ struct CustomToolWrapper: NativeTool {
         }
 
         // Store a pending callback so the URL handler can resolve it
-        ShortcutCallbackManager.shared.setPending(toolName: name)
+        ShortcutCallbackManager.shared.setPending(toolName: name, callbackToken: callbackToken)
 
         await MainActor.run {
             UIApplication.shared.open(url)

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os.lock
 
 /// Routes tool calls: native tools → MCP servers → OpenClaw fallback.
 @MainActor
@@ -177,28 +178,51 @@ final class NativeToolRouter {
             }
         }
 
-        // Race: tool execution vs timeout
-        let result: ToolResult = await withTaskGroup(of: ToolResult.self) { group in
-            // The actual work
-            group.addTask {
+        // Race: tool execution vs timeout.
+        //
+        // Deliberately *not* a task group. A group implicitly awaits all of its children before
+        // returning, so when the timeout sentinel won the race the group still blocked until the
+        // real work finished — `cancelAll()` only signals cooperative cancellation, and most tools
+        // here (HomeKit writes, URL-scheme launches, third-party SDK calls) never check it. The
+        // "timeout" therefore bounded nothing.
+        //
+        // Instead the two racers resume a single continuation and `resolved` decides the winner, so
+        // the caller returns on time. Cancellation is still requested, but work that ignores it is
+        // abandoned rather than waited on — and logged if it lands late, since its side effect will
+        // have happened after the model was told the call timed out.
+        let resolved = OSAllocatedUnfairLock(initialState: false)
+        /// Returns true for the first caller only.
+        func claim() -> Bool {
+            resolved.withLock { alreadyResolved in
+                if alreadyResolved { return false }
+                alreadyResolved = true
+                return true
+            }
+        }
+
+        let result: ToolResult = await withCheckedContinuation { continuation in
+            let workTask = Task {
+                let outcome: ToolResult
                 do {
-                    let result = try await work()
-                    return .success(result)
+                    outcome = .success(try await work())
                 } catch {
-                    return .failure("Tool error: \(error.localizedDescription)")
+                    outcome = .failure("Tool error: \(error.localizedDescription)")
+                }
+                if claim() {
+                    continuation.resume(returning: outcome)
+                } else {
+                    NSLog("[NativeToolRouter] Tool %@ finished after it timed out — its effect landed late",
+                          name)
                 }
             }
 
-            // Timeout sentinel
-            group.addTask { [toolTimeoutSeconds] in
+            Task { [toolTimeoutSeconds] in
                 try? await Task.sleep(nanoseconds: UInt64(toolTimeoutSeconds * 1_000_000_000))
-                return .failure("Tool '\(name)' timed out after \(Int(toolTimeoutSeconds))s")
+                guard claim() else { return }
+                workTask.cancel()   // best effort; cancellation-aware tools stop here
+                continuation.resume(
+                    returning: .failure("Tool '\(name)' timed out after \(Int(toolTimeoutSeconds))s"))
             }
-
-            // First to finish wins
-            let first = await group.next()!
-            group.cancelAll()
-            return first
         }
 
         stillWorkingTask.cancel()

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
@@ -88,7 +88,8 @@ final class NativeToolRouter {
                 // Plan W: when the block is the presence autonomy ceiling on an acting tool (the
                 // user is idle/away), hold it for re-engagement instead of reporting a hard safety
                 // block — the action was deferred, not forbidden.
-                if context.autonomy != .autoAct, PromptInjectionPolicy.isHighImpact(toolName: name) {
+                if context.autonomy != .autoAct,
+                   PromptInjectionPolicy.isHighImpact(toolName: name, args: args) {
                     let summary = PromptInjectionPolicy.actionSummary(toolName: name, args: args)
                     onActionHeld?(summary)
                     NSLog("[NativeToolRouter] Held %@ for re-engagement (autonomy=%@)", name, context.autonomy.rawValue)
@@ -96,17 +97,22 @@ final class NativeToolRouter {
                 }
                 return .failure("'\(name)' was blocked by a safety rule (\(reason)). Do not retry; tell the user it was blocked for safety.")
             case .confirm(let reason):
-                if let coordinator = confirmationCoordinator {
-                    // High-impact tools get the richer action summary; other rules use their reason.
-                    let summary = PromptInjectionPolicy.isHighImpact(toolName: name)
-                        ? PromptInjectionPolicy.actionSummary(toolName: name, args: args)
-                        : reason
-                    NSLog("[NativeToolRouter] Safety supervisor requires confirmation for %@: %@", name, reason)
-                    let approved = await coordinator.requestConfirmation(toolName: name, summary: summary)
-                    guard approved else {
-                        NSLog("[NativeToolRouter] User declined %@", name)
-                        return .failure("The user did NOT approve this action, so '\(name)' was not performed. Do not retry it; tell the user it was cancelled unless they explicitly ask again.")
-                    }
+                guard let coordinator = confirmationCoordinator else {
+                    // No confirmation UI wired (e.g. headless): fail closed rather than actuate
+                    // blind, exactly as the agent-mode-off floor above does. Falling through here
+                    // would make the *more* autonomous mode the one that skips the gate.
+                    NSLog("[NativeToolRouter] No confirmation coordinator; refusing %@ (%@)", name, reason)
+                    return .failure("'\(name)' requires user confirmation, which isn't available right now, so it was not performed. Tell the user to try again with the app in the foreground.")
+                }
+                // High-impact tools get the richer action summary; other rules use their reason.
+                let summary = PromptInjectionPolicy.isHighImpact(toolName: name, args: args)
+                    ? PromptInjectionPolicy.actionSummary(toolName: name, args: args)
+                    : reason
+                NSLog("[NativeToolRouter] Safety supervisor requires confirmation for %@: %@", name, reason)
+                let approved = await coordinator.requestConfirmation(toolName: name, summary: summary)
+                guard approved else {
+                    NSLog("[NativeToolRouter] User declined %@", name)
+                    return .failure("The user did NOT approve this action, so '\(name)' was not performed. Do not retry it; tell the user it was cancelled unless they explicitly ask again.")
                 }
             }
         }

--- a/OpenGlasses/Sources/Services/PromptInjectionPolicy.swift
+++ b/OpenGlasses/Sources/Services/PromptInjectionPolicy.swift
@@ -11,9 +11,9 @@ import Foundation
 ///  1. **Framing** — untrusted tool output is wrapped in a labelled envelope before it is fed
 ///     back to the model, so the model can tell data from instructions. See ``wrap(toolName:content:)``.
 ///  2. **Human-in-the-loop** — high-impact / irreversible tool calls (send a message, actuate
-///     smart home, run a shortcut, delegate to the gateway) are gated behind an explicit user
-///     confirmation when agent mode is on. See ``isHighImpact(toolName:)`` and the
-///     ``ToolConfirmationCoordinator``.
+///     smart home, run a shortcut, delegate to the gateway, start a coding-agent run) are gated
+///     behind an explicit user confirmation when agent mode is on. See
+///     ``isHighImpact(toolName:args:)`` and the ``ToolConfirmationCoordinator``.
 ///
 /// The system prompt block in ``systemPromptPolicy`` tells the model the rules; the envelope and
 /// the confirmation gate enforce them even if the model is talked into ignoring the prompt.
@@ -81,8 +81,32 @@ enum PromptInjectionPolicy {
         "execute",          // OpenClaw gateway — can do anything on the user's machine
     ]
 
-    static func isHighImpact(toolName: String) -> Bool {
-        highImpactTools.contains(toolName)
+    /// Whether this specific call takes a real-world action and so needs human confirmation.
+    ///
+    /// Args-aware because not every tool is all-or-nothing. `code_agent` dispatches an arbitrary
+    /// free-text task to a remote coding agent on `start` — the same blast radius as `execute`,
+    /// which is unconditionally high-impact — but its other actions are not: `status` is a read,
+    /// `cancel`/`deny` only ever reduce what's running, and `confirm` is itself the answer to a
+    /// consent prompt. Gating those would put a confirmation in front of routine, harmless calls
+    /// and train the wearer to approve reflexively, weakening the one prompt that matters. See
+    /// [[ToolConfirmationCoordinator]].
+    static func isHighImpact(toolName: String, args: [String: Any]) -> Bool {
+        if highImpactTools.contains(toolName) { return true }
+        if toolName == "code_agent" { return isDispatchingAgentRun(args) }
+        return false
+    }
+
+    /// Whether a `code_agent` call would start a run.
+    ///
+    /// Mirrors `AgentControlTool`'s own parsing, which defaults a missing action to `start` — so a
+    /// call with no `action` (or a non-string one) dispatches, and must be gated. Leading/trailing
+    /// space is trimmed here but not there, which can only over-classify, never under-classify.
+    static func isDispatchingAgentRun(_ args: [String: Any]) -> Bool {
+        guard let action = (args["action"] as? String)?
+            .trimmingCharacters(in: .whitespaces).lowercased(), !action.isEmpty else {
+            return true   // absent/blank action == "start"
+        }
+        return action == "start"
     }
 
     /// A short, human-readable description of what a high-impact call will do, shown in the
@@ -112,6 +136,10 @@ enum PromptInjectionPolicy {
             return "Export / share clinical data (\(str("action") ?? "export"))"
         case "execute":
             return "Ask the OpenClaw gateway to: \(preview(str("task") ?? compactArgs(args)))"
+        case "code_agent":
+            // Only `start` reaches a confirmation prompt (see `isDispatchingAgentRun`).
+            let project = str("project").map { " on \($0)" } ?? ""
+            return "Start a coding-agent run\(project): \(preview(str("prompt") ?? compactArgs(args)))"
         default:
             return "Run \(toolName): \(compactArgs(args))"
         }

--- a/OpenGlasses/Sources/Services/ShortcutCallbackManager.swift
+++ b/OpenGlasses/Sources/Services/ShortcutCallbackManager.swift
@@ -4,16 +4,58 @@ import Foundation
 /// When a shortcut runs via x-callback-url and finishes, it redirects back
 /// to openglasses://shortcut-result with the output. This manager bridges
 /// the async gap between the URL open and the callback.
+///
+/// The return leg is an `openglasses://` deep link, which any app on the device can open — so
+/// without a check another app could answer a pending `run_shortcut` with text of its choosing
+/// while the real shortcut was still running, and that text would be handed to the model as the
+/// tool's result. The app therefore mints a fresh token per invocation, stamps it on the three
+/// callback URLs it gives to Shortcuts, and accepts a callback only if it carries that token.
+/// Unlike [[DeepLinkTrust]]'s app-group secret this one is per-call and burned on use, so a
+/// captured callback URL can't be replayed against a later invocation.
 @MainActor
 class ShortcutCallbackManager {
     static let shared = ShortcutCallbackManager()
 
+    /// Query item carrying the per-invocation token.
+    static let queryName = "cb"
+
     private var pendingToolName: String?
+    private var pendingToken: String?
     private var continuation: CheckedContinuation<String?, Never>?
 
-    /// Mark that we're waiting for a shortcut result.
-    func setPending(toolName: String) {
+    /// A fresh callback token. 128 bits, URL-safe: it rides *unencoded* inside the outer
+    /// `shortcuts://x-callback-url` query, so the alphabet must avoid `&`, which is a delimiter
+    /// there. Base64url with the padding stripped satisfies that.
+    static func makeCallbackToken() -> String {
+        var bytes = [UInt8](repeating: 0, count: 16)
+        if SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) != errSecSuccess {
+            bytes = (0..<16).map { _ in UInt8.random(in: .min ... .max) }
+        }
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// The token carried by a callback URL, if any. Pure — testable without a live callback.
+    static func token(in url: URL) -> String? {
+        guard let value = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first(where: { $0.name == queryName })?.value, !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    /// Whether `url` is the answer to the invocation that minted `expected`.
+    static func isMatchingCallback(url: URL, expected: String?) -> Bool {
+        guard let expected, !expected.isEmpty, let presented = token(in: url) else { return false }
+        return DeepLinkTrust.constantTimeEquals(presented, expected)
+    }
+
+    /// Mark that we're waiting for a shortcut result, and which token will authenticate it.
+    func setPending(toolName: String, callbackToken: String) {
         pendingToolName = toolName
+        pendingToken = callbackToken
     }
 
     /// Wait for the shortcut to callback. Returns the output text or nil on timeout.
@@ -25,8 +67,7 @@ class ShortcutCallbackManager {
             Task {
                 try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
                 if let pending = self.continuation {
-                    self.continuation = nil
-                    self.pendingToolName = nil
+                    self.clearPending()
                     pending.resume(returning: nil)
                 }
             }
@@ -34,8 +75,17 @@ class ShortcutCallbackManager {
     }
 
     /// Called when the app receives a callback URL from a shortcut.
-    /// URL format: openglasses://shortcut-result?output=...
+    /// URL format: openglasses://shortcut-result?cb=<token>&output=...
     func handleCallback(url: URL) {
+        guard Self.isMatchingCallback(url: url, expected: pendingToken) else {
+            // Either nothing is pending, or this came from something other than the shortcut we
+            // launched. Never resolve on it — whatever it carries becomes tool output the model
+            // reads.
+            NSLog("[ShortcutCallback] Ignored callback with missing or mismatched token: %@",
+                  url.host ?? "?")
+            return
+        }
+
         let host = url.host
         let params = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
         let output = params?.first(where: { $0.name == "output" })?.value
@@ -45,25 +95,33 @@ class ShortcutCallbackManager {
         case "shortcut-result":
             let result = output ?? "Shortcut completed successfully."
             NSLog("[ShortcutCallback] Result: %@", String(result.prefix(200)))
-            continuation?.resume(returning: result)
-            continuation = nil
-            pendingToolName = nil
+            resume(with: result)
 
         case "shortcut-cancel":
             NSLog("[ShortcutCallback] Cancelled")
-            continuation?.resume(returning: "Shortcut was cancelled.")
-            continuation = nil
-            pendingToolName = nil
+            resume(with: "Shortcut was cancelled.")
 
         case "shortcut-error":
             let error = output ?? "Shortcut encountered an error."
             NSLog("[ShortcutCallback] Error: %@", error)
-            continuation?.resume(returning: "Shortcut error: \(error)")
-            continuation = nil
-            pendingToolName = nil
+            resume(with: "Shortcut error: \(error)")
 
         default:
             break
         }
+    }
+
+    /// Resolve the pending wait and burn the token, so the same callback URL can't be replayed
+    /// against whatever invocation comes next.
+    private func resume(with result: String) {
+        let pending = continuation
+        clearPending()
+        pending?.resume(returning: result)
+    }
+
+    private func clearPending() {
+        continuation = nil
+        pendingToolName = nil
+        pendingToken = nil
     }
 }

--- a/OpenGlasses/Sources/Shared/DeepLinkTrust.swift
+++ b/OpenGlasses/Sources/Shared/DeepLinkTrust.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// Caller authentication for the `openglasses://` URL scheme.
+///
+/// A custom URL scheme is an **unauthenticated entry point**: any app on the device can call
+/// `openURL("openglasses://action/photo")` and iOS will deliver it with no prompt and no usable
+/// record of who sent it. Several of the app's deep links act on the world — they capture a frame
+/// from the glasses camera and send it to an LLM, enable the microphone, or run a user-configured
+/// quick action — so left open they are a silent capture trigger for any installed app.
+///
+/// iOS offers no reliable caller identity here (`sourceApplication` is absent through SwiftUI's
+/// `onOpenURL` and unreliable generally), so trust is established by a shared secret instead: the
+/// app mints a random token into the app-group container, the first-party producers that live in
+/// that group (the widgets) stamp it onto the links they build, and the app requires it on any link
+/// that acts. A third-party app cannot read another app's group container, so it cannot mint a
+/// link that passes.
+///
+/// Compiled into **both** the app and the widget extension — the producer and the consumer must
+/// agree on the query name and the policy, so they share one file.
+enum DeepLinkTrust {
+    static let appGroupID = "group.com.openglasses.app"
+
+    /// Query item carrying the token. Short because widget links are built by hand.
+    static let queryName = "k"
+
+    private static let defaultsKey = "deepLinkTrustToken"
+
+    /// Test seam: when set, used instead of the real app-group defaults.
+    static var testDefaults: UserDefaults?
+
+    private static var store: UserDefaults? {
+        testDefaults ?? UserDefaults(suiteName: appGroupID)
+    }
+
+    // MARK: - Token lifecycle
+
+    /// The current token, or `nil` if one has never been minted.
+    static var current: String? {
+        store?.string(forKey: defaultsKey).flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    /// Mint a token if there isn't one. Called by the app at launch, before any URL can be handled,
+    /// so the app side is never the reason a link fails to validate.
+    @discardableResult
+    static func ensureToken() -> String? {
+        if let existing = current { return existing }
+        guard let store else { return nil }
+        let token = makeToken()
+        store.set(token, forKey: defaultsKey)
+        return token
+    }
+
+    /// 128 bits, URL-safe. Not a credential — a capability token for one process boundary.
+    private static func makeToken() -> String {
+        var bytes = [UInt8](repeating: 0, count: 16)
+        if SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) != errSecSuccess {
+            bytes = (0..<16).map { _ in UInt8.random(in: .min ... .max) }
+        }
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    // MARK: - Producing (widgets)
+
+    /// Stamp the token onto a first-party deep link. Returns the URL unchanged when no token
+    /// exists (the app has never launched), in which case an acting link is simply ignored.
+    static func sign(_ urlString: String) -> String {
+        guard let token = current else { return urlString }
+        let separator = urlString.contains("?") ? "&" : "?"
+        return "\(urlString)\(separator)\(queryName)=\(token)"
+    }
+
+    /// Convenience for the widgets, which need a non-optional `URL`.
+    static func signedURL(_ urlString: String) -> URL? { URL(string: sign(urlString)) }
+
+    // MARK: - Consuming (app)
+
+    /// Whether `url` carries the current token. Constant-time compare — the token is short-lived
+    /// only in the sense that it never rotates, so don't leak it a byte at a time through timing.
+    static func isTrusted(_ url: URL) -> Bool {
+        guard let expected = current, !expected.isEmpty else { return false }
+        let presented = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first { $0.name == queryName }?.value
+        guard let presented, !presented.isEmpty else { return false }
+        return constantTimeEquals(presented, expected)
+    }
+
+    static func constantTimeEquals(_ a: String, _ b: String) -> Bool {
+        let x = Array(a.utf8), y = Array(b.utf8)
+        guard x.count == y.count else { return false }
+        var diff: UInt8 = 0
+        for (i, j) in zip(x, y) { diff |= i ^ j }
+        return diff == 0
+    }
+
+    // MARK: - Policy
+
+    /// Whether a link makes the app *do* something, and so may only be honoured from a caller that
+    /// proved it is first-party.
+    ///
+    /// The dividing line is capability: a link that captures, listens, or actuates needs trust; one
+    /// that only navigates or *reduces* what the app is doing does not. Disconnecting the glasses
+    /// and turning listening off stay open on purpose — a hostile caller gains nothing by stopping
+    /// the microphone, and gating them would break the "panic off" path for no benefit.
+    ///
+    /// Pure, and the single place the policy lives, so the classification is testable directly.
+    static func requiresTrustedCaller(host: String?, action: String) -> Bool {
+        let action = action.lowercased()
+        switch host {
+        case "action":
+            // ask / photo / describe — capture a frame, or open the mic.
+            return true
+        case "listen":
+            return action != "off"
+        case "quickaction":
+            // Runs a user-configured action; contents are arbitrary.
+            return true
+        case "persona":
+            // Applies persona routing and then immediately starts a listening turn.
+            return true
+        case "connect":
+            // `connectAndListen` — brings up the glasses and opens the mic.
+            return true
+        case "disconnect":
+            return false
+        default:
+            // Unknown hosts do nothing today; the Wearables SDK callback path is separate.
+            return false
+        }
+    }
+}

--- a/OpenGlassesTests/AgentConfirmationGapTests.swift
+++ b/OpenGlassesTests/AgentConfirmationGapTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+import CoreLocation
+@testable import OpenGlasses
+
+/// Two gaps in the human-in-the-loop backstop, both found in a security review.
+///
+///  1. `code_agent` dispatches an arbitrary free-text task to a remote coding agent but was absent
+///     from the high-impact set, so an injected instruction could start a run unconfirmed — while
+///     `execute`, which has the same blast radius, was gated.
+///  2. The agent-mode `.confirm` branch in `NativeToolRouter` executed the tool when no
+///     confirmation coordinator was wired, so the *more* autonomous mode was the one that skipped
+///     the gate. The agent-mode-off floor already failed closed.
+@MainActor
+final class AgentConfirmationGapTests: XCTestCase {
+
+    private func context(rules: Set<SafetyRuleKind>,
+                         autonomy: Autonomy = .autoAct) -> SafetyContext {
+        SafetyContext(now: Date(), location: nil, homeRegion: nil, enabledRules: rules,
+                      quietHoursStart: 22, quietHoursEnd: 7, autonomy: autonomy)
+    }
+
+    // MARK: - code_agent classification
+
+    func testStartingAnAgentRunIsHighImpact() {
+        XCTAssertTrue(PromptInjectionPolicy.isHighImpact(toolName: "code_agent",
+                                                        args: ["action": "start", "prompt": "ship it"]))
+    }
+
+    /// `AgentControlTool` defaults a missing action to `start`, so the gate must too — otherwise
+    /// omitting the argument is a trivial bypass.
+    func testAgentCallWithNoActionIsTreatedAsStart() {
+        XCTAssertTrue(PromptInjectionPolicy.isHighImpact(toolName: "code_agent", args: [:]))
+        XCTAssertTrue(PromptInjectionPolicy.isHighImpact(toolName: "code_agent", args: ["prompt": "x"]))
+    }
+
+    /// A non-string action also falls back to `start` inside the tool.
+    func testAgentCallWithNonStringActionIsTreatedAsStart() {
+        XCTAssertTrue(PromptInjectionPolicy.isHighImpact(toolName: "code_agent", args: ["action": 7]))
+    }
+
+    func testStartClassificationIgnoresCaseAndSurroundingSpace() {
+        for raw in ["START", "Start", " start ", "\tstart"] {
+            XCTAssertTrue(PromptInjectionPolicy.isHighImpact(toolName: "code_agent",
+                                                            args: ["action": raw]),
+                          "‘\(raw)’ should be gated")
+        }
+    }
+
+    /// The other half of the rule: routine actions must NOT prompt. Gating `status` would train
+    /// the wearer to approve reflexively and blunt the prompt that matters.
+    func testNonDispatchingAgentActionsAreNotGated() {
+        for action in ["status", "cancel", "confirm", "deny", "switch_harness"] {
+            XCTAssertFalse(PromptInjectionPolicy.isHighImpact(toolName: "code_agent",
+                                                             args: ["action": action]),
+                           "‘\(action)’ should not require confirmation")
+        }
+    }
+
+    func testAgentRunSummaryNamesThePromptAndProject() {
+        let summary = PromptInjectionPolicy.actionSummary(
+            toolName: "code_agent", args: ["action": "start", "prompt": "delete the repo", "project": "api"])
+        XCTAssertTrue(summary.contains("delete the repo"))
+        XCTAssertTrue(summary.contains("api"))
+    }
+
+    // MARK: - Supervisor verdicts
+
+    func testSupervisorConfirmsAgentDispatch() {
+        let verdict = SafetySupervisor.evaluate(tool: "code_agent",
+                                                args: ["action": "start", "prompt": "x"],
+                                                context: context(rules: [.needsVoiceApproval]))
+        guard case .confirm = verdict else {
+            return XCTFail("starting a coding-agent run should require confirmation, got \(verdict)")
+        }
+    }
+
+    func testSupervisorAllowsAgentStatus() {
+        let verdict = SafetySupervisor.evaluate(tool: "code_agent", args: ["action": "status"],
+                                                context: context(rules: [.needsVoiceApproval]))
+        XCTAssertEqual(verdict, .allow)
+    }
+
+    /// The Plan W autonomy ceiling is also args-aware: an idle wearer holds a dispatch but can
+    /// still ask for status.
+    func testAutonomyCeilingHoldsDispatchButNotStatus() {
+        let idle = context(rules: [], autonomy: .paused)
+        guard case .block = SafetySupervisor.evaluate(tool: "code_agent",
+                                                      args: ["action": "start", "prompt": "x"],
+                                                      context: idle) else {
+            return XCTFail("a paused wearer should not dispatch an agent run")
+        }
+        XCTAssertEqual(SafetySupervisor.evaluate(tool: "code_agent", args: ["action": "status"],
+                                                 context: idle), .allow)
+    }
+
+    // MARK: - Fail-closed when no confirmation UI is available
+
+    func testAgentModeConfirmFailsClosedWithoutCoordinator() async {
+        let saved = Config.agentModeEnabled
+        Config.setAgentModeEnabled(true)
+        defer { Config.setAgentModeEnabled(saved) }
+
+        let registry = NativeToolRegistry(locationService: LocationService())
+        registry.register(GapFakeTool(name: "send_message"))
+        let router = NativeToolRouter(registry: registry)
+        router.confirmationCoordinator = nil          // headless: nothing can present a prompt
+        router.safetyContextProvider = { [weak self] in
+            self!.context(rules: [.needsVoiceApproval])
+        }
+
+        let result = await router.handleToolCall(name: "send_message", args: [:])
+        guard case .failure(let message) = result else {
+            return XCTFail("a confirm verdict with no coordinator must not execute the tool")
+        }
+        XCTAssertTrue(message.contains("requires user confirmation"), "got: \(message)")
+    }
+
+    /// Same situation, reached through the newly gated tool.
+    func testAgentDispatchFailsClosedWithoutCoordinator() async {
+        let saved = Config.agentModeEnabled
+        Config.setAgentModeEnabled(true)
+        defer { Config.setAgentModeEnabled(saved) }
+
+        let registry = NativeToolRegistry(locationService: LocationService())
+        registry.register(GapFakeTool(name: "code_agent"))
+        let router = NativeToolRouter(registry: registry)
+        router.confirmationCoordinator = nil
+        router.safetyContextProvider = { [weak self] in
+            self!.context(rules: [.needsVoiceApproval])
+        }
+
+        let result = await router.handleToolCall(name: "code_agent",
+                                                 args: ["action": "start", "prompt": "x"])
+        guard case .failure = result else {
+            return XCTFail("an unconfirmable agent dispatch must not run")
+        }
+    }
+
+    /// The gate must not become a blanket block: a routine action still runs headlessly.
+    func testAgentStatusStillRunsWithoutCoordinator() async {
+        let saved = Config.agentModeEnabled
+        Config.setAgentModeEnabled(true)
+        defer { Config.setAgentModeEnabled(saved) }
+
+        let registry = NativeToolRegistry(locationService: LocationService())
+        registry.register(GapFakeTool(name: "code_agent"))
+        let router = NativeToolRouter(registry: registry)
+        router.confirmationCoordinator = nil
+        router.safetyContextProvider = { [weak self] in
+            self!.context(rules: [.needsVoiceApproval])
+        }
+
+        let result = await router.handleToolCall(name: "code_agent", args: ["action": "status"])
+        guard case .success = result else {
+            return XCTFail("status is a read — it should not need a confirmation UI")
+        }
+    }
+}
+
+private struct GapFakeTool: NativeTool {
+    let name: String
+    var description = "fake"
+    var parametersSchema: [String: Any] = ["type": "object", "properties": [:] as [String: Any]]
+    func execute(args: [String: Any]) async throws -> String { "ran:\(name)" }
+}

--- a/OpenGlassesTests/DeepLinkTrustTests.swift
+++ b/OpenGlassesTests/DeepLinkTrustTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import OpenGlasses
+
+/// The `openglasses://` scheme is an unauthenticated entry point — any app on the device can open
+/// it silently. These cover the two halves of the fix: which links demand a first-party caller,
+/// and whether a presented token is actually accepted.
+final class DeepLinkTrustTests: XCTestCase {
+
+    private let suiteName = "DeepLinkTrustTests"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults().removePersistentDomain(forName: suiteName)
+        DeepLinkTrust.testDefaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        DeepLinkTrust.testDefaults = nil
+        UserDefaults().removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    private func url(_ s: String) -> URL { URL(string: s)! }
+
+    // MARK: - Policy: what needs a trusted caller
+
+    func testActingLinksRequireTrust() {
+        let acting: [(String, String)] = [
+            ("action", "photo"),      // captures a frame from the glasses
+            ("action", "describe"),   // captures and sends to the LLM
+            ("action", "ask"),        // opens the mic
+            ("listen", "on"),
+            ("listen", "toggle"),
+            ("quickaction", "some-id"),
+            ("persona", "some-id"),   // applies routing then starts a listening turn
+            ("connect", "connect"),   // connectAndListen
+        ]
+        for (host, action) in acting {
+            XCTAssertTrue(DeepLinkTrust.requiresTrustedCaller(host: host, action: action),
+                          "\(host)/\(action) acts and must require a trusted caller")
+        }
+    }
+
+    /// Capability-*reducing* links stay open on purpose — a hostile caller gains nothing by
+    /// stopping the mic, and gating them would break the panic-off path.
+    func testCapabilityReducingLinksStayOpen() {
+        XCTAssertFalse(DeepLinkTrust.requiresTrustedCaller(host: "listen", action: "off"))
+        XCTAssertFalse(DeepLinkTrust.requiresTrustedCaller(host: "disconnect", action: "disconnect"))
+    }
+
+    func testUnknownHostNeedsNoTrust() {
+        XCTAssertFalse(DeepLinkTrust.requiresTrustedCaller(host: "shortcut-result", action: ""))
+        XCTAssertFalse(DeepLinkTrust.requiresTrustedCaller(host: nil, action: ""))
+    }
+
+    func testListenOffIsCaseInsensitive() {
+        XCTAssertFalse(DeepLinkTrust.requiresTrustedCaller(host: "listen", action: "OFF"))
+    }
+
+    // MARK: - Token round trip
+
+    func testSignedLinkIsTrusted() {
+        DeepLinkTrust.ensureToken()
+        let signed = DeepLinkTrust.sign("openglasses://action/photo")
+        XCTAssertTrue(DeepLinkTrust.isTrusted(url(signed)))
+    }
+
+    func testSigningPreservesExistingQuery() {
+        DeepLinkTrust.ensureToken()
+        let signed = DeepLinkTrust.sign("openglasses://action/photo?mode=wide")
+        XCTAssertTrue(signed.contains("mode=wide"))
+        XCTAssertTrue(DeepLinkTrust.isTrusted(url(signed)))
+    }
+
+    func testTokenIsStableAcrossCalls() {
+        let first = DeepLinkTrust.ensureToken()
+        let second = DeepLinkTrust.ensureToken()
+        XCTAssertNotNil(first)
+        XCTAssertEqual(first, second, "re-minting would invalidate links already on screen")
+    }
+
+    // MARK: - Rejection
+
+    func testUnsignedLinkIsNotTrusted() {
+        DeepLinkTrust.ensureToken()
+        XCTAssertFalse(DeepLinkTrust.isTrusted(url("openglasses://action/photo")))
+    }
+
+    func testWrongTokenIsNotTrusted() {
+        DeepLinkTrust.ensureToken()
+        XCTAssertFalse(DeepLinkTrust.isTrusted(url("openglasses://action/photo?k=guessed")))
+    }
+
+    func testEmptyTokenIsNotTrusted() {
+        DeepLinkTrust.ensureToken()
+        XCTAssertFalse(DeepLinkTrust.isTrusted(url("openglasses://action/photo?k=")))
+    }
+
+    /// A near-miss must not pass — guards against a prefix/substring comparison creeping in.
+    func testTruncatedTokenIsNotTrusted() {
+        guard let token = DeepLinkTrust.ensureToken(), token.count > 4 else {
+            return XCTFail("expected a token")
+        }
+        XCTAssertFalse(DeepLinkTrust.isTrusted(url("openglasses://action/photo?k=\(token.dropLast())")))
+        XCTAssertFalse(DeepLinkTrust.isTrusted(url("openglasses://action/photo?k=\(token)x")))
+    }
+
+    /// With no token minted at all, nothing is trusted — `isTrusted` must never default to true.
+    func testNothingIsTrustedBeforeAnyTokenExists() {
+        XCTAssertNil(DeepLinkTrust.current)
+        XCTAssertFalse(DeepLinkTrust.isTrusted(url("openglasses://action/photo?k=anything")))
+        XCTAssertFalse(DeepLinkTrust.isTrusted(url("openglasses://action/photo")))
+    }
+
+    func testTokenIsLongEnoughToResistGuessing() {
+        guard let token = DeepLinkTrust.ensureToken() else { return XCTFail("expected a token") }
+        XCTAssertGreaterThanOrEqual(token.count, 20, "128 bits of base64url is ~22 chars")
+    }
+
+    func testDistinctTokensAreMintedPerContainer() {
+        let first = DeepLinkTrust.ensureToken()
+        UserDefaults().removePersistentDomain(forName: suiteName)
+        DeepLinkTrust.testDefaults = UserDefaults(suiteName: suiteName)
+        let second = DeepLinkTrust.ensureToken()
+        XCTAssertNotEqual(first, second, "tokens must be random, not derived from a constant")
+    }
+
+    // MARK: - Comparison primitive
+
+    func testConstantTimeEqualsMatchesEquality() {
+        XCTAssertTrue(DeepLinkTrust.constantTimeEquals("abc", "abc"))
+        XCTAssertFalse(DeepLinkTrust.constantTimeEquals("abc", "abd"))
+        XCTAssertFalse(DeepLinkTrust.constantTimeEquals("abc", "ab"))
+        XCTAssertFalse(DeepLinkTrust.constantTimeEquals("", "a"))
+        XCTAssertTrue(DeepLinkTrust.constantTimeEquals("", ""))
+    }
+}

--- a/OpenGlassesTests/ShortcutCallbackTrustTests.swift
+++ b/OpenGlassesTests/ShortcutCallbackTrustTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import OpenGlasses
+
+/// The x-callback-url return leg is an `openglasses://` deep link, so any app on the device can
+/// open it. While a `run_shortcut` call is pending (up to 30s) another app could answer it with
+/// text of its own, and that text is handed to the model as the tool's result. These cover the
+/// one-shot token that closes it.
+@MainActor
+final class ShortcutCallbackTrustTests: XCTestCase {
+
+    private func url(_ s: String) -> URL { URL(string: s)! }
+
+    // MARK: - Token matching
+
+    func testCallbackWithTheMintedTokenMatches() {
+        let token = ShortcutCallbackManager.makeCallbackToken()
+        XCTAssertTrue(ShortcutCallbackManager.isMatchingCallback(
+            url: url("openglasses://shortcut-result?cb=\(token)&output=hi"), expected: token))
+    }
+
+    func testCallbackWithoutATokenIsRejected() {
+        let token = ShortcutCallbackManager.makeCallbackToken()
+        XCTAssertFalse(ShortcutCallbackManager.isMatchingCallback(
+            url: url("openglasses://shortcut-result?output=spoofed"), expected: token))
+    }
+
+    func testCallbackWithAWrongTokenIsRejected() {
+        let token = ShortcutCallbackManager.makeCallbackToken()
+        XCTAssertFalse(ShortcutCallbackManager.isMatchingCallback(
+            url: url("openglasses://shortcut-result?cb=guessed&output=spoofed"), expected: token))
+    }
+
+    /// Nothing pending: a callback arriving unprompted must never match.
+    func testCallbackWithNothingPendingIsRejected() {
+        let token = ShortcutCallbackManager.makeCallbackToken()
+        XCTAssertFalse(ShortcutCallbackManager.isMatchingCallback(
+            url: url("openglasses://shortcut-result?cb=\(token)"), expected: nil))
+        XCTAssertFalse(ShortcutCallbackManager.isMatchingCallback(
+            url: url("openglasses://shortcut-result?cb=\(token)"), expected: ""))
+    }
+
+    func testNearMissTokenIsRejected() {
+        let token = ShortcutCallbackManager.makeCallbackToken()
+        XCTAssertFalse(ShortcutCallbackManager.isMatchingCallback(
+            url: url("openglasses://shortcut-result?cb=\(token.dropLast())"), expected: token))
+        XCTAssertFalse(ShortcutCallbackManager.isMatchingCallback(
+            url: url("openglasses://shortcut-result?cb=\(token)x"), expected: token))
+    }
+
+    func testEmptyTokenParamIsRejected() {
+        let token = ShortcutCallbackManager.makeCallbackToken()
+        XCTAssertNil(ShortcutCallbackManager.token(in: url("openglasses://shortcut-result?cb=")))
+        XCTAssertFalse(ShortcutCallbackManager.isMatchingCallback(
+            url: url("openglasses://shortcut-result?cb="), expected: token))
+    }
+
+    func testTokensAreUniquePerInvocation() {
+        let tokens = Set((0..<50).map { _ in ShortcutCallbackManager.makeCallbackToken() })
+        XCTAssertEqual(tokens.count, 50, "a reused token would let one callback answer another call")
+    }
+
+    // MARK: - Wire format
+
+    /// The token rides unencoded inside the outer `shortcuts://x-callback-url` query. That's only
+    /// safe because its alphabet contains no `&` (the outer delimiter) — assert it, since a change
+    /// to the generator would silently truncate the callback URL Shortcuts receives.
+    func testTokenAlphabetCannotBreakOutOfTheOuterQuery() {
+        for _ in 0..<50 {
+            let token = ShortcutCallbackManager.makeCallbackToken()
+            XCTAssertFalse(token.contains("&"), "‘\(token)’ would terminate the x-success value")
+            XCTAssertFalse(token.contains("?"))
+            XCTAssertFalse(token.contains("="))
+            XCTAssertFalse(token.contains("+"))
+            XCTAssertFalse(token.contains("/"))
+        }
+    }
+
+    /// A nested `?` inside a query value is legal and non-delimiting, so the callback URL must
+    /// survive a round trip through the outer URL exactly as built.
+    func testCallbackURLSurvivesEmbeddingInTheOuterQuery() {
+        let token = ShortcutCallbackManager.makeCallbackToken()
+        let inner = "openglasses://shortcut-result?cb=\(token)"
+        let outer = url("shortcuts://x-callback-url/run-shortcut?name=Test&x-success=\(inner)")
+
+        let extracted = URLComponents(url: outer, resolvingAgainstBaseURL: false)?
+            .queryItems?.first { $0.name == "x-success" }?.value
+        XCTAssertEqual(extracted, inner, "the callback URL must reach Shortcuts intact")
+
+        // And the app must still recognise its own token coming back.
+        XCTAssertTrue(ShortcutCallbackManager.isMatchingCallback(url: url(extracted!), expected: token))
+    }
+
+    /// The outer `name` param must not be swallowed by the nested query.
+    func testOuterParamsStillParseAlongsideTheNestedCallback() {
+        let token = ShortcutCallbackManager.makeCallbackToken()
+        let outer = url("shortcuts://x-callback-url/run-shortcut?name=Test"
+                        + "&x-success=openglasses://shortcut-result?cb=\(token)"
+                        + "&x-cancel=openglasses://shortcut-cancel?cb=\(token)")
+        let items = URLComponents(url: outer, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        XCTAssertEqual(items.first { $0.name == "name" }?.value, "Test")
+        XCTAssertNotNil(items.first { $0.name == "x-cancel" }?.value)
+        XCTAssertNil(items.first { $0.name == "cb" }?.value,
+                     "the nested token must not surface as an outer parameter")
+    }
+
+    // MARK: - End to end through the manager
+
+    func testSpoofedCallbackDoesNotResolveButTheRealOneDoes() async {
+        let manager = ShortcutCallbackManager()
+        let token = ShortcutCallbackManager.makeCallbackToken()
+        manager.setPending(toolName: "run_shortcut", callbackToken: token)
+
+        async let pending = manager.waitForResult(timeout: 5)
+
+        // Let the continuation be installed before any callback arrives.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // A hostile app answers first — must be ignored.
+        manager.handleCallback(url: url("openglasses://shortcut-result?output=spoofed"))
+        manager.handleCallback(url: url("openglasses://shortcut-result?cb=wrong&output=spoofed"))
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // The real shortcut answers.
+        manager.handleCallback(url: url("openglasses://shortcut-result?cb=\(token)&output=real"))
+
+        let result = await pending
+        XCTAssertEqual(result, "real", "the spoofed callbacks must not have resolved the wait")
+    }
+
+    /// The token is burned on use, so a captured callback can't answer the next invocation.
+    func testCallbackTokenIsNotReplayable() async {
+        let manager = ShortcutCallbackManager()
+        let token = ShortcutCallbackManager.makeCallbackToken()
+        manager.setPending(toolName: "run_shortcut", callbackToken: token)
+
+        async let first = manager.waitForResult(timeout: 5)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        manager.handleCallback(url: url("openglasses://shortcut-result?cb=\(token)&output=first"))
+        let firstResult = await first
+        XCTAssertEqual(firstResult, "first")
+
+        // A second invocation mints a different token; the old callback must not answer it.
+        let newToken = ShortcutCallbackManager.makeCallbackToken()
+        manager.setPending(toolName: "run_shortcut", callbackToken: newToken)
+        async let second = manager.waitForResult(timeout: 1)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        manager.handleCallback(url: url("openglasses://shortcut-result?cb=\(token)&output=replayed"))
+
+        let secondResult = await second
+        XCTAssertNil(secondResult, "the replayed callback should have been ignored, leaving a timeout")
+    }
+
+    func testCancelAndErrorCallbacksAlsoRequireTheToken() async {
+        let manager = ShortcutCallbackManager()
+        let token = ShortcutCallbackManager.makeCallbackToken()
+        manager.setPending(toolName: "run_shortcut", callbackToken: token)
+
+        async let pending = manager.waitForResult(timeout: 5)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        manager.handleCallback(url: url("openglasses://shortcut-cancel"))
+        manager.handleCallback(url: url("openglasses://shortcut-error?output=fake"))
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        manager.handleCallback(url: url("openglasses://shortcut-cancel?cb=\(token)"))
+        let result = await pending
+        XCTAssertEqual(result, "Shortcut was cancelled.")
+    }
+}

--- a/OpenGlassesTests/ToolTimeoutTests.swift
+++ b/OpenGlassesTests/ToolTimeoutTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import OpenGlasses
+
+/// The tool timeout has to actually bound the caller's wait.
+///
+/// It used to race the work against a sentinel inside a `withTaskGroup`, but a task group awaits
+/// all of its children before returning — so when the sentinel won, the group still blocked until
+/// the real work finished. `cancelAll()` only *requests* cancellation, and most tools here (HomeKit
+/// writes, URL-scheme launches, third-party SDK calls) never check it. The timeout bounded nothing.
+@MainActor
+final class ToolTimeoutTests: XCTestCase {
+
+    private func router(with tool: NativeTool, timeout: TimeInterval) -> NativeToolRouter {
+        let registry = NativeToolRegistry(locationService: LocationService())
+        registry.register(tool)
+        let router = NativeToolRouter(registry: registry)
+        router.toolTimeoutSeconds = timeout
+        return router
+    }
+
+    /// The regression: a tool that ignores cancellation must not hold the turn open past the
+    /// timeout. Before the fix this returned only after the tool's full 2s.
+    func testTimeoutReturnsWithoutWaitingForUncancellableWork() async {
+        let router = router(with: UncancellableTool(name: "slow_tool", seconds: 2.0), timeout: 0.3)
+
+        let started = Date()
+        let result = await router.handleToolCall(name: "slow_tool", args: [:])
+        let elapsed = Date().timeIntervalSince(started)
+
+        guard case .failure(let message) = result else {
+            return XCTFail("expected a timeout failure, got \(result)")
+        }
+        XCTAssertTrue(message.contains("timed out"), "got: \(message)")
+        XCTAssertLessThan(elapsed, 1.5,
+                          "returned after \(elapsed)s — the timeout is still waiting on the work")
+    }
+
+    /// The timeout must not fire on work that finishes in time, and the real result must survive.
+    func testFastToolReturnsItsOwnResult() async {
+        let router = router(with: UncancellableTool(name: "quick_tool", seconds: 0.05), timeout: 5)
+
+        let result = await router.handleToolCall(name: "quick_tool", args: [:])
+        guard case .success(let text) = result else {
+            return XCTFail("expected success, got \(result)")
+        }
+        XCTAssertEqual(text, "finished")
+    }
+
+    /// A throwing tool still reports its own error rather than a timeout.
+    func testThrowingToolReportsItsError() async {
+        let router = router(with: ThrowingTool(name: "bad_tool"), timeout: 5)
+
+        let result = await router.handleToolCall(name: "bad_tool", args: [:])
+        guard case .failure(let message) = result else {
+            return XCTFail("expected failure, got \(result)")
+        }
+        XCTAssertTrue(message.contains("Tool error"), "got: \(message)")
+        XCTAssertFalse(message.contains("timed out"))
+    }
+
+    /// Only one of the two racers may resolve the call — a late finisher must not resume the
+    /// continuation a second time (which would trap).
+    func testLateFinisherDoesNotDoubleResolve() async {
+        let router = router(with: UncancellableTool(name: "slow_tool", seconds: 0.4), timeout: 0.1)
+
+        let result = await router.handleToolCall(name: "slow_tool", args: [:])
+        guard case .failure = result else { return XCTFail("expected the timeout to win") }
+
+        // Give the abandoned work time to finish and attempt its resume. If the guard were wrong
+        // this crashes the test process rather than failing an assertion.
+        try? await Task.sleep(nanoseconds: 700_000_000)
+    }
+}
+
+// MARK: - Fixtures
+
+/// Ignores cancellation on purpose: `try?` swallows the `CancellationError` from `Task.sleep`, so
+/// the loop keeps running to its wall-clock deadline the way a real SDK call would.
+private struct UncancellableTool: NativeTool {
+    let name: String
+    let seconds: TimeInterval
+    var description = "test fixture"
+    var parametersSchema: [String: Any] = ["type": "object", "properties": [:] as [String: Any]]
+
+    func execute(args: [String: Any]) async throws -> String {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return "finished"
+    }
+}
+
+private struct ThrowingTool: NativeTool {
+    let name: String
+    var description = "test fixture"
+    var parametersSchema: [String: Any] = ["type": "object", "properties": [:] as [String: Any]]
+
+    struct Boom: Error {}
+    func execute(args: [String: Any]) async throws -> String { throw Boom() }
+}

--- a/project.base.yml
+++ b/project.base.yml
@@ -159,6 +159,9 @@ targets:
     sources:
       - path: GlassesActivityWidget
       - path: OpenGlasses/Sources/Models/GlassesActivityAttributes.swift
+      # Shared with the main app — the widget stamps the deep-link trust token that the
+      # app requires on any link that acts (capture, listen, quick action).
+      - path: OpenGlasses/Sources/Shared/DeepLinkTrust.swift
     entitlements:
       path: GlassesActivityWidget/GlassesActivityWidget.entitlements
       properties:


### PR DESCRIPTION
Follow-up to #264 — the four remaining items from that review, plus one found while fixing them.

## 1. `code_agent` could start a run without confirmation

`AgentControlTool` dispatches an arbitrary free-text task to a remote coding agent — the same blast radius as `execute`, which *is* in `PromptInjectionPolicy.highImpactTools`. `code_agent` wasn't, so injected content could start a run with no confirmation. The tool's own `confirm` case is explicitly hardened against self-approval, which suggests the missing gate on `start` was an oversight.

**Why not just add the name to the set.** `code_agent` isn't all-or-nothing. `status` is a read, `cancel`/`deny` only ever reduce what's running, and `confirm` is itself the answer to a consent prompt. Gating those would put a confirmation in front of routine calls and train the wearer to approve reflexively, weakening the one prompt that matters.

So the classification is now args-aware. `isHighImpact(toolName:args:)` gates `code_agent` only when the call would dispatch, and `isDispatchingAgentRun` mirrors `AgentControlTool`'s own parsing — a missing or non-string `action` defaults to `start` there, so it's gated here too and omitting the argument isn't a bypass. `args` is threaded through `SafetySupervisor.apply` and `autonomyCeiling`; all four call sites updated, no name-only variant left behind. The Plan W autonomy ceiling inherits this: an idle wearer holds a dispatch but can still ask for status.

## 2. The agent-mode confirmation gate failed open

```swift
case .confirm(let reason):
    if let coordinator = confirmationCoordinator { ... }
    // no else — fell through and executed
```

The agent-mode-*off* floor 35 lines above already handles this — *"fail closed rather than actuate blind"*. The more autonomous mode had the weaker default. Both now fail closed.

## 3. The tool timeout bounded nothing

`executeWithTimeout` raced the work against a sentinel inside a `withTaskGroup`, but **a task group awaits all of its children before returning** — so when the sentinel won, the group still blocked until the real work finished. `cancelAll()` only requests cooperative cancellation, and most tools here (HomeKit writes, URL-scheme launches, third-party SDK calls) never check it. A hung tool held the turn open indefinitely.

The two racers now resolve a single continuation with a lock picking the winner, so the caller returns on time and work that ignores cancellation is abandoned rather than waited on. A late finisher can't double-resume, and it logs when it lands — its side effect happened after the model was told the call timed out.

The regression test asserts a 2 s uncancellable tool returns at a 0.3 s timeout; it now returns in 0.306 s.

## 4. `openglasses://` accepted commands from any app

A custom URL scheme is an unauthenticated entry point: any installed app can open one silently, and iOS exposes no usable caller identity (`sourceApplication` is absent through SwiftUI's `onOpenURL`). Several links act — `action/photo` and `action/describe` capture a frame from the glasses and send it to an LLM, `listen/on` opens the mic, `quickaction` runs a stored action, `persona` and `connect` both start a listening turn. That made the app a silent capture trigger for anything on the device.

Trust is now a shared secret: the app mints a token into the app-group container at launch, the widgets stamp it onto the links they build (`DeepLinkTrust.signedURL`), and the app requires it on any link that acts. Another app can't read our group container, so it can't mint a link that passes. `DeepLinkTrust` is compiled into both the app and the widget extension so producer and consumer can't drift.

Capability-*reducing* links (`disconnect`, `listen/off`) stay open deliberately — a hostile caller gains nothing by stopping the microphone, and gating them would break the panic-off path. The policy is one pure function, so the classification is tested directly rather than through the URL handler.

## 5. The Shortcuts callback leg was spoofable

Found while doing #4 — same class of bug. `run_shortcut` hands Shortcuts three `openglasses://shortcut-{result,cancel,error}` callback URLs and waits up to 30 s. That return leg is a deep link anyone can open, so another app could answer the pending call with text of its own, which is then handed to the model as the tool's result. Tool output already gets the untrusted-data envelope, so this was spoofing rather than direct injection — but nothing stopped an unrelated caller from resolving the wait.

The app now mints a one-shot token per invocation, stamps it on the three callback URLs, and ignores any callback without it. The token is burned when the wait resolves, so a captured URL can't be replayed against the next invocation.

The token rides unencoded, as these callback values already did — `?` and `=` are legal inside a query value, and base64url contains no `&` to break out of the outer `shortcuts://x-callback-url` query. That's the risky part and the part I can't exercise on a simulator, so it's pinned by tests: the callback URL round-trips through the outer query byte-for-byte, the outer params still parse alongside the nested one, and the generator's alphabet is asserted to stay clear of the delimiters.

## Verification

- Full suite: **2225 tests, 0 failures**
- Release build: green

New tests: `AgentConfirmationGapTests`, `ToolTimeoutTests`, `DeepLinkTrustTests`, `ShortcutCallbackTrustTests` (47 cases). Also fixed a warning introduced in #264 (`clearSession` discarding `removeValue`'s result).

## Note on the runs

An earlier full-suite run failed `GlassesDisplayInteractiveTests.testNonInteractiveFlashAutoClears`, which asserts a 50 ms HUD flash has cleared after a fixed 120 ms settle. It took 8.4 s while a Release build ran concurrently, and passes in 0.387 s in isolation — timing-sensitive under load, in a subsystem this PR doesn't touch (being fixed separately). Two other runs hit the intermittent CoreSimulator launch flake (`failed to launch com.openglasses.app`), cleared by shutdown → erase → boot. The numbers above are from clean runs on the final source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)