### PR TITLE
Fix saved-notes schema clash and frozen caption cursors

### DIFF
--- a/OpenGlasses/Sources/Services/AmbientCaptionService.swift
+++ b/OpenGlasses/Sources/Services/AmbientCaptionService.swift
@@ -11,10 +11,13 @@ class AmbientCaptionService: ObservableObject {
     @Published var currentCaption = ""
     @Published var captionHistory: [CaptionEntry] = []
 
-    struct CaptionEntry: Identifiable {
+    struct CaptionEntry: Identifiable, CaptionSequenced {
         let id = UUID()
         let text: String
         let timestamp: Date
+        /// Monotonic id assigned on insert. `captionHistory` is capped, so consumers cannot track
+        /// their position by array count — they track this instead (see `CaptionCursor`).
+        let seq: UInt64
         /// Diarized speaker id (`nil` = unlabeled / single-speaker path). Resolve to a display
         /// name via `speakerRegistry`.
         var speaker: Int? = nil
@@ -80,6 +83,15 @@ class AmbientCaptionService: ObservableObject {
 
     /// Max history entries to keep
     private let maxHistory = 50
+
+    /// Ever-increasing caption id. Never reset — a consumer holding an older `seq` must not have
+    /// it silently reused, or it would stop seeing new captions.
+    private var nextSeq: UInt64 = 0
+
+    private func makeSeq() -> UInt64 {
+        nextSeq += 1
+        return nextSeq
+    }
 
     /// Rolling transcript for current utterance
     private var lastFinalizedText = ""
@@ -389,7 +401,7 @@ class AmbientCaptionService: ObservableObject {
     /// transcript and assistant have context about what was seen.
     func insertVisualNote(_ description: String) {
         let note = "[Visual: \(description)]"
-        let entry = CaptionEntry(text: note, timestamp: Date())
+        let entry = CaptionEntry(text: note, timestamp: Date(), seq: makeSeq())
         captionHistory.insert(entry, at: 0)
         if captionHistory.count > maxHistory {
             captionHistory = Array(captionHistory.prefix(maxHistory))
@@ -432,8 +444,8 @@ class AmbientCaptionService: ObservableObject {
         guard trimmed != lastFinalizedText else { return }
 
         lastFinalizedText = trimmed
-        let entry = CaptionEntry(text: trimmed, timestamp: Date(), speaker: speaker,
-                                 original: original, language: language)
+        let entry = CaptionEntry(text: trimmed, timestamp: Date(), seq: makeSeq(),
+                                 speaker: speaker, original: original, language: language)
         captionHistory.insert(entry, at: 0)
 
         // Trim history

--- a/OpenGlasses/Sources/Services/AudioRecordingService.swift
+++ b/OpenGlasses/Sources/Services/AudioRecordingService.swift
@@ -31,7 +31,7 @@ class AudioRecordingService: ObservableObject {
     private var recordingStartDate: Date?
 
     private(set) var recordingTranscript = ""
-    private var lastCaptionCount = 0
+    private var captionCursor = CaptionCursor()
 
     private static let audioConsumerId = "audio_recording"
 
@@ -46,7 +46,7 @@ class AudioRecordingService: ObservableObject {
         guard !isRecording else { return }
 
         let tempDir = FileManager.default.temporaryDirectory
-        let fileName = "OG_Audio_\(Int(Date().timeIntervalSince1970)).m4a"
+        let fileName = Self.recordingFileName()
         let url = tempDir.appendingPathComponent(fileName)
         try? FileManager.default.removeItem(at: url)
 
@@ -70,7 +70,11 @@ class AudioRecordingService: ObservableObject {
         self.outputURL = url
         self.audioStartTime = nil
         self.recordingTranscript = ""
-        self.lastCaptionCount = 0
+        // Start from the present: captions already buffered predate this recording.
+        self.captionCursor = CaptionCursor()
+        if let captions = ambientCaptionService {
+            _ = self.captionCursor.take(newestFirst: captions.captionHistory)
+        }
         self.recordingStartDate = Date()
         self.recordingDuration = 0
         self.isRecording = true
@@ -134,16 +138,19 @@ class AudioRecordingService: ObservableObject {
 
     // MARK: - Private
 
+    /// A recording can be stopped and restarted within one second. Include a UUID so each
+    /// session owns a distinct audio file instead of colliding on a timestamp-only name.
+    static func recordingFileName(now: Date = Date(), id: UUID = UUID()) -> String {
+        "OG_Audio_\(Int(now.timeIntervalSince1970))_\(id.uuidString).m4a"
+    }
+
     private func collectCaptions() {
         guard let captions = ambientCaptionService else { return }
-        let history = captions.captionHistory
-        guard history.count > lastCaptionCount else { return }
-        let newEntries = history[lastCaptionCount...]
+        let newEntries = captionCursor.take(newestFirst: captions.captionHistory)
         let newText = newEntries.map(\.text).joined(separator: " ")
         if !newText.isEmpty {
             recordingTranscript += (recordingTranscript.isEmpty ? "" : " ") + newText
         }
-        lastCaptionCount = history.count
     }
 
     private func saveToDocuments(_ src: URL) -> URL? {

--- a/OpenGlasses/Sources/Services/CaptionCursor.swift
+++ b/OpenGlasses/Sources/Services/CaptionCursor.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// A caption entry carrying a monotonically increasing sequence number.
+protocol CaptionSequenced {
+    var seq: UInt64 { get }
+}
+
+/// Tracks which caption entries a consumer has already read.
+///
+/// `AmbientCaptionService.captionHistory` is a bounded newest-first buffer (`maxHistory`), so
+/// consumers cannot track their position by array count: once the buffer is full its count
+/// stops growing and a count-based cursor concludes "nothing new" forever — recording
+/// transcripts and the live meeting summary both went silent after `maxHistory` captions.
+/// Sequence numbers survive eviction.
+struct CaptionCursor {
+    private(set) var lastSeq: UInt64 = 0
+
+    /// Returns the entries not yet seen, oldest → newest.
+    /// - Parameter history: caption history ordered newest → oldest.
+    mutating func take<T: CaptionSequenced>(newestFirst history: [T]) -> [T] {
+        // History is descending by `seq`, so every unseen entry is at the front.
+        let fresh = history.prefix { $0.seq > lastSeq }
+        guard let newest = fresh.first else { return [] }
+        lastSeq = newest.seq
+        return Array(fresh.reversed())
+    }
+}

--- a/OpenGlasses/Sources/Services/MeetingAssistantService.swift
+++ b/OpenGlasses/Sources/Services/MeetingAssistantService.swift
@@ -23,8 +23,9 @@ class MeetingAssistantService: ObservableObject {
     /// Caption text accumulated since the last analysis round.
     private var bufferText: String = ""
 
-    /// Number of caption entries we have already consumed from the history array.
-    private var consumedCount: Int = 0
+    /// Position in the caption stream. Sequence-based, because `captionHistory` is capped and
+    /// stops growing once full.
+    private var cursor = CaptionCursor()
 
     /// Task managing the 60-second periodic trigger.
     private var timerTask: Task<Void, Never>?
@@ -44,7 +45,9 @@ class MeetingAssistantService: ObservableObject {
         self.llm = llm
         fullTranscript = []
         bufferText = ""
-        consumedCount = 0
+        // Start from the present: anything already in the buffer predates this meeting.
+        cursor = CaptionCursor()
+        _ = cursor.take(newestFirst: captionService.captionHistory)
         isAnalysing = false
         lastSummary = ""
 
@@ -84,18 +87,13 @@ class MeetingAssistantService: ObservableObject {
     /// Called whenever `captionHistory` publishes a new value.
     /// `captionHistory` is newest-first; we need entries we haven't seen yet.
     private func handleCaptionUpdate(_ history: [AmbientCaptionService.CaptionEntry]) {
-        let totalCount = history.count
-        let newCount = totalCount - consumedCount
-        guard newCount > 0 else { return }
+        let newEntries = cursor.take(newestFirst: history)
+        guard !newEntries.isEmpty else { return }
 
-        // The newest entries are at the front of the array.
-        // We want only the ones we haven't consumed yet, in chronological order.
-        let newEntries = Array(history.prefix(newCount).reversed())
         for entry in newEntries {
             fullTranscript.append(entry.text)
             bufferText += (bufferText.isEmpty ? "" : " ") + entry.text
         }
-        consumedCount = totalCount
 
         // Trigger early if the buffer already has ≥ 100 words.
         let wordCount = bufferText.split(whereSeparator: \.isWhitespace).count

--- a/OpenGlasses/Sources/Services/NativeTools/BrainTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/BrainTool.swift
@@ -228,7 +228,7 @@ struct BrainTool: NativeTool {
         }
 
         // Meeting summaries (keyword match over saved notes).
-        let meetingNotes = UserDefaults.standard.array(forKey: "saved_notes") as? [[String: String]] ?? []
+        let meetingNotes = SavedNotesStore.load()
         let meetingLines = meetingNotes.reversed().compactMap { note -> String? in
             guard let content = note["content"] else { return nil }
             let haystack = "\(note["title"] ?? "") \(content)".lowercased()

--- a/OpenGlasses/Sources/Services/NativeTools/FitnessCoachingTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/FitnessCoachingTool.swift
@@ -337,13 +337,15 @@ struct FitnessCoachingTool: NativeTool {
     }
 
     private func saveWorkoutNote(summary: String) {
+        let now = Date()
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
-        let key = "saved_notes"
-        var notes = UserDefaults.standard.stringArray(forKey: key) ?? []
-        let note = "[\(formatter.string(from: Date()))] Workout: \(summary)"
-        notes.append(note)
-        UserDefaults.standard.set(notes, forKey: key)
+        formatter.timeStyle = .none
+        SavedNotesStore.append(
+            title: "Workout Note — \(formatter.string(from: now))",
+            content: summary,
+            date: ISO8601DateFormatter().string(from: now)
+        )
     }
 }
 

--- a/OpenGlasses/Sources/Services/NativeTools/MeetingSummaryTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/MeetingSummaryTool.swift
@@ -245,16 +245,11 @@ struct MeetingSummaryTool: NativeTool {
     }
 
     private func saveNote(title: String, content: String) {
-        let key = "saved_notes"
-        var notes = UserDefaults.standard.array(forKey: key) as? [[String: String]] ?? []
-        notes.append([
-            "title": title,
-            "content": content,
-            "date": ISO8601DateFormatter().string(from: Date())
-        ])
-        // Keep max 50 notes
-        if notes.count > 50 { notes = Array(notes.suffix(50)) }
-        UserDefaults.standard.set(notes, forKey: key)
+        SavedNotesStore.append(
+            title: title,
+            content: content,
+            date: ISO8601DateFormatter().string(from: Date())
+        )
 
         // Feed the knowledge graph: typed edges from the summary, plus mentioned_in
         // edges linking known people to this meeting.

--- a/OpenGlasses/Sources/Services/SavedNotesStore.swift
+++ b/OpenGlasses/Sources/Services/SavedNotesStore.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// The single persistence boundary for the shared `saved_notes` key.
+///
+/// Historically two tools wrote this key with different schemas: `MeetingSummaryTool` stored
+/// `[[String: String]]` dictionaries while `FitnessCoachingTool` stored plain `[String]` lines.
+/// Whichever wrote second made the other's `as?` cast fail, so its next write started from an
+/// empty array and silently destroyed the existing notes. Every reader and writer now goes
+/// through this store, which speaks the canonical dictionary schema and migrates legacy
+/// string entries on read.
+enum SavedNotesStore {
+    /// Internal so tests can seed legacy values without duplicating the on-disk key literal.
+    static let storageKey = "saved_notes"
+
+    static func load(defaults: UserDefaults = .standard) -> [[String: String]] {
+        guard let rawNotes: [Any] = defaults.array(forKey: storageKey) else { return [] }
+
+        var convertedLegacyEntry = false
+        let notes = rawNotes.compactMap { rawNote -> [String: String]? in
+            if let note = rawNote as? [String: String] {
+                return note
+            }
+            if let legacyNote = rawNote as? String {
+                convertedLegacyEntry = true
+                return migrate(legacyNote)
+            }
+            return nil
+        }
+
+        // Persist only when migration actually occurred. A canonical read remains read-only.
+        if convertedLegacyEntry {
+            defaults.set(notes, forKey: storageKey)
+        }
+
+        return notes
+    }
+
+    static func save(
+        _ notes: [[String: String]],
+        defaults: UserDefaults = .standard
+    ) {
+        defaults.set(Array(notes.suffix(50)), forKey: storageKey)
+    }
+
+    static func append(
+        title: String,
+        content: String,
+        date: String,
+        defaults: UserDefaults = .standard
+    ) {
+        var notes = load(defaults: defaults)
+        notes.append([
+            "title": title,
+            "content": content,
+            "date": date,
+        ])
+        save(notes, defaults: defaults)
+    }
+
+    private static func migrate(_ legacyNote: String) -> [String: String] {
+        let split = splitDatePrefix(from: legacyNote)
+        var content = split.content
+        let parsedDate = split.dateText.flatMap(parseLegacyDate)
+
+        let title: String
+        let workoutPrefix = "Workout: "
+        if content.hasPrefix(workoutPrefix) {
+            content.removeFirst(workoutPrefix.count)
+            if let dateText = split.dateText, !dateText.isEmpty {
+                title = "Workout Note — \(dateText)"
+            } else {
+                title = "Workout Note"
+            }
+        } else {
+            title = String(content.prefix(60))
+        }
+
+        var note = [
+            "title": title,
+            "content": content,
+        ]
+        if let parsedDate {
+            note["date"] = ISO8601DateFormatter().string(from: parsedDate)
+        }
+        return note
+    }
+
+    private static func splitDatePrefix(from legacyNote: String) -> (dateText: String?, content: String) {
+        guard legacyNote.hasPrefix("["),
+              let closingBracket = legacyNote.range(of: "] ") else {
+            return (nil, legacyNote)
+        }
+
+        let dateStart = legacyNote.index(after: legacyNote.startIndex)
+        let dateText = String(legacyNote[dateStart..<closingBracket.lowerBound])
+        let content = String(legacyNote[closingBracket.upperBound...])
+        return (dateText, content)
+    }
+
+    private static func parseLegacyDate(_ dateText: String) -> Date? {
+        // The original writer used the current locale. The fallbacks also cover notes
+        // migrated after a locale change, including the historical UK day-first form.
+        let localeIdentifiers = [
+            Locale.current.identifier,
+            "en_GB",
+            "en_US",
+        ]
+
+        for localeIdentifier in localeIdentifiers {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: localeIdentifier)
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .none
+            if let date = formatter.date(from: dateText) {
+                return date
+            }
+        }
+        return nil
+    }
+}

--- a/OpenGlasses/Sources/Services/Siri/SpotlightIndexService.swift
+++ b/OpenGlasses/Sources/Services/Siri/SpotlightIndexService.swift
@@ -30,7 +30,7 @@ enum SiriContentProvider {
             )
         }
         if config.isEnabled(.meetingSummary) {
-            let raw = defaults.array(forKey: "saved_notes") as? [[String: String]] ?? []
+            let raw = SavedNotesStore.load(defaults: defaults)
             records += SiriContentAdapters.meetingSummaries(rawSavedNotes: raw)
         }
         if config.isEnabled(.savedLocation) {

--- a/OpenGlasses/Sources/Services/VideoRecordingService.swift
+++ b/OpenGlasses/Sources/Services/VideoRecordingService.swift
@@ -67,6 +67,9 @@ class VideoRecordingService: ObservableObject {
     /// Transcript accumulated during recording (from ambient captions).
     @Published private(set) var recordingTranscript: String = ""
     private var transcriptEntries: [String] = []
+    /// Position in the caption stream. Sequence-based, because `captionHistory` is capped and
+    /// stops growing once full.
+    private var captionCursor = CaptionCursor()
 
     var formattedDuration: String {
         let hours = Int(recordingDuration) / 3600
@@ -238,6 +241,11 @@ class VideoRecordingService: ObservableObject {
         self.lastFrameAt = nil
         self.recordingTranscript = ""
         self.transcriptEntries = []
+        // Start from the present: captions already buffered predate this recording.
+        self.captionCursor = CaptionCursor()
+        if let captions = ambientCaptionService {
+            _ = self.captionCursor.take(newestFirst: captions.captionHistory)
+        }
         self.isRecording = true
 
         // Subscribe to video frames on a background queue
@@ -401,16 +409,13 @@ class VideoRecordingService: ObservableObject {
     /// Collect new caption entries from ambient captions into the recording transcript.
     private func collectCaptions() {
         guard let captions = ambientCaptionService else { return }
-        let history = captions.captionHistory
-        let newCount = history.count - transcriptEntries.count
-        guard newCount > 0 else { return }
+        let newEntries = captionCursor.take(newestFirst: captions.captionHistory)
+        guard !newEntries.isEmpty else { return }
 
-        // captionHistory is newest-first, so take the new entries from the front
-        let newEntries = history.prefix(newCount)
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "HH:mm:ss"
 
-        for entry in newEntries.reversed() {
+        for entry in newEntries {
             let timestamp = dateFormatter.string(from: entry.timestamp)
             let line = "[\(timestamp)] \(entry.text)"
             transcriptEntries.append(line)

--- a/OpenGlassesTests/CaptionCursorTests.swift
+++ b/OpenGlassesTests/CaptionCursorTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import OpenGlasses
+
+/// `AmbientCaptionService.captionHistory` is a *bounded* newest-first buffer (`maxHistory`).
+/// Consumers used to track their position with a plain count, which freezes permanently once
+/// the buffer stops growing — the live meeting summary and the saved transcript both went
+/// silent after `maxHistory` finalized captions. `CaptionCursor` tracks sequence numbers, which
+/// survive eviction.
+final class CaptionCursorTests: XCTestCase {
+
+    private struct Entry: CaptionSequenced, Equatable {
+        let seq: UInt64
+        let text: String
+    }
+
+    /// Newest-first, matching `captionHistory` ordering.
+    private func history(_ seqs: [UInt64]) -> [Entry] {
+        seqs.sorted(by: >).map { Entry(seq: $0, text: "c\($0)") }
+    }
+
+    func testEmptyHistoryYieldsNothing() {
+        var cursor = CaptionCursor()
+        XCTAssertTrue(cursor.take(newestFirst: [Entry]()).isEmpty)
+    }
+
+    func testFirstTakeReturnsEverythingOldestFirst() {
+        var cursor = CaptionCursor()
+        let taken = cursor.take(newestFirst: history([1, 2, 3]))
+        XCTAssertEqual(taken.map(\.seq), [1, 2, 3])
+    }
+
+    func testSecondTakeOnUnchangedHistoryReturnsNothing() {
+        var cursor = CaptionCursor()
+        let buffer = history([1, 2, 3])
+        _ = cursor.take(newestFirst: buffer)
+        XCTAssertTrue(cursor.take(newestFirst: buffer).isEmpty)
+    }
+
+    func testTakeReturnsOnlyEntriesAddedSinceLastTake() {
+        var cursor = CaptionCursor()
+        _ = cursor.take(newestFirst: history([1, 2, 3]))
+        let taken = cursor.take(newestFirst: history([1, 2, 3, 4, 5]))
+        XCTAssertEqual(taken.map(\.seq), [4, 5])
+    }
+
+    /// The regression that motivated this type: once the ring buffer is full its `count` stops
+    /// growing, so a count-based cursor concluded "nothing new" forever.
+    func testKeepsDeliveringAfterBufferStartsEvicting() {
+        let cap = 4
+        var cursor = CaptionCursor()
+        var buffer = history([1, 2, 3, 4])
+        XCTAssertEqual(cursor.take(newestFirst: buffer).map(\.seq), [1, 2, 3, 4])
+
+        // Two more captions arrive; the buffer is at cap, so 1 and 2 are evicted and
+        // `buffer.count` stays at 4 — exactly the condition that froze the old cursor.
+        buffer = Array(history([3, 4, 5, 6]).prefix(cap))
+        XCTAssertEqual(buffer.count, cap)
+
+        XCTAssertEqual(cursor.take(newestFirst: buffer).map(\.seq), [5, 6])
+    }
+
+    /// A consumer that falls far enough behind loses the evicted captions, but must resync to
+    /// what is still in the buffer rather than stall or replay.
+    func testResyncsWhenEverythingInBufferIsNew() {
+        var cursor = CaptionCursor()
+        _ = cursor.take(newestFirst: history([1, 2]))
+        let taken = cursor.take(newestFirst: history([7, 8, 9]))
+        XCTAssertEqual(taken.map(\.seq), [7, 8, 9])
+    }
+
+    /// A fresh cursor seeded against a populated buffer starts from the present — that is how a
+    /// new recording avoids inheriting the previous conversation's captions.
+    func testFreshCursorSeededOnExistingBufferSkipsTheBacklog() {
+        var cursor = CaptionCursor()
+        let backlog = history([1, 2, 3])
+        _ = cursor.take(newestFirst: backlog)
+        XCTAssertEqual(cursor.take(newestFirst: history([1, 2, 3, 4])).map(\.seq), [4])
+    }
+}
+
+/// Companion fix from the same review: a recording stopped and restarted within one second used
+/// to collide on the timestamp-only audio file name.
+@MainActor
+final class AudioRecordingFileNameTests: XCTestCase {
+    func testRecordingFileNamesRemainUniqueWithinTheSameSecond() {
+        let now = Date(timeIntervalSince1970: 1_000)
+
+        let first = AudioRecordingService.recordingFileName(now: now, id: UUID())
+        let second = AudioRecordingService.recordingFileName(now: now, id: UUID())
+
+        XCTAssertNotEqual(first, second)
+        XCTAssertTrue(first.hasSuffix(".m4a"))
+        XCTAssertTrue(second.hasSuffix(".m4a"))
+    }
+}

--- a/OpenGlassesTests/SavedNotesStoreTests.swift
+++ b/OpenGlassesTests/SavedNotesStoreTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import OpenGlasses
+
+final class SavedNotesStoreTests: XCTestCase {
+    private final class TrackingUserDefaults: UserDefaults {
+        var savedNotesWriteCount = 0
+
+        override func set(_ value: Any?, forKey defaultName: String) {
+            if defaultName == SavedNotesStore.storageKey {
+                savedNotesWriteCount += 1
+            }
+            super.set(value, forKey: defaultName)
+        }
+    }
+
+    private var suiteName: String!
+    private var defaults: TrackingUserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "SavedNotesStoreTests-\(UUID().uuidString)"
+        defaults = TrackingUserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testMixedLegacyAndCanonicalNotesSurviveInOriginalOrder() {
+        let canonical = [
+            "title": "Meeting Summary — later",
+            "content": "Canonical content",
+            "date": "2026-07-27T09:00:00Z",
+        ]
+        defaults.set(["Legacy content", canonical], forKey: SavedNotesStore.storageKey)
+
+        let notes = SavedNotesStore.load(defaults: defaults)
+
+        XCTAssertEqual(notes.count, 2)
+        XCTAssertEqual(notes[0]["content"], "Legacy content")
+        XCTAssertEqual(notes[1], canonical)
+    }
+
+    func testLegacyWorkoutGetsCanonicalTitleContentAndDate() {
+        defaults.set(
+            ["[26 Jul 2026] Workout: ran 5k"],
+            forKey: SavedNotesStore.storageKey
+        )
+
+        let note = SavedNotesStore.load(defaults: defaults)[0]
+
+        XCTAssertTrue(note["title"]?.hasPrefix("Workout Note —") == true)
+        XCTAssertEqual(note["content"], "ran 5k")
+        XCTAssertNotNil(note["date"].flatMap { ISO8601DateFormatter().date(from: $0) })
+    }
+
+    func testMigrationWritesBackOnceAndCanonicalReadDoesNotRewrite() throws {
+        let canonical = ["title": "Meeting Summary", "content": "Decision"]
+        defaults.set(["Legacy content", canonical], forKey: SavedNotesStore.storageKey)
+        defaults.savedNotesWriteCount = 0
+
+        _ = SavedNotesStore.load(defaults: defaults)
+
+        XCTAssertEqual(defaults.savedNotesWriteCount, 1)
+        let migrated = try XCTUnwrap(defaults.array(forKey: SavedNotesStore.storageKey))
+        XCTAssertTrue(migrated.allSatisfy { $0 is [String: String] })
+
+        defaults.savedNotesWriteCount = 0
+        let beforeSecondLoad = try XCTUnwrap(migrated as? [[String: String]])
+        _ = SavedNotesStore.load(defaults: defaults)
+
+        XCTAssertEqual(defaults.savedNotesWriteCount, 0)
+        XCTAssertEqual(
+            defaults.array(forKey: SavedNotesStore.storageKey) as? [[String: String]],
+            beforeSecondLoad
+        )
+    }
+
+    func testUnparseableLegacyStringIsPreservedAsContent() {
+        let legacy = "[not a date] A legacy note that must survive"
+        defaults.set([legacy], forKey: SavedNotesStore.storageKey)
+
+        let notes = SavedNotesStore.load(defaults: defaults)
+
+        XCTAssertEqual(notes.count, 1)
+        XCTAssertEqual(notes[0]["content"], "A legacy note that must survive")
+        XCTAssertEqual(notes[0]["title"], "A legacy note that must survive")
+        XCTAssertNil(notes[0]["date"])
+    }
+
+    func testSaveCapsAtNewestFiftyEntries() {
+        let notes = (0..<55).map { index in
+            ["title": "Note \(index)", "content": "Content \(index)"]
+        }
+
+        SavedNotesStore.save(notes, defaults: defaults)
+        let loaded = SavedNotesStore.load(defaults: defaults)
+
+        XCTAssertEqual(loaded.count, 50)
+        XCTAssertEqual(loaded.first?["title"], "Note 5")
+        XCTAssertEqual(loaded.last?["title"], "Note 54")
+    }
+
+    /// The regression that motivated the store: the workout writer used to store a plain string
+    /// array, so its next write after a meeting summary clobbered the dictionary-schema notes.
+    func testAppendingWorkoutAfterMeetingPreservesMeetingSummary() {
+        let meetingTitle = "Meeting Summary — 26/07/2026, 10:00"
+        SavedNotesStore.append(
+            title: meetingTitle,
+            content: "Ship the data-loss fix",
+            date: "2026-07-26T09:00:00Z",
+            defaults: defaults
+        )
+        SavedNotesStore.append(
+            title: "Workout Note — 26 Jul 2026",
+            content: "ran 5k",
+            date: "2026-07-26T10:00:00Z",
+            defaults: defaults
+        )
+
+        let notes = SavedNotesStore.load(defaults: defaults)
+        let meetings = SiriContentAdapters.meetingSummaries(rawSavedNotes: notes)
+
+        XCTAssertEqual(notes.count, 2)
+        XCTAssertEqual(notes[0]["title"], meetingTitle)
+        XCTAssertTrue(notes[0]["title"]?.hasPrefix(SiriContentAdapters.meetingSummaryTitlePrefix) == true)
+        XCTAssertEqual(meetings.count, 1)
+        XCTAssertEqual(meetings[0].text, "Ship the data-loss fix")
+    }
+}

--- a/OpenGlassesTests/SpeakerDiarizationCoreTests.swift
+++ b/OpenGlassesTests/SpeakerDiarizationCoreTests.swift
@@ -112,7 +112,7 @@ final class SpeakerDiarizationCoreTests: XCTestCase {
         // The diarization-off / single-speaker path never sets a speaker id
         // (`finalizeCaption` defaults it to nil) — those captions get no chip.
         XCTAssertNil(SpeakerChipModel.chip(speaker: nil, registry: freshRegistry()))
-        let entry = AmbientCaptionService.CaptionEntry(text: "hello", timestamp: Date())
+        let entry = AmbientCaptionService.CaptionEntry(text: "hello", timestamp: Date(), seq: 1)
         XCTAssertNil(SpeakerChipModel.chip(speaker: entry.speaker, registry: freshRegistry()))
     }
 


### PR DESCRIPTION
## Summary

Two long-standing silent data-loss bugs, plus one companion fix.

### 1. `saved_notes` schema clash (notes silently destroyed)

`MeetingSummaryTool` stored `saved_notes` as `[[String: String]]` dictionaries while `FitnessCoachingTool` stored plain `[String]` lines under the same UserDefaults key. Whichever tool wrote second made the other's `as?` cast fail, so its next write started from an empty array — saving a workout note after a meeting summary wiped the meeting summary, and vice versa.

**Fix:** new `SavedNotesStore` is the single persistence boundary. Canonical dictionary schema; legacy string entries are migrated once on read (with date/title recovery for old workout lines); 50-note cap preserved. `MeetingSummaryTool`, `FitnessCoachingTool`, `BrainTool`, and the Spotlight index all go through it now.

### 2. Frozen caption cursors (transcripts go silent after ~50 captions)

`captionHistory` is a bounded newest-first buffer (`maxHistory = 50`), but three consumers tracked their position by array **count**: `AudioRecordingService`, `VideoRecordingService`, and `MeetingAssistantService`. Once the buffer filled, count stopped growing and each concluded "nothing new" forever — recording transcripts and the live meeting summary froze mid-session.

**Fix:** `CaptionEntry` now carries a monotonic `seq` and consumers read through a new `CaptionCursor`, which survives eviction. This also fixes two latent bugs in the same code: `AudioRecordingService` joined the newest-first backlog in reverse chronological order, and recordings/meetings used to inherit captions buffered *before* they started — cursors now seed from the present.

### 3. Recording filename collision

Audio recording filenames were timestamp-only (`OG_Audio_<epoch>.m4a`); a stop/restart within the same second reused the file. Names now include a UUID.

## Verification

- Full simulator suite green: **2,743 tests passed**, including new `SavedNotesStoreTests` (schema migration, write-once, clobber regression) and `CaptionCursorTests` (eviction freeze regression, resync, backlog seeding)
- Unsigned Release build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)