### PR TITLE
CK P3: device-smoke groundwork — tuning knobs, perf instrumentation, measured baselines

### DIFF
--- a/OpenGlasses/Sources/App/Views/FingerspellingSettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/FingerspellingSettingsView.swift
@@ -7,6 +7,8 @@ import SwiftUI
 struct FingerspellingSettingsView: View {
     @EnvironmentObject private var appState: AppState
     @AppStorage("fingerspellingEnabled") private var enabled: Bool = false
+    @AppStorage("fingerspellingDecodeEveryFrames") private var decodeEveryFrames: Int = 8
+    @AppStorage("fingerspellingConfidenceFloor") private var confidenceFloor: Double = 0.5
     @StateObject private var downloader = FingerspellingModelDownloader()
     @ObservedObject private var session = FingerspellingSessionService.shared
 
@@ -26,6 +28,7 @@ struct FingerspellingSettingsView: View {
                 modelSection
                 if downloader.state == .ready {
                     sessionSection
+                    tuningSection
                 }
             }
         }
@@ -127,6 +130,42 @@ struct FingerspellingSettingsView: View {
             Text("Live Recognition")
         } footer: {
             Text("Works best with the signer 1–2 m away, facing the camera, at a camera frame rate of 15 fps or higher (Settings › Look & Feel › Camera).")
+        }
+    }
+
+    // MARK: - Tuning (Plan CK P3)
+
+    @ViewBuilder
+    private var tuningSection: some View {
+        Section {
+            Stepper(value: $decodeEveryFrames, in: 2...30) {
+                HStack {
+                    Text("Decode every")
+                    Spacer()
+                    Text("\(decodeEveryFrames) frames")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Stepper(value: $confidenceFloor, in: 0...0.9, step: 0.05) {
+                HStack {
+                    Text("Confidence floor")
+                    Spacer()
+                    Text(confidenceFloor == 0 ? "off"
+                         : String(format: "%.2f", confidenceFloor))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if session.isActive, let perf = session.perfSummary {
+                HStack {
+                    Text("Pipeline")
+                    Spacer()
+                    Text(perf).font(.footnote.monospaced()).foregroundStyle(.secondary)
+                }
+            }
+        } header: {
+            Text("Tuning")
+        } footer: {
+            Text("Device-smoke knobs: shorter decode intervals lower latency but cost battery; the confidence floor trades missed letters against false ones (0 = pure greedy decode). Changes apply the next time recognition starts.")
         }
     }
 }

--- a/OpenGlasses/Sources/Services/SignLanguage/FingerspellingSessionService.swift
+++ b/OpenGlasses/Sources/Services/SignLanguage/FingerspellingSessionService.swift
@@ -34,6 +34,9 @@ final class FingerspellingSessionService: ObservableObject {
     @Published private(set) var lastCommittedWord: String?
     /// User-facing status/problem line ("Model not downloaded", extraction errors, …).
     @Published private(set) var statusDetail: String?
+    /// Rolling per-stage latency line ("landmarks 34 ms · decode 58 ms") — P3 smoke
+    /// instrumentation, refreshed each decode tick.
+    @Published private(set) var perfSummary: String?
 
     private var frameContinuation: AsyncStream<(UIImage, Int)>.Continuation?
     private var pump: Task<Void, Never>?
@@ -56,7 +59,8 @@ final class FingerspellingSessionService: ObservableObject {
     /// of building latency; tests pass nil (unbounded) so synchronous bursts all arrive.
     func start(dependencies: Dependencies,
                decodeEveryFrames: Int = 8,
-               frameBufferLimit: Int? = 2) {
+               frameBufferLimit: Int? = 2,
+               rules: DecodeStabilityPolicy.Rules = FingerspellingLiveDecoder.ctcRules()) {
         guard !isActive else { return }
         isActive = true
         statusDetail = nil
@@ -72,7 +76,8 @@ final class FingerspellingSessionService: ObservableObject {
         frameContinuation = continuation
         let pipeline = FingerspellingPipeline(landmarks: dependencies.landmarks,
                                               inference: dependencies.inference,
-                                              decodeEveryFrames: decodeEveryFrames)
+                                              decodeEveryFrames: decodeEveryFrames,
+                                              rules: rules)
         pump = Task { [weak self] in
             for await (image, timestamp) in stream {
                 let outcome = await pipeline.process(image: image,
@@ -141,6 +146,10 @@ final class FingerspellingSessionService: ObservableObject {
             return
         }
 
+        // P3 tuning knobs (Settings › Fingerspelling › Tuning): decode cadence and the
+        // observation confidence floor, adjustable on device without rebuilds.
+        var rules = FingerspellingLiveDecoder.ctcRules()
+        rules.confidenceFloor = Config.fingerspellingConfidenceFloor
         start(dependencies: Dependencies(
             landmarks: built.0,
             inference: built.1.logits(for:),
@@ -152,7 +161,9 @@ final class FingerspellingSessionService: ObservableObject {
             },
             clearCaption: { [weak display] in
                 display?.clear()
-            }))
+            }),
+            decodeEveryFrames: Config.fingerspellingDecodeEveryFrames,
+            rules: rules)
 
         self.camera = camera
         frameSubscription = camera.framePublisher.sink { [weak self] image in
@@ -175,6 +186,9 @@ final class FingerspellingSessionService: ObservableObject {
         guard let dependencies else { return }
         if let problem = outcome.problem {
             statusDetail = problem
+        }
+        if let summary = outcome.perfSummary {
+            perfSummary = summary
         }
         for event in outcome.events {
             switch event {
@@ -209,6 +223,8 @@ actor FingerspellingPipeline {
     struct Outcome {
         var events: [DecodeStabilityPolicy.Event] = []
         var problem: String?
+        /// Rolling perf summary, refreshed once per decode tick (P3 smoke instrumentation).
+        var perfSummary: String?
     }
 
     private let landmarks: HolisticLandmarkProviding
@@ -216,6 +232,9 @@ actor FingerspellingPipeline {
     private let decodeEveryFrames: Int
     private var decoder: FingerspellingLiveDecoder
     private var framesSinceDecode = 0
+    /// Rolling per-stage latencies (ms) over the last ~2 s of frames.
+    private var extractionSamples: [Double] = []
+    private var decodeSamples: [Double] = []
 
     init(landmarks: HolisticLandmarkProviding,
          inference: @escaping FingerspellingLiveDecoder.Inference,
@@ -230,6 +249,7 @@ actor FingerspellingPipeline {
     func process(image: UIImage, timestampMilliseconds: Int) -> Outcome {
         var outcome = Outcome()
         let frame: HolisticFrame
+        let extractionStart = CACurrentMediaTime()
         do {
             frame = try landmarks.holisticFrame(for: image,
                                                 timestampMilliseconds: timestampMilliseconds)
@@ -237,18 +257,43 @@ actor FingerspellingPipeline {
             outcome.problem = "Landmark extraction failed: \(error.localizedDescription)"
             return outcome
         }
+        recordSample(&extractionSamples, since: extractionStart)
         outcome.events = decoder.append(frame)
 
         framesSinceDecode += 1
         guard framesSinceDecode >= decodeEveryFrames,
               decoder.windowedFrameCount > 0 else { return outcome }
         framesSinceDecode = 0
+        let decodeStart = CACurrentMediaTime()
         do {
             outcome.events += try decoder.tick(infer: inference)
+            recordSample(&decodeSamples, since: decodeStart)
+            outcome.perfSummary = perfSummary()
         } catch {
             outcome.problem = "Decode failed: \(error.localizedDescription)"
         }
         return outcome
+    }
+
+    // MARK: - P3 instrumentation
+
+    private func recordSample(_ samples: inout [Double], since start: CFTimeInterval) {
+        samples.append((CACurrentMediaTime() - start) * 1000)
+        if samples.count > 30 { samples.removeFirst(samples.count - 30) }
+    }
+
+    /// One line per decode tick, e.g. "landmarks 34 ms · decode 58 ms" — read live in the
+    /// Tuning section and via `[CK-Perf]` in Console during device smoke.
+    private func perfSummary() -> String? {
+        func median(_ samples: [Double]) -> Double? {
+            guard !samples.isEmpty else { return nil }
+            return samples.sorted()[samples.count / 2]
+        }
+        guard let extraction = median(extractionSamples),
+              let decode = median(decodeSamples) else { return nil }
+        let summary = "landmarks \(Int(extraction)) ms · decode \(Int(decode)) ms"
+        NSLog("[CK-Perf] %@", summary)
+        return summary
     }
 
     func flush() -> Outcome {

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -2893,6 +2893,17 @@ struct Config {
 
     static func setFingerspellingEnabled(_ enabled: Bool) { fingerspellingEnabled = enabled }
 
+    /// P3 tuning knobs, runtime-adjustable so device smoke needs no rebuilds
+    /// (Settings › Accessibility › Fingerspelling › Tuning). Defaults match the shipped
+    /// P2 values; both are read at session start.
+    /// Decode cadence in appended frames (≈ every 0.5 s at 15 fps with the default 8).
+    @UserDefaultsBacked("fingerspellingDecodeEveryFrames", default: 8)
+    static var fingerspellingDecodeEveryFrames: Int
+    /// Confidence floor on per-row CTC observations (0 disables the floor entirely —
+    /// pure greedy decode, matching the offline gate).
+    @UserDefaultsBacked("fingerspellingConfidenceFloor", default: 0.5)
+    static var fingerspellingConfidenceFloor: Double
+
     /// Master toggle for the Field Assist feature. When off, no vaults are loaded
     /// and the FieldSessionTool is not registered.
     static var fieldAssistEnabled: Bool {

--- a/OpenGlassesTests/FingerspellingPerfHarnessTests.swift
+++ b/OpenGlassesTests/FingerspellingPerfHarnessTests.swift
@@ -1,0 +1,122 @@
+import CoreML
+import UIKit
+import XCTest
+@testable import OpenGlasses
+
+/// P3 perf harness (Plan CK): measures the two heavy stages of the live pipeline against
+/// the real artefacts, headlessly. Env-gated like the engine parity test — set
+/// `CK_FS_MLPACKAGE` (model package path) and `CK_LANDMARKER_TASK` (holistic task path);
+/// CI skips.
+///
+/// The decode half runs in any configuration. The landmarker half needs the MediaPipe
+/// calculators (Release `-force_load`) — but note that on the 8 GB dev MacBook Air a
+/// Release-configuration `xcodebuild test` reliably hangs at runner bootstrap (the same
+/// abseil static-init contention that pushed force_load out of Debug), so in practice the
+/// landmarker latency numbers come from the live pipeline's built-in `[CK-Perf]`
+/// instrumentation during device smoke instead; this test stays for hosts/devices where
+/// Release-config testing works.
+///
+/// Output (test log): median/p90 per-frame landmark latency, median/max per-tick decode
+/// latency, and the implied comfortable frame rate + decode cadence — the numbers that
+/// seed the on-device Tuning defaults.
+final class FingerspellingPerfHarnessTests: XCTestCase {
+
+    private func environmentURL(_ key: String) throws -> URL {
+        guard let path = ProcessInfo.processInfo.environment[key] else {
+            throw XCTSkip("\(key) not set — perf harness runs locally against real artefacts")
+        }
+        return URL(fileURLWithPath: path)
+    }
+
+    private func measureMs(_ block: () throws -> Void) rethrows -> Double {
+        let start = CACurrentMediaTime()
+        try block()
+        return (CACurrentMediaTime() - start) * 1000
+    }
+
+    private func summarize(_ name: String, _ samples: [Double]) {
+        let sorted = samples.sorted()
+        let median = sorted[sorted.count / 2]
+        let p90 = sorted[min(Int(Double(sorted.count) * 0.9), sorted.count - 1)]
+        print("[CK-P3] \(name): median \(String(format: "%.1f", median)) ms, "
+              + "p90 \(String(format: "%.1f", p90)) ms, "
+              + "max \(String(format: "%.1f", sorted.last ?? 0)) ms over \(samples.count) runs")
+    }
+
+    /// A camera-sized frame with enough structure that the graph does real work
+    /// (gradient + blobs; without a person it reports no landmarks, which is fine —
+    /// the graph still runs its detector stages every frame).
+    private func syntheticFrame(seed: Int) -> UIImage {
+        let size = CGSize(width: 1280, height: 720)
+        return UIGraphicsImageRenderer(size: size).image { context in
+            let colors = [UIColor(white: 0.85, alpha: 1), UIColor(white: 0.35, alpha: 1)]
+            colors[seed % 2].setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+            UIColor(hue: CGFloat(seed % 10) / 10, saturation: 0.6,
+                    brightness: 0.7, alpha: 1).setFill()
+            for blob in 0..<6 {
+                let x = CGFloat((seed * 97 + blob * 211) % 1100)
+                let y = CGFloat((seed * 61 + blob * 149) % 600)
+                context.cgContext.fillEllipse(in: CGRect(x: x, y: y, width: 140, height: 180))
+            }
+        }
+    }
+
+    func testLandmarkerPerFrameLatency() throws {
+        let taskURL = try environmentURL("CK_LANDMARKER_TASK")
+        let service: HolisticLandmarkService
+        do {
+            service = try HolisticLandmarkService(taskModelURL: taskURL)
+        } catch {
+            throw XCTSkip("landmarker unavailable (Debug link has no calculators): \(error)")
+        }
+
+        let frames = (0..<40).map(syntheticFrame(seed:))
+        // Warmup: first detections page in the graph.
+        for (index, frame) in frames.prefix(5).enumerated() {
+            _ = try? service.holisticFrame(for: frame, timestampMilliseconds: index)
+        }
+        var samples: [Double] = []
+        for (index, frame) in frames.dropFirst(5).enumerated() {
+            let ms = measureMs {
+                _ = try? service.holisticFrame(for: frame, timestampMilliseconds: 1000 + index)
+            }
+            samples.append(ms)
+        }
+        summarize("landmarker per-frame (no-person floor)", samples)
+        let median = samples.sorted()[samples.count / 2]
+        print("[CK-P3] implied max sustainable camera rate ≈ \(Int(1000 / max(median, 1))) fps "
+              + "(simulator CPU; device numbers differ)")
+    }
+
+    func testDecodePerTickLatency() throws {
+        let modelURL = try environmentURL("CK_FS_MLPACKAGE")
+        let configuration = MLModelConfiguration()
+        let engine = try FingerspellingInferenceEngine(modelPackageURL: modelURL,
+                                                       configuration: configuration)
+
+        // A representative mid-conversation window: 240 present frames of plausible
+        // standardized values.
+        var frames: [HolisticFrame] = []
+        var generator = SystemRandomNumberGenerator()
+        for index in 0..<240 {
+            let points = (0..<HolisticLayout.landmarkCount).map { _ in
+                SIMD3(x: Float.random(in: 0.2...0.8, using: &generator),
+                      y: Float.random(in: 0.2...0.8, using: &generator),
+                      z: Float.random(in: -0.1...0.1, using: &generator))
+            }
+            frames.append(HolisticFrame(timestamp: TimeInterval(index) / 15, points: points))
+        }
+        let input = try XCTUnwrap(HolisticWindower.modelInput(for: frames))
+
+        _ = try engine.logits(for: input) // warmup / compile cache
+        var samples: [Double] = []
+        for _ in 0..<12 {
+            samples.append(try measureMs { _ = try engine.logits(for: input) })
+        }
+        summarize("decode per-tick (240-frame window)", samples)
+        let median = samples.sorted()[samples.count / 2]
+        print("[CK-P3] at 15 fps, decode-every-8-frames budget is 533 ms; "
+              + "median tick uses \(Int(100 * median / 533))% of it")
+    }
+}

--- a/OpenGlassesTests/WearablesBootstrapTests.swift
+++ b/OpenGlassesTests/WearablesBootstrapTests.swift
@@ -79,6 +79,10 @@ final class WearablesBootstrapTests: XCTestCase {
         XCTAssertEqual(bare.errorDescription, "Meta SDK not registered")
     }
 
+    // `resetForTesting` only exists in Debug app builds; these two tests compile out of a
+    // Release-configuration test run (used by the Plan CK P3 perf harness) rather than
+    // breaking the whole test target's build.
+    #if DEBUG
     /// "Not attempted" and "attempted and failed" need opposite fixes, so they must not report the
     /// same thing. Conflating a bad configuration with an absent one is a real time sink.
     func testStatusDescriptionDistinguishesNotAttemptedFromFailed() {
@@ -94,4 +98,5 @@ final class WearablesBootstrapTests: XCTestCase {
         XCTAssertNil(WearablesBootstrap.failureReason)
         XCTAssertEqual(WearablesBootstrap.statusDescription, "not configured")
     }
+    #endif
 }

--- a/docs/plans/CK-sign-language.md
+++ b/docs/plans/CK-sign-language.md
@@ -197,6 +197,56 @@ decode cadence tuning (per-second re-decode vs gap-triggered; re-feeding refined
 confidence-floor tuning against live logit distributions, and the drop-face fallback
 decision if perf demands it.
 
+## P3 — device smoke (protocol; no signer required)
+
+Groundwork shipped with this phase: runtime **Tuning** knobs (decode cadence + confidence
+floor, Settings › Accessibility › Fingerspelling — no rebuilds between trials), live
+**pipeline instrumentation** (a rolling "landmarks N ms · decode N ms" line in the Tuning
+section and as `[CK-Perf]` in Console, refreshed per decode tick), and the env-gated
+**perf harness** (`FingerspellingPerfHarnessTests`, `CK_LANDMARKER_TASK`/
+`CK_FS_MLPACKAGE`). Finding recorded during this phase: a Release-configuration
+`xcodebuild test` hangs at runner bootstrap on the 8 GB dev machine — the same abseil
+static-init contention that pushed `-force_load` out of Debug — so the landmarker half of
+the harness is effectively device-only. Simulator decode-tick baseline (Debug config,
+CPU-only, real mlpackage, full 240-frame window): **median 1088 ms / p90 1103 ms** —
+2× the 533 ms decode-every-8-at-15 fps budget on this worst-case substrate. Two readings:
+(a) the frame-dropping hand-off already makes a slow decode degrade gracefully (drops
+frames, never queues latency); (b) the on-device number (ANE, fp16) from the `[CK-Perf]`
+line is the real cadence decider — if it also exceeds ~500 ms, raise decode-every toward
+12–16 in Tuning or shrink the window (a P4 candidate: decode over the trailing ~256
+frames instead of 768).
+
+**App-size delta (measured, device Release):** the graph-archive `-force_load` costs
+**38.0 MB** of app binary — 156.4 MB with vs 118.4 MB linking the same archive without
+force_load (registrars dead-stripped). That is the App Store price of the MediaPipe
+runtime; the drop-face fallback would not reduce it (same graph archive), so any size
+reclaim would have to come from a slimmer custom graph build — noted as a P4-if-ever.
+
+The smoke protocol is designed to run **solo** — no ASL signer available:
+
+1. **Battery/thermal/frame-rate run (no signer needed at all):** Release build on device,
+   camera at 15 fps, start recognition pointed at any busy scene. Record: battery % at
+   0/15/30 min, thermal state (`Wearables.deviceStateStream` thermal level for the
+   glasses + iPhone warmth), whether frames drop (provisional-word cadence stutter).
+   Repeat at 24 fps if the 15 fps run stays cool.
+2. **Accuracy feel via screen replay:** point the glasses at a monitor playing ASL
+   fingerspelling practice videos (names/words at natural speed, e.g. any "fingerspelling
+   practice" series) from ~1–1.5 m. The camera sees a real signer; the full live path
+   runs. Known caveats: flat image (no depth), screen glare — treat as a lower bound.
+   Record: words committed vs shown, letter substitutions, latency from last letter to
+   speech.
+3. **Handshape sanity via self-spelling:** with an ASL alphabet chart, slowly spell a
+   name at arm's length facing a mirror-mounted phone or the glasses on a stand.
+   Fingerspelling is 26 static-ish handshapes — no signing fluency needed. This checks
+   the camera-facing geometry note (P2) with real 3-D hands.
+4. **Tuning sweep:** for each scenario, try decode-every 4/8/12 frames and confidence
+   floor 0/0.35/0.5 — the Tuning section applies on next start. If battery or thermals
+   fail the 30-minute bar, the recorded fallback is dropping the face landmarks
+   (29.2% CER, ablation table above) — that decision gets its own follow-up if needed.
+5. **Debug-build note:** the calculators only register under Release's `-force_load`; a
+   Debug device run needs those flags copied to Debug in `project.base.yml` for the
+   session (revert before committing).
+
 ## Open questions
 
 - Model provenance/licensing (must be clean for a proprietary app — trained-by-us is

--- a/project.base.yml
+++ b/project.base.yml
@@ -120,7 +120,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "348"
+        CURRENT_PROJECT_VERSION: "349"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -210,7 +210,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "348"
+        CURRENT_PROJECT_VERSION: "349"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -248,7 +248,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "348"
+        CURRENT_PROJECT_VERSION: "349"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "348"
+        CURRENT_PROJECT_VERSION: "349"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "348"
+        CURRENT_PROJECT_VERSION: "349"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## Plan CK P3 — device-smoke groundwork: tuning knobs, live perf instrumentation, measured baselines, solo protocol

Everything headlessly-measurable is measured; everything the physical smoke needs is now in the app or the plan doc. Designed for **solo execution** — no ASL signer required.

### Shipped

- **Runtime Tuning** (Settings › Accessibility › Fingerspelling › Tuning): decode cadence (2–30 frames) and confidence floor (0 = pure greedy), applied at session start — smoke trials iterate without rebuilds.
- **Live pipeline instrumentation**: rolling median "landmarks N ms · decode N ms", refreshed each decode tick, shown in the Tuning section and logged as `[CK-Perf]` — this is where the real on-device landmarker/ANE numbers will come from.
- **Perf harness** (`FingerspellingPerfHarnessTests`, env-gated `CK_LANDMARKER_TASK` / `CK_FS_MLPACKAGE`; CI skips).
- **Solo smoke protocol** in the plan doc: battery/thermal/frame-rate run (no signer needed at all), accuracy feel via screen-replayed fingerspelling practice videos, handshape sanity via chart self-spelling, tuning sweep matrix, Debug-build force_load note.

### Measured

| What | Number | Note |
|---|---|---|
| Decode per tick (full 240-frame window, real mlpackage) | **median 1088 ms, p90 1103 ms** | simulator CPU, Debug — the worst-case substrate; on-device ANE fp16 is the real decider via `[CK-Perf]`. The frame-dropping hand-off means a slow decode drops frames rather than queueing latency. |
| Graph-archive `-force_load` app-size cost | **38.0 MB** (156.4 → 118.4 MB) | device Release binary, measured with/without; the App Store price of the landmark runtime. Drop-face wouldn't reduce it — noted as P4-if-ever. |

### Findings

- **Release-configuration `xcodebuild test` reliably hangs at runner bootstrap on the 8 GB dev machine** — the same abseil static-init contention that pushed `-force_load` out of Debug, now reproduced 3× in Release-config testing (including after a sim erase). Consequence: the harness's landmarker half is device-only; documented in the harness and plan. `WearablesBootstrapTests`' Debug-only reset tests now compile out of Release test runs (they broke the target's Release build).
- Project-generation gotcha rediscovered the hard way: a test file added after `xcodegen generate` silently yields "Executed 0 tests" under `-only-testing` — the first "green" harness run was vacuous; regenerated and re-run for the real numbers above.

### Verification

Full suite **2732 tests, 0 failures, 3 designed skips** (engine parity + the two env-gated harness halves); Release sim build green. Build 349.

### What remains (requires hands on the hardware)

The physical smoke itself, following the protocol: battery/thermal at 15/24 fps, `[CK-Perf]` latency readings, screen-replay accuracy feel, tuning sweep. The Tuning knobs + instrumentation mean that session needs no development tooling — just the app and Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
