### PR TITLE
Reword the RunGlassesAction intent description so the upload passes ITMS-90626

### DIFF
--- a/OpenGlasses/Sources/App/Intents/RunGlassesActionIntent.swift
+++ b/OpenGlasses/Sources/App/Intents/RunGlassesActionIntent.swift
@@ -6,8 +6,11 @@ import Foundation
 /// the user has exposed in Settings → Siri & Search.
 struct RunGlassesActionIntent: AppIntent {
     static var title: LocalizedStringResource = "Run OpenGlasses Action"
+    // App Intent metadata must not name a reserved term — App Store Connect rejects the upload
+    // with ITMS-90626 ("Invalid Siri Support") if a title or description contains "Siri" (or
+    // "Apple"). Ordinary UI copy is unaffected; only extracted intent metadata is scanned.
     static var description = IntentDescription(
-        "Run an OpenGlasses action you've exposed to Siri — built-in, authored, or custom"
+        "Run an OpenGlasses action you've exposed for voice — built-in, authored, or custom"
     )
 
     static var isDiscoverable: Bool { true }


### PR DESCRIPTION
Fixes the ITMS-90626 upload rejection:

> Invalid Siri Support. App Intent description "Run an OpenGlasses action you've exposed to Siri — built-in, authored, or custom" cannot contain "siri"

App Store Connect scans **extracted App Intent metadata** — titles, descriptions, AppShortcut phrases — and rejects reserved terms in them. Dropped the word; the description now reads "exposed for voice", which is what the sentence meant anyway.

## Audited the whole surface, not just the flagged string

Every other `IntentDescription`, intent title, and `AppShortcut` phrase is clean. The only other "Siri" under `Intents/` is a code comment. Ordinary UI copy is **not** scanned — the settings rows saying "Siri Shortcuts", `SiriExposureView`'s "Siri & Search" title and so on are all fine and untouched.

## Residual risk worth knowing

The runtime dialog strings in this same file still say "Check OpenGlasses Settings → Siri & Search" when telling the user a missing action needs re-enabling. Those are values returned from `perform()`, not extracted metadata, so they shouldn't trip the check. Flagging rather than pre-emptively reworghtint them, since they're the clearest wording for the user. If a future upload disagrees, that's where to look.

## Verification

String-literal change only, so no behavioural risk. Not build-verified — worth noting that App Intent *metadata* problems only surface in a Release/SDK build via `appintentsmetadataprocessor`, and a bad intent can silently wipe **all** intent metadata. A plain string swap can't do that, but the upload itself is the real check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
