### PR TITLE
Meeting recorder: preserved recordings with playback and transcripts

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -530,6 +530,15 @@ class AppState: ObservableObject, AppStateProtocol {
     let cameraService = CameraService()
     let videoRecorder = VideoRecordingService()
     let audioRecorder = AudioRecordingService()
+    let recordedSessionStore = RecordedSessionStore()
+    let recordingTranscriber = RecordingTranscriber()
+    /// Lazy: depends on the services above; first touched from the Recordings UI.
+    lazy var sessionRecorder = SessionRecorderController(
+        audioRecorder: audioRecorder,
+        wakeWordService: wakeWordService,
+        store: recordedSessionStore,
+        transcriber: recordingTranscriber
+    )
     let meetingAssistant = MeetingAssistantService()
     let broadcastService = BroadcastService()
     /// Broadcast chat read-aloud (Plan CI) — lives and dies with the broadcast session.

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -2380,6 +2380,16 @@ class AppState: ObservableObject, AppStateProtocol {
         case .openApp:
             guard let scheme = action.urlScheme, let url = URL(string: scheme) else { return }
             await UIApplication.shared.open(url)
+        case .toggleRecording:
+            if sessionRecorder.isRecording {
+                await sessionRecorder.stop()
+            } else {
+                do {
+                    try await sessionRecorder.start()
+                } catch {
+                    errorMessage = error.localizedDescription
+                }
+            }
         }
     }
 

--- a/OpenGlasses/Sources/App/Views/BottomControlBar.swift
+++ b/OpenGlasses/Sources/App/Views/BottomControlBar.swift
@@ -440,20 +440,55 @@ private struct QuickActionTiles: View {
 
     var body: some View {
         ForEach(actions) { action in
-            BarButton(
-                icon: action.icon,
-                label: action.label,
-                isBusy: executingActionId == action.id
-            ) {
-                guard executingActionId == nil else { return }
-                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                executingActionId = action.id
-                Task {
-                    await appState.executeQuickAction(action)
-                    executingActionId = nil
+            if action.type == .toggleRecording {
+                // Live tile: reflects recording state + duration, unlike the fire-and-forget tiles.
+                RecordingQuickActionTile(
+                    action: action,
+                    controller: appState.sessionRecorder,
+                    audioRecorder: appState.audioRecorder
+                )
+            } else {
+                BarButton(
+                    icon: action.icon,
+                    label: action.label,
+                    isBusy: executingActionId == action.id
+                ) {
+                    guard executingActionId == nil else { return }
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    executingActionId = action.id
+                    Task {
+                        await appState.executeQuickAction(action)
+                        executingActionId = nil
+                    }
                 }
+                .accessibilityHint(executingActionId == action.id ? "Running" : "Double-tap to execute")
             }
-            .accessibilityHint(executingActionId == action.id ? "Running" : "Double-tap to execute")
         }
+    }
+}
+
+/// The record-meeting quick action as a live dock tile: red stop icon + elapsed duration while
+/// a preserved recording is running. Observes the controller directly because a nested
+/// ObservableObject's changes don't republish through `appState`.
+private struct RecordingQuickActionTile: View {
+    @EnvironmentObject var appState: AppState
+    let action: QuickAction
+    @ObservedObject var controller: SessionRecorderController
+    @ObservedObject var audioRecorder: AudioRecordingService
+
+    var body: some View {
+        BarButton(
+            icon: controller.isRecording ? "stop.circle.fill" : action.icon,
+            label: controller.isRecording ? audioRecorder.formattedDuration : action.label,
+            isActive: controller.isRecording,
+            tint: .red
+        ) {
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+            Task { await appState.executeQuickAction(action) }
+        }
+        .accessibilityLabel("Record meeting")
+        .accessibilityValue(controller.isRecording
+                            ? "Recording, \(audioRecorder.formattedDuration)" : "Stopped")
+        .accessibilityHint("Double-tap to start or stop recording.")
     }
 }

--- a/OpenGlasses/Sources/App/Views/MeetingRecordsView.swift
+++ b/OpenGlasses/Sources/App/Views/MeetingRecordsView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+/// Lists meeting summaries stored in the shared `saved_notes` key, filtering out
+/// entries written by other note tools using the canonical meeting-title prefix.
+struct MeetingRecordsView: View {
+    @State private var records: [MeetingRecord] = []
+
+    var body: some View {
+        List {
+            if records.isEmpty {
+                ContentUnavailableView(
+                    "No meeting records yet",
+                    systemImage: "text.book.closed",
+                    description: Text("Summaries appear here after the Meeting Summary tool runs. Say \"hey meeting\", or ask the assistant to summarize the meeting.")
+                )
+            } else {
+                ForEach(records) { record in
+                    NavigationLink {
+                        MeetingRecordDetailView(record: record)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(record.title)
+                                .font(.headline)
+
+                            if let date = record.date {
+                                Text(date.formatted(date: .abbreviated, time: .shortened))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                Text("Date unavailable")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Text(record.content)
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(2)
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+                .onDelete(perform: deleteRecords)
+            }
+        }
+        .navigationTitle("Meeting Records")
+        .navigationBarTitleDisplayMode(.inline)
+        .task {
+            loadRecords()
+        }
+        .refreshable {
+            loadRecords()
+        }
+    }
+
+    private func loadRecords() {
+        let notes = SavedNotesStore.load()
+        let formatter = ISO8601DateFormatter()
+
+        records = notes.compactMap { note in
+            guard let title = note["title"],
+                  title.hasPrefix(SiriContentAdapters.meetingSummaryTitlePrefix),
+                  let content = note["content"] else {
+                return nil
+            }
+
+            let dateString = note["date"]
+            return MeetingRecord(
+                id: recordID(title: title, dateString: dateString),
+                title: title,
+                content: content,
+                date: dateString.flatMap { formatter.date(from: $0) }
+            )
+        }
+        .sorted { lhs, rhs in
+            switch (lhs.date, rhs.date) {
+            case let (left?, right?):
+                return left > right
+            case (.some, .none):
+                return true
+            case (.none, .some), (.none, .none):
+                return false
+            }
+        }
+    }
+
+    private func deleteRecords(at offsets: IndexSet) {
+        var notes = SavedNotesStore.load()
+
+        for offset in offsets.sorted(by: >) {
+            let record = records[offset]
+            if let index = notes.firstIndex(where: { note in
+                guard note["title"] == record.title else { return false }
+                return recordID(title: record.title, dateString: note["date"]) == record.id
+            }) {
+                notes.remove(at: index)
+            }
+        }
+
+        SavedNotesStore.save(notes)
+        loadRecords()
+    }
+
+    private func recordID(title: String, dateString: String?) -> String {
+        "\(title)\u{1F}\(dateString ?? "")"
+    }
+}
+
+private struct MeetingRecord: Identifiable {
+    let id: String
+    let title: String
+    let content: String
+    let date: Date?
+}
+
+private struct MeetingRecordDetailView: View {
+    let record: MeetingRecord
+
+    var body: some View {
+        ScrollView {
+            Text(record.content)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+                .padding()
+        }
+        .navigationTitle(record.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                ShareLink(item: record.content) {
+                    Image(systemName: "square.and.arrow.up")
+                }
+                .accessibilityLabel("Share meeting record")
+            }
+        }
+    }
+}

--- a/OpenGlasses/Sources/App/Views/QuickActionsOverlay.swift
+++ b/OpenGlasses/Sources/App/Views/QuickActionsOverlay.swift
@@ -20,29 +20,23 @@ struct QuickActionsOverlay: View {
         if appState.isConnected && isIdle && appState.currentMode == .direct && !actions.isEmpty {
             HStack(spacing: 12) {
                 ForEach(actions) { action in
-                    Button {
-                        executeAction(action)
-                    } label: {
-                        VStack(spacing: 4) {
-                            ZStack {
-                                Color.clear
-                                    .frame(width: 44, height: 44)
-                                    .glassEffect(in: .circle)
-
-                                Image(systemName: action.icon)
-                                    .font(.system(size: 17, weight: .medium))
-                                    .foregroundStyle(.white)
-                            }
-
-                            Text(action.label)
-                                .font(.system(size: 9, weight: .medium))
-                                .foregroundStyle(.white.opacity(0.7))
-                                .lineLimit(1)
+                    if action.type == .toggleRecording {
+                        RecordingOverlayButton(
+                            action: action,
+                            controller: appState.sessionRecorder
+                        ) {
+                            executeAction(action)
                         }
+                    } else {
+                        Button {
+                            executeAction(action)
+                        } label: {
+                            OverlayButtonLabel(icon: action.icon, label: action.label)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(action.label)
+                        .accessibilityHint("Double-tap to execute")
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(action.label)
-                    .accessibilityHint("Double-tap to execute")
                 }
             }
             .padding(.top, 8)
@@ -57,5 +51,53 @@ struct QuickActionsOverlay: View {
             defer { isExecuting = false }
             await appState.executeQuickAction(action)
         }
+    }
+}
+
+/// Shared circular icon + caption used by every overlay button.
+private struct OverlayButtonLabel: View {
+    let icon: String
+    let label: String
+    var iconColor: Color = .white
+
+    var body: some View {
+        VStack(spacing: 4) {
+            ZStack {
+                Color.clear
+                    .frame(width: 44, height: 44)
+                    .glassEffect(in: .circle)
+
+                Image(systemName: icon)
+                    .font(.system(size: 17, weight: .medium))
+                    .foregroundStyle(iconColor)
+            }
+
+            Text(label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.white.opacity(0.7))
+                .lineLimit(1)
+        }
+    }
+}
+
+/// Record-meeting overlay button — observes the controller so the icon flips to a red stop
+/// while a preserved recording is running.
+private struct RecordingOverlayButton: View {
+    let action: QuickAction
+    @ObservedObject var controller: SessionRecorderController
+    let execute: () -> Void
+
+    var body: some View {
+        Button(action: execute) {
+            OverlayButtonLabel(
+                icon: controller.isRecording ? "stop.circle.fill" : action.icon,
+                label: controller.isRecording ? "Recording" : action.label,
+                iconColor: controller.isRecording ? .red : .white
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Record meeting")
+        .accessibilityValue(controller.isRecording ? "Recording" : "Stopped")
+        .accessibilityHint("Double-tap to start or stop recording.")
     }
 }

--- a/OpenGlasses/Sources/App/Views/QuickActionsSettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/QuickActionsSettingsView.swift
@@ -228,6 +228,7 @@ struct QuickActionsSettingsView: View {
         case .homeAssistant: return [action.haService, action.haEntityId].compactMap { $0 }.joined(separator: " → ")
         case .siriShortcut: return action.shortcutName ?? "Shortcut"
         case .openApp: return action.urlScheme ?? "URL"
+        case .toggleRecording: return "Start/stop meeting recording"
         }
     }
 }
@@ -478,7 +479,7 @@ struct QuickActionEditorView: View {
                         Text("The URL scheme to open. Examples: weixin://, spotify://, shortcuts://")
                     }
 
-                case .photo:
+                case .photo, .toggleRecording:
                     EmptyView()
                 }
             }
@@ -794,6 +795,7 @@ struct QuickActionEditorView: View {
         case .homeAssistant: return "house"
         case .siriShortcut: return "shortcuts"
         case .openApp: return "arrow.up.forward.app"
+        case .toggleRecording: return "record.circle"
         }
     }
 

--- a/OpenGlasses/Sources/App/Views/RecordingsView.swift
+++ b/OpenGlasses/Sources/App/Views/RecordingsView.swift
@@ -1,0 +1,390 @@
+import AVFoundation
+import SwiftUI
+
+/// Preserved meeting recordings: list, playback, transcript, and the record/stop control.
+struct RecordingsView: View {
+    @ObservedObject var store: RecordedSessionStore
+    @ObservedObject var controller: SessionRecorderController
+    @ObservedObject var audioRecorder: AudioRecordingService
+    @State private var recordingError: String?
+
+    var body: some View {
+        Group {
+            if store.sessions.isEmpty {
+                ContentUnavailableView(
+                    "No recordings yet",
+                    systemImage: "waveform",
+                    description: Text("Tap the record button to capture a meeting. Recordings and their transcripts appear here.")
+                )
+            } else {
+                List {
+                    ForEach(store.sessions) { session in
+                        NavigationLink {
+                            RecordedSessionDetailView(
+                                session: session,
+                                store: store,
+                                controller: controller
+                            )
+                        } label: {
+                            RecordedSessionRow(session: session)
+                        }
+                    }
+                    .onDelete(perform: deleteSessions)
+                }
+            }
+        }
+        .navigationTitle("Recordings")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                recordButton
+            }
+        }
+        .alert("Recording failed", isPresented: Binding(
+            get: { recordingError != nil },
+            set: { if !$0 { recordingError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(recordingError ?? "")
+        }
+    }
+
+    private var recordButton: some View {
+        Button {
+            Task {
+                if controller.isRecording {
+                    await controller.stop()
+                } else {
+                    do {
+                        try await controller.start()
+                    } catch {
+                        recordingError = error.localizedDescription
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: controller.isRecording ? "stop.circle.fill" : "record.circle")
+                if controller.isRecording {
+                    Text(audioRecorder.formattedDuration)
+                        .font(.system(.caption, design: .monospaced))
+                }
+            }
+            .foregroundStyle(controller.isRecording ? .red : Color.accentColor)
+        }
+        .accessibilityLabel("Record meeting")
+        .accessibilityValue(controller.isRecording ? "Recording \(audioRecorder.formattedDuration)" : "Stopped")
+        .accessibilityHint("Double-tap to start or stop recording.")
+    }
+
+    private func deleteSessions(at offsets: IndexSet) {
+        let sessions = store.sessions
+        for offset in offsets {
+            let session = sessions[offset]
+            controller.cancelTranscription(for: session.id)
+            store.delete(session)
+        }
+    }
+}
+
+/// Sheet presentation wrapper for entry points that are not already in a navigation stack.
+struct RecordingsSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var store: RecordedSessionStore
+    let controller: SessionRecorderController
+    let audioRecorder: AudioRecordingService
+
+    var body: some View {
+        NavigationStack {
+            RecordingsView(store: store, controller: controller, audioRecorder: audioRecorder)
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+        }
+    }
+}
+
+private struct RecordedSessionRow: View {
+    let session: RecordedSession
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(session.title)
+                .font(.headline)
+
+            HStack(spacing: 8) {
+                Text(session.startedAt.formatted(date: .abbreviated, time: .shortened))
+                Text(RecordingTimeFormatter.string(from: session.duration))
+                Spacer()
+                TranscriptionStateBadge(state: session.state)
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+private struct RecordedSessionDetailView: View {
+    @ObservedObject private var store: RecordedSessionStore
+    private let controller: SessionRecorderController
+    private let initialSession: RecordedSession
+    @StateObject private var playback: RecordingPlaybackController
+
+    init(
+        session: RecordedSession,
+        store: RecordedSessionStore,
+        controller: SessionRecorderController
+    ) {
+        self.initialSession = session
+        self.store = store
+        self.controller = controller
+        _playback = StateObject(
+            wrappedValue: RecordingPlaybackController(audioURL: store.audioURL(for: session))
+        )
+    }
+
+    private var session: RecordedSession {
+        store.sessions.first(where: { $0.id == initialSession.id }) ?? initialSession
+    }
+
+    private var canTranscribeAgain: Bool {
+        guard session.state != .transcribing else { return false }
+        let transcriptIsEmpty = session.transcript
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+        return session.state == .failed || session.state == .unavailable || transcriptIsEmpty
+    }
+
+    var body: some View {
+        List {
+            Section("Recording") {
+                LabeledContent("Date") {
+                    Text(session.startedAt.formatted(date: .abbreviated, time: .shortened))
+                }
+                LabeledContent("Duration") {
+                    Text(RecordingTimeFormatter.string(from: session.duration))
+                }
+
+                HStack(spacing: 12) {
+                    Button {
+                        playback.togglePlayback()
+                    } label: {
+                        Image(systemName: playback.isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                            .font(.title)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(playback.isPlaying ? "Pause recording" : "Play recording")
+
+                    Text(RecordingTimeFormatter.playbackTime(
+                        elapsed: playback.elapsed,
+                        duration: playback.duration
+                    ))
+                    .font(.system(.body, design: .monospaced))
+
+                    Spacer()
+
+                    ShareLink(item: store.audioURL(for: session)) {
+                        Label("Share Audio", systemImage: "square.and.arrow.up")
+                    }
+                }
+
+                if let failureReason = playback.failureReason {
+                    Text(failureReason)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+            }
+
+            Section {
+                HStack {
+                    Text("Status")
+                    Spacer()
+                    TranscriptionStateBadge(state: session.state)
+                }
+
+                if let failureReason = session.failureReason, !failureReason.isEmpty {
+                    Text(failureReason)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                if session.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text("No transcript available.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(session.transcript)
+                        .textSelection(.enabled)
+                }
+
+                if canTranscribeAgain {
+                    Button {
+                        controller.transcribeAgain(session)
+                    } label: {
+                        Label("Transcribe Again", systemImage: "arrow.clockwise")
+                    }
+                }
+            } header: {
+                Text("Transcript")
+            }
+        }
+        .navigationTitle(session.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .onDisappear {
+            playback.pause()
+        }
+    }
+}
+
+private struct TranscriptionStateBadge: View {
+    let state: TranscriptionState
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if state == .transcribing {
+                ProgressView()
+                    .controlSize(.mini)
+            }
+            Text(state.displayName)
+        }
+        .font(.caption2.weight(.semibold))
+        .foregroundStyle(state.tint)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(state.tint.opacity(0.12), in: Capsule())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Transcript \(state.displayName)")
+    }
+}
+
+private extension TranscriptionState {
+    var displayName: String {
+        switch self {
+        case .pending: return "Pending"
+        case .transcribing: return "Transcribing"
+        case .done: return "Done"
+        case .failed: return "Failed"
+        case .unavailable: return "Unavailable"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .pending: return .orange
+        case .transcribing: return .blue
+        case .done: return .green
+        case .failed: return .red
+        case .unavailable: return .secondary
+        }
+    }
+}
+
+private enum RecordingTimeFormatter {
+    static func string(from interval: TimeInterval) -> String {
+        let totalSeconds = max(0, Int(interval.rounded()))
+        let hours = totalSeconds / 3_600
+        let minutes = (totalSeconds % 3_600) / 60
+        let seconds = totalSeconds % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    static func playbackTime(elapsed: TimeInterval, duration: TimeInterval) -> String {
+        "\(string(from: elapsed)) / \(string(from: duration))"
+    }
+}
+
+@MainActor
+private final class RecordingPlaybackController: NSObject, ObservableObject, AVAudioPlayerDelegate {
+    @Published private(set) var isPlaying = false
+    @Published private(set) var elapsed: TimeInterval = 0
+    @Published private(set) var duration: TimeInterval = 0
+    @Published private(set) var failureReason: String?
+
+    private var player: AVAudioPlayer?
+    private var progressTimer: Timer?
+
+    init(audioURL: URL) {
+        super.init()
+        do {
+            let player = try AVAudioPlayer(contentsOf: audioURL)
+            self.player = player
+            self.duration = player.duration
+            player.delegate = self
+            player.prepareToPlay()
+        } catch {
+            failureReason = "The audio file could not be opened: \(error.localizedDescription)"
+        }
+    }
+
+    deinit {
+        progressTimer?.invalidate()
+    }
+
+    func togglePlayback() {
+        isPlaying ? pause() : play()
+    }
+
+    func pause() {
+        player?.pause()
+        isPlaying = false
+        stopProgressTimer()
+        updateElapsed()
+    }
+
+    private func play() {
+        guard let player else { return }
+        if player.currentTime >= player.duration {
+            player.currentTime = 0
+        }
+        guard player.play() else {
+            failureReason = "The audio file could not be played."
+            return
+        }
+        isPlaying = true
+        failureReason = nil
+        startProgressTimer()
+    }
+
+    private func startProgressTimer() {
+        stopProgressTimer()
+        progressTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateElapsed()
+            }
+        }
+    }
+
+    private func stopProgressTimer() {
+        progressTimer?.invalidate()
+        progressTimer = nil
+    }
+
+    private func updateElapsed() {
+        elapsed = player?.currentTime ?? 0
+    }
+
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.isPlaying = false
+            self.stopProgressTimer()
+            self.updateElapsed()
+        }
+    }
+
+    nonisolated func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
+        let reason = error?.localizedDescription ?? "Unknown playback error"
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.isPlaying = false
+            self.stopProgressTimer()
+            self.failureReason = "The audio file could not be played: \(reason)"
+        }
+    }
+}

--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -686,6 +686,33 @@ struct HardwarePrivacyView: View {
             }
 
             Section {
+                NavigationLink {
+                    RecordingsView(
+                        store: appState.recordedSessionStore,
+                        controller: appState.sessionRecorder,
+                        audioRecorder: appState.audioRecorder
+                    )
+                } label: {
+                    HStack {
+                        Label("Recordings", systemImage: "waveform")
+                        Spacer()
+                        if appState.sessionRecorder.isRecording {
+                            Text("Recording").foregroundStyle(.red)
+                        }
+                    }
+                }
+                NavigationLink {
+                    MeetingRecordsView()
+                } label: {
+                    Label("Meeting Records", systemImage: "text.book.closed")
+                }
+            } header: {
+                Text("Recordings")
+            } footer: {
+                Text("Preserved meeting recordings with playback and transcripts, and summaries saved by the Meeting Summary tool.")
+            }
+
+            Section {
                 InfoToggle(
                     title: "Blur Bystander Faces",
                     isOn: $privacyFilterEnabled,

--- a/OpenGlasses/Sources/Models/QuickAction.swift
+++ b/OpenGlasses/Sources/Models/QuickAction.swift
@@ -14,6 +14,7 @@ struct QuickAction: Codable, Identifiable {
         case homeAssistant = "homeAssistant"
         case siriShortcut = "siriShortcut"
         case openApp = "openApp"
+        case toggleRecording = "toggleRecording"
 
         var id: String { rawValue }
 
@@ -25,6 +26,7 @@ struct QuickAction: Codable, Identifiable {
             case .homeAssistant: return "Home Assistant"
             case .siriShortcut: return "Siri Shortcut"
             case .openApp: return "Open App"
+            case .toggleRecording: return "Record Meeting"
             }
         }
 
@@ -36,6 +38,7 @@ struct QuickAction: Codable, Identifiable {
             case .homeAssistant: return "Call a Home Assistant service"
             case .siriShortcut: return "Run a Siri Shortcut by name"
             case .openApp: return "Open an app via URL scheme"
+            case .toggleRecording: return "Start or stop a preserved meeting recording"
             }
         }
     }
@@ -82,9 +85,19 @@ struct QuickAction: Codable, Identifiable {
         promptText: "Start a Field Assist session on my default vault. Briefly confirm you're ready and what you can help me troubleshoot."
     )
 
+    /// Built-in record toggle — merged into existing users' persisted lists like the travel
+    /// templates, so the meeting recorder is reachable without reconfiguring the speed dial.
+    static let recordMeeting = QuickAction(
+        id: "record-meeting",
+        label: "Record",
+        icon: "record.circle",
+        type: .toggleRecording
+    )
+
     static let defaults: [QuickAction] = [
         QuickAction(id: "describe", label: "Describe", icon: "eye", type: .photoThenPrompt,
                     promptText: "Describe what you see in this image in detail."),
+        recordMeeting,
         QuickAction(id: "calendar", label: "Event", icon: "calendar", type: .photoThenPrompt,
                     promptText: "Extract any event details from this image (dates, times, locations, names) and create a calendar entry summary."),
         QuickAction(id: "task", label: "Task", icon: "checklist", type: .photoThenPrompt,

--- a/OpenGlasses/Sources/Services/Display/HUDMenuBuilder.swift
+++ b/OpenGlasses/Sources/Services/Display/HUDMenuBuilder.swift
@@ -117,7 +117,7 @@ enum HUDMenuBuilder {
         switch type {
         case .prompt, .photoThenPrompt: return .message
         case .homeAssistant: return .location
-        case .photo, .siriShortcut, .openApp: return .none
+        case .photo, .siriShortcut, .openApp, .toggleRecording: return .none
         }
     }
 }

--- a/OpenGlasses/Sources/Services/NativeTools/QuickActionTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/QuickActionTool.swift
@@ -76,6 +76,8 @@ struct QuickActionTool: NativeTool {
                     detail += " \(qa.shortcutName ?? "")"
                 case .openApp:
                     detail += " \(qa.urlScheme ?? "")"
+                case .toggleRecording:
+                    detail += " Start/stop meeting recording"
                 }
                 lines.append("- **\(qa.label)**: \(detail)")
             }

--- a/OpenGlasses/Sources/Services/RecordedSessionStore.swift
+++ b/OpenGlasses/Sources/Services/RecordedSessionStore.swift
@@ -1,0 +1,156 @@
+import Combine
+import Foundation
+
+enum TranscriptionState: String, Codable, Sendable {
+    case pending
+    case transcribing
+    case done
+    case failed
+    case unavailable
+}
+
+struct RecordedSession: Codable, Identifiable, Equatable, Sendable {
+    var id: UUID
+    var title: String
+    var startedAt: Date
+    var duration: TimeInterval
+    var audioFileName: String
+    var transcript: String
+    var state: TranscriptionState
+    var failureReason: String?
+
+    /// Applies a post-recording result without letting an empty recognizer result erase
+    /// useful live captions collected while the recording was in progress.
+    func applyingTranscription(
+        _ postHocTranscript: String,
+        state newState: TranscriptionState,
+        failureReason newFailureReason: String? = nil
+    ) -> RecordedSession {
+        var updated = self
+        let cleanedTranscript = postHocTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !cleanedTranscript.isEmpty {
+            updated.transcript = cleanedTranscript
+        }
+        updated.state = newState
+        updated.failureReason = newFailureReason
+        return updated
+    }
+}
+
+/// Persists meeting recordings' metadata + transcript as JSON in Documents, alongside the audio
+/// files that `AudioRecordingService` already saves under Documents/Recordings/.
+@MainActor
+final class RecordedSessionStore: ObservableObject {
+    @Published private(set) var sessions: [RecordedSession] = []
+
+    static let storageFileName = "recorded_sessions.json"
+    static let recordingsDirectoryName = "Recordings"
+
+    private let documentsDirectory: URL
+    private let fileManager: FileManager
+
+    init(
+        documentsDirectory: URL? = nil,
+        fileManager: FileManager = .default,
+        loadImmediately: Bool = true
+    ) {
+        self.fileManager = fileManager
+        self.documentsDirectory = documentsDirectory
+            ?? fileManager.urls(for: .documentDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+
+        if loadImmediately {
+            load()
+        }
+    }
+
+    func load() {
+        do {
+            let data = try Data(contentsOf: storageURL)
+            sessions = try JSONDecoder().decode([RecordedSession].self, from: data)
+                .map(Self.normalized)
+            sortNewestFirst()
+        } catch {
+            sessions = []
+        }
+    }
+
+    func add(_ session: RecordedSession) {
+        let normalized = Self.normalized(session)
+        sessions.removeAll { $0.id == normalized.id }
+        sessions.append(normalized)
+        sortNewestFirst()
+        persist()
+    }
+
+    func update(_ session: RecordedSession) {
+        guard let index = sessions.firstIndex(where: { $0.id == session.id }) else { return }
+        sessions[index] = Self.normalized(session)
+        sortNewestFirst()
+        persist()
+    }
+
+    func delete(_ session: RecordedSession) {
+        let storedSession = sessions.first(where: { $0.id == session.id }) ?? session
+        sessions.removeAll { $0.id == session.id }
+
+        let fileName = Self.bareFileName(storedSession.audioFileName)
+        if !fileName.isEmpty {
+            let fileURL = recordingsDirectoryURL.appendingPathComponent(fileName, isDirectory: false)
+            do {
+                if fileManager.fileExists(atPath: fileURL.path) {
+                    try fileManager.removeItem(at: fileURL)
+                }
+            } catch {
+                NSLog("[RecordedSessionStore] Could not delete audio %@: %@", fileURL.path, error.localizedDescription)
+            }
+        }
+
+        persist()
+    }
+
+    /// Rebuilds the audio location from this launch's Documents container. Only the bare
+    /// filename is persisted because an iOS sandbox's absolute container path is not stable.
+    func audioURL(for session: RecordedSession) -> URL {
+        recordingsDirectoryURL
+            .appendingPathComponent(Self.bareFileName(session.audioFileName), isDirectory: false)
+    }
+
+    private var storageURL: URL {
+        documentsDirectory.appendingPathComponent(Self.storageFileName, isDirectory: false)
+    }
+
+    private var recordingsDirectoryURL: URL {
+        documentsDirectory.appendingPathComponent(Self.recordingsDirectoryName, isDirectory: true)
+    }
+
+    private func sortNewestFirst() {
+        sessions.sort {
+            if $0.startedAt == $1.startedAt {
+                return $0.id.uuidString > $1.id.uuidString
+            }
+            return $0.startedAt > $1.startedAt
+        }
+    }
+
+    private func persist() {
+        do {
+            try fileManager.createDirectory(at: documentsDirectory, withIntermediateDirectories: true)
+            let data = try JSONEncoder().encode(sessions)
+            try data.write(to: storageURL, options: .atomic)
+        } catch {
+            NSLog("[RecordedSessionStore] Persistence failed: %@", error.localizedDescription)
+        }
+    }
+
+    private static func normalized(_ session: RecordedSession) -> RecordedSession {
+        var session = session
+        session.audioFileName = bareFileName(session.audioFileName)
+        return session
+    }
+
+    private static func bareFileName(_ value: String) -> String {
+        let fileName = (value as NSString).lastPathComponent
+        return fileName == "." || fileName == ".." ? "" : fileName
+    }
+}

--- a/OpenGlasses/Sources/Services/RecordingTranscriber.swift
+++ b/OpenGlasses/Sources/Services/RecordingTranscriber.swift
@@ -1,0 +1,194 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+enum RecordingTranscriptionOutcome: Equatable, Sendable {
+    case success(String)
+    case failure(String)
+    case unavailable(String)
+}
+
+/// Post-processes preserved recordings. Cloud diarization is preferred when configured (and not
+/// HIPAA-locked); the downloaded on-device SenseVoice model is the private/offline fallback.
+@MainActor
+final class RecordingTranscriber {
+    private let deepgram: DeepgramBatchService
+    private let onDeviceEngine: OnDeviceASREngine
+    private let chunkDuration: TimeInterval
+
+    init(
+        deepgram: DeepgramBatchService = DeepgramBatchService(),
+        onDeviceEngine: OnDeviceASREngine? = nil,
+        chunkDuration: TimeInterval = 30
+    ) {
+        self.deepgram = deepgram
+        self.onDeviceEngine = onDeviceEngine ?? OnDeviceASREngine()
+        self.chunkDuration = chunkDuration
+    }
+
+    func transcribe(fileURL: URL) async -> RecordingTranscriptionOutcome {
+        var providerFailures: [String] = []
+        let canUseDeepgram = !Config.deepgramAPIKey.isEmpty
+            && !Config.hipaaMode
+
+        if canUseDeepgram {
+            do {
+                let turns = try await deepgram.diarize(
+                    fileURL: fileURL,
+                    mimeType: "audio/m4a"
+                )
+                let transcript = Self.join(turns: turns)
+                if !transcript.isEmpty {
+                    return .success(transcript)
+                }
+                providerFailures.append("Deepgram returned no transcript.")
+            } catch {
+                providerFailures.append(error.localizedDescription)
+            }
+        }
+
+        guard onDeviceEngine.isReady else {
+            if providerFailures.isEmpty {
+                return .unavailable(
+                    "Configure Deepgram or download the on-device speech recognition model."
+                )
+            }
+            return .failure(providerFailures.joined(separator: " "))
+        }
+
+        do {
+            let reader = try RecordingAudioChunkReader(
+                fileURL: fileURL,
+                chunkDuration: chunkDuration
+            )
+            var transcriptChunks: [String] = []
+
+            while let chunk = try await reader.nextChunk() {
+                try Task.checkCancellation()
+                let text = try await onDeviceEngine.transcribe(
+                    samples: chunk.samples,
+                    sampleRate: chunk.sampleRate
+                )
+                let cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !cleaned.isEmpty {
+                    transcriptChunks.append(cleaned)
+                }
+            }
+
+            return .success(transcriptChunks.joined(separator: "\n"))
+        } catch is CancellationError {
+            return .failure("Transcription was cancelled.")
+        } catch {
+            providerFailures.append(error.localizedDescription)
+            return .failure(providerFailures.joined(separator: " "))
+        }
+    }
+
+    static func join(turns: [SpeakerTurn]) -> String {
+        let usableTurns = turns.compactMap { turn -> SpeakerTurn? in
+            let text = turn.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+            return SpeakerTurn(
+                speaker: turn.speaker,
+                text: text,
+                start: turn.start,
+                end: turn.end
+            )
+        }
+        let hasMultipleSpeakers = Set(usableTurns.compactMap(\.speaker)).count > 1
+
+        return usableTurns.map { turn in
+            if hasMultipleSpeakers, let speaker = turn.speaker {
+                return "Speaker \(speaker + 1): \(turn.text)"
+            }
+            return turn.text
+        }
+        .joined(separator: hasMultipleSpeakers ? "\n" : " ")
+    }
+}
+
+private struct RecordingAudioChunk: Sendable {
+    let samples: [Float]
+    let sampleRate: Double
+}
+
+/// Owns the decoder off the main actor and yields only one bounded PCM window at a time. A long
+/// recording therefore never accumulates its decoded audio in memory while ASR is running.
+private actor RecordingAudioChunkReader {
+    private let file: AVAudioFile
+    private let format: AVAudioFormat
+    private let frameCapacity: AVAudioFrameCount
+
+    init(fileURL: URL, chunkDuration: TimeInterval) throws {
+        guard chunkDuration > 0 else {
+            throw RecordingTranscriberError.invalidAudioFormat
+        }
+
+        let file = try AVAudioFile(
+            forReading: fileURL,
+            commonFormat: .pcmFormatFloat32,
+            interleaved: false
+        )
+        let format = file.processingFormat
+        guard format.sampleRate > 0, format.channelCount > 0 else {
+            throw RecordingTranscriberError.invalidAudioFormat
+        }
+
+        let requestedFrames = max(1, Int(format.sampleRate * chunkDuration))
+        self.file = file
+        self.format = format
+        self.frameCapacity = AVAudioFrameCount(min(requestedFrames, Int(UInt32.max)))
+    }
+
+    func nextChunk() throws -> RecordingAudioChunk? {
+        try Task.checkCancellation()
+        guard file.framePosition < file.length else { return nil }
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: frameCapacity
+        ) else {
+            throw RecordingTranscriberError.couldNotAllocateBuffer
+        }
+
+        try file.read(into: buffer, frameCount: frameCapacity)
+        let frameCount = Int(buffer.frameLength)
+        guard frameCount > 0 else { return nil }
+        guard let channelData = buffer.floatChannelData else {
+            throw RecordingTranscriberError.unsupportedPCMFormat
+        }
+
+        let channelCount = Int(format.channelCount)
+        var mono = [Float](repeating: 0, count: frameCount)
+        if channelCount == 1 {
+            mono.withUnsafeMutableBufferPointer { destination in
+                destination.baseAddress?.update(from: channelData[0], count: frameCount)
+            }
+        } else {
+            let scale = 1 / Float(channelCount)
+            for channel in 0..<channelCount {
+                let source = channelData[channel]
+                for frame in 0..<frameCount {
+                    mono[frame] += source[frame] * scale
+                }
+            }
+        }
+
+        return RecordingAudioChunk(samples: mono, sampleRate: format.sampleRate)
+    }
+}
+
+private enum RecordingTranscriberError: LocalizedError {
+    case invalidAudioFormat
+    case couldNotAllocateBuffer
+    case unsupportedPCMFormat
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidAudioFormat:
+            return "The recording has an invalid audio format."
+        case .couldNotAllocateBuffer:
+            return "The recording could not be decoded."
+        case .unsupportedPCMFormat:
+            return "The recording's decoded PCM format is unsupported."
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/SessionRecorderController.swift
+++ b/OpenGlasses/Sources/Services/SessionRecorderController.swift
@@ -1,0 +1,153 @@
+import Combine
+import Foundation
+
+enum SessionRecorderError: LocalizedError {
+    case alreadyRecording
+
+    var errorDescription: String? {
+        switch self {
+        case .alreadyRecording:
+            return "Another recording is already in progress."
+        }
+    }
+}
+
+/// Orchestrates one preserved meeting recording: shared-engine startup (even when wake-word
+/// listening is off), `AudioRecordingService` capture with live captions, then post-hoc
+/// transcription through `RecordingTranscriber` with a pending → transcribing → done/failed
+/// state machine persisted in `RecordedSessionStore`.
+@MainActor
+final class SessionRecorderController: ObservableObject {
+    @Published private(set) var isRecording = false
+
+    private let audioRecorder: AudioRecordingService
+    private let wakeWordService: WakeWordService
+    private let store: RecordedSessionStore
+    private let transcriber: RecordingTranscriber
+
+    private var startedAt: Date?
+    private var startedEngineForRecording = false
+    private var transcriptionTasks: [UUID: Task<Void, Never>] = [:]
+
+    init(
+        audioRecorder: AudioRecordingService,
+        wakeWordService: WakeWordService,
+        store: RecordedSessionStore,
+        transcriber: RecordingTranscriber
+    ) {
+        self.audioRecorder = audioRecorder
+        self.wakeWordService = wakeWordService
+        self.store = store
+        self.transcriber = transcriber
+    }
+
+    func start() async throws {
+        guard !isRecording, !audioRecorder.isRecording else {
+            throw SessionRecorderError.alreadyRecording
+        }
+
+        let engineWasRunning = wakeWordService.getAudioEngine()?.isRunning == true
+        try await wakeWordService.ensureAudioEngineRunningForConsumers()
+
+        do {
+            try audioRecorder.startRecording()
+            startedEngineForRecording = !engineWasRunning && !wakeWordService.isListening
+            startedAt = Date()
+            isRecording = true
+        } catch {
+            if !engineWasRunning, !wakeWordService.isListening {
+                wakeWordService.stopListening()
+            }
+            throw error
+        }
+    }
+
+    func stop() async {
+        guard isRecording else { return }
+
+        let sessionStart = startedAt ?? Date().addingTimeInterval(-audioRecorder.recordingDuration)
+        let savedURL = await audioRecorder.stopRecording()
+        let duration = audioRecorder.recordingDuration
+        let liveTranscript = audioRecorder.recordingTranscript
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        isRecording = false
+        startedAt = nil
+        if startedEngineForRecording, !wakeWordService.isListening {
+            wakeWordService.stopListening()
+        }
+        startedEngineForRecording = false
+
+        guard let savedURL else { return }
+
+        let session = RecordedSession(
+            id: UUID(),
+            title: Self.title(at: sessionStart),
+            startedAt: sessionStart,
+            duration: duration,
+            audioFileName: savedURL.lastPathComponent,
+            transcript: liveTranscript,
+            state: .pending,
+            failureReason: nil
+        )
+        store.add(session)
+        beginTranscription(for: session)
+    }
+
+    func transcribeAgain(_ session: RecordedSession) {
+        guard transcriptionTasks[session.id] == nil,
+              let current = store.sessions.first(where: { $0.id == session.id }) else {
+            return
+        }
+        beginTranscription(for: current)
+    }
+
+    func cancelTranscription(for sessionID: UUID) {
+        transcriptionTasks.removeValue(forKey: sessionID)?.cancel()
+    }
+
+    private func beginTranscription(for session: RecordedSession) {
+        let task = Task(priority: .utility) { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.transcriptionTasks[session.id] = nil }
+
+            var inProgress = session
+            inProgress.state = .transcribing
+            inProgress.failureReason = nil
+            self.store.update(inProgress)
+
+            let outcome = await self.transcriber.transcribe(
+                fileURL: self.store.audioURL(for: inProgress)
+            )
+            guard !Task.isCancelled else { return }
+
+            let current = self.store.sessions.first(where: { $0.id == inProgress.id }) ?? inProgress
+            let completed: RecordedSession
+            switch outcome {
+            case .success(let transcript):
+                completed = current.applyingTranscription(transcript, state: .done)
+            case .failure(let reason):
+                completed = current.applyingTranscription(
+                    "",
+                    state: .failed,
+                    failureReason: reason
+                )
+            case .unavailable(let reason):
+                completed = current.applyingTranscription(
+                    "",
+                    state: .unavailable,
+                    failureReason: reason
+                )
+            }
+            self.store.update(completed)
+        }
+        transcriptionTasks[session.id] = task
+    }
+
+    private static func title(at date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return "Recording — \(formatter.string(from: date))"
+    }
+}

--- a/OpenGlasses/Sources/Services/WakeWordService.swift
+++ b/OpenGlasses/Sources/Services/WakeWordService.swift
@@ -497,6 +497,30 @@ class WakeWordService: NSObject, ObservableObject {
         recognitionRequest = nil
     }
 
+    /// Start the shared engine for an explicit audio-buffer consumer even when always-on wake-word
+    /// listening is disabled. Unlike `startListening()`, this only needs microphone permission and
+    /// does not create a Speech recognition task.
+    func ensureAudioEngineRunningForConsumers() async throws {
+        if let engine = audioEngine, engine.isRunning { return }
+
+        guard await AVAudioApplication.requestRecordPermission() else {
+            errorMessage = "Microphone permission denied"
+            throw WakeWordError.microphonePermissionDenied
+        }
+
+        await configureAudioSession()
+        if let oldEngine = audioEngine {
+            oldEngine.stop()
+            oldEngine.inputNode.removeTap(onBus: 0)
+            audioEngine = nil
+        }
+        try createAndStartAudioEngine()
+
+        guard audioEngine?.isRunning == true else {
+            throw WakeWordError.configurationError("Shared audio engine did not start")
+        }
+    }
+
     /// Get the current audio engine (for shared use by TranscriptionService)
     func getAudioEngine() -> AVAudioEngine? {
         return audioEngine

--- a/OpenGlasses/Sources/Services/WatchConnectivityManager.swift
+++ b/OpenGlasses/Sources/Services/WatchConnectivityManager.swift
@@ -262,6 +262,8 @@ extension WatchConnectivityManager: WCSessionDelegate {
                         await appState.captureAndAnalyzePhoto()
                     case .prompt:
                         await appState.capturePhotoAndSend(prompt: action.label)
+                    case .toggleRecording:
+                        await appState.executeQuickAction(action)
                     default:
                         await appState.capturePhotoAndSend(prompt: action.label)
                     }

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -1482,7 +1482,7 @@ struct Config {
         if let data = UserDefaults.standard.data(forKey: "quickActions"),
            let actions = try? JSONDecoder().decode([QuickAction].self, from: data),
            !actions.isEmpty {
-            let merged = mergeTravelQuickActions(into: actions)
+            let merged = mergeBuiltInQuickActions(into: actions)
             if merged.count != actions.count {
                 setQuickActions(merged)
             }
@@ -1507,10 +1507,14 @@ struct Config {
         }
     }
 
-    private static func mergeTravelQuickActions(into actions: [QuickAction]) -> [QuickAction] {
+    /// Append any built-in actions (travel templates, the record toggle) a user's persisted
+    /// list predates, so new built-ins reach existing installs — same merge semantics the
+    /// travel templates have always had.
+    private static func mergeBuiltInQuickActions(into actions: [QuickAction]) -> [QuickAction] {
         var merged = actions
         let existingIds = Set(actions.map(\.id))
-        for template in QuickAction.travelTemplates where !existingIds.contains(template.id) {
+        for template in QuickAction.travelTemplates + [QuickAction.recordMeeting]
+        where !existingIds.contains(template.id) {
             merged.append(template)
         }
         return merged

--- a/OpenGlassesTests/RecordedSessionStoreTests.swift
+++ b/OpenGlassesTests/RecordedSessionStoreTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+@testable import OpenGlasses
+
+@MainActor
+final class RecordedSessionStoreTests: XCTestCase {
+    private func withTemporaryDirectory<T>(_ body: (URL) throws -> T) throws -> T {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordedSessionStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        return try body(directory)
+    }
+
+    private func makeSession(
+        id: UUID = UUID(),
+        startedAt: Date = Date(timeIntervalSince1970: 1_000),
+        audioFileName: String = "recording.m4a",
+        transcript: String = "",
+        state: TranscriptionState = .pending
+    ) -> RecordedSession {
+        RecordedSession(
+            id: id,
+            title: "Recording — Test",
+            startedAt: startedAt,
+            duration: 12,
+            audioFileName: audioFileName,
+            transcript: transcript,
+            state: state,
+            failureReason: nil
+        )
+    }
+
+    func testRoundTripAddUpdateAndDelete() throws {
+        try withTemporaryDirectory { directory in
+            let id = UUID()
+            let store = RecordedSessionStore(documentsDirectory: directory)
+            var session = makeSession(id: id)
+            store.add(session)
+
+            var reloaded = RecordedSessionStore(documentsDirectory: directory)
+            XCTAssertEqual(reloaded.sessions, [session])
+
+            session.duration = 42
+            session.transcript = "Updated transcript"
+            reloaded.update(session)
+
+            reloaded = RecordedSessionStore(documentsDirectory: directory)
+            XCTAssertEqual(reloaded.sessions.first?.duration, 42)
+            XCTAssertEqual(reloaded.sessions.first?.transcript, "Updated transcript")
+
+            reloaded.delete(session)
+            XCTAssertTrue(RecordedSessionStore(documentsDirectory: directory).sessions.isEmpty)
+        }
+    }
+
+    func testSessionsAreNewestFirst() throws {
+        try withTemporaryDirectory { directory in
+            let store = RecordedSessionStore(documentsDirectory: directory)
+            let oldest = makeSession(startedAt: Date(timeIntervalSince1970: 100))
+            let newest = makeSession(startedAt: Date(timeIntervalSince1970: 300))
+            let middle = makeSession(startedAt: Date(timeIntervalSince1970: 200))
+
+            store.add(oldest)
+            store.add(newest)
+            store.add(middle)
+
+            XCTAssertEqual(store.sessions.map(\.startedAt), [
+                newest.startedAt,
+                middle.startedAt,
+                oldest.startedAt,
+            ])
+        }
+    }
+
+    func testDeleteUnlinksAudioFile() throws {
+        try withTemporaryDirectory { directory in
+            let store = RecordedSessionStore(documentsDirectory: directory)
+            let session = makeSession(audioFileName: "preserved.m4a")
+            let audioURL = store.audioURL(for: session)
+            try FileManager.default.createDirectory(
+                at: audioURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            XCTAssertTrue(FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8)))
+            store.add(session)
+
+            store.delete(session)
+
+            XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
+            XCTAssertTrue(store.sessions.isEmpty)
+        }
+    }
+
+    func testCorruptJSONLoadsAsEmptyWithoutCrashing() throws {
+        try withTemporaryDirectory { directory in
+            let storageURL = directory.appendingPathComponent(RecordedSessionStore.storageFileName)
+            try Data("not-json".utf8).write(to: storageURL)
+
+            let store = RecordedSessionStore(documentsDirectory: directory)
+
+            XCTAssertTrue(store.sessions.isEmpty)
+        }
+    }
+
+    /// Only the bare filename is persisted: an iOS sandbox's absolute container path changes
+    /// between launches, so the audio URL must be rebuilt from the current Documents directory.
+    func testAudioURLUsesCurrentDocumentsDirectoryAndBareFileName() throws {
+        try withTemporaryDirectory { firstDirectory in
+            try withTemporaryDirectory { currentDirectory in
+                let session = makeSession(
+                    audioFileName: "/old/container/Documents/Recordings/moved.m4a"
+                )
+                let firstStore = RecordedSessionStore(documentsDirectory: firstDirectory)
+                let currentStore = RecordedSessionStore(documentsDirectory: currentDirectory)
+                firstStore.add(session)
+                currentStore.add(session)
+
+                XCTAssertEqual(firstStore.sessions.first?.audioFileName, "moved.m4a")
+                XCTAssertEqual(currentStore.sessions.first?.audioFileName, "moved.m4a")
+                XCTAssertEqual(
+                    currentStore.audioURL(for: session),
+                    currentDirectory
+                        .appendingPathComponent(RecordedSessionStore.recordingsDirectoryName)
+                        .appendingPathComponent("moved.m4a")
+                )
+                XCTAssertNotEqual(
+                    firstStore.audioURL(for: session).deletingLastPathComponent(),
+                    currentStore.audioURL(for: session).deletingLastPathComponent()
+                )
+            }
+        }
+    }
+
+    func testStateTransitionsPendingToTranscribingToDone() throws {
+        try withTemporaryDirectory { directory in
+            let store = RecordedSessionStore(documentsDirectory: directory)
+            var session = makeSession(state: .pending)
+            store.add(session)
+            XCTAssertEqual(store.sessions.first?.state, .pending)
+
+            session.state = .transcribing
+            store.update(session)
+            XCTAssertEqual(store.sessions.first?.state, .transcribing)
+
+            session.state = .done
+            session.transcript = "Finished transcript"
+            store.update(session)
+            XCTAssertEqual(store.sessions.first?.state, .done)
+            XCTAssertEqual(store.sessions.first?.transcript, "Finished transcript")
+        }
+    }
+
+    func testEmptyPostHocTranscriptDoesNotClobberLiveCaptionText() {
+        let session = makeSession(transcript: "Useful live-caption text")
+
+        let completed = session.applyingTranscription("   \n", state: .done)
+
+        XCTAssertEqual(completed.transcript, "Useful live-caption text")
+        XCTAssertEqual(completed.state, .done)
+    }
+
+    // MARK: - RecordingTranscriber.join (pure)
+
+    func testJoinLabelsSpeakersOnlyWhenMultiplePresent() {
+        let multi: [SpeakerTurn] = [
+            SpeakerTurn(speaker: 0, text: "Hello", start: 0, end: 1),
+            SpeakerTurn(speaker: 1, text: "Hi there", start: 1, end: 2),
+            SpeakerTurn(speaker: 0, text: "  ", start: 2, end: 3),
+        ]
+        XCTAssertEqual(
+            RecordingTranscriber.join(turns: multi),
+            "Speaker 1: Hello\nSpeaker 2: Hi there"
+        )
+
+        let single: [SpeakerTurn] = [
+            SpeakerTurn(speaker: 0, text: "Just", start: 0, end: 1),
+            SpeakerTurn(speaker: 0, text: "me", start: 1, end: 2),
+        ]
+        XCTAssertEqual(RecordingTranscriber.join(turns: single), "Just me")
+    }
+}


### PR DESCRIPTION
## Summary

Audio recordings become first-class, persistent sessions — recorded, played back, transcribed, and browsable — instead of a one-shot file handed to the share sheet.

### Deterministic core (all headless-tested)

- **`RecordedSessionStore`** — JSON-persisted sessions (title, start, duration, audio filename, transcript, state) in Documents, newest-first, atomic writes, corrupt-file tolerance. Only the bare audio filename is persisted: an iOS sandbox's absolute container path is not stable across launches, so the URL is rebuilt per-launch (regression-tested).
- **`RecordingTranscriber`** — post-hoc transcription with a provider ladder: Deepgram batch diarization when a key is configured (**HIPAA mode hard-disables it**, consistent with Plan BM), else the on-device SenseVoice engine. On-device decoding streams through a chunked actor (30s windows), so a long recording never accumulates decoded PCM in memory. Speaker labels are emitted only when more than one speaker was detected.
- **`SessionRecorderController`** — start/stop orchestration over the existing `AudioRecordingService` (so live captions keep feeding the transcript while recording), a pending → transcribing → done / failed / unavailable state machine, "transcribe again" for failed/empty results, and the guarantee that an empty post-hoc recognizer result never clobbers live-caption text.
- **`WakeWordService.ensureAudioEngineRunningForConsumers()`** — starts the shared audio engine for an explicit buffer consumer without enabling wake-word listening or creating a Speech recognition task. The controller stops the engine after recording only when it was the one that started it.

### UI

- **Recordings** (Settings → Recordings): record/stop with live duration in the toolbar, playback with elapsed/total time, share audio, transcript with status badge, swipe-to-delete (which also cancels in-flight transcription and unlinks the audio file).
- **Meeting Records**: summaries saved by the Meeting Summary tool (filtered from `SavedNotesStore` by the canonical title prefix), with share and delete.
- **Record quick action** (second commit): a new `.toggleRecording` quick-action type with a built-in "Record" action, shipped in the defaults and merged into existing users' persisted lists (same semantics as the travel templates). The dock tile and status-ring overlay button are live — red stop icon while recording, elapsed duration on the tile — and the action editor, quick-action tool listing, HUD menu, and watch handler all cover the new type.

## Verification

- Full simulator suite green: **2,753 tests passed**, including 8 new tests (store round-trip/ordering/corruption, path stability across container moves, state transitions, live-caption preservation, speaker-label joining); re-run green after the quick-action commit
- Unsigned Release build green (both commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)