### PR TITLE
Fix the App Store Connect upload rejections: MediaPipe bundle versions and the DAT URL scheme

### DIFF
--- a/OpenGlasses/Info.plist
+++ b/OpenGlasses/Info.plist
@@ -25,7 +25,7 @@
 		<dict>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>mwdat-YOUR_META_APP_ID</string>
+				<string>mwdat-$(MWDAT_META_APP_ID)</string>
 				<string>openglasses</string>
 			</array>
 		</dict>

--- a/Scripts/fetch-mediapipe-frameworks.sh
+++ b/Scripts/fetch-mediapipe-frameworks.sh
@@ -18,12 +18,27 @@ repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 dest="$repo_root/Vendor/MediaPipeTasks/Frameworks"
 stamp="$dest/.fetched-$VERSION"
 
+# Google ships these frameworks with no CFBundleVersion / CFBundleShortVersionString, which App
+# Store Connect rejects on upload ("This bundle ... is invalid. The Info.plist file is missing the
+# required key: CFBundleVersion"). Embedded frameworks must carry both, so stamp the pinned
+# MediaPipe version into every slice. `plutil -replace` adds the key when absent, so this is
+# idempotent — and it runs on the already-fetched path too, so existing checkouts and warm CI
+# caches get repaired without a 1.2 GB re-download.
+patch_bundle_versions() {
+  local plist
+  while IFS= read -r plist; do
+    plutil -replace CFBundleVersion -string "$VERSION" "$plist"
+    plutil -replace CFBundleShortVersionString -string "$VERSION" "$plist"
+  done < <(find "$dest" -path "*.framework/Info.plist" -type f)
+}
+
 if [ -f "$stamp" ] \
    && [ -d "$dest/MediaPipeTasksVision.xcframework" ] \
    && [ -d "$dest/MediaPipeTasksCommon.xcframework" ] \
    && [ -f "$dest/graph_libraries/libMediaPipeTasksCommon_device_graph.a" ] \
    && [ -f "$dest/graph_libraries/libMediaPipeTasksCommon_simulator_graph.a" ]; then
-  echo "MediaPipeTasks ${VERSION} already fetched."
+  patch_bundle_versions
+  echo "MediaPipeTasks ${VERSION} already fetched (bundle versions verified)."
   exit 0
 fi
 
@@ -49,6 +64,8 @@ mkdir -p "$dest/graph_libraries"
 mv "$work/vision/frameworks/MediaPipeTasksVision.xcframework" "$dest/"
 mv "$work/common/frameworks/MediaPipeTasksCommon.xcframework" "$dest/"
 mv "$work/common/frameworks/graph_libraries/"*.a "$dest/graph_libraries/"
+
+patch_bundle_versions
 
 touch "$stamp"
 echo "MediaPipeTasks ${VERSION} installed under Vendor/MediaPipeTasks/Frameworks."


### PR DESCRIPTION
Unblocks TestFlight. An upload of 2026.8 surfaced five messages; **one is the actual blocker**, the rest are long-standing advisories.

## The blocker: MediaPipe frameworks have no version keys

Google ships `MediaPipeTasksCommon` and `MediaPipeTasksVision` with neither `CFBundleVersion` nor `CFBundleShortVersionString`, and `fetch-mediapipe-frameworks.sh` only downloaded and moved them — so App Store Connect rejected both bundles ("is invalid. The Info.plist file is missing the required key"). These are hard errors, and new: they arrived with the Plan CK MediaPipe vendoring, so **every archive since then would have failed the same way**.

The script now stamps the pinned version into every slice with `plutil -replace`, which adds the key when absent and is therefore idempotent. It also runs on the already-fetched path, so existing checkouts and warm CI caches repair themselves without a 1.2 GB re-download — and since `ci_scripts/ci_post_clone.sh` calls the same script, Xcode Cloud is covered.

Audited the other five embedded frameworks while here — MWDAT ×3, WebRTC, onnxruntime all carry both keys — so this is the whole of it.

**Verified:** all four framework slices now carry `1.0.0` for both keys; a re-run is a clean no-op and repairs in place without re-downloading.

## Also: the DAT URL scheme was a hardcoded placeholder

`Info.plist` declared the literal `mwdat-YOUR_META_APP_ID` while the `MWDAT` dict seventy lines below correctly used `$(MWDAT_META_APP_ID)`. Underscores aren't legal in a URL scheme, which is what the validator objected to.

This is **validation-noise cleanup, not a functional fix**. Glasses registration has worked fine for the last month with the placeholder in place, so nothing depends on this scheme today — the SDK uses `MWDAT.MetaAppID`, which always resolved correctly. Changing it to `mwdat-$(MWDAT_META_APP_ID)` simply matches Meta's convention and silences the advisory.

**Verified:** processed `Info.plist` resolves to `mwdat-688603774243722`.

## Not blockers (no action needed)

- **"Unsupported SDK or Xcode version"** — advisory only. As the message itself states, beta SDKs are fine to *build and upload* to App Store Connect; only App Store **submission** requires an RC. Beta-built TestFlight builds have been working for a month.
- **The seven "Upload Symbols Failed" messages** — warnings, not rejections. The vendored frameworks ship without dSYMs, so crashes inside them won't symbolicate. Nothing to fix in our code.

## Note for CI archives

The scheme fix only takes effect when `MWDAT_META_APP_ID` holds the app id at archive time. Locally that comes from `project.local.yml`. Xcode Cloud has no such file, so `project.base.yml`'s `YOUR_META_APP_ID` default would apply and the advisory would reappear — cosmetic, given the above, but worth setting as an Xcode Cloud environment variable if you want a clean validation report.

Branched off main rather than stacked on #305 so it isn't gated behind that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
