### PR TITLE
DAT SDK 0.9.0: consolidated Camera capability + compatibility-refusal surfacing

### DIFF
--- a/.claude/rules/dat-conventions.md
+++ b/.claude/rules/dat-conventions.md
@@ -2,27 +2,37 @@
 description: Swift patterns, async/await, naming conventions, key types for DAT SDK iOS development
 ---
 
-# DAT SDK Conventions (iOS) — v0.8.0
+# DAT SDK Conventions (iOS) — v0.9.0
 
 ## Architecture
 
 The SDK is organized into modules:
-- **MWDATCore**: Device discovery, registration, permissions, device selectors, `DeviceSession`, device state (`deviceStateStream` / `ThermalLevel`)
-- **MWDATCamera**: `Stream`, `VideoFrame`, `PhotoData`, photo capture
-- **MWDATDisplay**: in-lens HUD — `Display` + view types (`FlexBox`, `Text`, `Button`, `Image`, `Icon`, `VideoPlayer`)
+- **MWDATCore**: Device discovery, registration, permissions, device selectors, `DeviceSession`, device state (`deviceStateStream` / `ThermalLevel`), `ListenerTokenBag`
+- **MWDATCamera**: `Camera` (owns the hardware resource) → `Stream`, `VideoFrame`, `PhotoData`, photo capture
+- **MWDATDisplay**: in-lens HUD — `Display` + view types (`FlexBox`, `Text`, `Button`, `ButtonGroup`, `Image`, `Icon`, `VideoPlayer`)
 - **MWDATMockDevice**: `MockDeviceKit` for testing without hardware (UI-test oriented)
+
+Minimum deployment target is **iOS 17.2** (bumped from 15.2 in 0.9.0).
 
 ## Swift Patterns
 
-- Most SDK operations are `async/await`, **but** `Stream.start()/stop()` and `Display.start()/stop()`
-  are **synchronous** as of 0.8.0 (no `await`). `Display.send(_:)` / `Display.clearDisplay()` are async.
-- Capabilities are managed through their `DeviceSession`: `addStream(config:)` / `addDisplay()` (and
-  removal). There is no `Capability` protocol / `addCapability` (removed in 0.8.0).
+- Most SDK operations are `async/await`, **but** `Stream.start()/stop()`, `Camera.stop()` and
+  `Display.start()/stop()` are **synchronous** (no `await`). `Display.send(_:)` /
+  `Display.clearDisplay()` are async.
+- Capabilities are managed through their `DeviceSession`: `addCamera(config:)` / `addDisplay()`.
+  0.9.0 consolidated the camera: `addStream(config:)` is **removed** — `addCamera(config:)` returns
+  a `Camera` whose `.stream` is the streaming session. `Camera.stop()` detaches the capability and
+  cascades to its children; `stream.stop()` alone pauses streaming but keeps the capability attached.
+- The camera capability is process-wide and frees only when the `Camera` finishes stopping
+  (`CameraState.stopped`) — re-adding before then throws `capabilityAlreadyActive`.
 - Observe streams via the `Announcer` publishers' `.listen {}` (`statePublisher`, `videoFramePublisher`,
-  `photoDataPublisher`, `errorPublisher`).
+  `photoDataPublisher`, `errorPublisher`); `Camera.statePublisher` reports the capability lifecycle.
+  Aggregate listener tokens with `ListenerTokenBag` / `token.store(in:)` (0.9.0) to cancel together.
+- `DeviceSession.stateStream()` / `errorStream()` **finish** once the session reaches `.stopped`
+  (0.9.0); a stream created after stop finishes immediately — `for await` loops exit on their own.
 - Annotate UI-updating code with `@MainActor`; never block the main thread with frame processing.
-- All SDK errors conform to **`DatError`** (`LocalizedError`) with a consistent `description` (0.8.0
-  unified error model). `capturePhoto(format:)` returns `Bool` (request accepted); the photo arrives on
+- All SDK errors conform to **`DatError`** (`LocalizedError`) with a consistent `description`.
+  `capturePhoto(format:)` returns `Bool` (request accepted); the photo arrives on
   `photoDataPublisher` and stream errors on `errorPublisher` (`StreamError`).
 
 ## Naming Conventions
@@ -31,7 +41,7 @@ The SDK is organized into modules:
 |------|-----------|---------|
 | Entry point | `Wearables.shared` | `Wearables.shared.startRegistration()` |
 | Sessions | `DeviceSession` | `Wearables.shared.createSession(deviceSelector:)` |
-| Camera | `Stream` / `StreamConfiguration` | `deviceSession.addStream(config:)` |
+| Camera | `Camera` / `StreamConfiguration` | `deviceSession.addCamera(config:)` → `camera.stream` |
 | Selectors | `*DeviceSelector` | `AutoDeviceSelector(wearables:filter:)`, `SpecificDeviceSelector` |
 | Publishers | `*Publisher` (Announcer) | `statePublisher`, `videoFramePublisher`, `errorPublisher` |
 
@@ -39,8 +49,8 @@ The SDK is organized into modules:
 
 ```swift
 import MWDATCore    // Registration, devices, permissions, DeviceSession, device state
-import MWDATCamera  // Stream, StreamConfiguration, VideoFrame, PhotoData, photo capture
-import MWDATDisplay // Display + view types (FlexBox/Text/Button/Image/Icon/VideoPlayer)
+import MWDATCamera  // Camera, Stream, StreamConfiguration, VideoFrame, PhotoData, photo capture
+import MWDATDisplay // Display + view types (FlexBox/Text/Button/ButtonGroup/Image/Icon/VideoPlayer)
 ```
 
 For testing:
@@ -53,16 +63,26 @@ import MWDATMockDevice  // MockDeviceKit, MockGlasses, MockCameraKit; pairGlasse
 - `Wearables` — SDK entry point. Call `Wearables.configure()` at launch, then use `Wearables.shared`.
   Device state via `Wearables.deviceStateStream(for:)` (`DeviceState.thermalLevel`); there is no
   `DeviceStateSession` (removed in 0.7.0).
-- `DeviceSession` — owns the connection; create with a device selector, then `addStream`/`addDisplay`.
-- `Stream` — camera streaming session (`addStream(config:)`); `start()/stop()` are sync; `capturePhoto(format:) -> Bool`.
+- `DeviceSession` — owns the connection; create with a device selector, then `addCamera`/`addDisplay`.
+- `Camera` — owns the camera hardware resource (0.9.0); `camera.stream` is the streaming session,
+  `camera.state`/`statePublisher` report the capability lifecycle (`CameraState`), `stop()` is sync
+  and cascades to the stream.
+- `Stream` — camera streaming session (reached via `camera.stream`); `start()/stop()` are sync;
+  `capturePhoto(format:) -> Bool`.
 - `StreamConfiguration` — video codec, resolution, frame rate.
 - `Display` — in-lens HUD; `send(_:)` replaces content (async), `clearDisplay()` blanks it (async),
-  `start()/stop()` are sync.
+  `start()/stop()` are sync. `ButtonGroup` (+ `ButtonGroupBuilder`/`ButtonGroupAlignment`) lays out
+  button rows (0.9.0); the component result builder supports full if/else.
 - `Device.supportsDisplay()` / `DeviceType.supportsDisplay` — capability gate; `AutoDeviceSelector(wearables:filter:)`
   can constrain selection (e.g. `filter: { $0.supportsDisplay() }`).
 - `DeviceType` — `.rayBanMeta`, `.oakleyMetaHSTN`, `.oakleyMetaVanguard`, `.rayBanMetaOptics`, `.metaGlasses`.
-- `MockDeviceKit` — `pairGlasses(model: GlassesModel)` (throws `MockDeviceKitError`); oriented at the
+- `ListenerTokenBag` — actor aggregating listener tokens; `insert(_:)`/`clear()` are nonisolated,
+  `cancelAll()` is async; `AnyListenerToken.store(in:)` is the sugar.
+- `MockDeviceKit` — `pairGlasses(model: GlassesModel)` (throws `MockDeviceKitError`, a `DatError`
+  as of 0.9.0); `MockCameraKit.setCameraFeed(cameraFacing:)` is synchronous (0.9.0). Oriented at the
   UI-test process (`MockDeviceTestClient`), not headless unit tests (`Wearables` fatals there).
+  0.9.0 aligned the mock's `Info.plist` link-availability checks with real devices — missing
+  Bluetooth/Wi-Fi entries fail identically on mock and hardware.
 
 ## Error Handling
 
@@ -79,12 +99,16 @@ stream.errorPublisher.listen { (error: StreamError) in /* map via CameraErrorPol
 ```
 
 Notes from the field:
-- `CaptureError` (`.photo_capture_timeout` / `.photo_capture_failed`) is *declared* but not emitted by
-  any public API in 0.8.0 — handle the `StreamError` cases on `errorPublisher` instead.
-- **WiFi transport** (0.8.0) is transparent — no app-facing API; the SDK negotiates it.
+- `CaptureError` was **removed** in 0.9.0 (it was declared but never emitted in 0.8.0). Photo-capture
+  failure now arrives as `StreamError.photoCaptureFailed` on `errorPublisher`.
+- `StreamError.hingesClosed` now also fires when the device is doffed (0.9.0) — previously that case
+  collapsed into a generic pause.
+- **WiFi transport** is transparent — no app-facing API; the SDK negotiates it.
+- The DAT App Model (DAM) is always enabled as of 0.9.0 — the `MWDAT.DAMEnabled` Info.plist opt-out
+  key is ignored. Crash-reporting opt-out: `MWDAT > CrashReporting > OptOut` (Bool, default `false`).
 
 ## Links
 
-- [iOS API Reference](https://wearables.developer.meta.com/docs/reference/ios_swift/dat/0.8)
+- [iOS API Reference](https://wearables.developer.meta.com/docs/reference/ios_swift/dat/0.9)
 - [Developer Documentation](https://wearables.developer.meta.com/docs/develop/)
 - [GitHub Repository](https://github.com/facebook/meta-wearables-dat-ios)

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -412,17 +412,15 @@ struct OpenGlassesApp: App {
         NSLog("[OpenGlasses] AppLinkURLScheme (Universal Link): \(appLinkURL ?? "nil")")
         NSLog("[OpenGlasses] MetaAppID: \(metaAppID ?? "nil")")
 
-        do {
-            let parsed = try Configuration(bundle: .main)
-            let app = parsed.appConfiguration
-            NSLog("[OpenGlasses] Parsed config bundleIdentifier=\(app.bundleIdentifier)")
-            NSLog("[OpenGlasses] Parsed config appLinkURLScheme=\(app.appLinkURLScheme ?? "nil")")
-            NSLog("[OpenGlasses] Parsed config metaAppId=\(app.metaAppId ?? "nil")")
-            NSLog("[OpenGlasses] Parsed config clientTokenPresent=\(app.clientToken != nil)")
-            NSLog("[OpenGlasses] Parsed config teamID=\(app.teamID ?? "nil")")
-            NSLog("[OpenGlasses] Parsed attestation hasCompleteData=\(parsed.attestationConfiguration.hasCompleteData)")
-        } catch {
-            NSLog("[OpenGlasses] Configuration(bundle:) parse failed: \(error.localizedDescription)")
+        // DAT 0.9.0 removed the public `Configuration(bundle:)` parser, so log the raw
+        // MWDAT dictionary fields the SDK reads instead (same diagnostic intent: catch a
+        // placeholder or build-setting-substitution miss before it bites registration).
+        let clientToken = mwdat?["ClientToken"] as? String
+        let teamID = mwdat?["TeamID"] as? String
+        NSLog("[OpenGlasses] Config clientTokenPresent=\(clientToken?.isEmpty == false)")
+        NSLog("[OpenGlasses] Config teamID=\(teamID ?? "nil")")
+        if metaAppID?.hasPrefix("YOUR_") == true || clientToken?.contains("YOUR_") == true {
+            NSLog("[OpenGlasses] ⚠️ MWDAT config still contains placeholder values")
         }
     }
 }

--- a/OpenGlasses/Sources/App/Views/HUDPreviewView.swift
+++ b/OpenGlasses/Sources/App/Views/HUDPreviewView.swift
@@ -177,10 +177,30 @@ private struct ComponentView: View {
         } else if let icon = component as? MWDATDisplay.Icon {
             SwiftUI.Image(systemName: sfSymbol(for: icon.name))
                 .foregroundColor(AppAccent.aiCoral)
+        } else if let group = component as? MWDATDisplay.ButtonGroup {
+            buttonGroupView(group)
         } else if let nested = component as? MWDATDisplay.FlexBox {
             FlexBoxView(flexBox: nested)
         } else {
             EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func buttonGroupView(_ group: MWDATDisplay.ButtonGroup) -> some View {
+        HStack(spacing: 8) {
+            ForEach(Array(group.buttons.enumerated()), id: \.offset) { item in
+                buttonView(item.element)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: groupAlignment(group.alignment))
+    }
+
+    private func groupAlignment(_ alignment: MWDATDisplay.ButtonGroupAlignment) -> SwiftUI.Alignment {
+        switch alignment {
+        case .start: return .leading
+        case .end: return .trailing
+        default: return .center
         }
     }
 

--- a/OpenGlasses/Sources/Services/CameraErrorPolicy.swift
+++ b/OpenGlasses/Sources/Services/CameraErrorPolicy.swift
@@ -1,7 +1,7 @@
 import Foundation
 import MWDATCamera
 
-/// Pure mapping from the DAT SDK's typed camera `StreamError` (0.8.0 unified `DatError` model) to a
+/// Pure mapping from the DAT SDK's typed camera `StreamError` (unified `DatError` model) to a
 /// user-facing message and a capture-recovery decision.
 ///
 /// Replaces fragile `String(describing:).contains(...)` matching with the typed enum, and decides
@@ -33,6 +33,8 @@ enum CameraErrorPolicy {
             return "Glasses video streaming hit an error — try again."
         case .internalError:
             return "The glasses camera hit an internal error — try again."
+        case .photoCaptureFailed:
+            return "The glasses couldn't take that photo — try again."
         @unknown default:
             return error.errorDescription ?? "The glasses camera hit an error."
         }
@@ -46,7 +48,9 @@ enum CameraErrorPolicy {
         switch error {
         case .hingesClosed, .timeout, .thermalCritical, .thermalEmergency,
              .peakPowerShutdown, .batteryCritical, .permissionDenied,
-             .deviceNotConnected, .deviceNotFound:
+             .deviceNotConnected, .deviceNotFound, .photoCaptureFailed:
+            // .photoCaptureFailed (0.9.0, replaces the never-emitted CaptureError) is the
+            // device saying THIS capture is dead — fall back to the latest frame now.
             return true
         case .internalError, .videoStreamingError:
             return false

--- a/OpenGlasses/Sources/Services/CameraService.swift
+++ b/OpenGlasses/Sources/Services/CameraService.swift
@@ -24,6 +24,10 @@ class CameraService: ObservableObject {
     /// Lazily initialized after Wearables.configure() has been called.
     private lazy var deviceSelector = AutoDeviceSelector(wearables: Wearables.shared)
     private var deviceSession: DeviceSession?
+    /// DAT 0.9.0: the `Camera` owns the camera hardware resource; the `Stream` hangs off it.
+    /// Detaching the capability is `camera.stop()` (cascades to the stream) — `stream.stop()`
+    /// alone only pauses streaming and keeps the capability attached for cheap restarts.
+    private var cameraCapability: MWDATCamera.Camera?
     private var streamSession: MWDATCamera.Stream?
     private var photoListenerToken: (any AnyListenerToken)?
     private var stateListenerToken: (any AnyListenerToken)?
@@ -159,7 +163,7 @@ class CameraService: ObservableObject {
                     let currentState = Wearables.shared.registrationState.rawValue
                     if currentState < 3 { throw CameraError.sdkNotRegistered }
                 }
-                if (error as? CameraError) == .permissionDenied { throw error }
+                if case .permissionDenied? = error as? CameraError { throw error }
                 if attempt == maxAttempts - 1 { throw CameraError.sdkNotRegistered }
             }
         }
@@ -266,7 +270,7 @@ class CameraService: ObservableObject {
             }
         }()
         let fps = UInt(Config.cameraFrameRate)
-        guard let stream = try deviceSession.addStream(
+        guard let camera = try deviceSession.addCamera(
             config: MWDATCamera.StreamConfiguration(
                 videoCodec: .raw,
                 resolution: resolution,
@@ -275,11 +279,12 @@ class CameraService: ObservableObject {
         ) else {
             throw CameraError.streamNotReady
         }
-        streamSession = stream
+        cameraCapability = camera
+        streamSession = camera.stream
         activeStreamResolution = effectiveResolution
-        attachListeners(to: stream)
+        attachListeners(to: camera.stream)
         // (session error watcher already attached above, before start)
-        NSLog("[Camera] Created persistent Stream (.\(effectiveResolution), \(fps)fps)")
+        NSLog("[Camera] Created persistent Camera capability (.\(effectiveResolution), \(fps)fps)")
     }
 
     /// BR P2: device-level errors (incl. `.datAppOnTheGlassesUpdateRequired`) arrive on the
@@ -375,7 +380,7 @@ class CameraService: ObservableObject {
 
         // Start the session if not already running
         if session.state == .stopped {
-            session.start()  // DAT 0.8.0: Stream.start() is synchronous
+            session.start()  // DAT 0.8.0+: Stream.start() is synchronous
         }
 
         // Wait for streaming state. During a cold start the stream bounces through .stopped
@@ -474,6 +479,9 @@ class CameraService: ObservableObject {
         // launch, link up at +4.7s. Retry with backoff (~12s window) while the link returns.
         var sessionError: Error?
         var firstError: Error?
+        // Fresh cycle, fresh verdict — a stale notice from before a glasses update must not
+        // abort attempts that could now succeed (the watcher re-sets it if still true).
+        compatibilityNotice = nil
         for attempt in 1...4 {
             do {
                 try await ensureSession()
@@ -483,6 +491,13 @@ class CameraService: ObservableObject {
                 if firstError == nil { firstError = error }
                 sessionError = error
                 NSLog("[Camera] ensureSession attempt %d/4 failed: %@", attempt, error.localizedDescription)
+                // A compatibility refusal (outdated glasses-side DAT app / firmware) arrives on
+                // the session error stream and kills the session before .started. Retrying can
+                // never succeed — stop churning and surface the actionable update message.
+                if let notice = compatibilityNotice {
+                    NSLog("[Camera] Compatibility refusal — aborting session retries")
+                    throw CameraError.incompatible(notice)
+                }
                 if Self.isSessionAlreadyExists(error) {
                     // The phantom is a glasses-side session still tearing down — either our
                     // own previous one, or one LEAKED by a killed/reinstalled app instance
@@ -756,34 +771,35 @@ class CameraService: ObservableObject {
         }
     }
 
-    /// BR P2: drop the Stream and its listeners but keep the DeviceSession alive — a failed
-    /// stream must not strand a half-open session (`ensureSession` re-adds the stream on
-    /// the retained session).
+    /// BR P2: drop the Camera capability and its listeners but keep the DeviceSession alive —
+    /// a failed stream must not strand a half-open session (`ensureSession` re-adds the camera
+    /// on the retained session).
     private func teardownStreamOnly() async {
-        if let stream = streamSession {
-            stream.stop()
-            await awaitStreamStopped(stream)
+        if let camera = cameraCapability {
+            camera.stop()  // cascades to the stream
+            await awaitCameraStopped(camera)
         }
         stateListenerToken = nil
         videoFrameListenerToken = nil
         photoListenerToken = nil
         errorListenerToken = nil
+        cameraCapability = nil
         streamSession = nil
         activeStreamResolution = nil
-        NSLog("[Camera] Stream torn down (session retained)")
+        NSLog("[Camera] Camera capability torn down (session retained)")
     }
 
-    /// Bounded wait for a stopped stream to actually reach `.stopped`. The camera
-    /// capability is process-wide and is freed when the stream finishes stopping — not
-    /// when the session is torn down — so arming a replacement stream before then throws
+    /// Bounded wait for a stopped Camera to actually reach `.stopped`. The camera
+    /// capability is process-wide and is freed when the Camera finishes stopping — not
+    /// when the session is torn down — so arming a replacement camera before then throws
     /// `capabilityAlreadyActive`. `stop()` is synchronous but the state transition isn't.
-    private func awaitStreamStopped(_ stream: MWDATCamera.Stream, timeout: Duration = .seconds(2)) async {
+    private func awaitCameraStopped(_ camera: MWDATCamera.Camera, timeout: Duration = .seconds(2)) async {
         let deadline = ContinuousClock.now + timeout
         while ContinuousClock.now < deadline {
-            if stream.state == .stopped { return }
+            if camera.state == .stopped { return }
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
-        NSLog("[Camera] Stream did not reach .stopped within %.0fs — proceeding",
+        NSLog("[Camera] Camera did not reach .stopped within %.0fs — proceeding",
               Double(timeout.components.seconds))
     }
 
@@ -791,17 +807,18 @@ class CameraService: ObservableObject {
     private func resetSession() async {
         sessionErrorTask?.cancel()
         sessionErrorTask = nil
-        if let stream = streamSession {
-            stream.stop()
-            // Wait for the capability to actually free (see `awaitStreamStopped`) so the
-            // retry loop's next `ensureSession` doesn't collide with the dying stream.
-            await awaitStreamStopped(stream)
+        if let camera = cameraCapability {
+            camera.stop()
+            // Wait for the capability to actually free (see `awaitCameraStopped`) so the
+            // retry loop's next `ensureSession` doesn't collide with the dying camera.
+            await awaitCameraStopped(camera)
         }
         deviceSession?.stop()
         stateListenerToken = nil
         videoFrameListenerToken = nil
         photoListenerToken = nil
         errorListenerToken = nil
+        cameraCapability = nil
         streamSession = nil
         activeStreamResolution = nil
         deviceSession = nil
@@ -891,7 +908,7 @@ class CameraService: ObservableObject {
         // No-op: audio session management is handled by WakeWordService
     }
 
-    // Error mapping now lives in the pure, typed `CameraErrorPolicy` (DAT 0.8.0 unified errors).
+    // Error mapping now lives in the pure, typed `CameraErrorPolicy` (DAT unified `DatError` model).
 }
 
 enum CameraError: LocalizedError {
@@ -902,6 +919,9 @@ enum CameraError: LocalizedError {
     case sdkNotRegistered
     case streamNotReady
     case sessionBusy
+    /// The session was refused for a compatibility reason (e.g. the glasses-side DAT app is
+    /// too old for this SDK). Carries the actionable `DATCompatibilityMessage` copy.
+    case incompatible(String)
 
     var errorDescription: String? {
         switch self {
@@ -912,6 +932,7 @@ enum CameraError: LocalizedError {
         case .sdkNotRegistered: return "Meta SDK not registered — open Meta app first"
         case .streamNotReady: return "Camera stream not ready — try again"
         case .sessionBusy: return "The glasses are still releasing a previous camera session — try again in about a minute"
+        case .incompatible(let message): return message
         }
     }
 }

--- a/OpenGlasses/Sources/Services/CameraService.swift
+++ b/OpenGlasses/Sources/Services/CameraService.swift
@@ -29,10 +29,9 @@ class CameraService: ObservableObject {
     /// alone only pauses streaming and keeps the capability attached for cheap restarts.
     private var cameraCapability: MWDATCamera.Camera?
     private var streamSession: MWDATCamera.Stream?
-    private var photoListenerToken: (any AnyListenerToken)?
-    private var stateListenerToken: (any AnyListenerToken)?
-    private var videoFrameListenerToken: (any AnyListenerToken)?
-    private var errorListenerToken: (any AnyListenerToken)?
+    /// DAT 0.9.0 `ListenerTokenBag`: the four per-stream listeners (state, video frame,
+    /// photo, error) live and die together, so they're cancelled as one in teardown.
+    private let streamListenerBag = ListenerTokenBag()
     private var photoContinuation: CheckedContinuation<Data, Error>?
 
     /// Whether camera permission has been granted (cached to avoid re-checking).
@@ -307,7 +306,7 @@ class CameraService: ObservableObject {
     private func attachListeners(to session: MWDATCamera.Stream) {
         var frameCount = 0
 
-        stateListenerToken = session.statePublisher.listen { [weak self] state in
+        session.statePublisher.listen { [weak self] state in
             Task { @MainActor in
                 guard let self else { return }
                 NSLog("[Camera] State changed: %@", String(describing: state))
@@ -325,9 +324,9 @@ class CameraService: ObservableObject {
                     break
                 }
             }
-        }
+        }.store(in: streamListenerBag)
 
-        videoFrameListenerToken = session.videoFramePublisher.listen { [weak self] frame in
+        session.videoFramePublisher.listen { [weak self] frame in
             // Immediate pixel buffer copy: `makeUIImage()` copies the pixel data out of
             // the VideoToolbox buffer pool right away, preventing VT pool exhaustion
             // that can occur if the buffer is held across async boundaries.
@@ -344,15 +343,15 @@ class CameraService: ObservableObject {
                 self.onVideoFrame?(image)
                 self.framePublisher.send(image)
             }
-        }
+        }.store(in: streamListenerBag)
 
-        photoListenerToken = session.photoDataPublisher.listen { [weak self] photoData in
+        session.photoDataPublisher.listen { [weak self] photoData in
             Task { @MainActor in
                 self?.handlePhotoData(photoData)
             }
-        }
+        }.store(in: streamListenerBag)
 
-        errorListenerToken = session.errorPublisher.listen { [weak self] error in
+        session.errorPublisher.listen { [weak self] error in
             Task { @MainActor in
                 guard let self else { return }
                 let message = CameraErrorPolicy.message(for: error)
@@ -371,7 +370,7 @@ class CameraService: ObservableObject {
                     }
                 }
             }
-        }
+        }.store(in: streamListenerBag)
     }
 
     /// Wait for the session to reach `.streaming` state, starting it if necessary.
@@ -779,10 +778,7 @@ class CameraService: ObservableObject {
             camera.stop()  // cascades to the stream
             await awaitCameraStopped(camera)
         }
-        stateListenerToken = nil
-        videoFrameListenerToken = nil
-        photoListenerToken = nil
-        errorListenerToken = nil
+        await streamListenerBag.cancelAll()
         cameraCapability = nil
         streamSession = nil
         activeStreamResolution = nil
@@ -814,10 +810,7 @@ class CameraService: ObservableObject {
             await awaitCameraStopped(camera)
         }
         deviceSession?.stop()
-        stateListenerToken = nil
-        videoFrameListenerToken = nil
-        photoListenerToken = nil
-        errorListenerToken = nil
+        await streamListenerBag.cancelAll()
         cameraCapability = nil
         streamSession = nil
         activeStreamResolution = nil

--- a/OpenGlasses/Sources/Services/Device/DeviceSessionCoordinator.swift
+++ b/OpenGlasses/Sources/Services/Device/DeviceSessionCoordinator.swift
@@ -57,7 +57,7 @@ final class DeviceSessionCoordinator {
     // MARK: - Lifecycle
 
     /// Lend the shared session to `capability`, creating it on the first acquire. The caller then
-    /// adds its own capability to the returned session (`addStream` for the camera, `addDisplay` for
+    /// adds its own capability to the returned session (`addCamera` for the camera, `addDisplay` for
     /// the HUD).
     @discardableResult
     func acquire(_ capability: Capability) throws -> DeviceSessionHandle {

--- a/OpenGlasses/Sources/Services/Display/MetaDisplayBackend.swift
+++ b/OpenGlasses/Sources/Services/Display/MetaDisplayBackend.swift
@@ -176,20 +176,33 @@ final class MetaDisplayBackend: GlassesDisplayBackend {
                     Text(line.text, style: line.style, color: line.color)
                 }
             }
-            for button in buttonModels {
-                let id = button.id
-                Button(label: button.label, style: button.style, iconName: button.iconName, onClick: { [weak self] in
-                    Task { @MainActor in self?.onItemSelected?(id) }
-                })
+            // DAT 0.9.0 `ButtonGroup`: the sanctioned container for button rows (bare
+            // buttons as loose FlexBox children predate it; flex params on a Button wrap
+            // it in a label-clipping FlexChildWrapper, which the group avoids).
+            if !buttonModels.isEmpty {
+                ButtonGroup(alignment: .center) {
+                    for button in buttonModels {
+                        let id = button.id
+                        Button(label: button.label, style: button.style, iconName: button.iconName, onClick: { [weak self] in
+                            Task { @MainActor in self?.onItemSelected?(id) }
+                        })
+                    }
+                }
             }
         }
     }
 
     /// Test helper: the `onClick` actions of the interactive buttons in `screen`'s
-    /// rendered tree, in order (simulated Neural-Band selections).
+    /// rendered tree, in order (simulated Neural-Band selections). Buttons live inside
+    /// the tree's `ButtonGroup` (with a loose-Button fallback for future shapes).
     func testButtonActions(for screen: HUDScreen) -> [() -> Void] {
         makeScreenView(screen).children
-            .compactMap { ($0 as? Button)?.onClick }
+            .flatMap { child -> [Button] in
+                if let group = child as? ButtonGroup { return group.buttons }
+                if let button = child as? Button { return [button] }
+                return []
+            }
+            .compactMap(\.onClick)
             .map { onClick in { onClick() } }
     }
 

--- a/OpenGlasses/Sources/Services/StreamRecoveryPolicy.swift
+++ b/OpenGlasses/Sources/Services/StreamRecoveryPolicy.swift
@@ -5,11 +5,11 @@ import MWDATCamera
 /// Plan BR P2 — tiered camera-stream recovery + DAT compatibility messaging (pure).
 ///
 /// Stall recovery previously tore down the whole `DeviceSession` every time. The session
-/// is the expensive, slow-to-restart half (BT connection + permission state); the `Stream`
-/// is cheap. Policy: rebuild the stream on the retained session first, and only escalate
-/// to a full session reset when stream-level rebuilds keep failing. (DAT 0.8 has no
-/// `removeStream` — a stream rebuild is stop + `addStream(config:)` on the live session;
-/// if that throws, the caller escalates.)
+/// is the expensive, slow-to-restart half (BT connection + permission state); the `Camera`
+/// capability is cheap. Policy: rebuild the camera on the retained session first, and only
+/// escalate to a full session reset when camera-level rebuilds keep failing. (DAT 0.9 has
+/// no `removeCamera` — a rebuild is `Camera.stop()` + `addCamera(config:)` on the live
+/// session; if that throws, the caller escalates.)
 enum StreamRecoveryPolicy {
     enum Action: Equatable {
         /// Stop + re-add the Stream; keep the DeviceSession.

--- a/ci_scripts/Package.resolved
+++ b/ci_scripts/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/facebook/meta-wearables-dat-ios.git",
       "state" : {
-        "revision" : "2e30f1253ab76ee3c448a29dce39114ab09763c3",
-        "version" : "0.8.0"
+        "revision" : "9b1b83d791dfebff7afd452e924a256819094b64",
+        "version" : "0.9.0"
       }
     },
     {

--- a/project.base.yml
+++ b/project.base.yml
@@ -59,10 +59,11 @@ packages:
   meta-wearables-dat-ios:
     url: https://github.com/facebook/meta-wearables-dat-ios.git
     # Pinned exact, not `from:`. For a 0.x package `from:` admits any later 0.y, and this SDK
-    # breaks API on minor bumps: 0.8.0 removed the `Capability` protocol and `addCapability` and
-    # made Stream.start()/stop() synchronous; 0.7.0 removed `DeviceStateSession` outright. A
-    # published 0.9.0 would be adopted on the next resolve and break the build with no change here.
-    version: "0.8.0"
+    # breaks API on minor bumps: 0.9.0 replaced `addStream` with the consolidated `Camera`
+    # capability (`addCamera`) and removed `CaptureError`; 0.8.0 removed the `Capability`
+    # protocol; 0.7.0 removed `DeviceStateSession` outright. A published 0.10.0 would be
+    # adopted on the next resolve and break the build with no change here.
+    version: "0.9.0"
   HaishinKit:
     url: https://github.com/shogo4405/HaishinKit.swift.git
     from: "2.2.5"
@@ -120,7 +121,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "349"
+        CURRENT_PROJECT_VERSION: "350"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -210,7 +211,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "349"
+        CURRENT_PROJECT_VERSION: "350"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -248,7 +249,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "349"
+        CURRENT_PROJECT_VERSION: "350"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "349"
+        CURRENT_PROJECT_VERSION: "350"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "349"
+        CURRENT_PROJECT_VERSION: "350"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## Summary
- Bumps `meta-wearables-dat-ios` 0.8.0 → 0.9.0 and migrates to the consolidated `Camera` capability: `addStream(config:)` → `addCamera(config:)` with the stream at `camera.stream`; teardown and stall recovery detach at the Camera level (`camera.stop()` cascades) and wait on `CameraState.stopped` before re-arming.
- Handles the new `StreamError.photoCaptureFailed` (replaces the removed, never-emitted `CaptureError`) in `CameraErrorPolicy`: user-facing message + immediate capture abort onto the latest-frame fallback.
- Replaces the removed public `Configuration(bundle:)` startup diagnostics with direct `MWDAT` Info.plist reads, including a placeholder-value warning.
- **Live-traced fix:** a compatibility refusal (`datAppOnTheGlassesUpdateRequired`) previously churned the full 4-attempt session retry loop (~20 s) and surfaced as a generic "Camera stream not ready — try again". `CameraService` now aborts retries the moment the compatibility notice arrives and throws `CameraError.incompatible` carrying the actionable update copy; the notice is cleared each cycle so it can't go stale after the glasses update.
- `dat-conventions.md` rewritten for 0.9.0; `ci_scripts/Package.resolved` refreshed; build 350.

## ⚠️ Not physically testable yet
The glasses-side DAT component **refuses 0.9.0 sessions** with `datAppOnTheGlassesUpdateRequired` — reproduced deterministically on GiPhone + Ray-Ban Meta with Meta AI v127 fully updated, glasses power-cycled, and the app connection unlinked/relinked. The device-side rollout lags the 2-day-old SDK release, so **glasses streaming and photo capture could not be exercised end-to-end on 0.9.0**. Expect them to start working without code changes once Meta ships the device-side update; a physical smoke test is owed then.

## Verification
- Full unit suite: **2,756 tests, 0 failures** (3 expected skips), iPhone 17 Pro simulator
- Device build + install + launch on GiPhone (iPhone Air)
- Refusal path verified end-to-end on device: one attempt → abort → actionable message (previously 4 retries → generic error)
- No other `MWDAT*` call sites affected (audited all importing files); no `MockCameraKit`/`setCameraFeed` usage; `Localizable.xcstrings` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)