### PR TITLE
Actually retry the MediaPipe download — --retry alone never covered connection resets

### DIFF
--- a/Scripts/fetch-mediapipe-frameworks.sh
+++ b/Scripts/fetch-mediapipe-frameworks.sh
@@ -6,6 +6,14 @@
 # so both local checkouts and CI (ci_scripts/ci_post_clone.sh) populate them with this
 # script. Pinned versions + sha256 so the build is reproducible; idempotent (skips work
 # when the frameworks are already in place).
+#
+# Xcode Cloud caveat: GitHub egress works there (XcodeGen installs fine) but dl.google.com has
+# been observed resetting the connection a few seconds in — `curl: (35) Recv failure:
+# Connection reset by peer`, which fails the whole archive. The retry flags below are the first
+# line of defence. If resets prove persistent rather than intermittent, the durable fix is to
+# mirror these two tarballs as release assets on our own GitHub repo (assets allow up to 2 GB;
+# the larger archive is ~351 MB) and point the URLs there, since GitHub is reachable from CI.
+# Local archives are unaffected either way.
 set -euo pipefail
 
 VERSION="1.0.0"
@@ -47,7 +55,24 @@ trap 'rm -rf "$work"' EXIT
 
 fetch() { # url sha256 out
   echo "Downloading $1 …"
-  curl -fsSL --retry 3 -o "$3" "$1"
+  # `--retry` on its own only covers what curl classes as transient — timeouts, 5xx, 408, 429.
+  # It does NOT retry a connection reset, which is exactly how Xcode Cloud fails on
+  # dl.google.com: `curl: (35) Recv failure: Connection reset by peer`, aborting
+  # ci_post_clone.sh with exit 35 on the first reset despite `--retry 3`. `--retry-all-errors`
+  # is what covers it. `-C -` resumes rather than restarting a part-received archive (these are
+  # ~350 MB+), and `--speed-limit/--speed-time` turn a stalled-but-open socket into a retryable
+  # error instead of a hang.
+  local rc=0
+  curl -fsS -L \
+       --retry 5 --retry-all-errors --retry-delay 5 \
+       --speed-limit 1024 --speed-time 60 \
+       -C - -o "$3" "$1" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "fetch failed for $1 (curl exit $rc)" >&2
+    echo "  If this is Xcode Cloud: GitHub egress works there but dl.google.com resets — see the" >&2
+    echo "  mirror note in the header comment." >&2
+    exit "$rc"
+  fi
   echo "$2  $3" | shasum -a 256 -c - >/dev/null || {
     echo "sha256 mismatch for $1" >&2; exit 1; }
 }


### PR DESCRIPTION
An Xcode Cloud archive died in `ci_post_clone.sh` with exit 35:

```
Downloading https://dl.google.com/cpdc/…/MediaPipeTasksVision-1.0.0.tar.gz …
curl: (35) Recv failure: Connection reset by peer
```

## The retry that wasn't

The script already passed `--retry 3`, so this looked like it had retried and given up. **It hadn't.** curl's `--retry` only covers what it classes as transient — timeouts, 5xx, 408, 429. A connection reset isn't in that set, so the download aborted on the *first* reset with no retry whatsoever, and `set -euo pipefail` propagated 35 out of `ci_post_clone.sh`, failing the archive.

`--retry-all-errors` is what actually covers it. Also added:

- **`--retry-delay 5`** — space retries out instead of hammering a CDN that just dropped us
- **`-C -`** — resume rather than restart; at ~350 MB+ a reset near the end previously discarded the entire transfer
- **`--speed-limit 1024 --speed-time 60`** — turns a stalled-but-open socket into a retryable error instead of a hang
- **An explicit failure message** naming the URL and curl's exit code, so the next failure diagnoses itself instead of surfacing as a bare "exited with code 35"

## Scope: this is flakiness, not a blocked path

A re-run of the same archive **succeeded with no code change** (build 358), which is what tells us these resets are intermittent. Corroborating: GitHub egress from Xcode Cloud is fine — XcodeGen installs seconds earlier in the same script — and both `dl.google.com` URLs return 200. So retrying is the right-sized response; no mirror needed.

If resets ever become persistent, the header comment records the durable fix: mirror the two tarballs as release assets on our own repo, since GitHub is demonstrably reachable from CI.

## Verification

Full cold download, stamp removed, ~1.2 GB refetched **with these flags**:

- both tarballs fetched, sha256 verified
- plists stamped to `1.0.0 / 1.0.0`
- both graph static libraries in place (410 MB device / 813 MB simulator)
- early-exit path still prints `already fetched (bundle versions verified)`

That proves the happy path isn't broken. The CI failure itself can only be verified by an Xcode Cloud run — worth saying plainly rather than implying this is confirmed fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
