### PR TITLE
Harden turn cancellation: barge-in races and the master listening toggle

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2130,7 +2130,8 @@ class AppState: ObservableObject, AppStateProtocol {
     func handleBargeIn(_ bargeInText: String) {
         print("⚡ Barge-in: '\(bargeInText)' — stopping TTS and processing")
         speechService.stopSpeaking()
-        currentLLMTask?.cancel()
+        let interruptedTask = currentLLMTask
+        interruptedTask?.cancel()
         currentLLMTask = nil
         isProcessing = false
         speechService.stopThinkingSound()
@@ -2140,10 +2141,12 @@ class AppState: ObservableObject, AppStateProtocol {
             return
         }
 
-        // Feed the barge-in text directly into the conversation pipeline
-        // handleTranscription handles conversation store, LLM call, etc.
-        Task {
-            await handleTranscription(bargeInText)
+        // Let the cancelled turn finish its cleanup before starting the replacement. Otherwise its
+        // finish closure can race the new turn and reset processing/listening state mid-flight.
+        Task { @MainActor [weak self] in
+            await interruptedTask?.value
+            guard let self, self.inConversation, self.listeningEnabled, !self.isProcessing else { return }
+            await self.handleTranscription(bargeInText)
         }
     }
 
@@ -2165,7 +2168,10 @@ class AppState: ObservableObject, AppStateProtocol {
             }
             NSLog("[Listening] Enabled")
         } else {
-            // Stop everything: wake word, transcription, TTS, Live Activity
+            // Stop everything: wake word, transcription, TTS, Live Activity — including any
+            // in-flight LLM turn, whose finish stage would otherwise resume listening.
+            currentLLMTask?.cancel()
+            currentLLMTask = nil
             wakeWordService.stopListening()
             transcriptionService.stopRecording()
             speechService.stopSpeaking()
@@ -2173,6 +2179,9 @@ class AppState: ObservableObject, AppStateProtocol {
             // Release any audio pause held by an in-flight conversation so Music/Podcasts resume.
             Task { await wakeWordService.forceResumeOtherAudio() }
             isListening = false
+            isProcessing = false
+            inConversation = false
+            activePersona = nil
             NSLog("[Listening] Disabled")
         }
     }
@@ -2866,8 +2875,13 @@ class AppState: ObservableObject, AppStateProtocol {
     /// - Parameter ensureEngine: run the audio-engine keepalive first — needed after TTS playback,
     ///   which may have interrupted the engine.
     private func resumeListeningOrReturnToWakeWord(ensureEngine: Bool = false) async {
+        // The user may have disabled listening while the turn was finishing — a finish stage
+        // must never turn the microphone back on behind their back.
+        guard listeningEnabled else { return }
         if inConversation {
             if ensureEngine { try? await wakeWordService.ensureAudioEngineRunning() }
+            // The engine keepalive suspends; re-check the user didn't flip the toggle meanwhile.
+            guard listeningEnabled, inConversation else { return }
             isListening = true
             transcriptionService.startRecording()
         } else {
@@ -4166,6 +4180,11 @@ class AppState: ObservableObject, AppStateProtocol {
         // End active conversation thread
         if Config.conversationPersistenceEnabled && conversationStore.activeThreadId != nil {
             conversationStore.endThread()
+        }
+        // The master toggle wins over every restart rule below.
+        if !listeningEnabled {
+            print("🔇 Listening disabled — wake word listener stays off")
+            return
         }
         // In silent mode, don't restart wake word UNLESS we just finished an
         // active conversation — the user was just talking, so they expect the

--- a/OpenGlasses/Sources/Services/Flow/ConversationTurnRunner.swift
+++ b/OpenGlasses/Sources/Services/Flow/ConversationTurnRunner.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-/// The execution skeleton of one LLM turn (Plan BG P2): send → post-process → cancellation check →
-/// accept → speak, with a `finish` stage that ALWAYS runs — success, error, or cancellation.
+/// The execution skeleton of one LLM turn (Plan BG P2): send → cancellation check → post-process →
+/// cancellation check → accept → cancellation check → speak, with a `finish` stage that ALWAYS runs
+/// — success, error, or cancellation.
 ///
 /// `handleTranscription`'s photo and normal turns both run this skeleton inside the tracked
 /// `currentLLMTask`; only the stage bodies differ, so they are injected as `@MainActor` closures
@@ -27,7 +28,8 @@ enum ConversationTurnRunner {
         let accept: @MainActor (String) async -> Void
         /// Speak the response (wrapped in the stop-listener on the live host).
         let speak: @MainActor (String) async -> Void
-        /// The turn was cancelled (barge-in / stop / cancel) — nothing was accepted or spoken.
+        /// The turn was cancelled (barge-in / stop / cancel) — the reply was never spoken, and
+        /// stages after the point of cancellation never ran.
         let onCancelled: @MainActor () -> Void
         /// `send` failed with a non-cancellation error: publish/speak the failure.
         let onError: @MainActor (Error) async -> Void
@@ -40,16 +42,26 @@ enum ConversationTurnRunner {
     static func run(_ deps: Deps) async {
         do {
             let raw = try await deps.send()
+            // `postProcess` can persist memory and inject prompt state, so a response cancelled
+            // while in flight must not reach it.
+            try Task.checkCancellation()
             let response = await deps.postProcess(raw)
-            // If the user barged in / stopped while the LLM was working, don't accept or speak
-            // the now-stale reply.
+            // Each injected async stage can yield the main actor. Re-check before every visible
+            // step so a barge-in cannot persist, mirror, or speak a stale response.
             try Task.checkCancellation()
             await deps.accept(response)
+            try Task.checkCancellation()
             await deps.speak(response)
         } catch is CancellationError {
             deps.onCancelled()
         } catch {
-            await deps.onError(error)
+            // URLSession/provider SDKs can surface their own error after the parent task was
+            // cancelled. The interruption wins: do not speak an error after a user barge-in.
+            if Task.isCancelled {
+                deps.onCancelled()
+            } else {
+                await deps.onError(error)
+            }
         }
         await deps.finish()
     }

--- a/OpenGlassesTests/ConversationTurnRunnerTests.swift
+++ b/OpenGlassesTests/ConversationTurnRunnerTests.swift
@@ -14,7 +14,8 @@ final class ConversationTurnRunnerTests: XCTestCase {
     private func recordingDeps(
         into log: Box<[String]>,
         send: (@MainActor () async throws -> String)? = nil,
-        postProcess: (@MainActor (String) async -> String)? = nil
+        postProcess: (@MainActor (String) async -> String)? = nil,
+        accept: (@MainActor (String) async -> Void)? = nil
     ) -> ConversationTurnRunner.Deps {
         ConversationTurnRunner.Deps(
             send: {
@@ -27,7 +28,10 @@ final class ConversationTurnRunnerTests: XCTestCase {
                 guard let postProcess else { return raw }
                 return await postProcess(raw)
             },
-            accept: { log.value.append("accept(\($0))") },
+            accept: {
+                log.value.append("accept(\($0))")
+                if let accept { await accept($0) }
+            },
             speak: { log.value.append("speak(\($0))") },
             onCancelled: { log.value.append("onCancelled") },
             onError: { log.value.append("onError(\(type(of: $0)))") },
@@ -57,8 +61,9 @@ final class ConversationTurnRunnerTests: XCTestCase {
         XCTAssertEqual(log.value, ["send", "onError(TestError)", "finish"])
     }
 
-    /// Barge-in / stop cancel the tracked turn task; a turn cancelled while the LLM was working
-    /// must never accept or speak the now-stale reply — but must still finish.
+    /// Barge-in / stop cancel the tracked turn task; a stale response must not run
+    /// post-processing side effects (memory persistence), be accepted, or be spoken — but must
+    /// still finish.
     func testCancellationDuringSendNeverSpeaksStaleReplyButStillFinishes() async {
         let log = Box<[String]>([])
         // Cancel the surrounding task from inside `send`, as a barge-in would while the LLM call
@@ -70,8 +75,7 @@ final class ConversationTurnRunnerTests: XCTestCase {
         // Run inside a child task (mirroring `currentLLMTask`) so the cancellation stays scoped
         // to the turn, not the test's own task.
         await Task { await ConversationTurnRunner.run(deps) }.value
-        XCTAssertEqual(log.value, ["send", "postProcess(stale)", "onCancelled", "finish"],
-                       "post-processing may complete, but the stale reply is never accepted or spoken")
+        XCTAssertEqual(log.value, ["send", "onCancelled", "finish"])
     }
 
     /// A `send` that surfaces cancellation by throwing (e.g. a cancelled URLSession call) is
@@ -81,5 +85,28 @@ final class ConversationTurnRunnerTests: XCTestCase {
         let deps = recordingDeps(into: log, send: { throw CancellationError() })
         await ConversationTurnRunner.run(deps)
         XCTAssertEqual(log.value, ["send", "onCancelled", "finish"])
+    }
+
+    /// Provider SDKs can throw their own error type after the parent task was already cancelled
+    /// (a barge-in mid-request). The interruption wins: no error is spoken.
+    func testCancelledTaskWithProviderErrorReportsCancelledNotError() async {
+        let log = Box<[String]>([])
+        let deps = recordingDeps(into: log, send: {
+            withUnsafeCurrentTask { $0?.cancel() }
+            throw TestError()
+        })
+        await Task { await ConversationTurnRunner.run(deps) }.value
+        XCTAssertEqual(log.value, ["send", "onCancelled", "finish"])
+    }
+
+    /// A barge-in that lands while `accept` is persisting/mirroring the response must still stop
+    /// the reply from being spoken.
+    func testCancellationAfterAcceptNeverSpeaks() async {
+        let log = Box<[String]>([])
+        let deps = recordingDeps(into: log, accept: { _ in
+            withUnsafeCurrentTask { $0?.cancel() }
+        })
+        await Task { await ConversationTurnRunner.run(deps) }.value
+        XCTAssertEqual(log.value, ["send", "postProcess(raw)", "accept(raw)", "onCancelled", "finish"])
     }
 }


### PR DESCRIPTION
## Summary

Closes the cancellation gaps around one LLM turn. All three are user-visible on device: stale replies spoken after a barge-in, error apologies spoken for user interruptions, and the microphone coming back on after the user disabled listening.

### 1. `ConversationTurnRunner` re-checks cancellation at every stage

The skeleton had a single check (between post-process and accept). Now:

- **Before post-process** — it persists memory and injects prompt state, so a response cancelled while in flight must not reach it.
- **Before speak** — `accept` is async and can yield the main actor; a barge-in landing inside it must still stop the reply from being spoken.
- **In the catch** — URLSession/provider SDKs can throw their own error type after the parent task was cancelled. The interruption wins: `onCancelled`, not `onError`, so no apology is spoken for a user interruption.

### 2. Barge-in no longer races its replacement turn

`handleBargeIn` cancelled `currentLLMTask` and immediately dispatched the replacement. The cancelled turn's `finish` stage (which resets `isProcessing` and resumes listening) could then fire mid-flight of the new turn. It now awaits the interrupted task's cleanup, then re-checks `inConversation` / `listeningEnabled` / `!isProcessing` before dispatching.

### 3. The master listening toggle actually wins

- Disabling listening now also cancels the in-flight LLM turn and clears `isProcessing` / `inConversation` / `activePersona` — previously the turn kept running and its finish stage restarted the mic.
- `resumeListeningOrReturnToWakeWord` and `returnToWakeWord` now guard on `listeningEnabled`, including a re-check after the engine-keepalive suspension point, so a finishing turn can never re-enable the microphone behind the user's back.

## Verification

- Full simulator suite green: **2,745 tests passed**, including two new regression tests (provider-error-after-cancel → `onCancelled`; cancel-during-accept → never speaks) and the tightened stale-reply expectation (post-process no longer runs on a cancelled turn)
- Unsigned Release build green
- One earlier run hit the known intermittent CoreSimulator "runner hung" flake; recovered via erase+boot and re-ran clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)