### PR TITLE
Retry the XcodeGen release download in ci_post_clone

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -27,7 +27,12 @@ if ! command -v xcodegen >/dev/null 2>&1; then
   tools_dir="$PWD/.ci-tools/xcodegen-${XCODEGEN_VERSION}"
   rm -rf "$tools_dir"
   mkdir -p "$tools_dir"
-  curl -fsSL "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip" \
+  # Retries: a single connect failure here (curl exit 7) killed a whole archive under `set -e` —
+  # release assets redirect to objects.githubusercontent.com, a different host from the one the
+  # clone proved reachable, and Xcode Cloud's network drops it occasionally. --retry-all-errors
+  # covers connect-level failures, which plain --retry does not consider transient.
+  curl -fsSL --retry 8 --retry-all-errors --retry-delay 3 --connect-timeout 20 \
+    "https://github.com/yonaskolb/XcodeGen/releases/download/${XCODEGEN_VERSION}/xcodegen.zip" \
     -o "$tools_dir/xcodegen.zip"
   unzip -oq "$tools_dir/xcodegen.zip" -d "$tools_dir"
   xcodegen_bin="$(find "$tools_dir" -type f -name xcodegen -path '*/bin/*' | head -n 1)"


### PR DESCRIPTION
The Xcode Cloud archive on `main` (post-#267 merge) failed in `ci_post_clone.sh` with exit code 7 — that's curl "failed to connect" on the XcodeGen release download, fatal under `set -e`.

**Not the dependency pins from #267**: I regenerated the project, re-resolved against the new exact pins, and `ci_scripts/Package.resolved` came out byte-identical — the committed lockfile was already in sync. The failure is network-transient: release assets redirect to `objects.githubusercontent.com`, a different host from the one the clone itself proved reachable, and Xcode Cloud's network drops it occasionally (same family as the known ghcr.io resolution failure that forced the release-download approach in the first place).

Fix: `--retry 8 --retry-all-errors --retry-delay 3 --connect-timeout 20` on the curl. `--retry-all-errors` matters — plain `--retry` doesn't consider connect-level failures transient, so it wouldn't have retried this one.

Merging this re-triggers the archive on the merge commit, which doubles as the retry. Alternatively hit Rebuild on the failed build in App Store Connect first if you want the artifact sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)