### PR TITLE
Give every signed target a development team in local signing config

### DIFF
--- a/Scripts/setup-local-dev.sh
+++ b/Scripts/setup-local-dev.sh
@@ -48,6 +48,26 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Config/Entitlements/Personal/GlassesActivityWidget.entitlements
         DEVELOPMENT_TEAM: ${team}
         PRODUCT_BUNDLE_IDENTIFIER: ${widget_bundle}
+
+  # The remaining signed targets need a team as well, or a command-line device build fails on
+  # them ("Signing for X requires a development team"). Xcode's GUI hides this by filling the
+  # team in automatically, so the gap only surfaces in CI or a headless
+  # \`xcodebuild -destination 'platform=iOS,...'\`. They keep the committed entitlements —
+  # their only capability is the shared app group, which any team can sign.
+  OpenGlassesShareExtension:
+    settings:
+      base:
+        DEVELOPMENT_TEAM: ${team}
+
+  OpenGlassesWatch:
+    settings:
+      base:
+        DEVELOPMENT_TEAM: ${team}
+
+  OpenGlassesWatchWidget:
+    settings:
+      base:
+        DEVELOPMENT_TEAM: ${team}
 EOF
 }
 

--- a/project.local.yml.example
+++ b/project.local.yml.example
@@ -23,10 +23,25 @@ targets:
         CODE_SIGN_ENTITLEMENTS: Config/Entitlements/Personal/GlassesActivityWidget.entitlements
         DEVELOPMENT_TEAM: YOUR_APPLE_TEAM_ID
 
-  # Teleprompter Share Extension (PR B). Copy Config/Entitlements/Personal/GlassesActivityWidget.entitlements
-  # to OpenGlassesShareExtension.entitlements (same app group) for device builds.
+  # Every remaining signed target needs a team as well, or a command-line device build fails
+  # on it ("Signing for X requires a development team"). Building from Xcode's GUI hides this,
+  # because automatic signing fills the team in for you — so the gap only shows up in CI or in
+  # a headless `xcodebuild -destination 'platform=iOS,...'`.
+  #
+  # Unlike the app and the widget, these three keep the committed entitlements: their only
+  # capability is the shared app group, which any team can sign. There's no personal override
+  # to copy, and none is needed.
   OpenGlassesShareExtension:
     settings:
       base:
-        CODE_SIGN_ENTITLEMENTS: Config/Entitlements/Personal/OpenGlassesShareExtension.entitlements
+        DEVELOPMENT_TEAM: YOUR_APPLE_TEAM_ID
+
+  OpenGlassesWatch:
+    settings:
+      base:
+        DEVELOPMENT_TEAM: YOUR_APPLE_TEAM_ID
+
+  OpenGlassesWatchWidget:
+    settings:
+      base:
         DEVELOPMENT_TEAM: YOUR_APPLE_TEAM_ID


### PR DESCRIPTION
Found while building OpenGlasses for a physical device from the command line.

## The failure

```
error: Signing for "OpenGlassesShareExtension" requires a development team.
error: Signing for "OpenGlassesWatchWidget" requires a development team.
error: Signing for "OpenGlassesWatch" requires a development team.
** BUILD FAILED **
```

`project.local.yml.example` set `DEVELOPMENT_TEAM` for the app, the widget and the Share Extension. `Scripts/setup-local-dev.sh` generated it for only the app and the widget. Neither covered `OpenGlassesWatch` or `OpenGlassesWatchWidget`.

Building from Xcode's GUI hides this — automatic signing fills the team in for you — so the gap only shows up in CI or a headless `xcodebuild -destination 'platform=iOS,...'`, which is exactly where it's most annoying.

## Also fixed

The example pointed the Share Extension at `Config/Entitlements/Personal/OpenGlassesShareExtension.entitlements`, a file that doesn't exist in the repo and that `setup-local-dev.sh` never creates. Anyone copying the example verbatim cleared the missing-team error and walked straight into a missing-entitlements one.

The three targets added here keep their committed entitlements instead. Unlike the app and widget — which need personal overrides because HomeKit / CarPlay / increased-memory-limit can't be signed by every team — these three only declare the shared app group, which any team can sign. No personal override is needed, so the example no longer implies one.

## Verification

- `Scripts/generate-xcodeproj.sh` now emits a team for all ten signed build configurations (previously the three targets above had none).
- The generator's heredoc output parses as valid YAML with the team substituted into all five targets.
- A full `xcodebuild -configuration Release -destination 'platform=iOS,id=...'` device build succeeds and installs.

Note that `project.local.yml` itself is gitignored, so existing clones need the three stanzas adding by hand (or re-run `Scripts/setup-local-dev.sh`); this PR fixes the two sources that new clones come from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)