### PR TITLE
Add LFM2.5-2.6B to the local model catalog, with think-block suppression

### DIFF
--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -562,6 +562,15 @@ class LLMService: ObservableObject {
             rawResponse = try await sendOpenAICompatible(text, systemPrompt: fullPrompt, config: modelConfig, includeTools: includeTools, imageData: imageData, onToken: onToken, onStreamReset: onStreamReset)
         }
 
+        // Local reasoning models (LFM2.5) are stripped at the generate layer —
+        // LocalLLMService owns the template-opened <think> handling and every local
+        // consumer needs the clean answer, not just this path. Surface the suppressed
+        // chain-of-thought for the prompt inspector and return the (already clean) text.
+        if provider == .local, let localThink = localLLMService?.lastReasoning {
+            lastReasoning = localThink
+            return rawResponse
+        }
+
         // Strip <think> tags: keep reasoning in history but don't speak it
         if Config.agentModeEnabled {
             let (spoken, reasoning) = Self.stripThinkTags(rawResponse)
@@ -2875,6 +2884,14 @@ extension LLMService {
     }
 
     static func stripThinkTags(_ text: String) -> (spoken: String, reasoning: String?) {
+        // Template-opened reasoning (LFM-style chat templates emit the opening <think> as
+        // part of the generation prompt): the completion carries a bare </think> with no
+        // opener. Re-open so the paired-tag pass below handles both shapes.
+        var text = text
+        if let close = text.range(of: "</think>"),
+           text[..<close.lowerBound].range(of: "<think>") == nil {
+            text = "<think>" + text
+        }
         let pattern = "<think>[\\s\\S]*?</think>"
         guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
             return (text, nil)

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -23,6 +23,10 @@ final class LocalLLMService: ObservableObject {
     private var modelContainer: ModelContainer?
     private var activeDownloadTask: Task<Void, Error>?
 
+    /// Chain-of-thought stripped from the last generation (reasoning models only; nil
+    /// otherwise). Surfaced by LLMService for the prompt inspector — never spoken.
+    private(set) var lastReasoning: String?
+
     /// Injectable download primitive (BK P5) so a test can drive a fake download — and its
     /// cancellation — without touching the network. `nil` ⇒ the real `HubClient` path. Reports
     /// fractional progress; throws (e.g. `CancellationError`) to abort.
@@ -108,6 +112,16 @@ final class LocalLLMService: ObservableObject {
             notes: "Tiny vision model — basic photo understanding"
         ),
         // Text-only MLX models
+        RecommendedModel(
+            id: "LiquidAI/LFM2.5-2.6B-MLX-4bit",
+            name: "LFM2.5 2.6B (Reasoning)",
+            estimatedSize: "1.6 GB",
+            hasVision: false,
+            hasToolCalling: true,
+            notes: "Liquid AI hybrid reasoning model — thinks before every answer (expect a "
+                + "pause before speech starts), then answers with strong tool use and "
+                + "instruction following. Best quality per GB of the text-only models."
+        ),
         RecommendedModel(
             id: "mlx-community/Qwen2.5-3B-Instruct-4bit",
             name: "Qwen 2.5 3B",
@@ -491,9 +505,24 @@ final class LocalLLMService: ObservableObject {
         }
         defer { NotificationCenter.default.removeObserver(bgObserver) }
 
-        // Generate
-        let parameters = GenerateParameters(maxTokens: 512, temperature: 0.7, topP: 0.9)
+        // Generate — sampling and token cap are per-model (reasoning models differ)
+        let parameters = Self.generateParameters(for: loadedModelId)
         let stream = try await container.generate(input: input, parameters: parameters)
+
+        // Reasoning models (LFM2.5) start every completion inside a template-opened <think>
+        // block. Suppress it on the token stream (the UI preview must not show — and TTS
+        // must not speak — chain-of-thought) and strip it from the returned text below.
+        let isReasoningModel = LocalModelBudget.reasoningModelIds.contains(loadedModelId ?? "")
+        var filteredOnToken = onToken
+        if isReasoningModel, let onToken {
+            // No end-of-stream flush needed: the caller replaces the streamed preview with
+            // the (fully stripped) returned text, so a held-back tail is only cosmetic.
+            let filter = ThinkStreamFilter()
+            filteredOnToken = { chunk in
+                let visible = filter.ingest(chunk)
+                if !visible.isEmpty { onToken(visible) }
+            }
+        }
 
         // Drive the stream through the pure loop below so we can bail out *before* requesting the
         // next token — before MLX submits the next Metal command buffer. Non-text generations
@@ -510,13 +539,31 @@ final class LocalLLMService: ObservableObject {
             isBackgrounded: { [weak self] in
                 (self?.enteredBackgroundDuringGeneration ?? false) || UIApplication.shared.applicationState == .background
             },
-            onToken: onToken
+            onToken: filteredOnToken
         )
         // Memory telemetry per turn — footprint should now stay flat across questions;
         // before the cacheLimit cap it grew ~0.7 GB per turn until the Jetsam kill.
         NSLog("🔬 LocalLLM.generate done — mlx active=%dMB cache=%dMB, app footprint=%dMB",
               Memory.activeMemory / 1_048_576, Memory.cacheMemory / 1_048_576,
               Int(MemoryHeadroom.appFootprintBytes() / 1_048_576))
+
+        // Strip the think block from the RETURNED text too, at this layer rather than in
+        // LLMService: every consumer (tool-call parsing, corrective regens, uncertainty
+        // re-ask query rewriting, agent scheduler) must see the answer only — think text
+        // routinely "announces" plans and would false-trigger the announce-without-action
+        // corrective regen, or leak reasoning into a web-search query. An all-think
+        // completion (reserve exhausted mid-think) returns empty here, which the caller's
+        // empty-completion guard surfaces as a catchable error instead of dead air.
+        if isReasoningModel {
+            let (spoken, reasoning) = ThinkStreamFilter.strip(output)
+            lastReasoning = reasoning
+            if let reasoning {
+                NSLog("🔬 LocalLLM.generate think block: %d chars — %@",
+                      reasoning.count, String(reasoning.prefix(160)))
+            }
+            return spoken
+        }
+        lastReasoning = nil
         return output.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
@@ -580,6 +627,27 @@ final class LocalLLMService: ObservableObject {
         NSLog("🔬 LocalLLM.generateVisionTurn done — mlx active=%dMB cache=%dMB",
               Memory.activeMemory / 1_048_576, Memory.cacheMemory / 1_048_576)
         return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Sampling parameters per model. Reasoning models (LFM2.5) follow Liquid's recommended
+    /// low-temperature settings (temp 0.1, top-k 50, repetition penalty 1.1) and take their
+    /// token cap from `LocalModelBudget.generationReserve(for:)` — the think block spends
+    /// from the same cap as the spoken answer, so they get the larger reasoning reserve.
+    /// Everything else keeps the long-standing defaults.
+    nonisolated static func generateParameters(for modelId: String?) -> GenerateParameters {
+        if let modelId, LocalModelBudget.reasoningModelIds.contains(modelId) {
+            return GenerateParameters(
+                maxTokens: LocalModelBudget.generationReserve(for: modelId),
+                temperature: 0.1,
+                topK: 50,
+                repetitionPenalty: 1.1
+            )
+        }
+        return GenerateParameters(
+            maxTokens: LocalModelBudget.generationReserve(for: modelId),
+            temperature: 0.7,
+            topP: 0.9
+        )
     }
 
     /// Shape token ids for the loaded model (see the call site in `generate` for why):

--- a/OpenGlasses/Sources/Services/LocalModelBudget.swift
+++ b/OpenGlasses/Sources/Services/LocalModelBudget.swift
@@ -17,9 +17,27 @@ import Foundation
 ///
 /// No MLX import — deliberately headless-testable.
 enum LocalModelBudget {
-    /// Tokens reserved for the model's own output. Must match `GenerateParameters(maxTokens:)`
-    /// in `LocalLLMService.generate`; if that changes, change this.
+    /// Tokens reserved for the model's own output. `LocalLLMService.generate` derives its
+    /// `GenerateParameters(maxTokens:)` from `generationReserve(for:)`, so budget and cap
+    /// can't drift apart.
     static let generationReserve = 512
+
+    /// Models that always emit chain-of-thought before the answer (LFM2.5's chat template
+    /// pre-opens a `<think>` block on every turn). The think tokens spend from the same
+    /// generation budget as the spoken answer, so these models get a larger reserve —
+    /// 512 could exhaust mid-think and produce an all-reasoning (empty-spoken) turn.
+    static let reasoningModelIds: Set<String> = [
+        "LiquidAI/LFM2.5-2.6B-MLX-4bit",
+    ]
+
+    /// Generation reserve for reasoning models: think block + answer.
+    static let reasoningGenerationReserve = 1024
+
+    /// Per-model generation reserve (tokens the model may emit this turn).
+    static func generationReserve(for modelId: String?) -> Int {
+        guard let modelId, reasoningModelIds.contains(modelId) else { return generationReserve }
+        return reasoningGenerationReserve
+    }
 
     /// Small extra cushion for chat-template scaffolding and count drift between our estimate and
     /// the model's actual tokenization.
@@ -42,6 +60,7 @@ enum LocalModelBudget {
         "mlx-community/gemma-2-2b-it-4bit": 4096,
         "mlx-community/gemma-4-e2b-it-4bit": 4096,
         "mlx-community/SmolVLM2-2.2B-Instruct-mlx": 4096,
+        "LiquidAI/LFM2.5-2.6B-MLX-4bit": 4096,   // 128K advertised; memory is the real ceiling
     ]
 
     /// Real context window for a model id, or the conservative default for an unknown id.
@@ -50,11 +69,12 @@ enum LocalModelBudget {
         return window
     }
 
-    /// Maximum tokenized-prompt length for a model: its window minus the generation reserve and a
+    /// Maximum tokenized-prompt length for a model: its window minus its generation reserve and a
     /// safety margin. Never returns less than a small floor so a mis-entered window can't produce a
     /// zero/negative budget that rejects every prompt.
     static func promptBudget(for modelId: String?) -> Int {
-        promptBudget(contextWindow: contextWindow(for: modelId))
+        max(minimumBudget,
+            contextWindow(for: modelId) - generationReserve(for: modelId) - safetyMargin)
     }
 
     /// Budget from an explicit window (unit-test entry point).

--- a/OpenGlasses/Sources/Services/ThinkStreamFilter.swift
+++ b/OpenGlasses/Sources/Services/ThinkStreamFilter.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Incremental `<think>` suppressor for on-device reasoning models (LFM2.5).
+///
+/// A reasoning model spends the start of every completion on chain-of-thought. Two wrinkles
+/// make a plain regex insufficient on the streaming path:
+///  1. **The opening tag never appears in the output.** LFM2.5's chat template emits `<think>`
+///     as part of the generation prompt, so the completion is `…reasoning…</think>answer` —
+///     the stream begins *inside* the think block (`startsInThink`).
+///  2. **Tags straddle chunk boundaries.** The detokenizer can split `</think>` across two
+///     chunks (`"</th"` + `"ink>"`), so the filter holds back the shortest suffix that could
+///     still become a tag instead of matching per-chunk.
+///
+/// `ingest(_:)` returns the speakable text of a chunk (usually empty while thinking);
+/// `flush()` releases any held-back tail at end of stream. Suppressed text accumulates in
+/// `reasoning` for the prompt inspector. Deliberately headless — no MLX import — so the
+/// boundary cases are unit-testable.
+final class ThinkStreamFilter {
+    private static let openTag = "<think>"
+    private static let closeTag = "</think>"
+
+    private var inThink: Bool
+    /// Swallow whitespace right after a think block — the answer conventionally starts
+    /// after a blank line, which may arrive in a *later* chunk than the close tag.
+    private var trimLeadingWhitespace: Bool
+    private var pending = ""
+    /// Suppressed chain-of-thought, accumulated across the stream.
+    private(set) var reasoning = ""
+
+    init(startsInThink: Bool = true) {
+        self.inThink = startsInThink
+        self.trimLeadingWhitespace = startsInThink
+    }
+
+    /// Feed one streamed chunk; returns the part that is speakable *now*.
+    func ingest(_ chunk: String) -> String {
+        pending += chunk
+        var visible = ""
+        while true {
+            if inThink {
+                guard let close = pending.range(of: Self.closeTag) else {
+                    // Everything except a possible partial `</think>` at the tail is reasoning.
+                    let hold = Self.partialTagSuffixLength(of: pending, tag: Self.closeTag)
+                    reasoning += pending.dropLast(hold)
+                    pending = String(pending.suffix(hold))
+                    return visible
+                }
+                reasoning += pending[..<close.lowerBound]
+                pending = String(pending[close.upperBound...])
+                inThink = false
+                trimLeadingWhitespace = true
+            } else {
+                if trimLeadingWhitespace {
+                    pending = String(pending.drop(while: \.isWhitespace))
+                    if pending.isEmpty { return visible }   // more whitespace may follow next chunk
+                    trimLeadingWhitespace = false
+                }
+                guard let open = pending.range(of: Self.openTag) else {
+                    let hold = Self.partialTagSuffixLength(of: pending, tag: Self.openTag)
+                    visible += pending.dropLast(hold)
+                    pending = String(pending.suffix(hold))
+                    return visible
+                }
+                visible += pending[..<open.lowerBound]
+                pending = String(pending[open.upperBound...])
+                inThink = true
+            }
+        }
+    }
+
+    /// End of stream: release a held-back tail that never completed into a tag.
+    /// (While thinking, a partial tail is reasoning, not speech.)
+    func flush() -> String {
+        defer { pending = "" }
+        if inThink {
+            reasoning += pending
+            return ""
+        }
+        return pending
+    }
+
+    /// Strip a complete (non-streamed) completion. Returns the speakable text and the
+    /// suppressed reasoning (nil when the model emitted no think content).
+    static func strip(_ text: String, startsInThink: Bool = true) -> (spoken: String, reasoning: String?) {
+        let filter = ThinkStreamFilter(startsInThink: startsInThink)
+        var spoken = filter.ingest(text)
+        spoken += filter.flush()
+        let reasoning = filter.reasoning.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (spoken.trimmingCharacters(in: .whitespacesAndNewlines),
+                reasoning.isEmpty ? nil : reasoning)
+    }
+
+    /// Length of the longest suffix of `text` that is a proper prefix of `tag` — the part
+    /// that might still grow into the tag on the next chunk and must be held back.
+    private static func partialTagSuffixLength(of text: String, tag: String) -> Int {
+        let maxLen = min(text.count, tag.count - 1)
+        guard maxLen > 0 else { return 0 }
+        for len in stride(from: maxLen, through: 1, by: -1) {
+            if tag.hasPrefix(text.suffix(len)) { return len }
+        }
+        return 0
+    }
+}

--- a/OpenGlassesTests/LocalModelBudgetTests.swift
+++ b/OpenGlassesTests/LocalModelBudgetTests.swift
@@ -36,6 +36,35 @@ final class LocalModelBudgetTests: XCTestCase {
                        LocalModelBudget.minimumBudget)
     }
 
+    // MARK: - Reasoning-model reserve (LFM2.5)
+
+    func testReasoningModelGetsLargerGenerationReserve() {
+        // The think block spends from the same cap as the answer — 512 exhausts mid-think.
+        let lfm = "LiquidAI/LFM2.5-2.6B-MLX-4bit"
+        XCTAssertTrue(LocalModelBudget.reasoningModelIds.contains(lfm))
+        XCTAssertEqual(LocalModelBudget.generationReserve(for: lfm),
+                       LocalModelBudget.reasoningGenerationReserve)
+        XCTAssertGreaterThan(LocalModelBudget.reasoningGenerationReserve,
+                             LocalModelBudget.generationReserve)
+    }
+
+    func testNonReasoningModelKeepsDefaultReserve() {
+        XCTAssertEqual(LocalModelBudget.generationReserve(for: "mlx-community/Qwen2.5-3B-Instruct-4bit"),
+                       LocalModelBudget.generationReserve)
+        XCTAssertEqual(LocalModelBudget.generationReserve(for: nil),
+                       LocalModelBudget.generationReserve)
+    }
+
+    func testReasoningModelPromptBudgetSubtractsItsOwnReserve() {
+        // Budget must shrink by the REASONING reserve, or prompt + think + answer overflows
+        // the window mid-stream (the uncatchable per-token OOM the budget exists to prevent).
+        let lfm = "LiquidAI/LFM2.5-2.6B-MLX-4bit"
+        XCTAssertEqual(LocalModelBudget.promptBudget(for: lfm),
+                       LocalModelBudget.contextWindow(for: lfm)
+                           - LocalModelBudget.reasoningGenerationReserve
+                           - LocalModelBudget.safetyMargin)
+    }
+
     // MARK: - Truncation: drop oldest history first
 
     /// Each history turn counts as 10 tokens; system + user baseline is 20. Lets us drive the

--- a/OpenGlassesTests/ThinkStreamFilterTests.swift
+++ b/OpenGlassesTests/ThinkStreamFilterTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import OpenGlasses
+
+/// ThinkStreamFilter — incremental `<think>` suppression for local reasoning models (LFM2.5).
+/// The stream starts INSIDE a template-opened think block (the opening tag never appears in
+/// the completion), and tags can straddle chunk boundaries. All pure/headless.
+final class ThinkStreamFilterTests: XCTestCase {
+
+    /// Drive a filter with chunks and collect what it would emit to the UI/TTS preview.
+    private func emitted(_ chunks: [String], startsInThink: Bool = true) -> String {
+        let filter = ThinkStreamFilter(startsInThink: startsInThink)
+        var out = chunks.map { filter.ingest($0) }.joined()
+        out += filter.flush()
+        return out
+    }
+
+    // MARK: - Template-opened reasoning (the LFM2.5 shape)
+
+    func testSuppressesReasoningUntilBareCloseTag() {
+        let out = emitted(["The user asks 2+2.", " Simple arithmetic.", "</think>\n\n", "It's 4."])
+        XCTAssertEqual(out, "It's 4.")
+    }
+
+    func testCloseTagSplitAcrossChunksAtEveryBoundary() {
+        let stream = "reasoning here</think>\n\nAnswer text."
+        // Split the stream at every index — the tag must be found regardless of chunking.
+        for i in stream.indices {
+            let chunks = [String(stream[..<i]), String(stream[i...])]
+            XCTAssertEqual(emitted(chunks), "Answer text.", "failed splitting at \(stream.distance(from: stream.startIndex, to: i))")
+        }
+    }
+
+    func testSingleCharacterChunks() {
+        let stream = "think think</think>\nAnswer."
+        let chunks = stream.map(String.init)
+        XCTAssertEqual(emitted(chunks), "Answer.")
+    }
+
+    func testWhitespaceAfterCloseTagArrivingInLaterChunksIsSwallowed() {
+        let out = emitted(["reasoning</think>", "\n", "\n", "Answer."])
+        XCTAssertEqual(out, "Answer.")
+    }
+
+    func testAllThinkCompletionEmitsNothingAndKeepsReasoning() {
+        // Reserve exhausted mid-think: nothing speakable; reasoning is preserved for the log.
+        let filter = ThinkStreamFilter()
+        var out = filter.ingest("endless reasoning that never closes")
+        out += filter.flush()
+        XCTAssertEqual(out, "")
+        XCTAssertEqual(filter.reasoning, "endless reasoning that never closes")
+    }
+
+    func testReasoningAccumulatesAcrossChunks() {
+        let filter = ThinkStreamFilter()
+        _ = filter.ingest("part one, ")
+        _ = filter.ingest("part two</think>answer")
+        XCTAssertEqual(filter.reasoning, "part one, part two")
+    }
+
+    // MARK: - Explicit paired tags (re-entry, or a non-template-opened model)
+
+    func testPairedThinkBlockMidAnswerIsSuppressed() {
+        let out = emitted(["first</think>Start. ", "<think>hidden</think>", " End."],
+                          startsInThink: true)
+        // Whitespace right after a think block is swallowed, so the join stays single-spaced.
+        XCTAssertEqual(out, "Start. End.")
+    }
+
+    func testStartsInAnswerModePassesTextThrough() {
+        let out = emitted(["Plain answer, ", "no tags at all."], startsInThink: false)
+        XCTAssertEqual(out, "Plain answer, no tags at all.")
+    }
+
+    func testOpenTagSplitAcrossChunksSuppressesFromTagStart() {
+        let out = emitted(["Visible. <thi", "nk>hidden</think>", "More."], startsInThink: false)
+        XCTAssertEqual(out, "Visible. More.")
+    }
+
+    func testPartialTagLookalikeAtEndOfStreamIsReleasedByFlush() {
+        // "<th" held back in case it grows into <think> — flush must release it as real text.
+        let out = emitted(["Compare a < b <th"], startsInThink: false)
+        XCTAssertEqual(out, "Compare a < b <th")
+    }
+
+    func testAngleBracketMathIsNotSwallowed() {
+        let out = emitted(["x < y and y <= z."], startsInThink: false)
+        XCTAssertEqual(out, "x < y and y <= z.")
+    }
+
+    // MARK: - Whole-completion strip (the non-streamed path)
+
+    func testStripSeparatesSpokenAndReasoning() {
+        let (spoken, reasoning) = ThinkStreamFilter.strip("chain of thought</think>\n\nThe answer.")
+        XCTAssertEqual(spoken, "The answer.")
+        XCTAssertEqual(reasoning, "chain of thought")
+    }
+
+    func testStripAllThinkReturnsEmptySpoken() {
+        // The caller's empty-completion guard turns this into a catchable error — not dead air.
+        let (spoken, reasoning) = ThinkStreamFilter.strip("never stopped thinking")
+        XCTAssertEqual(spoken, "")
+        XCTAssertEqual(reasoning, "never stopped thinking")
+    }
+
+    func testStripWithNoThinkContentInAnswerMode() {
+        let (spoken, reasoning) = ThinkStreamFilter.strip("Just an answer.", startsInThink: false)
+        XCTAssertEqual(spoken, "Just an answer.")
+        XCTAssertNil(reasoning)
+    }
+}
+
+/// LLMService.stripThinkTags — the caller-side safety net now also normalizes the
+/// template-opened shape (bare `</think>`, no opener).
+@MainActor
+final class StripThinkTagsTemplateOpenedTests: XCTestCase {
+
+    func testPairedTagsStillStripped() {
+        let (spoken, reasoning) = LLMService.stripThinkTags("<think>why</think>Answer.")
+        XCTAssertEqual(spoken, "Answer.")
+        XCTAssertEqual(reasoning, "why")
+    }
+
+    func testBareCloseTagTreatedAsTemplateOpened() {
+        let (spoken, reasoning) = LLMService.stripThinkTags("reasoning first</think>\n\nAnswer.")
+        XCTAssertEqual(spoken, "Answer.")
+        XCTAssertEqual(reasoning, "reasoning first")
+    }
+
+    func testNoTagsPassThrough() {
+        let (spoken, reasoning) = LLMService.stripThinkTags("No tags here.")
+        XCTAssertEqual(spoken, "No tags here.")
+        XCTAssertNil(reasoning)
+    }
+}


### PR DESCRIPTION
## What

Adds Liquid AI's **LFM2.5-2.6B** (4-bit MLX, 1.6 GB) to the on-device model catalog — the strongest text-only local option per gigabyte, post-trained for tool use and instruction following.

The pinned `mlx-swift-lm` 3.31.3 already carries the `lfm2` architecture and the nested-rope-params fix these checkpoints need, so **no dependency bump**.

The catalog points at `LiquidAI/LFM2.5-2.6B-MLX-4bit` (flat single-quant repo), never the umbrella `-MLX` repo — that one holds all eight quantizations in subfolders and would pull ~15 GB through the hub downloader.

## The complication: it always thinks

Its chat template opens a `<think>` block on every assistant turn, so completions arrive as `…reasoning…</think>answer` — with **no opening tag**, since the template emitted it as part of the generation prompt. Three consequences:

- **`ThinkStreamFilter`** (new) suppresses the block incrementally on the token stream, so chain-of-thought never reaches the TTS preview. It holds back the shortest suffix that could still grow into a tag — the detokenizer splits `</think>` across chunks (`"</th"` + `"ink>"`), which a per-chunk regex misses.
- **Stripping happens at the `LocalLLMService` layer**, not in `LLMService`, because every local consumer needs the clean answer: think text routinely narrates plans ("I should look that up"), which would false-trigger the announce-without-action corrective regen, or leak reasoning into an uncertainty-re-ask web query.
- **Reasoning models get a 1024-token generation reserve** instead of 512 — the think block spends from the same cap as the answer. The prompt budget subtracts *their* reserve, or prompt + think + answer overflows the window mid-stream (the uncatchable per-token OOM the budget exists to prevent). `generate()` now derives `maxTokens` from the same reserve, so cap and budget can no longer drift apart.

Sampling follows Liquid's recommendation for this model (temp 0.1, top-k 50, repetition penalty 1.1) rather than the catalog-wide 0.7/0.9. `LLMService.stripThinkTags` also learned the template-opened shape as a safety net.

## Testing

Full suite green: **2776 tests, 0 failures**. 17 new tests cover the filter (every chunk-boundary split of a `</think>`, single-character chunks, all-think completions, `<` in maths not being swallowed) and the reserve/budget arithmetic.

## Still owed — device smoke

Two things only real hardware answers:
1. **First-token latency** behind the think block (~30 tok/s on phone × a few hundred think tokens).
2. **Whether it follows our `<tool_call>` prompt format.** Its native format is pythonic (`<|tool_call_start|>`), and mlx-swift-lm's parser for that landed in 3.31.4 — the release that breaks Gemma 4 VLM loads, so we stay on 3.31.3 and rely on prompt compliance.

## Licensing

LFM Open License (lfm1.0), user-downloaded at runtime — the model is never redistributed with the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)