### PR TITLE
Clear every compiler warning in our own sources (Swift 6 groundwork), and fix the blur relay's fake weak capture

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -738,7 +738,7 @@ class AppState: ObservableObject, AppStateProtocol {
                     if let all = try? Data(contentsOf: url) {
                         try? all.suffix(100_000).write(to: url)
                     }
-                    try? handle.seekToEnd()
+                    _ = try? handle.seekToEnd()
                 }
                 try? handle.write(contentsOf: data)
             } else {
@@ -2647,7 +2647,9 @@ class AppState: ObservableObject, AppStateProtocol {
             return
         }
         do {
-            let photoData = try await cameraService.capturePhoto()
+            // The data is discarded on purpose: `capturePhoto()` saves every capture to the
+            // "Glasses" album itself, and this path only reports that it landed.
+            _ = try await cameraService.capturePhoto()
             // Restore audio for wake word if in direct mode
             if currentMode == .direct {
                 cameraService.restoreAudioForWakeWord()
@@ -3896,7 +3898,9 @@ class AppState: ObservableObject, AppStateProtocol {
             },
             capturePhoto: { [weak self] in
                 guard let self else { throw RemoteInvokeError.unavailable }
-                let data = try await self.cameraService.capturePhoto()
+                // Discarded on purpose — `capturePhoto()` files it in the "Glasses" album; the
+                // remote caller only needs the capture to have happened.
+                _ = try await self.cameraService.capturePhoto()
                 self.cameraService.restoreAudioForWakeWord()
             },
             startAudioRecording: { [weak self] in

--- a/OpenGlasses/Sources/Services/BroadcastService.swift
+++ b/OpenGlasses/Sources/Services/BroadcastService.swift
@@ -423,6 +423,11 @@ enum BroadcastError: LocalizedError {
 
 /// BS P2: seam for the shared mic tap (adopted by WakeWordService — the same fan-out the
 /// video recorder uses). Kept minimal so tests can inject a fake.
+///
+/// `@MainActor` because both the adopter (`WakeWordService`) and both call sites
+/// (`startBroadcast`/`stopBroadcast`) are main-actor: the consumer *registry* is main-actor
+/// state, even though the handlers themselves are `@Sendable` and run on the audio thread.
+@MainActor
 protocol BroadcastAudioProviding: AnyObject {
     func addAudioBufferConsumer(id: String, handler: @escaping @Sendable (AVAudioPCMBuffer) -> Void)
     func removeAudioBufferConsumer(id: String)

--- a/OpenGlasses/Sources/Services/Display/Even/EvenBLETransport.swift
+++ b/OpenGlasses/Sources/Services/Display/Even/EvenBLETransport.swift
@@ -15,10 +15,15 @@ import Foundation
 final class EvenBLETransport: NSObject, ObservableObject, EvenTransporting {
 
     // Community-reconstructed UUIDs (base 00002760-08C2-11E1-9073-0E8AC72EXXXX).
-    static let writeCharUUID = CBUUID(string: "00002760-08C2-11E1-9073-0E8AC72E5401")
-    static let notifyCharUUID = CBUUID(string: "00002760-08C2-11E1-9073-0E8AC72E5402")
-    static let renderCharUUID = CBUUID(string: "00002760-08C2-11E1-9073-0E8AC72E6402")
-    static let advertisedNamePrefix = "Even G2"
+    //
+    // `nonisolated` because the CoreBluetooth delegate callbacks below read them before hopping
+    // to the main actor — matching a UUID or an advertised name must not cost an actor hop on the
+    // BLE callback queue. `CBUUID` isn't annotated `Sendable`, but these are immutable value
+    // objects created once, so `nonisolated(unsafe)` states that rather than working around it.
+    nonisolated(unsafe) static let writeCharUUID = CBUUID(string: "00002760-08C2-11E1-9073-0E8AC72E5401")
+    nonisolated(unsafe) static let notifyCharUUID = CBUUID(string: "00002760-08C2-11E1-9073-0E8AC72E5402")
+    nonisolated(unsafe) static let renderCharUUID = CBUUID(string: "00002760-08C2-11E1-9073-0E8AC72E6402")
+    nonisolated static let advertisedNamePrefix = "Even G2"
 
     var onEvent: (([UInt8]) -> Void)?
     var onDisconnect: ((Error?) -> Void)?

--- a/OpenGlasses/Sources/Services/GoogleOAuthService.swift
+++ b/OpenGlasses/Sources/Services/GoogleOAuthService.swift
@@ -139,9 +139,20 @@ final class GoogleOAuthService: NSObject, ObservableObject {
 extension GoogleOAuthService: ASWebAuthenticationPresentationContextProviding {
     nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         MainActor.assumeIsolated {
-            UIApplication.shared.connectedScenes
-                .compactMap { ($0 as? UIWindowScene)?.keyWindow }
-                .first ?? ASPresentationAnchor()
+            let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+            // Prefer the scene the user is actually looking at, then any key window, then any
+            // window at all — an existing window always beats a fresh one as an anchor.
+            if let anchor = scenes.first(where: { $0.activationState == .foregroundActive })?.keyWindow {
+                return anchor
+            }
+            if let anchor = scenes.lazy.compactMap(\.keyWindow).first { return anchor }
+            if let anchor = scenes.lazy.flatMap(\.windows).first { return anchor }
+            if let scene = scenes.first { return UIWindow(windowScene: scene) }
+            // Unreachable: `start()` is only called from a user-initiated sign-in, which requires
+            // a live window scene. `init(windowScene:)` is the only UIWindow initialiser that
+            // survives iOS 26, so a scene-less process has no anchor to offer — and the empty
+            // window this used to return could never have presented anything either.
+            preconditionFailure("presentationAnchor requested with no connected UIWindowScene")
         }
     }
 }

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -2487,7 +2487,7 @@ class LLMService: ObservableObject {
     /// The reduced tool set a local model is offered — only simple, reliable, self-contained tools
     /// (each resolves its own inputs, e.g. `get_weather`/`where_am_i` read LocationService directly,
     /// so the 2B model never has to supply coordinates it doesn't have).
-    static let localSafeTools: Set<String> = [
+    nonisolated static let localSafeTools: Set<String> = [
         "get_weather", "get_datetime", "calculate", "set_timer",
         "flashlight", "brightness", "calendar", "reminder",
         "set_alarm", "step_count", "device_info", "music_control",

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -153,7 +153,7 @@ final class LocalLLMService: ObservableObject {
     /// (verified 2026-07-16), so vision is *attempted* — and a mapping failure now demotes
     /// gracefully to the text factory (`loadModel`), with image turns refused honestly by
     /// the vision guard in LLMService. Nothing regresses if a checkpoint doesn't cooperate.
-    static let visionModelIds: Set<String> = [
+    nonisolated static let visionModelIds: Set<String> = [
         "mlx-community/SmolVLM2-2.2B-Instruct-mlx",
         "mlx-community/SmolVLM2-500M-Video-Instruct-mlx",
         "mlx-community/gemma-4-e2b-it-4bit",
@@ -578,19 +578,6 @@ final class LocalLLMService: ObservableObject {
         container: ModelContainer,
         onToken: ((String) -> Void)?
     ) async throws -> String {
-        guard let ciImage = CIImage(data: imageData) else {
-            throw LocalLLMError.generationFailed("Couldn't decode the photo.")
-        }
-
-        var chat: [Chat.Message] = [.system(systemPrompt)]
-        for turn in history.suffix(4) {
-            chat.append(turn.role == "assistant" ? .assistant(turn.content) : .user(turn.content))
-        }
-        chat.append(.user(userMessage, images: [.ciImage(ciImage)]))
-        // 896² is Gemma's native vision resolution and a sane cap for every supported VLM —
-        // a full-resolution glasses photo through the image pipeline is a pure memory spike.
-        let userInput = UserInput(chat: chat,
-                                  processing: .init(resize: CGSize(width: 896, height: 896)))
         let parameters = GenerateParameters(maxTokens: 512, temperature: 0.7, topP: 0.9)
 
         // Same mid-generation backgrounding watch as the text path (Metal in the background
@@ -609,7 +596,22 @@ final class LocalLLMService: ObservableObject {
         defer { NotificationCenter.default.removeObserver(bgObserver) }
 
         NSLog("🔬 LocalLLM.generateVisionTurn model=%@ image=%dKB", loadedModelId ?? "?", imageData.count / 1024)
+        // `UserInput` (and the `CIImage` inside it) isn't `Sendable`, so it's built *inside* the
+        // `@Sendable` closure from Sendable ingredients only — the image data, the prompt strings
+        // and the history — rather than constructed out here and captured across the boundary.
         let output = try await container.perform { context -> String in
+            guard let ciImage = CIImage(data: imageData) else {
+                throw LocalLLMError.generationFailed("Couldn't decode the photo.")
+            }
+            var chat: [Chat.Message] = [.system(systemPrompt)]
+            for turn in history.suffix(4) {
+                chat.append(turn.role == "assistant" ? .assistant(turn.content) : .user(turn.content))
+            }
+            chat.append(.user(userMessage, images: [.ciImage(ciImage)]))
+            // 896² is Gemma's native vision resolution and a sane cap for every supported VLM —
+            // a full-resolution glasses photo through the image pipeline is a pure memory spike.
+            let userInput = UserInput(chat: chat,
+                                      processing: .init(resize: CGSize(width: 896, height: 896)))
             let lmInput = try await context.processor.prepare(input: userInput)
             let stream = try MLXLMCommon.generate(input: lmInput, parameters: parameters, context: context)
             var iterator = stream.makeAsyncIterator()

--- a/OpenGlasses/Sources/Services/Navigation/WalkingRouteService.swift
+++ b/OpenGlasses/Sources/Services/Navigation/WalkingRouteService.swift
@@ -111,7 +111,10 @@ final class WalkingRouteService: ObservableObject {
 
     private func walkingRoute(from origin: CLLocationCoordinate2D, to item: MKMapItem) async throws -> MKRoute {
         let request = MKDirections.Request()
-        request.source = MKMapItem(placemark: MKPlacemark(coordinate: origin))
+        // A coordinate-only origin: no address to attach, which is all `MKDirections` reads.
+        request.source = MKMapItem(
+            location: CLLocation(latitude: origin.latitude, longitude: origin.longitude),
+            address: nil)
         request.destination = item
         request.transportType = .walking
         let response = try await MKDirections(request: request).calculate()

--- a/OpenGlasses/Sources/Services/SignLanguage/FingerspellingModel.swift
+++ b/OpenGlasses/Sources/Services/SignLanguage/FingerspellingModel.swift
@@ -52,6 +52,34 @@ struct FingerspellingModelBundle: Equatable {
     static let modelPackageName = "Fingerspelling2P.mlpackage"
     static let landmarkerTaskName = "holistic_landmarker.task"
 
+    /// Production installer: fetch each required file (sub-paths preserved) with URLSession.
+    ///
+    /// Lives on the bundle rather than the `@MainActor` downloader, mirroring `ASRModelBundle`:
+    /// the download loop and its file moves have no business on the main actor, and a `static`
+    /// on the main-actor class couldn't be read from the downloader's default argument without
+    /// a hop. The `await` on `progress` is a genuine hop to the `@MainActor` handler.
+    static let liveInstaller: FingerspellingModelDownloader.Installer = { bundle, destination, progress in
+        let files = bundle.requiredFiles
+        var completed = 0
+        for path in files {
+            guard let url = bundle.huggingFaceResolveURL(for: path) else {
+                throw FingerspellingDownloadError.notConfigured
+            }
+            let dest = destination.appendingPathComponent(path)
+            try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            let (tempURL, response) = try await URLSession.shared.download(from: url)
+            if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+                throw FingerspellingDownloadError.incompleteDownload(missing: "\(path) (HTTP \(http.statusCode))")
+            }
+            try? FileManager.default.removeItem(at: dest)
+            try FileManager.default.moveItem(at: tempURL, to: dest)
+            completed += 1
+            let fraction = Double(completed) / Double(max(files.count, 1))
+            await progress(fraction)
+        }
+    }
+
     /// The active bundle; the repo comes from Settings so publishing the artefact needs no
     /// app update.
     static var active: FingerspellingModelBundle {
@@ -161,7 +189,7 @@ final class FingerspellingModelDownloader: ObservableObject {
     init(bundle: FingerspellingModelBundle = .active,
          modelDirectory: URL? = nil,
          fileManager: FileManager = .default,
-         installer: @escaping Installer = FingerspellingModelDownloader.liveInstaller) {
+         installer: @escaping Installer = FingerspellingModelBundle.liveInstaller) {
         self.bundle = bundle
         self.fileManager = fileManager
         self.modelDirectory = modelDirectory
@@ -230,26 +258,4 @@ final class FingerspellingModelDownloader: ObservableObject {
         state = store.state
     }
 
-    /// Production installer: fetch each required file (sub-paths preserved) with URLSession.
-    static let liveInstaller: Installer = { bundle, destination, progress in
-        let files = bundle.requiredFiles
-        var completed = 0
-        for path in files {
-            guard let url = bundle.huggingFaceResolveURL(for: path) else {
-                throw FingerspellingDownloadError.notConfigured
-            }
-            let dest = destination.appendingPathComponent(path)
-            try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(),
-                                                    withIntermediateDirectories: true)
-            let (tempURL, response) = try await URLSession.shared.download(from: url)
-            if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
-                throw FingerspellingDownloadError.incompleteDownload(missing: "\(path) (HTTP \(http.statusCode))")
-            }
-            try? FileManager.default.removeItem(at: dest)
-            try FileManager.default.moveItem(at: tempURL, to: dest)
-            completed += 1
-            let fraction = Double(completed) / Double(max(files.count, 1))
-            await progress(fraction)
-        }
-    }
 }

--- a/OpenGlasses/Sources/Services/SignLanguage/FingerspellingSessionService.swift
+++ b/OpenGlasses/Sources/Services/SignLanguage/FingerspellingSessionService.swift
@@ -86,7 +86,7 @@ final class FingerspellingSessionService: ObservableObject {
             }
             let finale = await pipeline.flush()
             await self?.apply(finale)
-            await self?.finishStopped()
+            self?.finishStopped()
         }
     }
 

--- a/OpenGlasses/Sources/Services/Triggers/MediaTriggerService.swift
+++ b/OpenGlasses/Sources/Services/Triggers/MediaTriggerService.swift
@@ -131,7 +131,7 @@ final class MediaTriggerService {
         guard !isRunning, isEnabled() else { return }
         isRunning = true
         let center = NotificationCenter.default
-        let reevaluate: (Notification) -> Void = { [weak self] _ in
+        let reevaluate: @Sendable (Notification) -> Void = { [weak self] _ in
             Task { @MainActor in self?.evaluate() }
         }
         // Every signal that the audio world changed funnels into one re-evaluation; the policy

--- a/OpenGlasses/Sources/Services/VideoRecordingService.swift
+++ b/OpenGlasses/Sources/Services/VideoRecordingService.swift
@@ -130,7 +130,9 @@ class VideoRecordingService: ObservableObject {
     var onAutoStopped: ((String) -> Void)?
 
     /// Seconds without a frame (after at least one arrived) before recording auto-stops.
-    static let frameStallSeconds: TimeInterval = 15
+    /// `nonisolated` so `shouldAutoStop`'s default argument (evaluated outside the actor) can
+    /// read it without a hop.
+    nonisolated static let frameStallSeconds: TimeInterval = 15
 
     /// Wall-clock of the most recent appended frame (nil until the first frame arrives).
     /// Written from the background frame queue, read by the main-actor watchdog tick.

--- a/OpenGlasses/Sources/Services/Vision/OutboundFrameRelay.swift
+++ b/OpenGlasses/Sources/Services/Vision/OutboundFrameRelay.swift
@@ -109,7 +109,11 @@ final class OutboundFrameRelay: ObservableObject {
                     return
                 }
 
-                self.queue.async {
+                // `[weak self]` here as well as on the inner `Task`: after the `guard let self`
+                // above, `self` is a strong local, so an unannotated closure would capture it
+                // strongly and the inner `[weak self]` would be decorative — a relay released
+                // mid-pipeline would be held alive to composite and publish one more frame.
+                self.queue.async { [weak self] in
                     let blurred = Self.composite(image, rects: rects, context: context) ?? image
                     Task { @MainActor [weak self] in self?.finish(with: blurred) }
                 }

--- a/OpenGlassesTests/ASRModelStoreTests.swift
+++ b/OpenGlassesTests/ASRModelStoreTests.swift
@@ -124,7 +124,7 @@ final class ASRModelStoreTests: XCTestCase {
             for name in bundle.requiredFiles {
                 try Data(repeating: 0x42, count: 8).write(to: destination.appendingPathComponent(name))
             }
-            await progress(1.0)
+            progress(1.0)
         }
         let downloader = ASRModelDownloader(bundle: bundle, modelDirectory: modelDir, installer: installer)
         await downloader.download()

--- a/OpenGlassesTests/FingerspellingLiveDecoderTests.swift
+++ b/OpenGlassesTests/FingerspellingLiveDecoderTests.swift
@@ -108,7 +108,7 @@ final class FingerspellingLiveDecoderTests: XCTestCase {
         appendFrames(&decoder, 4)
         // A three-way tie between letters: the argmax is a letter but its softmax
         // probability ≈ 1/3 — under the 0.5 confidence floor, so it must count as blank.
-        let events = try decoder.tick(infer: { input in
+        let events = decoder.tick(infer: { input in
             let validRows = (input.frameCount + 1) / 2
             var tied = [Float](repeating: -20, count: 62)
             tied[33] = 5; tied[34] = 5; tied[35] = 5 // 'a', 'b', 'c'
@@ -152,7 +152,7 @@ final class FingerspellingLiveDecoderTests: XCTestCase {
         appendFrames(&decoder, 2)
         XCTAssertEqual(decoder.windowedFrameCount, HolisticWindower.windowLength)
         var fedRows = 0
-        _ = try decoder.tick(infer: { input in
+        _ = decoder.tick(infer: { input in
             fedRows = (input.frameCount + 1) / 2
             return (0..<fedRows).map { _ in self.logitRow(nil) }
         })

--- a/OpenGlassesTests/FingerspellingModelTests.swift
+++ b/OpenGlassesTests/FingerspellingModelTests.swift
@@ -72,7 +72,7 @@ final class FingerspellingModelTests: XCTestCase {
                                                             withIntermediateDirectories: true)
                     try Data("model-bytes".utf8).write(to: dest)
                 }
-                await progress(1.0)
+                progress(1.0)
             })
         await downloader.download()
         XCTAssertEqual(downloader.state, .ready)

--- a/OpenGlassesTests/KokoroModelDownloaderTests.swift
+++ b/OpenGlassesTests/KokoroModelDownloaderTests.swift
@@ -35,7 +35,7 @@ final class KokoroModelDownloaderTests: XCTestCase {
     /// Writes every required file + directory into `destination` (a complete, valid install).
     private func fullInstaller(progressSteps: [Double] = []) -> KokoroModelDownloader.Installer {
         { bundle, destination, progress in
-            for step in progressSteps { await progress(step) }
+            for step in progressSteps { progress(step) }
             try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
             for name in bundle.requiredFiles {
                 try Data(repeating: 0x42, count: 8).write(to: destination.appendingPathComponent(name))

--- a/OpenGlassesTests/WakeWordHardeningTests.swift
+++ b/OpenGlassesTests/WakeWordHardeningTests.swift
@@ -50,7 +50,10 @@ final class WakeWordHardeningTests: XCTestCase {
         let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 256)!
         buffer.frameLength = 256
 
-        let received = NSCountedSet()
+        // `nonisolated(unsafe)`: `NSCountedSet` isn't `Sendable`, and the forwarders below are
+        // `@Sendable` closures called from a background queue. Every touch is `lock`-guarded —
+        // which is the point of the test — so the unsafety is the discipline, not a hole.
+        nonisolated(unsafe) let received = NSCountedSet()
         let lock = NSLock()
         box.setForwarders(["a": { _ in lock.lock(); received.add("a"); lock.unlock() }])
 

--- a/project.base.yml
+++ b/project.base.yml
@@ -121,7 +121,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "350"
+        CURRENT_PROJECT_VERSION: "351"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -221,7 +221,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "350"
+        CURRENT_PROJECT_VERSION: "351"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -259,7 +259,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "350"
+        CURRENT_PROJECT_VERSION: "351"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "350"
+        CURRENT_PROJECT_VERSION: "351"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "350"
+        CURRENT_PROJECT_VERSION: "351"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
Clears every compiler warning in our own sources (app + test targets). Several were "this is an error in the Swift 6 language mode", so this is also Swift 6 migration groundwork. Vendored/SPM warnings are out of scope.

## One real bug

`OutboundFrameRelay.blur` — the inner `queue.async` sat inside a closure that had already bound `self` strongly via `guard let self`, so its `[weak self]` Task was decorative. A relay released mid-pipeline was held alive to finish the composite and publish one more frame. The outer capture is weak now, which is what the surrounding code always intended.

## Main-actor isolation

Immutable configuration made genuinely `nonisolated` rather than hopping — these are read from CoreBluetooth and capture callbacks where an actor hop would change timing.

- `EvenBLETransport`'s characteristic UUIDs and advertised-name prefix. `CBUUID` isn't annotated `Sendable`, so the three UUIDs are `nonisolated(unsafe)` — immutable value objects created once, stated rather than worked around.
- `LocalLLMService.visionModelIds`, `LLMService.localSafeTools`, `VideoRecordingService.frameStallSeconds`.
- `FingerspellingModelDownloader.liveInstaller` moves onto the nonisolated `FingerspellingModelBundle`, mirroring the existing `ASRModelBundle` precedent. That also resolves the redundant `await progress(...)`: the closure is no longer main-actor-inferred, so the hop is real — and the download's file I/O leaves the main thread.

## Sendable

- The vision turn's `UserInput` (and the `CIImage` in it) is built **inside** the `@Sendable` closure from Sendable ingredients only, instead of crossing the boundary.
- `MediaTriggerService`'s notification handler is typed `@Sendable`.
- `BroadcastAudioProviding` is `@MainActor` — the adopter and both call sites already were; only the handlers it registers are `@Sendable`.

## iOS 26 deprecations

Deployment target is 26.0, so no availability gates were needed.

- The OAuth presentation anchor walks connected scenes: foreground-active key window → any key window → any window → a new window on a scene. `init(windowScene:)` is the only surviving `UIWindow` initialiser, so the scene-less tail traps rather than returning an unpresentable empty window. **Worth a reviewer's eye** — it's a new trap where there wasn't one, though `signIn()` is only reachable from a Settings button tap, which requires a live scene, and the empty window it replaced could never have presented anything.
- Walking routes use `MKMapItem(location:address:)` instead of the deprecated `MKPlacemark`.

## Also

Two discarded `capturePhoto()` results made explicit (it files every capture to the "Glasses" album itself), a discarded `seekToEnd()`, two redundant `try`s on non-throwing closures passed to a `rethrows` function, and three redundant `await`s in the download tests.

## Verification

- Debug simulator build: clean, **2852 tests, 0 failures, 3 skipped**
- Release build (device arm64, real SDK): **succeeded**, zero warnings in our sources
- Debug device build: clean, installed and running on hardware

Every edited file was confirmed present in the build's `SwiftCompile` lines — an incremental build can silently skip a file, making a fixed warning and an unrecompiled file look identical. Three fixes initially looked verified and weren't; they were forced to rebuild and re-checked.

Build bumped to 351 per the per-merge convention; marketing version unchanged (no new feature).

## Not addressed

Two xcodebuild notices remain, both pre-existing and neither a compiler warning: `OpenGlasses/Sources/Models` and `.../Shared` are members of multiple groups in the generated project. That's a `project.base.yml` group-layout artifact from the widget target referencing individual files inside a directory the app target includes wholesale — changing shared-file group placement risks the widget's target membership, so it's left alone.

Separately, a Release build does not *launch* on device — see #304. That's a vendored-dependency static-init deadlock, unrelated to this PR (the Release compile here is clean; the hang is pre-`main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
