### PR TITLE
Plan CU P1 — per-turn latency instrumentation

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -661,6 +661,10 @@ class AppState: ObservableObject, AppStateProtocol {
     /// Human-in-the-loop confirmation for high-impact / irreversible tool calls (prompt-injection backstop).
     let toolConfirmationCoordinator = ToolConfirmationCoordinator()
 
+    /// Plan CU P1 — the turn-latency ring buffer, surfaced for the Developer panel to observe.
+    /// `TurnRecorder` owns it and writes it from the turn path; nothing on this state does.
+    let turnLedger = TurnLedger.shared
+
     // Tier 1 services
     let conversationStore = ConversationStore()
     /// On-device FTS index over conversation turns for cross-session recall (Memory & Recall Phase 2).
@@ -705,6 +709,10 @@ class AppState: ObservableObject, AppStateProtocol {
             NSLog("[CO] Dropped a held utterance that went stale: %@", held.text)
             return
         }
+        // Plan CU P1: the replay is a brand-new turn, but the wearer has been waiting since the
+        // park — hand the recorder the park time so the turn carries `heldSeconds` rather than
+        // reporting a perceived latency that starts after the wait it was measuring.
+        TurnRecorder.noteHeldUtterance(parkedAt: held.heldAt)
         Task { @MainActor in await self.handleTranscription(held.text) }
     }
 
@@ -927,14 +935,17 @@ class AppState: ObservableObject, AppStateProtocol {
         videoRecorder.meetingAssistant = meetingAssistant
         videoRecorder.llmClosure = { [weak self] prompt in
             guard let self else { throw LLMError.missingAPIKey("AppState deallocated") }
-            return try await self.llmService.sendMessage(prompt)
+            // Off-turn (Plan CU P1): the meeting assistant runs on the recording's clock, alongside
+            // whatever the wearer is saying to the app — see `TurnRecorder.offTurn`.
+            return try await TurnRecorder.offTurn { try await self.llmService.sendMessage(prompt) }
         }
         audioRecorder.wakeWordService = wakeWordService
         audioRecorder.ambientCaptionService = ambientCaptions
         audioRecorder.meetingAssistant = meetingAssistant
         audioRecorder.llmClosure = { [weak self] prompt in
             guard let self else { throw LLMError.missingAPIKey("AppState deallocated") }
-            return try await self.llmService.sendMessage(prompt)
+            // Off-turn for the same reason as `videoRecorder.llmClosure` above.
+            return try await TurnRecorder.offTurn { try await self.llmService.sendMessage(prompt) }
         }
         medicalExportService.hipaaService = hipaaService
         faceRecognition.onRecognition = { [weak self] name in
@@ -2245,6 +2256,11 @@ class AppState: ObservableObject, AppStateProtocol {
     /// Stop the current response and process the barge-in text as a new query.
     func handleBargeIn(_ bargeInText: String) {
         print("⚡ Barge-in: '\(bargeInText)' — stopping TTS and processing")
+        // Plan CU P1: read before `stopSpeaking()` clears it. A barge-in over playback is a turn
+        // that worked and was cut short — its stage times are sound data. A barge-in while the
+        // model is still generating is a turn that never delivered, and the cancellation path tags
+        // that one `abandoned` instead.
+        if speechService.isSpeaking { TurnRecorder.noteInterrupted() }
         speechService.stopSpeaking()
         let interruptedTask = currentLLMTask
         interruptedTask?.cancel()
@@ -2352,13 +2368,19 @@ class AppState: ObservableObject, AppStateProtocol {
     private func sendPhotoToLLM(imageData: Data, prompt: String, userLog: String) async {
         isProcessing = true
         speechService.startThinkingSound()
+        // Plan CU P1: the phone-camera fallback and the photo command below are a second, hand-rolled
+        // turn spine — they predate `ConversationTurnRunner` and never went through it, so the marks
+        // that spine carries have to be repeated here or every "take a photo and…" turn is invisible.
+        TurnRecorder.beginTurn()
         do {
+            TurnRecorder.mark(.commit)
             let rawResponse = try await llmService.sendMessage(
                 prompt,
                 locationContext: locationService.locationContext,
                 imageData: imageData,
                 memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? prompt : nil) : nil
             )
+            TurnRecorder.mark(.generationDone)
             let response = Config.userMemoryEnabled ? userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse
             lastResponse = response
             if Config.conversationPersistenceEnabled {
@@ -2367,12 +2389,15 @@ class AppState: ObservableObject, AppStateProtocol {
             }
             isProcessing = false
             speechService.stopThinkingSound()
+            TurnRecorder.handOffToSpeech()
             await speechService.speak(response)
         } catch {
+            TurnRecorder.noteAbandoned()
             isProcessing = false
             speechService.stopThinkingSound()
             errorMessage = error.localizedDescription
         }
+        TurnRecorder.endTurn()
     }
 
     /// Capture a photo and send it to the LLM with a custom prompt.
@@ -2384,8 +2409,12 @@ class AppState: ObservableObject, AppStateProtocol {
         }
         isProcessing = true
         speechService.startThinkingSound()
+        TurnRecorder.beginTurn()
+        TurnRecorder.mark(.commit)
         do {
+            let grabStartedAt = Date()
             let photoData = try await cameraService.capturePhoto()
+            TurnRecorder.addFrameGrabTime(since: grabStartedAt)
             if currentMode == .direct {
                 cameraService.restoreAudioForWakeWord()
             }
@@ -2397,6 +2426,7 @@ class AppState: ObservableObject, AppStateProtocol {
                 imageData: photoData,
                 memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? prompt : nil) : nil
             )
+            TurnRecorder.mark(.generationDone)
             let response = Config.userMemoryEnabled ? userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse
             lastResponse = response
             if Config.conversationPersistenceEnabled {
@@ -2407,12 +2437,14 @@ class AppState: ObservableObject, AppStateProtocol {
             isProcessing = false
             speechService.stopThinkingSound()
             startStopListener()
+            TurnRecorder.handOffToSpeech()
             await speechService.speak(response)
             stopStopListener()
 
             let generator = UINotificationFeedbackGenerator()
             generator.notificationOccurred(.success)
         } catch {
+            TurnRecorder.noteAbandoned()
             if currentMode == .direct {
                 cameraService.restoreAudioForWakeWord()
             }
@@ -2422,6 +2454,7 @@ class AppState: ObservableObject, AppStateProtocol {
             let generator = UINotificationFeedbackGenerator()
             generator.notificationOccurred(.error)
         }
+        TurnRecorder.endTurn()
     }
 
     /// Toggle Assistive Mode (A3). Wires the shared service to this AppState's camera/LLM/TTS.
@@ -2518,8 +2551,12 @@ class AppState: ObservableObject, AppStateProtocol {
         }
         isProcessing = true
         speechService.startThinkingSound()
+        TurnRecorder.beginTurn()
+        TurnRecorder.mark(.commit)
         do {
+            let grabStartedAt = Date()
             let photoData = try await cameraService.capturePhoto()
+            TurnRecorder.addFrameGrabTime(since: grabStartedAt)
             if currentMode == .direct {
                 cameraService.restoreAudioForWakeWord()
             }
@@ -2532,6 +2569,7 @@ class AppState: ObservableObject, AppStateProtocol {
                 imageData: photoData,
                 memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? prompt : nil) : nil
             )
+            TurnRecorder.mark(.generationDone)
             var response = Config.userMemoryEnabled ? userMemory.parseAndExecuteCommands(in: rawResponse) : rawResponse
             // A phone-camera capture must SAY so — the phone sees the desk, not what the
             // glasses are pointed at, and an unannounced camera swap reads as hallucination.
@@ -2548,12 +2586,14 @@ class AppState: ObservableObject, AppStateProtocol {
             isProcessing = false
             speechService.stopThinkingSound()
             startStopListener()
+            TurnRecorder.handOffToSpeech()
             await speechService.speak(response)
             stopStopListener()
 
             let generator = UINotificationFeedbackGenerator()
             generator.notificationOccurred(.success)
         } catch {
+            TurnRecorder.noteAbandoned()
             if currentMode == .direct {
                 cameraService.restoreAudioForWakeWord()
             }
@@ -2563,6 +2603,7 @@ class AppState: ObservableObject, AppStateProtocol {
             let generator = UINotificationFeedbackGenerator()
             generator.notificationOccurred(.error)
         }
+        TurnRecorder.endTurn()
     }
 
     func captureAndSharePhoto() async {
@@ -3126,7 +3167,9 @@ class AppState: ObservableObject, AppStateProtocol {
                     await ConversationTurnRunner.run(.init(
                         send: {
                             // Capture and send to LLM concurrently — no extra round-trip speech
+                            let grabStartedAt = Date()
                             let photoData = try await self.cameraService.capturePhoto()
+                            TurnRecorder.addFrameGrabTime(since: grabStartedAt)
                             try Task.checkCancellation()
                             // Restore audio for wake word after camera capture (camera reconfigures for Bluetooth)
                             self.cameraService.restoreAudioForWakeWord()
@@ -3313,6 +3356,13 @@ class AppState: ObservableObject, AppStateProtocol {
             return data
         }
 
+        // Plan CU P1: the grab sits between commit and first token, so a vision turn's raw TTFT
+        // contains it — uncorrected, the Bluetooth stream's wait reads as model latency. Timed from
+        // here rather than from the top of the function: the already-streaming path above returns a
+        // frame we already had, and charging that to the model would be just as wrong in reverse.
+        let grabStartedAt = Date()
+        defer { TurnRecorder.addFrameGrabTime(since: grabStartedAt) }
+
         // Try to start streaming and capture
         do {
             try await cameraService.startStreaming()
@@ -3349,7 +3399,14 @@ class AppState: ObservableObject, AppStateProtocol {
             from: .init(name: from?.name ?? "the model", isLocal: from?.llmProvider == .local),
             to: .init(name: to?.name ?? "another model", isLocal: to?.llmProvider == .local),
             failure: failure)
+        // Plan CU P1: `speak` blocks until the whole notice has been *played*, and it sits inside
+        // the turn's commit → generationDone span while being the app talking, not the model.
+        // Unbracketed, a cascade turn charges those 2–4 s to `modelSeconds` and to TTFT and reports
+        // ~8 s of "model latency" for a 5 s model — the same mis-attribution `toolSeconds` exists to
+        // prevent, and it fires exactly when someone is looking at the panel.
+        let narrationStartedAt = Date()
         await speechService.speak(phrase, urgency: .low, mirrorToHUD: true)
+        TurnRecorder.addNonModelTime(since: narrationStartedAt)
         speechService.startThinkingSound()
     }
 
@@ -3453,11 +3510,18 @@ class AppState: ObservableObject, AppStateProtocol {
         if let directCall = classification.directToolCall,
            let router = llmService.nativeToolRouter {
             isProcessing = true
+            // Plan CU P1: tier-0 is a turn shape in its own right and the fastest one the app has —
+            // no backend is ever dispatched, so `commitAt`/`firstTokenAt`/`generationDoneAt` stay
+            // nil by construction. Leaving it unrecorded would mean the aggregate only ever
+            // described the slow turns.
+            TurnRecorder.beginTurn()
+            let toolStartedAt = Date()
             do {
                 let result = try await router.registry.executeTool(
                     name: directCall.toolName,
                     arguments: directCall.arguments
                 )
+                TurnRecorder.addToolTime(since: toolStartedAt)
                 lastResponse = result
                 print("⚡ Direct tool call: \(directCall.toolName) → \(result)")
 
@@ -3471,17 +3535,25 @@ class AppState: ObservableObject, AppStateProtocol {
                 }
 
                 startStopListener()
+                TurnRecorder.handOffToSpeech()
                 await speechService.speak(result)
                 stopStopListener()
             } catch {
                 // Fall through to normal LLM path if direct call fails
                 print("⚠️ Direct tool call failed, falling back to LLM: \(error)")
+                // Plan CU P1: the LLM turn below answers this same utterance, so seal this attempt
+                // as its own abandoned record and hand back the stamps it claimed. Sealed here
+                // rather than at the gate below, which `isProcessing = false` is about to skip.
+                TurnRecorder.abandonTurnReleasingUtterance()
                 isProcessing = false
                 // Don't return — continue to normal LLM path below
             }
 
             if isProcessing {
                 isProcessing = false
+                // Sealed before resuming: the resume path replays a held utterance, which starts
+                // the next turn.
+                TurnRecorder.endTurn()
                 await resumeListeningOrReturnToWakeWord(ensureEngine: true)
                 return
             }
@@ -3543,7 +3615,14 @@ class AppState: ObservableObject, AppStateProtocol {
                     // (cold launch / backgrounded when-in-use) instead of a location-less prompt.
                     let locationCtx: String?
                     if classification.relevantSections.contains(.location) {
+                        // Plan CU P1: a cold fix blocks for up to `awaitLocationContext`'s timeout
+                        // between commit and the backend call. Not a tool and not a frame grab, so
+                        // without this bracket it is charged in full to TTFT and `modelSeconds`, and
+                        // only on location-flavoured turns — skewing one slice of a cohort rather
+                        // than shifting the whole distribution, which is harder to notice.
+                        let locationWaitStartedAt = Date()
                         locationCtx = await locationService.awaitLocationContext()
+                        TurnRecorder.addNonModelTime(since: locationWaitStartedAt)
                     } else {
                         locationCtx = nil
                     }
@@ -4055,11 +4134,15 @@ class AppState: ObservableObject, AppStateProtocol {
         """
 
         do {
-            let response = try await llmService.sendMessage(
-                triagePrompt,
-                memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? triagePrompt : nil) : nil,
-                agentContext: currentAgentContext
-            )
+            // Plan CU P1: triage runs on OpenClaw's schedule, not the wearer's, and traverses the
+            // same `sendMessage` / `runToolLoop` a voice turn does — see `TurnRecorder.offTurn`.
+            let response = try await TurnRecorder.offTurn {
+                try await llmService.sendMessage(
+                    triagePrompt,
+                    memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? triagePrompt : nil) : nil,
+                    agentContext: currentAgentContext
+                )
+            }
 
             let cleaned = response.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -4130,11 +4213,14 @@ class AppState: ObservableObject, AppStateProtocol {
             """
 
             do {
-                let summary = try await llmService.sendMessage(
-                    summaryPrompt,
-                    memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? summaryPrompt : nil) : nil,
-                    agentContext: currentAgentContext
-                )
+                // Off-turn for the same reason as the triage call above.
+                let summary = try await TurnRecorder.offTurn {
+                    try await llmService.sendMessage(
+                        summaryPrompt,
+                        memoryContext: Config.userMemoryEnabled ? userMemory.systemPromptContext(query: Config.userMemoryRetrievalEnabled ? summaryPrompt : nil) : nil,
+                        agentContext: currentAgentContext
+                    )
+                }
                 let cleaned = summary.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !cleaned.uppercased().hasPrefix("SKIP") else { return }
 

--- a/OpenGlasses/Sources/App/Views/DeveloperPanelView.swift
+++ b/OpenGlasses/Sources/App/Views/DeveloperPanelView.swift
@@ -66,6 +66,18 @@ struct DeveloperPanelView: View {
             .buttonStyle(.plain)
             .disabled(runner.isRunning)
 
+            OGSection(header: "Turn Latency") {
+                NavigationLink {
+                    TurnTimelineDebugView(ledger: appState.turnLedger)
+                } label: {
+                    OGRow(
+                        "Turn Timeline", icon: "waveform.path.ecg",
+                        subtitle: "Recorded voice turns, stage breakdown, cohort latency"
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+
             OGSection(
                 header: "Debug Events",
                 footer: "The persistent field log lives in Documents/debug-events.log and survives relaunches."

--- a/OpenGlasses/Sources/App/Views/TurnTimelineDebugView.swift
+++ b/OpenGlasses/Sources/App/Views/TurnTimelineDebugView.swift
@@ -1,0 +1,394 @@
+import SwiftUI
+
+/// Developer → Turn Timeline (Plan CU P1): the sealed turns in `TurnLedger`, each expandable to
+/// its full stage-by-stage breakdown, plus the aggregate the plan insists on — perceived latency
+/// split by `backend` × `ttsEngine` × `micRoute`, never pooled (see `TurnTimeline.Cohort`).
+///
+/// Reads `TurnLedger` directly rather than through a view model — the same "pure core + thin view"
+/// split `SubsystemTestRunner`/`DeveloperPanelView` already use. This screen has nothing to add to
+/// that core beyond formatting.
+struct TurnTimelineDebugView: View {
+    @ObservedObject var ledger: TurnLedger
+    @Environment(\.appAccent) private var accent
+    @State private var expandedTurnIDs: Set<UUID> = []
+
+    /// The ring already caps at `ledger.maxCount`; this caps what one screen renders at once. A
+    /// non-lazy `VStack` (what `OGCard` builds on) holding 200 expandable rows is a lot of view
+    /// identity to keep alive for a "last N" list nobody scrolls that far into.
+    private static let displayLimit = 25
+
+    private var recentTurns: [TurnTimeline] {
+        Array(ledger.sealed.suffix(Self.displayLimit).reversed())
+    }
+
+    private var cohortEntries: [(key: TurnTimeline.Cohort, value: TurnLedger.Stats)] {
+        ledger.perceivedLatencyByCohort.sorted { cohortLabel($0.key) < cohortLabel($1.key) }
+    }
+
+    var body: some View {
+        OGScrollPage {
+            OGNotice(
+                text: "On-device only, per Plan CU P1 item 5 — no sink, no push. Perceived latency is speech end → first audio, the number this plan exists to move.",
+                systemImage: "gauge"
+            )
+
+            recentTurnsSection
+            cohortSection
+            exportSection
+        }
+        .textSelection(.enabled)
+        .tint(accent)
+        .navigationTitle("Turn Timeline")
+    }
+
+    // MARK: - Recent turns
+
+    private var recentTurnsSection: some View {
+        OGSection(
+            header: "Recent Turns",
+            footer: "Newest \(recentTurns.count) of \(ledger.sealed.count) sealed · \(ledger.inFlightCount) in flight. Tap a turn for its stage-by-stage breakdown."
+        ) {
+            if recentTurns.isEmpty {
+                Text(ledger.inFlightCount > 0
+                     ? "No sealed turns yet — \(ledger.inFlightCount) in flight."
+                     : "No sealed turns yet. A turn appears here once it's sealed.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .padding(16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                ForEach(Array(recentTurns.enumerated()), id: \.element.id) { index, turn in
+                    if index > 0 {
+                        // OGDivider's 57pt inset clears OGRow's icon tile; this row has none, so
+                        // it aligns to the row's own 16pt content edge instead.
+                        Rectangle()
+                            .fill(OGTheme.hairline)
+                            .frame(height: 0.5)
+                            .padding(.leading, 16)
+                    }
+                    turnRow(turn)
+                }
+            }
+        }
+    }
+
+    private func turnRow(_ turn: TurnTimeline) -> some View {
+        DisclosureGroup(isExpanded: expandedBinding(for: turn.id)) {
+            turnDetail(turn)
+        } label: {
+            turnHeaderLabel(turn)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private func expandedBinding(for id: UUID) -> Binding<Bool> {
+        Binding(
+            get: { expandedTurnIDs.contains(id) },
+            set: { isExpanded in
+                if isExpanded {
+                    expandedTurnIDs.insert(id)
+                } else {
+                    expandedTurnIDs.remove(id)
+                }
+            }
+        )
+    }
+
+    private func turnHeaderLabel(_ turn: TurnTimeline) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            HStack(spacing: 6) {
+                Text(Self.formatOptionalSeconds(turn.perceivedLatency))
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(.primary)
+                if turn.abandoned {
+                    OGStatusPill(text: "Abandoned", dot: OGTheme.error, tinted: false)
+                }
+                if turn.interrupted {
+                    OGStatusPill(text: "Interrupted", dot: OGTheme.warn, tinted: false)
+                }
+                Spacer(minLength: 0)
+            }
+            HStack(spacing: 6) {
+                OGChip(text: turn.backend?.label ?? "unknown", available: turn.backend != nil)
+                OGChip(text: turn.ttsEngine?.rawValue ?? "unknown", available: turn.ttsEngine != nil)
+                OGChip(text: turn.micRoute?.shortLabel ?? "unknown", available: turn.micRoute != nil)
+                Spacer(minLength: 0)
+                Text(turn.id.uuidString.prefix(8))
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func turnDetail(_ turn: TurnTimeline) -> some View {
+        let anchor = TurnTimeline.Stage.allCases.first { turn[$0] != nil }
+        return VStack(alignment: .leading, spacing: 10) {
+            clusterHeader("Stage marks")
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(TurnTimeline.Stage.allCases, id: \.self) { stage in
+                    HStack {
+                        Text(stage.label)
+                            .font(.caption2.monospaced())
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        stageMarkValue(turn, stage, anchor: anchor)
+                    }
+                }
+            }
+
+            clusterHeader("Derived")
+            derivedMetricsList(turn)
+
+            clusterHeader("Spans")
+            spansCluster(turn)
+        }
+        .padding(.horizontal, 4)
+        .padding(.top, 4)
+        .padding(.bottom, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func clusterHeader(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(.tertiary)
+    }
+
+    /// A stage mark is one of three completely different facts, and the row must not blur them:
+    /// never landed ("not recorded"), landed but nothing precedes it to measure from ("starts
+    /// here" — this turn's first mark), or landed with a measurable gap since the previous mark.
+    @ViewBuilder
+    private func stageMarkValue(_ turn: TurnTimeline, _ stage: TurnTimeline.Stage, anchor: TurnTimeline.Stage?) -> some View {
+        if turn[stage] == nil {
+            Text("not recorded")
+                .font(.caption2.monospaced())
+                .foregroundStyle(.tertiary)
+                .italic()
+        } else if stage == anchor {
+            Text("starts here")
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+                .italic()
+        } else if let segment = turn.segments.first(where: { $0.stage == stage }) {
+            Text(Self.formatSigned(segment.seconds))
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+        } else {
+            // Unreachable: a landed, non-anchor stage always has an earlier landed mark to gap
+            // from, so `segments` always carries an entry for it. Kept as a safe fallback rather
+            // than force-unwrapping.
+            Text("—")
+                .font(.caption2.monospaced())
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    @ViewBuilder
+    private func derivedMetricsList(_ turn: TurnTimeline) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            metricRow("Endpointing delay", turn.endpointingDelay)
+            metricRow("Time to first token", turn.timeToFirstToken)
+            metricRow("  model only, frame grab out", turn.modelTimeToFirstToken)
+            metricRow("Backend total", turn.backendSeconds)
+            metricRow("  model only, tools + frame grab out", turn.modelSeconds)
+            ttsLeadInRow(turn)
+            metricRow("TTS time to first byte", turn.ttsTimeToFirstByte)
+            metricRow("Playback", turn.playbackSeconds)
+            metricRow("HUD latency", turn.hudLatency)
+            metricRow("Total, speech end to done", turn.totalSeconds)
+            HStack {
+                Text("Generation rate")
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if let rate = turn.tokensPerSecond {
+                    Text(String(format: "%.1f tok/s", rate))
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("not recorded")
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.tertiary)
+                        .italic()
+                }
+            }
+        }
+    }
+
+    /// Signed on purpose, mirroring `TurnTimeline.ttsLeadIn` itself: negative means speech started
+    /// before generation finished, which is the good case and the entire point of sentence-
+    /// streaming TTS. A bare "-0.80s" reads as an error, so the good case gets a checkmark and a
+    /// plain-English gloss rather than relying on the sign alone.
+    @ViewBuilder
+    private func ttsLeadInRow(_ turn: TurnTimeline) -> some View {
+        HStack(alignment: .top) {
+            Text("TTS lead-in")
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+            Spacer()
+            VStack(alignment: .trailing, spacing: 2) {
+                if let leadIn = turn.ttsLeadIn {
+                    HStack(spacing: 4) {
+                        if leadIn < 0 {
+                            Image(systemName: "checkmark.circle.fill")
+                                .font(.caption2)
+                                .foregroundStyle(OGTheme.ok)
+                        }
+                        Text(Self.formatSigned(leadIn))
+                            .font(.caption2.monospaced())
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(leadIn < 0 ? "spoke before generation finished" : "waited after generation finished")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                } else {
+                    Text("not recorded")
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.tertiary)
+                        .italic()
+                }
+            }
+        }
+    }
+
+    private func spansCluster(_ turn: TurnTimeline) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Frame grab")
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(Self.formatSeconds(turn.frameGrabSeconds))
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+            HStack {
+                Text("Tool time (\(turn.toolIterations)×)")
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(Self.formatSeconds(turn.toolSeconds))
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+            HStack {
+                Text("App work in backend leg")
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(Self.formatSeconds(turn.nonModelSeconds))
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+            HStack {
+                Text("Held before this turn")
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(Self.formatSeconds(turn.heldSeconds))
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+            metricRow("Wait including hold", turn.waitIncludingHold)
+        }
+    }
+
+    private func metricRow(_ label: String, _ seconds: TimeInterval?) -> some View {
+        HStack {
+            Text(label)
+                .font(.caption2.monospaced())
+                .foregroundStyle(.secondary)
+            Spacer()
+            if let seconds {
+                Text(Self.formatSeconds(seconds))
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("not recorded")
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.tertiary)
+                    .italic()
+            }
+        }
+    }
+
+    // MARK: - Cohort aggregate
+
+    /// `TurnTimeline.Cohort` exists precisely so this can't be flattened into one number — see its
+    /// own doc comment. One `OGStatTile` per cohort, full width, keeps every combination legible
+    /// instead of cramming labels into a grid that would tempt someone to eyeball an average
+    /// across them.
+    private var cohortSection: some View {
+        OGSection(
+            header: "Perceived Latency by Cohort",
+            footer: "Split by backend × TTS engine × mic route — never pooled. An 8 kHz glasses mic and a cloud TTS engine are a different population from a phone mic and on-device TTS; averaging across them would describe neither."
+        ) {
+            if cohortEntries.isEmpty {
+                Text("No cohort has a sealed turn with a recorded perceived latency yet.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .padding(16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(cohortEntries, id: \.key) { entry in
+                        OGStatTile(
+                            value: Self.formatSeconds(entry.value.median),
+                            caption: "\(cohortLabel(entry.key)) · median · n=\(entry.value.count) · mean \(Self.formatSeconds(entry.value.mean))"
+                        )
+                    }
+                }
+                .padding(12)
+            }
+        }
+    }
+
+    private func cohortLabel(_ cohort: TurnTimeline.Cohort) -> String {
+        "\(cohort.backend?.label ?? "unknown") · \(cohort.ttsEngine?.rawValue ?? "unknown") · \(cohort.micRoute?.shortLabel ?? "unknown")"
+    }
+
+    // MARK: - Export
+
+    private var exportSection: some View {
+        let text = ledger.debugExport()
+        return OGSection(
+            header: "Export",
+            footer: "Plain text — turn history plus per-cohort latency stats (Plan CU P1 item 5: no sink, no push, this is the entire surface)."
+        ) {
+            Button {
+                UIPasteboard.general.string = text
+            } label: {
+                OGRow("Copy Diagnostics", icon: "doc.on.doc", mutedIcon: true, showsChevron: false) {
+                    OGRowValue(value: "\(ledger.sealed.count) turns")
+                }
+            }
+            .buttonStyle(.plain)
+
+            OGDivider()
+
+            ShareLink(item: text, subject: Text("OpenGlasses turn ledger")) {
+                OGRow("Share Diagnostics", icon: "square.and.arrow.up", mutedIcon: true, showsChevron: false) {
+                    EmptyView()
+                }
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Formatting
+
+    private static func formatSeconds(_ seconds: TimeInterval) -> String {
+        String(format: "%.2fs", seconds)
+    }
+
+    private static func formatOptionalSeconds(_ seconds: TimeInterval?) -> String {
+        guard let seconds else { return "not recorded" }
+        return formatSeconds(seconds)
+    }
+
+    private static func formatSigned(_ seconds: TimeInterval) -> String {
+        String(format: "%+.2fs", seconds)
+    }
+}

--- a/OpenGlasses/Sources/Services/AgentNotificationQueue.swift
+++ b/OpenGlasses/Sources/Services/AgentNotificationQueue.swift
@@ -201,12 +201,16 @@ class AgentNotificationQueue: ObservableObject {
 
         appState.speechService.startThinkingSound()
         do {
-            let response = try await appState.llmService.sendMessage(
-                prompt,
-                locationContext: appState.locationService.locationContext,
-                memoryContext: Config.userMemoryEnabled ? appState.userMemory.systemPromptContext() : nil,
-                agentContext: appState.currentAgentContext
-            )
+            // Off-turn (Plan CU P1): the digest fires on the queue's own schedule and shares the
+            // turn path's `sendMessage` / `runToolLoop` — see `TurnRecorder.offTurn`.
+            let response = try await TurnRecorder.offTurn {
+                try await appState.llmService.sendMessage(
+                    prompt,
+                    locationContext: appState.locationService.locationContext,
+                    memoryContext: Config.userMemoryEnabled ? appState.userMemory.systemPromptContext() : nil,
+                    agentContext: appState.currentAgentContext
+                )
+            }
             appState.lastResponse = response
             appState.speechService.stopThinkingSound()
             await appState.speechService.speak(response)

--- a/OpenGlasses/Sources/Services/AgentScheduler.swift
+++ b/OpenGlasses/Sources/Services/AgentScheduler.swift
@@ -280,12 +280,18 @@ class AgentScheduler: ObservableObject {
         """
 
         do {
-            let response = try await appState.llmService.sendMessage(
-                wrappedPrompt,
-                locationContext: appState.locationService.locationContext,
-                memoryContext: Config.userMemoryEnabled ? appState.userMemory.systemPromptContext() : nil,
-                agentContext: appState.currentAgentContext
-            )
+            // Plan CU P1: a scheduled run fires on its own timer and can overlap a voice turn,
+            // through the very `sendMessage` / `runToolLoop` that turn is using. Off-turn, so it
+            // cannot re-tag that turn's cohort with this run's model or add its tool seconds to it —
+            // see `TurnRecorder.offTurn`.
+            let response = try await TurnRecorder.offTurn {
+                try await appState.llmService.sendMessage(
+                    wrappedPrompt,
+                    locationContext: appState.locationService.locationContext,
+                    memoryContext: Config.userMemoryEnabled ? appState.userMemory.systemPromptContext() : nil,
+                    agentContext: appState.currentAgentContext
+                )
+            }
 
             let processed = Config.userMemoryEnabled
                 ? appState.userMemory.parseAndExecuteCommands(in: response)

--- a/OpenGlasses/Sources/Services/Audio/MicRoutePolicy.swift
+++ b/OpenGlasses/Sources/Services/Audio/MicRoutePolicy.swift
@@ -87,4 +87,25 @@ enum MicRoutePolicy {
             return ports.firstIndex { bluetoothMicPorts.contains($0.type) && !looksLikeGlasses(portName: $0.name) }
         }
     }
+
+    /// Which route the session's **live** input is on, given the ports it is currently routed to.
+    ///
+    /// The inverse of `preferredInputIndex`, and it exists because the two answers diverge
+    /// routinely: `preferredInputIndex` returns nil when the preferred port isn't there, and
+    /// `WakeWordService` then leaves capture on the phone while `Config.micRoute` still says
+    /// `.glasses`. A preference is not an observation — glasses go flat, sleep, or wander out of
+    /// range mid-session — and anything measuring the audio (Plan CU's cohorts, P2's acoustic
+    /// thresholds) must be told which mic actually carried the words, or an 8 kHz HFP population
+    /// and a 48 kHz phone-mic one end up in one bucket whose average describes neither.
+    ///
+    /// Classification mirrors `preferredInputIndex` exactly: a Bluetooth mic port whose name looks
+    /// like glasses is `.glasses`, any other Bluetooth mic port is `.headset`, anything else is the
+    /// phone. `nil` only for an empty list — a session with no input port has not been observed at
+    /// all, and the caller should fall back rather than assert a route nobody saw.
+    static func resolvedRoute(from ports: [(name: String, type: AVAudioSession.Port)]) -> MicRoute? {
+        guard !ports.isEmpty else { return nil }
+        if preferredInputIndex(for: .glasses, ports: ports) != nil { return .glasses }
+        if preferredInputIndex(for: .headset, ports: ports) != nil { return .headset }
+        return .phone
+    }
 }

--- a/OpenGlasses/Sources/Services/Diagnostics/TurnLedger.swift
+++ b/OpenGlasses/Sources/Services/Diagnostics/TurnLedger.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+/// Plan CU P1 — a bounded in-memory store of recent `TurnTimeline`s, plus the in-flight bookkeeping
+/// that lets one turn's marks be threaded through the existing turn path a call at a time instead of
+/// assembled all at once and recorded in a single shot.
+///
+/// A service that records every voice turn and never forgets one is a memory leak with a slow fuse —
+/// the cap is the point, not an afterthought. Two caps, because one alone isn't enough: `sealed` is
+/// bounded by count *and* by an approximate byte total, so a run of turns with unusually long
+/// `model` strings (a local model's filesystem path can run well past what a typical enum tag costs)
+/// can't blow past a count-only limit without a single one of them looking like "too many turns".
+///
+/// `@MainActor` / `ObservableObject` / `@Published`, the same shape `SubsystemTestRunner` uses, so
+/// the Developer-panel view observes this ledger exactly the way it already observes that runner.
+@MainActor
+final class TurnLedger: ObservableObject {
+
+    /// Count, median, and mean for one derived metric within one cohort — see `stats(for:)`.
+    struct Stats: Equatable {
+        let count: Int
+        let median: TimeInterval
+        let mean: TimeInterval
+    }
+
+    /// The bounded, chronological (oldest → newest) history of sealed turns.
+    @Published private(set) var sealed: [TurnTimeline] = []
+
+    /// Turns `start`ed but not yet `seal`ed. Not `@Published` — the panel's "last N turns" list is a
+    /// list of finished stories, and a turn that hasn't reached a stage worth drawing yet has
+    /// nothing to contribute to it.
+    private var inFlight: [UUID: TurnTimeline] = [:]
+
+    /// How many turns are currently being tracked but not yet sealed.
+    ///
+    /// Published even though `inFlight` itself is not, and the distinction is the point: the panel
+    /// says "N in flight" while a turn is running, which is the one moment the number is
+    /// informative and the one moment a computed read off an unpublished dictionary would never
+    /// refresh — the view would sit on "0 in flight" for the whole turn and correct itself to 0
+    /// again at the seal. The timelines stay unpublished, so the "finished stories only" rule above
+    /// still holds.
+    @Published private(set) var inFlightCount = 0
+
+    let maxCount: Int
+    let maxBytes: Int
+    private var sealedBytes = 0
+
+    /// - Parameters:
+    ///   - maxCount: sealed turns to retain. 200 is generous for a "last N turns" panel — this app
+    ///     produces turns on the order of hundreds a day, not thousands an hour.
+    ///   - maxBytes: approximate total footprint to retain, in `approximateByteSize(of:)` units.
+    ///     256 KB is far more than 200 turns cost at their fixed size alone; this bound exists for
+    ///     the pathological case — many turns with unusually long `model` names — not the common one.
+    init(maxCount: Int = 200, maxBytes: Int = 256 * 1024) {
+        self.maxCount = max(0, maxCount)
+        self.maxBytes = max(0, maxBytes)
+    }
+
+    // MARK: - Lifecycle: start, mark/update, seal
+    //
+    // "Marks arriving for an unknown/sealed turn must be dropped harmlessly, never crash" — every
+    // mutator below shares that contract. The turn path calls these from a dozen sites scattered
+    // across the app, TTS, and LLM services; a superseded turn's late mark landing here after its
+    // replacement has already sealed must never be the thing that crashes a voice interaction. It
+    // just has nowhere left to land.
+
+    /// Begin tracking `timeline` (a fresh one by default). Returns its id — equal to
+    /// `timeline.id` — for the caller to thread through `mark`/`update` and the eventual `seal`.
+    @discardableResult
+    func start(_ timeline: TurnTimeline = TurnTimeline()) -> UUID {
+        inFlight[timeline.id] = timeline
+        inFlightCount = inFlight.count
+        return timeline.id
+    }
+
+    /// Record `stage` at `time` on the in-flight turn `id`. A thin, named convenience over
+    /// `update(_:_:)` for the single most common call — every stage transition on every turn.
+    func mark(_ id: UUID, _ stage: TurnTimeline.Stage, at time: Date) {
+        update(id) { $0.mark(stage, at: time) }
+    }
+
+    /// Apply an arbitrary mutation to the in-flight turn `id` — a tag, an accumulator,
+    /// `abandoned`/`interrupted`, whatever `TurnTimeline`'s own mutating API already expresses.
+    ///
+    /// That API (`addToolTime`, the tag vars, `mark` itself, …) is the right vocabulary; the ledger
+    /// doesn't re-declare it as a wall of one-line forwarders that would just be a second copy to
+    /// keep in sync the next time the timeline grows a field.
+    func update(_ id: UUID, _ mutate: (inout TurnTimeline) -> Void) {
+        guard var timeline = inFlight[id] else { return }
+        mutate(&timeline)
+        inFlight[id] = timeline
+    }
+
+    /// Move `id` from in-flight to `sealed`, evicting the oldest sealed turns if the ring is now
+    /// over either bound. A second `seal` of the same id, or an id that was never `start`ed, is a
+    /// no-op.
+    ///
+    /// There is no separate "abandon" entry point: `abandoned`/`interrupted` are tags like any
+    /// other (set them via `update` before sealing), and a partial timeline seals exactly like a
+    /// complete one — cut short, it's still the most informative record of where that turn stopped.
+    func seal(_ id: UUID) {
+        guard let timeline = inFlight.removeValue(forKey: id) else { return }
+        inFlightCount = inFlight.count
+        sealed.append(timeline)
+        sealedBytes += Self.approximateByteSize(of: timeline)
+        trimToCapacity()
+    }
+
+    /// The current state of `id`, in-flight or sealed. `nil` if it's neither — never started, or
+    /// aged out of the ring.
+    func turn(_ id: UUID) -> TurnTimeline? {
+        inFlight[id] ?? sealed.first { $0.id == id }
+    }
+
+    /// Drop everything, in-flight and sealed alike. The Developer panel's "clear" action.
+    func reset() {
+        inFlight.removeAll()
+        inFlightCount = 0
+        sealed.removeAll()
+        sealedBytes = 0
+    }
+
+    private func trimToCapacity() {
+        while !sealed.isEmpty, sealed.count > maxCount || sealedBytes > maxBytes {
+            sealedBytes -= Self.approximateByteSize(of: sealed.removeFirst())
+        }
+    }
+
+    /// Approximate in-memory footprint of one sealed timeline, in bytes.
+    ///
+    /// Deliberately not a real measurement — `TurnTimeline` is a value type with no heap indirection
+    /// except its optional `model` string, and Swift has no cheap way to size a struct at runtime
+    /// regardless. What the cap needs to catch is the one field that can grow without bound while
+    /// everything else stays a fixed handful of bytes: a local model's filesystem path can run to a
+    /// hundred-plus characters. So: a flat allowance for the marks, tags, and accumulators, plus the
+    /// model name's real length. Not `private` — tests size `maxBytes` against this directly instead
+    /// of duplicating the estimate.
+    static func approximateByteSize(of timeline: TurnTimeline) -> Int {
+        fixedFootprint + (timeline.model?.utf8.count ?? 0)
+    }
+
+    private static let fixedFootprint = 200
+
+    // MARK: - Aggregates
+    //
+    // Grouped by `TurnTimeline.Cohort`, never flattened across it: an 8 kHz HFP mic and the phone's
+    // 48 kHz mic are two populations for every timing here, and so are a network TTS engine and an
+    // on-device one. Keying every result by `Cohort` makes pooling them a type error rather than a
+    // discipline someone has to remember at every call site.
+
+    /// `count`/`median`/`mean` of `metric`, evaluated over every sealed turn and grouped by cohort.
+    ///
+    /// A turn for which `metric` returns `nil` — an abandoned turn with no `firstAudioAt`, say —
+    /// contributes no data point, exactly as `TurnTimeline`'s own derived properties already treat a
+    /// missing mark. The median sits next to the mean, never instead of it: one slow 30 s turn
+    /// should not be able to move the headline the way it moves an average.
+    ///
+    /// Typical call: `ledger.stats(for: \.perceivedLatency)`.
+    func stats(for metric: (TurnTimeline) -> TimeInterval?) -> [TurnTimeline.Cohort: Stats] {
+        var byCohort: [TurnTimeline.Cohort: [TimeInterval]] = [:]
+        for timeline in sealed {
+            guard let value = metric(timeline) else { continue }
+            byCohort[timeline.cohort, default: []].append(value)
+        }
+        return byCohort.mapValues(Self.summarize)
+    }
+
+    /// `stats(for: \.perceivedLatency)` — the headline metric, pre-aggregated, named for what the
+    /// panel leads with rather than for the key path that computes it.
+    var perceivedLatencyByCohort: [TurnTimeline.Cohort: Stats] { stats(for: \.perceivedLatency) }
+
+    private static func summarize(_ values: [TimeInterval]) -> Stats {
+        let sorted = values.sorted()
+        let mean = sorted.reduce(0.0, +) / Double(sorted.count)
+        let mid = sorted.count / 2
+        let median = sorted.count.isMultiple(of: 2) ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid]
+        return Stats(count: sorted.count, median: median, mean: mean)
+    }
+
+    // MARK: - Debug export
+
+    /// Plain-text dump of the sealed history plus per-cohort perceived-latency stats, for the
+    /// Settings → Advanced → Developer "copy diagnostics" action. Text, not JSON: nothing parses
+    /// this back, a developer reads it, so legibility wins (see also Plan CU P1 item 5 — no sink, no
+    /// push; this on-device export is the entire surface).
+    func debugExport(now: Date = Date()) -> String {
+        var lines = [
+            "OpenGlasses turn ledger — \(sealed.count) turns sealed, \(inFlightCount) in flight " +
+            "(cap \(maxCount) turns / \(maxBytes) bytes)",
+            "Exported \(ISO8601DateFormatter().string(from: now))",
+            "",
+        ]
+
+        for timeline in sealed {
+            var line = "\(timeline.id.uuidString.prefix(8))  \(Self.cohortLabel(timeline.cohort))"
+            if let seconds = timeline.perceivedLatency { line += "  perceived=\(Self.formatSeconds(seconds))" }
+            if timeline.abandoned { line += "  ABANDONED" }
+            if timeline.interrupted { line += "  INTERRUPTED" }
+            lines.append(line)
+        }
+
+        lines.append("")
+        lines.append("Perceived latency by cohort (median / mean / n):")
+        let byCohort = perceivedLatencyByCohort
+        if byCohort.isEmpty {
+            lines.append("  (no sealed turn has reached first audio yet)")
+        }
+        for (cohort, stat) in byCohort.sorted(by: { Self.cohortLabel($0.key) < Self.cohortLabel($1.key) }) {
+            lines.append("  \(Self.cohortLabel(cohort)): median=\(Self.formatSeconds(stat.median))  " +
+                         "mean=\(Self.formatSeconds(stat.mean))  n=\(stat.count)")
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func cohortLabel(_ cohort: TurnTimeline.Cohort) -> String {
+        "\(cohort.backend?.label ?? "unknown")/\(cohort.ttsEngine?.rawValue ?? "unknown")/" +
+        "\(cohort.micRoute?.rawValue ?? "unknown")"
+    }
+
+    private static func formatSeconds(_ seconds: TimeInterval) -> String {
+        String(format: "%.2fs", seconds)
+    }
+}

--- a/OpenGlasses/Sources/Services/Diagnostics/TurnRecorder.swift
+++ b/OpenGlasses/Sources/Services/Diagnostics/TurnRecorder.swift
@@ -1,0 +1,387 @@
+import AVFoundation
+import Foundation
+
+/// Plan CU P1 — the seam between the live turn path and `TurnLedger`.
+///
+/// `TurnTimeline` is pure and `TurnLedger` is a store; neither knows which turn is happening right
+/// now, and the turn path has no way to tell them. The marks come from a dozen sites that cannot
+/// hand an id to one another: `TextToSpeechService` is a singleton that is passed a string,
+/// `GlassesDisplayService` drains a latest-wins render queue, `runToolLoop` is deliberately
+/// provider-neutral. This holds the one id they all mean, so each of those sites is a single
+/// statement instead of a new parameter threaded through four layers.
+///
+/// **Everything here is instrumentation and behaves like it.** Every entry point returns on its
+/// first line when recording is off or no turn is in flight; nothing throws; nothing suspends
+/// (every call site is already on the main actor); no call reads or writes state the turn path
+/// depends on. A voice turn must not be able to fail *because* we were measuring it.
+///
+/// One turn at a time, which is what the app already enforces through `isProcessing` /
+/// `TurnAdmissionPolicy`. `beginTurn()` seals whatever was still open rather than trusting every
+/// exit path in `handleTranscription` to have been found.
+@MainActor
+enum TurnRecorder {
+
+    /// How the live mic route is read. A named type because it is both a stored seam and a
+    /// parameter of `reset(ledger:now:micRoutePorts:)`.
+    typealias MicRoutePortsReader = () -> [(name: String, type: AVAudioSession.Port)]
+
+    /// The ledger every mark lands in, and the object the Developer panel observes.
+    ///
+    /// A `var` for one reason: the decisions below — which utterance a turn claims, the staleness
+    /// ceilings, the hand-off window — are only testable against a ledger the test owns. Production
+    /// never reassigns it; `TurnLedger.shared` is this object.
+    static var ledger = TurnLedger()
+
+    /// Where wall-clock time enters the recorder. `TurnTimeline` is pure precisely so every
+    /// derivation is a fixture test; this is the matching seam for the recorder's own arithmetic,
+    /// which is otherwise only reachable by sleeping in a test.
+    static var now: () -> Date = { Date() }
+
+    /// The session's current input ports, as `MicRoutePolicy.resolvedRoute(from:)` wants them.
+    static var micRoutePorts: MicRoutePortsReader = liveMicRoutePorts
+
+    static let liveMicRoutePorts: MicRoutePortsReader = {
+        AVAudioSession.sharedInstance().currentRoute.inputs.map { (name: $0.portName, type: $0.portType) }
+    }
+
+    /// Work the app started for itself — a scheduled agent run, notification triage, a background
+    /// summarisation — rather than for the turn in flight.
+    ///
+    /// These traverse the very code a turn does (`LLMService.sendMessage`, `runToolLoop`), so an
+    /// unguarded tag or span written from one of them lands on whichever turn happens to be open: a
+    /// scheduled Groq run re-tags a live on-device turn into the Groq cohort, and a background tool
+    /// loop adds its seconds to that turn's `toolSeconds` until `modelSeconds` clamps to 0.00 s and
+    /// reads as "the model took no time at all". A task-local rather than a flag because the two
+    /// overlap *in time* on the same actor — which task the work runs on is the only thing that
+    /// tells them apart.
+    @TaskLocal static var isOffTurnWork = false
+
+    /// Run `body` as off-turn work: nothing inside it can mark, tag, or accumulate onto the turn in
+    /// flight. Wrap the app's own background completions in this; the turn path never does.
+    static func offTurn<T>(_ body: () async throws -> T) async rethrows -> T {
+        try await $isOffTurnWork.withValue(true) { try await body() }
+    }
+
+    /// Recording is on by default: the ledger is a bounded ring buffer with no sink at all (Plan CU
+    /// P1 item 5), so leaving it on costs a few hundred bytes per turn, and a panel that stays empty
+    /// until someone finds a switch measures nothing. Off makes every call below return immediately.
+    static var isEnabled: Bool {
+        get { enabled }
+        set {
+            enabled = newValue
+            UserDefaults.standard.set(newValue, forKey: enabledKey)
+            if !newValue {
+                endTurn()
+                pendingSpeechEndAt = nil
+                pendingHeld = nil
+            }
+        }
+    }
+
+    /// Backing store, so `reset(…)` can put the recorder in a known state without writing the user's
+    /// real preference from a test.
+    private static var enabled: Bool = UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? true
+
+    private static let enabledKey = "turnLatencyRecordingEnabled"
+
+    /// The turn currently being recorded. `nil` between turns *and* whenever recording is off,
+    /// which is why the mark helpers only need to check `targetID`.
+    private static var currentID: UUID?
+
+    /// The turn a mark should land on, or `nil` when there is nothing to record: no turn in flight,
+    /// or this code path is running as off-turn work.
+    private static var targetID: UUID? { isOffTurnWork ? nil : currentID }
+
+    /// Set once per turn so the per-token `markFirstToken()` is a boolean test after the first.
+    private static var sawFirstToken = false
+
+    /// True between the turn handing its reply to the speech engine and playback ending — see
+    /// `handOffToSpeech(at:)`.
+    private static var speechHandedOff = false
+
+    /// When the mic last went quiet, waiting for the turn that will answer it.
+    private static var pendingSpeechEndAt: Date?
+
+    /// The utterance parked by `TurnAdmissionPolicy`, and when the replay that should claim it was
+    /// announced. Both halves are needed: the park time is what the turn records, while `notedAt` is
+    /// what the staleness ceiling is measured against — bounding the *park* would refuse a
+    /// legitimate 19 s hold for having been long, which is exactly the case `maxHoldAge` allows.
+    private static var pendingHeld: (parkedAt: Date, notedAt: Date)?
+
+    /// How long an unclaimed utterance stamp — a speech-end or a hold — stays attachable to the
+    /// next turn.
+    ///
+    /// A stamp is set when the utterance is ready and claimed by the turn that answers it, normally
+    /// within the same fraction of a second. But `handleTranscription` returns several times before
+    /// any turn begins: a voice command consumed by the pre-LLM chain ("stop", "next slide") leaves
+    /// a speech-end nobody claims, and a *held* utterance replayed into that same chain leaves a
+    /// hold nobody claims. With no ceiling the next turn — possibly a typed one, hours later —
+    /// inherits it and reports a preposterous perceived latency, or an hours-long wait with its own
+    /// speech-end overwritten at the begin instant. Generous enough that no real turn is ever
+    /// refused its own stamp.
+    private static let stampStaleness: TimeInterval = 30
+
+    // MARK: - The utterance, before it is a turn
+
+    /// The mic went quiet. Recorded here rather than marked on a turn because the turn does not
+    /// exist yet — `handleTranscription` may still route this utterance to the teleprompter, a
+    /// launcher, or nothing at all, and only the ones that reach a backend or the speech engine
+    /// become turns.
+    static func noteSpeechEnd(at time: Date) {
+        guard isEnabled else { return }
+        pendingSpeechEndAt = time
+    }
+
+    /// A new utterance is being captured, so any unclaimed stamp belongs to something that has
+    /// already been dealt with.
+    ///
+    /// Both stamps, not just the speech-end: a held utterance is replayed straight into
+    /// `handleTranscription` and can be consumed by the pre-LLM chain exactly as a fresh one can, and
+    /// the leftover hold would otherwise rewrite the next turn's speech-end at its own begin instant
+    /// and report the intervening minutes as `heldSeconds`.
+    static func forgetPendingUtterance() {
+        pendingSpeechEndAt = nil
+        pendingHeld = nil
+    }
+
+    /// An utterance parked by `TurnAdmissionPolicy.deferToQueue` is being replayed now. The turn it
+    /// starts owns both the park time and the wait.
+    static func noteHeldUtterance(parkedAt time: Date) {
+        guard isEnabled else { return }
+        pendingHeld = (parkedAt: time, notedAt: now())
+    }
+
+    // MARK: - Turn lifecycle
+
+    /// Start recording a turn, claiming whatever the utterance left behind.
+    ///
+    /// Seals any turn still open first. That is not tidiness: `handleTranscription` has half a dozen
+    /// early exits and the barge-in path starts a replacement turn from inside the old one's
+    /// teardown, so "the previous turn always called `endTurn()`" is an assumption that would be
+    /// wrong eventually. A displaced turn seals with exactly the marks it had.
+    static func beginTurn() {
+        guard isEnabled else { return }
+        endTurn()
+
+        let startedAt = now()
+        var timeline = TurnTimeline(micRoute: resolvedMicRoute())
+        if let held = pendingHeld, startedAt.timeIntervalSince(held.notedAt) <= stampStaleness {
+            timeline.mark(.held, at: held.parkedAt)
+            timeline.addHoldTime(startedAt.timeIntervalSince(held.parkedAt))
+            // The wearer stopped talking before the park, but this turn's own clock starts at the
+            // release. Marking speech-end back at the park would charge the hold to
+            // `perceivedLatency` and make every deferred utterance read as a slow backend;
+            // `heldSeconds` / `waitIncludingHold` carry that wait instead.
+            timeline.mark(.speechEnd, at: startedAt)
+        } else if let speechEnd = pendingSpeechEndAt,
+                  startedAt.timeIntervalSince(speechEnd) <= stampStaleness {
+            timeline.mark(.speechEnd, at: speechEnd)
+        }
+
+        pendingHeld = nil
+        pendingSpeechEndAt = nil
+        sawFirstToken = false
+        speechHandedOff = false
+        currentID = ledger.start(timeline)
+    }
+
+    /// Seal the current turn. Idempotent, so it can sit in a `finish` stage that also runs on the
+    /// error and cancellation paths.
+    static func endTurn() {
+        guard let id = currentID else { return }
+        currentID = nil
+        sawFirstToken = false
+        speechHandedOff = false
+        ledger.seal(id)
+    }
+
+    /// Seal a turn that failed before it reached a backend, handing its utterance back so the thing
+    /// about to answer the same words can claim it.
+    ///
+    /// The tier-0 direct-tool path is the case this exists for: on a tool error it falls straight
+    /// through to the normal LLM path, which begins a turn of its own. Without this the failed
+    /// attempt never seals at all (its caller clears `isProcessing` first, and the seal is gated
+    /// behind that flag) and, worse, the replacement finds the stamps already spent — so
+    /// `perceivedLatency` comes out nil on precisely the slowest turns the app has, a failed tool
+    /// call *plus* a full LLM round trip. Dropping those biases the headline aggregate fast, which
+    /// is the mirror image of the bias tier-0 recording was added to prevent.
+    static func abandonTurnReleasingUtterance() {
+        noteAbandoned()
+        if let id = currentID, let timeline = ledger.turn(id) {
+            pendingSpeechEndAt = timeline.speechEndAt
+            if let heldAt = timeline.heldAt {
+                pendingHeld = (parkedAt: heldAt, notedAt: now())
+            }
+        }
+        endTurn()
+    }
+
+    // MARK: - Marks
+
+    static func mark(_ stage: TurnTimeline.Stage, at time: Date? = nil) {
+        guard let id = targetID else { return }
+        ledger.mark(id, stage, at: time ?? now())
+    }
+
+    /// Record the turn's first streamed token.
+    ///
+    /// Separate from `mark(.firstToken)` because this one is called on every delta of a fast stream,
+    /// and the timeline's own first-wins check sits behind a dictionary lookup and a struct copy.
+    /// The local flag makes every token after the first a single boolean test.
+    static func markFirstToken() {
+        guard !sawFirstToken, targetID != nil else { return }
+        sawFirstToken = true
+        mark(.firstToken)
+    }
+
+    // MARK: - Tags and accumulated spans
+
+    /// Apply an arbitrary mutation to the current turn — the escape hatch for anything
+    /// `TurnTimeline`'s own mutating API already expresses.
+    static func update(_ mutate: (inout TurnTimeline) -> Void) {
+        guard let id = targetID else { return }
+        ledger.update(id, mutate)
+    }
+
+    /// Which pipeline and which model are about to serve this turn.
+    ///
+    /// Read at dispatch, never afterwards: `sendMessageCascading` restores the pre-turn active model
+    /// in a `defer` before it returns, so anything that asks *after* the turn names the model that
+    /// did not answer. Tags are last-wins, so a cascade's final attempt is the one that sticks —
+    /// which is also why `update`'s off-turn gate matters here more than anywhere else: this is the
+    /// cohort key, and a background completion re-tagging it files the turn under a backend that
+    /// never served it.
+    static func noteBackend(_ backend: TurnBackend, model: String?) {
+        update {
+            $0.backend = backend
+            $0.model = model
+        }
+    }
+
+    /// Seconds spent waiting on a frame from the glasses, timed from `start`.
+    static func addFrameGrabTime(since start: Date) {
+        update { $0.addFrameGrabTime(now().timeIntervalSince(start)) }
+    }
+
+    /// One tool round trip, timed from `start`.
+    static func addToolTime(since start: Date) {
+        update { $0.addToolTime(now().timeIntervalSince(start)) }
+    }
+
+    /// App-side work inside the backend leg — a spoken model-switch notice, a cold location fix —
+    /// timed from `start`. See `TurnTimeline.nonModelSeconds` for why it is held apart.
+    static func addNonModelTime(since start: Date) {
+        update { $0.addNonModelTime(now().timeIntervalSince(start)) }
+    }
+
+    /// One generation pass as the backend reported it — the only pair `tokensPerSecond` accepts.
+    static func addGeneration(tokens: Int, seconds: TimeInterval) {
+        update { $0.addGeneration(tokens: tokens, seconds: seconds) }
+    }
+
+    /// The turn never delivered: a backend error, a cancellation, a supersession.
+    static func noteAbandoned() {
+        update { $0.abandoned = true }
+    }
+
+    /// The wearer barged in over playback.
+    static func noteInterrupted() {
+        update { $0.interrupted = true }
+    }
+
+    // MARK: - Speech hand-off
+    //
+    // The speech marks cannot simply hang off `TextToSpeechService.speak`, because a turn speaks
+    // more than its reply: `narrateModelSwitch` says "switching to Groq" while the model is still
+    // generating, and that utterance would claim `firstAudio` — the exact mark the headline metric
+    // ends at, and the one every stage before it is measured against. So the turn path opens a
+    // window when it hands *the reply* to the engine, and the TTS and HUD marks below only land
+    // while that window is open.
+
+    /// The turn's reply is going to the speech engine now.
+    static func handOffToSpeech(at time: Date? = nil) {
+        guard targetID != nil else { return }
+        speechHandedOff = true
+        mark(.ttsRequested, at: time)
+    }
+
+    /// Which engine of the ElevenLabs → Kokoro → iOS chain actually spoke. Not the configured
+    /// preference: any engine in the chain can fall through to the next at runtime (no network, no
+    /// quota, no model), and a cloud round trip and an on-device synthesis are not comparable
+    /// numbers.
+    static func noteSpeechEngine(_ engine: TTSEngine) {
+        guard speechHandedOff else { return }
+        update { $0.ttsEngine = engine }
+    }
+
+    /// Audio started reaching the wearer — where `perceivedLatency` ends.
+    static func markPlaybackStart(at time: Date) {
+        guard speechHandedOff else { return }
+        mark(.firstAudio, at: time)
+    }
+
+    /// Playback finished.
+    ///
+    /// Does *not* close the hand-off window — `beginTurn`/`endTurn` do that. The HUD mirror is
+    /// enqueued at the top of `speak` but rendered by a queue that can be slower than the audio it
+    /// accompanies, and closing here would drop the lens mark on exactly the slow link that made it
+    /// worth measuring. Every mark inside the window is first-wins, so leaving it open until the
+    /// turn ends costs nothing.
+    static func markPlaybackEnd(at time: Date) {
+        guard speechHandedOff else { return }
+        mark(.spokeDone, at: time)
+    }
+
+    /// The reply reached the lens. Marked where content actually reaches the display backend, not
+    /// where it was requested — the render queue is latest-wins, so a requested frame can be
+    /// superseded and never rendered at all.
+    static func markHUDRendered(at time: Date) {
+        guard speechHandedOff else { return }
+        mark(.hudRendered, at: time)
+    }
+
+    // MARK: - Internals
+
+    /// Which mic route this turn is actually being captured on.
+    ///
+    /// Not `Config.micRoute`: that is a preference, and `WakeWordService.preferConfiguredMicIfAvailable`
+    /// leaves capture on the phone whenever the preferred port is absent — glasses flat, asleep, or
+    /// out of range — and says so in the log. Tagging those turns `.glasses` would put 8 kHz HFP
+    /// samples and 48 kHz phone-mic ones in one cohort and report a median describing neither, which
+    /// is the pooling `TurnTimeline.Cohort` exists to make impossible. The session's live input is
+    /// the observation; the preference is the fallback only when there is no input port to read.
+    private static func resolvedMicRoute() -> MicRoute? {
+        MicRoutePolicy.resolvedRoute(from: micRoutePorts()) ?? Config.micRoute
+    }
+
+    /// Point the recorder at a ledger, clock, and route the caller controls, and drop every scrap of
+    /// per-turn state. Tests only.
+    ///
+    /// The recorder's own decisions are the half of Plan CU P1 that determines whether the pure
+    /// core's invariants mean anything in production — which utterance a turn claims, the staleness
+    /// ceilings, the hand-off window that stops a model-switch notice claiming `firstAudio`. None of
+    /// them is reachable without a way to start from a known state, and every one of them can be
+    /// mutated away with the whole suite still green if it is not pinned.
+    /// Each argument is optional rather than defaulted to the production value because a default
+    /// argument is evaluated outside the main actor, and both of those values are isolated to it.
+    static func reset(ledger: TurnLedger? = nil,
+                      now: (() -> Date)? = nil,
+                      micRoutePorts: MicRoutePortsReader? = nil) {
+        self.ledger = ledger ?? TurnLedger()
+        self.now = now ?? { Date() }
+        self.micRoutePorts = micRoutePorts ?? liveMicRoutePorts
+        enabled = true
+        currentID = nil
+        sawFirstToken = false
+        speechHandedOff = false
+        pendingSpeechEndAt = nil
+        pendingHeld = nil
+    }
+}
+
+extension TurnLedger {
+    /// The app's one ledger, under the name a view reaches for. Same object as
+    /// `TurnRecorder.ledger` — the recorder owns it, because a ledger with no recorder writing to
+    /// it is an empty panel.
+    static var shared: TurnLedger { TurnRecorder.ledger }
+}

--- a/OpenGlasses/Sources/Services/Diagnostics/TurnTimeline.swift
+++ b/OpenGlasses/Sources/Services/Diagnostics/TurnTimeline.swift
@@ -1,0 +1,417 @@
+import Foundation
+
+/// Which pipeline answered a turn (Plan CU P1 tag).
+///
+/// Direct mode carries its provider because a Groq turn and an on-device MLX turn share the code
+/// path and nothing else. The two realtime backends are separate cases rather than providers
+/// because they endpoint server-side — their `commitAt` means something different, and pooling
+/// them with Direct mode would average away the one comparison worth having.
+enum TurnBackend: Hashable {
+    case direct(LLMProvider)
+    /// **Not produced yet.** `GeminiLiveSessionManager` has no turn boundaries wired to
+    /// `TurnRecorder`, so no realtime turn is recorded and this case is unreachable in the app.
+    /// Kept — with the grouping rule that goes with it — because P1's deliverable is the taxonomy,
+    /// and the Direct-vs-realtime comparison the plan calls "the most useful baseline we have"
+    /// needs the case to exist before the session managers can be taught to fill it.
+    case geminiLive
+    /// **Not produced yet** — see `geminiLive`.
+    case openAIRealtime
+
+    /// Compact form. This is a grouping key before it is a label, so it stays stable and terse.
+    var label: String {
+        switch self {
+        case .direct(let provider): return provider.rawValue
+        case .geminiLive: return "geminiLive"
+        case .openAIRealtime: return "openAIRealtime"
+        }
+    }
+}
+
+/// Plan CU P1 — the marks of one voice turn, and the durations derived from them.
+///
+/// We could not previously verify a single latency claim about this app: `SubsystemTestRunner`
+/// covers cold-start probes and nothing measured a live turn. Slowness was attributed by feel, and
+/// feel gets this exactly wrong — a fixed endpointing window is identical on every turn, so it
+/// reads as "the app's speed" rather than as one stage you could delete.
+///
+/// Pure value type: no `Date()` inside, no I/O, no singletons. Time is injected at every mark, so
+/// each derivation below is a fixture test rather than a stopwatch session.
+///
+/// **Every stage is optional and stays optional.** A turn can stop anywhere — barge-in,
+/// supersession, a backend error — and the partial timeline is still the most informative thing we
+/// have about that turn. Nothing here requires a turn to have finished, or even to have spoken.
+struct TurnTimeline: Identifiable, Equatable {
+
+    /// The nine marks, in canonical order. `allCases` *is* that order, so a panel can walk it.
+    enum Stage: String, CaseIterable {
+        /// Utterance parked by `TurnAdmissionPolicy.deferToQueue` while another turn was in flight.
+        case held
+        /// The mic went quiet — the end-of-turn decision point, and where perceived latency starts.
+        case speechEnd
+        /// Handed to a backend.
+        case commit
+        /// The backend produced its first output — *"is the model slow?"*
+        case firstToken
+        /// The model finished the reply.
+        case generationDone
+        /// Text handed to the speech engine.
+        case ttsRequested
+        /// The wearer actually hears something — perceived latency ends here.
+        case firstAudio
+        /// The reply mirrored to the lens.
+        case hudRendered
+        /// Playback finished.
+        case spokeDone
+
+        var label: String {
+            switch self {
+            case .held: return "Held"
+            case .speechEnd: return "Speech end"
+            case .commit: return "Commit"
+            case .firstToken: return "First token"
+            case .generationDone: return "Generation done"
+            case .ttsRequested: return "TTS requested"
+            case .firstAudio: return "First audio"
+            case .hudRendered: return "HUD rendered"
+            case .spokeDone: return "Playback done"
+            }
+        }
+    }
+
+    /// The tuple aggregates are grouped by, and the reason the ledger never reports a pooled mean.
+    ///
+    /// An 8 kHz Bluetooth HFP mic and the phone's 48 kHz mic are two populations for every timing
+    /// here. So are a cloud TTS whose first byte crosses a network and an on-device one that
+    /// synthesises on the GPU — and Kokoro on the GPU measurably slows local decode, so even tok/s
+    /// is comparable only *within* one engine. An average across them describes neither.
+    struct Cohort: Hashable {
+        let backend: TurnBackend?
+        let ttsEngine: TTSEngine?
+        let micRoute: MicRoute?
+    }
+
+    /// One gap between consecutive marks, labelled by the stage it ends at.
+    struct Segment: Equatable, Identifiable {
+        let stage: Stage
+        let seconds: TimeInterval
+        var id: Stage { stage }
+    }
+
+    let id: UUID
+
+    // MARK: - Marks
+    //
+    // Marks are **first-wins**: `mark(.firstToken, …)` called on every streamed delta records only
+    // the first, which is the one every derivation here is about. The tags below are last-wins for
+    // the opposite reason — a model name or a TTS engine is a fact about the turn that is often
+    // only settled once the fallback chain has stopped falling back.
+
+    private(set) var heldAt: Date?
+    private(set) var speechEndAt: Date?
+    private(set) var commitAt: Date?
+    private(set) var firstTokenAt: Date?
+    private(set) var generationDoneAt: Date?
+    private(set) var ttsRequestedAt: Date?
+    private(set) var firstAudioAt: Date?
+    private(set) var hudRenderedAt: Date?
+    private(set) var spokeDoneAt: Date?
+
+    // MARK: - Tags
+
+    var backend: TurnBackend?
+    var model: String?
+    var ttsEngine: TTSEngine?
+    var micRoute: MicRoute?
+
+    /// The turn never delivered — a backend error, a supersession, a wearer who walked away.
+    var abandoned: Bool
+    /// The wearer barged in over playback. Deliberately distinct from `abandoned`: this turn worked
+    /// and its stage times are sound data, the wearer simply stopped wanting the rest of it.
+    var interrupted: Bool
+
+    // MARK: - Accumulated spans
+    //
+    // These sit *inside* the marked stages and have to be visible separately, or the marks lie
+    // about the most common turn shapes we have.
+
+    /// Seconds spent waiting on a frame from the glasses. Falls inside commit → firstToken.
+    private(set) var frameGrabSeconds: TimeInterval
+    /// Seconds spent executing tools, accumulated across the whole tool loop.
+    private(set) var toolSeconds: TimeInterval
+    /// How many tool round trips this turn took.
+    private(set) var toolIterations: Int
+    /// Seconds this utterance spent parked by `TurnAdmissionPolicy` before its own turn began.
+    private(set) var heldSeconds: TimeInterval
+    /// Seconds inside the backend leg that the app spent on its own work rather than on the model.
+    ///
+    /// Two contributors today, and the rule generalises to any third: the spoken model-switch
+    /// notice (`narrateModelSwitch` blocks until the whole "switching to Groq" utterance has
+    /// *played*, 2–4 s, mid-cascade) and the cold location fix (up to 1.5 s, after commit and
+    /// before the backend is touched). Neither is a tool call and neither is a frame grab, so
+    /// without a bucket of their own they land in `modelSeconds` and in TTFT and read as a slow
+    /// model — the same mis-attribution `toolSeconds` exists to prevent, one layer over, and it
+    /// fires exactly when someone is looking at the panel. **Any `await` between `commit` and the
+    /// backend call that isn't the model belongs here.**
+    private(set) var nonModelSeconds: TimeInterval
+
+    /// Output tokens as **reported by the backend**, accumulated across every generation pass.
+    private(set) var tokenCount: Int
+    /// Decode time as **reported by the backend**, accumulated across every generation pass.
+    ///
+    /// Not the same quantity as the mark-derived `modelSeconds`, and never interchangeable with it:
+    /// this one pairs with `tokenCount` and is the only input `tokensPerSecond` will accept.
+    private(set) var generationSeconds: TimeInterval
+
+    init(id: UUID = UUID(),
+         backend: TurnBackend? = nil,
+         model: String? = nil,
+         ttsEngine: TTSEngine? = nil,
+         micRoute: MicRoute? = nil,
+         abandoned: Bool = false,
+         interrupted: Bool = false) {
+        self.id = id
+        self.backend = backend
+        self.model = model
+        self.ttsEngine = ttsEngine
+        self.micRoute = micRoute
+        self.abandoned = abandoned
+        self.interrupted = interrupted
+        self.frameGrabSeconds = 0
+        self.toolSeconds = 0
+        self.toolIterations = 0
+        self.heldSeconds = 0
+        self.nonModelSeconds = 0
+        self.tokenCount = 0
+        self.generationSeconds = 0
+    }
+
+    // MARK: - Recording
+
+    /// Record `stage` at `time`. First-wins — a repeated mark is a later event of the same kind,
+    /// and the first is the one the metric names.
+    mutating func mark(_ stage: Stage, at time: Date) {
+        switch stage {
+        case .held: if heldAt == nil { heldAt = time }
+        case .speechEnd: if speechEndAt == nil { speechEndAt = time }
+        case .commit: if commitAt == nil { commitAt = time }
+        case .firstToken: if firstTokenAt == nil { firstTokenAt = time }
+        case .generationDone: if generationDoneAt == nil { generationDoneAt = time }
+        case .ttsRequested: if ttsRequestedAt == nil { ttsRequestedAt = time }
+        case .firstAudio: if firstAudioAt == nil { firstAudioAt = time }
+        case .hudRendered: if hudRenderedAt == nil { hudRenderedAt = time }
+        case .spokeDone: if spokeDoneAt == nil { spokeDoneAt = time }
+        }
+    }
+
+    /// Record one generation pass's reported output.
+    ///
+    /// Tokens and their window travel in one call because separating them *is* the bug. A tool turn
+    /// runs the model more than once, and an API that lets a caller add pass 2's tokens without
+    /// pass 2's window will eventually be called exactly that way — which is how a turn ends up
+    /// reporting pass 2's token count over pass 1's time. Both accumulate, so `tokensPerSecond`
+    /// always divides the whole turn's tokens by the whole turn's decode time.
+    mutating func addGeneration(tokens: Int, seconds: TimeInterval) {
+        tokenCount += max(0, tokens)
+        generationSeconds += max(0, seconds)
+    }
+
+    /// Record one tool round trip. `iterations` defaults to one because the common case is one call
+    /// per round trip; pass the real count when a round trip fanned out.
+    mutating func addToolTime(_ seconds: TimeInterval, iterations: Int = 1) {
+        toolSeconds += max(0, seconds)
+        toolIterations += max(0, iterations)
+    }
+
+    /// Record time spent waiting on a frame. Accumulates — a multi-image turn grabs more than one.
+    mutating func addFrameGrabTime(_ seconds: TimeInterval) {
+        frameGrabSeconds += max(0, seconds)
+    }
+
+    /// Record time this utterance spent parked by `TurnAdmissionPolicy`.
+    ///
+    /// Recorded rather than derived from `heldAt → speechEndAt`, because the release is where the
+    /// duration is exactly known and an abandoned turn can lose either mark without losing the fact
+    /// that it waited.
+    mutating func addHoldTime(_ seconds: TimeInterval) {
+        heldSeconds += max(0, seconds)
+    }
+
+    /// Record app-side work that ran inside the backend leg. Accumulates — a cascade can narrate
+    /// once and still have waited on a location fix before it started.
+    mutating func addNonModelTime(_ seconds: TimeInterval) {
+        nonModelSeconds += max(0, seconds)
+    }
+
+    // MARK: - Access
+
+    /// The mark for `stage`, or `nil` if it never landed.
+    subscript(stage: Stage) -> Date? {
+        switch stage {
+        case .held: return heldAt
+        case .speechEnd: return speechEndAt
+        case .commit: return commitAt
+        case .firstToken: return firstTokenAt
+        case .generationDone: return generationDoneAt
+        case .ttsRequested: return ttsRequestedAt
+        case .firstAudio: return firstAudioAt
+        case .hudRendered: return hudRenderedAt
+        case .spokeDone: return spokeDoneAt
+        }
+    }
+
+    /// The turn's place on the wall clock: the first mark in canonical order that landed.
+    var startedAt: Date? {
+        Stage.allCases.compactMap { self[$0] }.first
+    }
+
+    var cohort: Cohort {
+        Cohort(backend: backend, ttsEngine: ttsEngine, micRoute: micRoute)
+    }
+
+    /// The landed marks reduced to consecutive gaps — the panel's stage breakdown.
+    ///
+    /// Stages that never landed are absorbed into the following segment rather than reported as
+    /// zero. A non-streaming backend has no first token of its own, and a zero-width bar there
+    /// would read as *"that stage was instant"* when it means *"we never saw it"*. Segments stay
+    /// signed so a backwards mark shows up in the breakdown instead of being quietly smoothed away.
+    var segments: [Segment] {
+        var result: [Segment] = []
+        var previous: Date?
+        for stage in Stage.allCases {
+            guard let at = self[stage] else { continue }
+            if let previous {
+                result.append(Segment(stage: stage, seconds: at.timeIntervalSince(previous)))
+            }
+            previous = at
+        }
+        return result
+    }
+
+    // MARK: - Derived: the headline
+
+    /// **speechEnd → firstAudio.** Everything inside it is dead air from the wearer's point of
+    /// view, and it is the number Plan CU exists to move.
+    ///
+    /// Measured from *this turn's* speech end, never from `heldAt`. A deferred utterance was parked
+    /// before its own turn began, so charging that wait to the pipeline would make every held turn
+    /// look like a backend problem. `heldSeconds` and `waitIncludingHold` carry it separately.
+    var perceivedLatency: TimeInterval? { Self.span(speechEndAt, firstAudioAt) }
+
+    /// What the wearer actually waited when their words were parked: the hold plus this turn's own
+    /// latency. Reported *next to* `perceivedLatency`, never instead of it — one is the wearer's
+    /// experience, the other is what the pipeline is answerable for.
+    var waitIncludingHold: TimeInterval? {
+        guard let perceived = perceivedLatency else { return nil }
+        return heldSeconds + perceived
+    }
+
+    // MARK: - Derived: stage spans
+
+    /// speechEnd → commit. Today this is almost entirely the silence window
+    /// (`SpeechContinuationPolicy.baseWindow`) — the fixed floor P2 exists to remove.
+    var endpointingDelay: TimeInterval? { Self.span(speechEndAt, commitAt) }
+
+    /// commit → firstToken, **including** any frame grab. Deliberately uncorrected: this is what
+    /// the turn cost. Ask `modelTimeToFirstToken` about the model alone.
+    var timeToFirstToken: TimeInterval? { Self.span(commitAt, firstTokenAt) }
+
+    /// `timeToFirstToken` with the frame grab and the app's own work taken back out.
+    ///
+    /// A vision turn waits on the glasses' Bluetooth stream between commit and first token, so its
+    /// raw TTFT contains seconds the model never saw. Compare that against a text turn's TTFT and
+    /// the conclusion is *"the vision model is slow"* — the wrong model, and then the wrong fix.
+    /// `nonModelSeconds` comes out for the same reason: a cold location fix or a spoken model-switch
+    /// notice sits in the same window and belongs to neither the radio nor the model. Floored at
+    /// zero: a negative here means the accounting overlapped the window, not that the model answered
+    /// before it was asked.
+    var modelTimeToFirstToken: TimeInterval? {
+        guard let ttft = timeToFirstToken else { return nil }
+        return max(0, ttft - frameGrabSeconds - nonModelSeconds)
+    }
+
+    /// commit → generationDone: the whole backend leg, tool round trips and frame grab included.
+    var backendSeconds: TimeInterval? { Self.span(commitAt, generationDoneAt) }
+
+    /// `backendSeconds` with the non-model work removed — tool execution, the frame grab, and the
+    /// app's own work inside the leg.
+    ///
+    /// We have 36+ native tools behind `ToolLoopDriver`, so one turn is routinely several LLM round
+    /// trips with execution between them. Uncorrected, a turn that spent four seconds inside a
+    /// HomeKit call reports four seconds of model latency and we go and optimise the model.
+    var modelSeconds: TimeInterval? {
+        guard let backend = backendSeconds else { return nil }
+        return max(0, backend - toolSeconds - frameGrabSeconds - nonModelSeconds)
+    }
+
+    /// generationDone → firstAudio, **signed on purpose**.
+    ///
+    /// Negative is the good case: speech started while the model was still generating, which is the
+    /// entire point of sentence-streaming TTS. Every other span here clamps a backwards result to
+    /// `nil`, because backwards usually means clock skew. This one must not — clamping would delete
+    /// the metric on exactly the turns it exists to characterise, and "no lead-in recorded" would
+    /// be indistinguishable from "TTS never started".
+    ///
+    /// **Not reachable as the app is wired today, and that is worth saying out loud.** Every Direct
+    /// mode spine hands the *whole* reply to the speech engine after `generationDone`, and
+    /// `TurnRecorder.markPlaybackStart` only accepts audio once that hand-off has happened — so
+    /// every recorded turn currently reports a positive lead-in. The signed form is kept because it
+    /// is the metric a streaming hand-off is judged by, not because P1 can already produce one;
+    /// reading a panel full of positives as "sentence streaming is off" would be the wrong
+    /// conclusion from the right number.
+    var ttsLeadIn: TimeInterval? {
+        guard let from = generationDoneAt, let to = firstAudioAt else { return nil }
+        return to.timeIntervalSince(from)
+    }
+
+    /// ttsRequested → firstAudio — *how slow is synthesis?*, which is a different question from
+    /// `ttsLeadIn` and answered by a different pair of marks.
+    ///
+    /// On a streamed reply the first sentence reaches the engine long before generation ends, so
+    /// lead-in goes negative while this stays firmly positive. Reading either one as the other is
+    /// the mistake the separation exists to prevent.
+    var ttsTimeToFirstByte: TimeInterval? { Self.span(ttsRequestedAt, firstAudioAt) }
+
+    /// firstAudio → spokeDone.
+    var playbackSeconds: TimeInterval? { Self.span(firstAudioAt, spokeDoneAt) }
+
+    /// speechEnd → hudRendered: `perceivedLatency` for the wearer reading the lens rather than
+    /// listening. On Display glasses the two channels can diverge by seconds.
+    var hudLatency: TimeInterval? { Self.span(speechEndAt, hudRenderedAt) }
+
+    /// speechEnd → spokeDone: the turn end to end.
+    var totalSeconds: TimeInterval? { Self.span(speechEndAt, spokeDoneAt) }
+
+    // MARK: - Derived: generation rate
+
+    /// Below this, a decode window is not a measurement.
+    ///
+    /// Not a filter on fast turns — even a local pass that emits four tokens occupies far more than
+    /// this. It catches the window that is effectively zero, where the division reports millions of
+    /// tokens per second and someone believes it.
+    static let minimumRateWindow: TimeInterval = 0.05
+
+    /// Tokens per second, from the backend-reported pair only: `tokenCount` over
+    /// `generationSeconds`, both accumulated across every pass of the turn.
+    ///
+    /// **Never from the marks.** Marks are first-wins and get backfilled for non-streaming
+    /// backends, so a rate taken from `firstTokenAt → generationDoneAt` can silently cover a
+    /// different span than the tokens it divides. Two failure modes live here and each costs a bug
+    /// to learn: a microsecond window dividing into millions of tok/s, and pass 2's token count
+    /// paired with pass 1's window. Accumulation defeats the second, `minimumRateWindow` the first.
+    /// Returning `nil` is the point — **no rate is better than a fictional one.**
+    var tokensPerSecond: Double? {
+        guard tokenCount > 0, generationSeconds >= Self.minimumRateWindow else { return nil }
+        return Double(tokenCount) / generationSeconds
+    }
+
+    // MARK: - Internals
+
+    /// Clamps a backwards span to `nil`. These marks sit on the wall clock and the wall clock can
+    /// step backwards, so a negative span is far likelier to be skew or an out-of-order mark than a
+    /// real ordering. `ttsLeadIn` is the one deliberate exception and computes its own.
+    private static func span(_ from: Date?, _ to: Date?) -> TimeInterval? {
+        guard let from, let to else { return nil }
+        let seconds = to.timeIntervalSince(from)
+        return seconds >= 0 ? seconds : nil
+    }
+}

--- a/OpenGlasses/Sources/Services/Flow/ConversationTurnRunner.swift
+++ b/OpenGlasses/Sources/Services/Flow/ConversationTurnRunner.swift
@@ -40,8 +40,15 @@ enum ConversationTurnRunner {
 
     @MainActor
     static func run(_ deps: Deps) async {
+        // Plan CU P1: this spine is where `commit` and `generationDone` are honest for every
+        // backend at once. Deliberately not inside `runToolLoop` — auxiliary completions
+        // (classification, history summarisation) run through that same loop *during* a turn, and
+        // first-wins marks would hand the turn its neighbour's timings.
+        TurnRecorder.beginTurn()
         do {
+            TurnRecorder.mark(.commit)
             let raw = try await deps.send()
+            TurnRecorder.mark(.generationDone)
             // `postProcess` can persist memory and inject prompt state, so a response cancelled
             // while in flight must not reach it.
             try Task.checkCancellation()
@@ -51,10 +58,13 @@ enum ConversationTurnRunner {
             try Task.checkCancellation()
             await deps.accept(response)
             try Task.checkCancellation()
+            TurnRecorder.handOffToSpeech()
             await deps.speak(response)
         } catch is CancellationError {
+            TurnRecorder.noteAbandoned()
             deps.onCancelled()
         } catch {
+            TurnRecorder.noteAbandoned()
             // URLSession/provider SDKs can surface their own error after the parent task was
             // cancelled. The interruption wins: do not speak an error after a user barge-in.
             if Task.isCancelled {
@@ -64,5 +74,6 @@ enum ConversationTurnRunner {
             }
         }
         await deps.finish()
+        TurnRecorder.endTurn()
     }
 }

--- a/OpenGlasses/Sources/Services/GlassesDisplayService.swift
+++ b/OpenGlasses/Sources/Services/GlassesDisplayService.swift
@@ -278,6 +278,11 @@ final class GlassesDisplayService: ObservableObject {
                                 try await self.activeBackend.showContent(
                                     title: content.title, body: content.body, icon: content.icon)
                                 self.isDisplayActive = true
+                                // Plan CU P1: marked here, where content reaches the backend, not
+                                // where it was requested. The queue above is latest-wins, so a
+                                // requested frame can be superseded and never render at all — a
+                                // missing `hudRenderedAt` is that, not a missing mark call.
+                                TurnRecorder.markHUDRendered(at: Date())
                             case .clear:
                                 try await self.activeBackend.clear()
                             }

--- a/OpenGlasses/Sources/Services/LLM/ToolLoopDriver.swift
+++ b/OpenGlasses/Sources/Services/LLM/ToolLoopDriver.swift
@@ -136,6 +136,13 @@ func runToolLoop(
 
         adapter.appendAssistantToolCall(turn)
 
+        // Plan CU P1: one round trip's execution, held apart from the model's own time. With 36+
+        // native tools behind this loop, a turn that spent four seconds inside a HomeKit call
+        // otherwise reports four seconds of model latency and we go and optimise the model. The
+        // `defer` covers the yield-to-human return below as well as the normal exit.
+        let toolsStartedAt = Date()
+        defer { TurnRecorder.addToolTime(since: toolsStartedAt) }
+
         var outcomes: [ToolDispatchOutcome] = []
         for call in turn.toolCalls {
             let outcome = await adapter.dispatcher.dispatch(call)

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -481,6 +481,12 @@ class LLMService: ObservableObject {
         }
 
         let provider = modelConfig.llmProvider
+        // Plan CU P1: tag the turn with the model that is about to serve it, read here rather than
+        // afterwards. `sendMessageCascading` restores the pre-turn active model in a `defer` before
+        // it returns, so anything that asks once the turn is over names the model that didn't
+        // answer. Tags are last-wins, so a cascade's final attempt is the one that sticks.
+        TurnRecorder.noteBackend(.direct(provider), model: modelConfig.model)
+
         let isOnDevice = (provider == .local || provider == .appleOnDevice)
         let hasNativeTools = nativeToolRouter != nil
         let includeOpenClaw = Config.isOpenClawAgentActive && openClawBridge != nil
@@ -1941,7 +1947,10 @@ class LLMService: ObservableObject {
             var events = parser.consume(chunk)
             if flush { events += parser.flush() }
             for event in events {
-                if let delta = accumulator.consume(event) { onToken(delta) }
+                if let delta = accumulator.consume(event) {
+                    TurnRecorder.markFirstToken()
+                    onToken(delta)
+                }
             }
         }
 
@@ -2107,6 +2116,7 @@ class LLMService: ObservableObject {
 
             if let chunk = delta["content"] as? String, !chunk.isEmpty {
                 fullContent += chunk
+                TurnRecorder.markFirstToken()
                 onToken(chunk)
             }
             if let calls = delta["tool_calls"] as? [[String: Any]] {
@@ -2183,6 +2193,7 @@ class LLMService: ObservableObject {
                         var b = blocks[idx] ?? ["type": "text", "text": ""]
                         b["text"] = ((b["text"] as? String) ?? "") + t
                         blocks[idx] = b
+                        TurnRecorder.markFirstToken()
                         onToken(t)
                     } else if dtype == "input_json_delta", let pj = delta["partial_json"] as? String {
                         toolJSON[idx, default: ""] += pj
@@ -2698,7 +2709,12 @@ class LLMService: ObservableObject {
             // Execute the tool
             print("🔧 Local model tool call: \(toolName)(\(toolArgs))")
             toolCallStatus = .executing(toolName)
+            // Plan CU P1: the on-device path is deliberately not on `runToolLoop` (see the comment
+            // above `sendLocal`), so its single tool round trip needs its own bracket. The
+            // generation passes either side of it report themselves through `addGeneration`.
+            let toolStartedAt = Date()
             let result = await router.handleToolCall(name: toolName, args: toolArgs)
+            TurnRecorder.addToolTime(since: toolStartedAt)
             toolCallStatus = .idle
 
             let resultText: String

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -526,21 +526,37 @@ final class LocalLLMService: ObservableObject {
 
         // Drive the stream through the pure loop below so we can bail out *before* requesting the
         // next token — before MLX submits the next Metal command buffer. Non-text generations
-        // (`.info`/`.toolCall`) are skipped; the loop keeps pulling until a text chunk or the end.
+        // (`.toolCall`/unknown) are skipped; the loop keeps pulling until a text chunk or the end.
+        //
+        // `.info` is the exception (Plan CU P1): MLX reports its own token count and decode time
+        // there, and that pair is the *only* input `TurnTimeline.tokensPerSecond` accepts — a rate
+        // taken from timeline marks would divide a first-wins, backfilled window into a token count
+        // it doesn't cover. Captured here and applied below rather than from inside the closure,
+        // which is deliberately kept free of anything that could suspend mid-generation.
+        var reported: GenerateCompletionInfo?
         var iterator = stream.makeAsyncIterator()
         let output = try await Self.drainTokenStream(
             nextChunk: {
                 while let generation = await iterator.next() {
                     if case .chunk(let text) = generation { return text }
-                    // .info / .toolCall / unknown — not spoken text; keep pulling.
+                    if case .info(let info) = generation { reported = info }
                 }
                 return nil
             },
             isBackgrounded: { [weak self] in
                 (self?.enteredBackgroundDuringGeneration ?? false) || UIApplication.shared.applicationState == .background
             },
-            onToken: filteredOnToken
+            // Plan CU P1: first-token is worth marking whether or not the caller wanted a streamed
+            // preview — voice turns pass no `onToken` at all, and this is the only per-chunk seam
+            // the local path has.
+            onToken: { chunk in
+                TurnRecorder.markFirstToken()
+                filteredOnToken?(chunk)
+            }
         )
+        if let reported {
+            TurnRecorder.addGeneration(tokens: reported.generationTokenCount, seconds: reported.generateTime)
+        }
         // Memory telemetry per turn — footprint should now stay flat across questions;
         // before the cacheLimit cap it grew ~0.7 GB per turn until the Jetsam kill.
         NSLog("🔬 LocalLLM.generate done — mlx active=%dMB cache=%dMB, app footprint=%dMB",
@@ -599,6 +615,7 @@ final class LocalLLMService: ObservableObject {
         // `UserInput` (and the `CIImage` inside it) isn't `Sendable`, so it's built *inside* the
         // `@Sendable` closure from Sendable ingredients only — the image data, the prompt strings
         // and the history — rather than constructed out here and captured across the boundary.
+        let report = LockedGenerationReport()
         let output = try await container.perform { context -> String in
             guard let ciImage = CIImage(data: imageData) else {
                 throw LocalLLMError.generationFailed("Couldn't decode the photo.")
@@ -619,12 +636,23 @@ final class LocalLLMService: ObservableObject {
                 nextChunk: {
                     while let generation = await iterator.next() {
                         if case .chunk(let text) = generation { return text }
+                        if case .info(let info) = generation { report.note(info) }
                     }
                     return nil
                 },
                 isBackgrounded: { backgroundedFlag.isSet },
-                onToken: onToken
+                onToken: { chunk in
+                    report.noteToken(at: Date())
+                    onToken?(chunk)
+                }
             )
+        }
+        // Plan CU P1: applied on this side of `container.perform`, where the main actor is ours
+        // again. First token is the wall-clock stamp the drain took; the token/decode pair is MLX's
+        // own report, the only pair `TurnTimeline.tokensPerSecond` will divide.
+        if let firstTokenAt = report.firstTokenAt { TurnRecorder.mark(.firstToken, at: firstTokenAt) }
+        if let completion = report.completion {
+            TurnRecorder.addGeneration(tokens: completion.generationTokenCount, seconds: completion.generateTime)
         }
         NSLog("🔬 LocalLLM.generateVisionTurn done — mlx active=%dMB cache=%dMB",
               Memory.activeMemory / 1_048_576, Memory.cacheMemory / 1_048_576)
@@ -891,5 +919,39 @@ final class LockedFlag: @unchecked Sendable {
     func set() {
         lock.lock(); defer { lock.unlock() }
         value = true
+    }
+}
+
+/// What a vision turn's token drain observed, collected off the main actor and applied to the turn
+/// timeline once `container.perform` returns (Plan CU P1).
+///
+/// The drain runs inside a `@Sendable` closure, so it cannot touch `TurnRecorder` — which is
+/// main-actor isolated — and must not hop there mid-generation either: a suspension between MLX
+/// token pulls is exactly the kind of cost instrumentation is not allowed to add. So the two facts
+/// worth keeping are parked behind a lock and read back on the other side.
+final class LockedGenerationReport: @unchecked Sendable {
+    private let lock = NSLock()
+    private var first: Date?
+    private var info: GenerateCompletionInfo?
+
+    /// Stamp the first token. Later tokens are a lock and a nil check.
+    func noteToken(at time: Date) {
+        lock.lock(); defer { lock.unlock() }
+        if first == nil { first = time }
+    }
+
+    func note(_ completion: GenerateCompletionInfo) {
+        lock.lock(); defer { lock.unlock() }
+        info = completion
+    }
+
+    var firstTokenAt: Date? {
+        lock.lock(); defer { lock.unlock() }
+        return first
+    }
+
+    var completion: GenerateCompletionInfo? {
+        lock.lock(); defer { lock.unlock() }
+        return info
     }
 }

--- a/OpenGlasses/Sources/Services/TextToSpeechService.swift
+++ b/OpenGlasses/Sources/Services/TextToSpeechService.swift
@@ -270,6 +270,13 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
             }
             do {
                 try Task.checkCancellation()
+                // Plan CU P1: which engine is speaking, which is not the configured preference —
+                // any engine here can fall through to the next at runtime (offline, no quota, no
+                // Kokoro model), and a cloud round trip and an on-device synthesis are not
+                // comparable numbers. Tagged on the way *in*, because the playback marks happen
+                // inside the call below; last-wins means an engine that throws is simply
+                // overwritten by the next one to try.
+                TurnRecorder.noteSpeechEngine(engine)
                 switch engine {
                 case .elevenLabs:
                     try await speakWithElevenLabs(text: text, apiKey: elevenLabsKey)
@@ -642,7 +649,13 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             self.speechContinuation = continuation
             player.delegate = self
-            player.play()
+            let started = player.play()
+            // Plan CU P1: the closest honest "the wearer is hearing this" on the ElevenLabs/Kokoro
+            // path. `AVAudioPlayer` has no did-start callback, so this is `play()` accepting the
+            // request rather than the first sample reaching the speaker — a fixed, small optimism
+            // that the iOS-voice path (a real `didStart`) does not share, so cross-engine
+            // first-audio comparisons carry it.
+            if started { TurnRecorder.markPlaybackStart(at: Date()) }
             print("🔊 ElevenLabs: Playing audio (\(String(format: "%.1f", player.duration))s)")
         }
     }
@@ -704,14 +717,20 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
     // MARK: - AVSpeechSynthesizerDelegate (iOS fallback)
 
     nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didStart utterance: AVSpeechUtterance) {
+        // Plan CU P1: stamped before the main-actor hop, so the measurement is the callback rather
+        // than the callback plus however long the main actor took to get to us.
+        let startedAt = Date()
         Task { @MainActor in
             self.isSpeaking = true
+            TurnRecorder.markPlaybackStart(at: startedAt)
         }
     }
 
     nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+        let finishedAt = Date()
         Task { @MainActor in
             print("🔊 iOS TTS: didFinish")
+            TurnRecorder.markPlaybackEnd(at: finishedAt)
             self.speechContinuation?.resume()
             self.speechContinuation = nil
         }
@@ -815,8 +834,13 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
 
 extension TextToSpeechService: AVAudioPlayerDelegate {
     nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        let finishedAt = Date()
         Task { @MainActor in
             print("🔊 ElevenLabs: Playback finished (success=\(flag))")
+            // Plan CU P1: only the clean finish is `spokeDone`. The decode-error path below resumes
+            // the same continuation the same way, so the *caller* can't tell them apart — which is
+            // exactly why the mark has to be made here and not where the continuation resumes.
+            if flag { TurnRecorder.markPlaybackEnd(at: finishedAt) }
             self.audioPlayer = nil
             self.speechContinuation?.resume()
             self.speechContinuation = nil

--- a/OpenGlasses/Sources/Services/TranscriptionService.swift
+++ b/OpenGlasses/Sources/Services/TranscriptionService.swift
@@ -38,6 +38,18 @@ class TranscriptionService: ObservableObject {
     private let noSpeechTimeout: TimeInterval = 10.0
     private var didReceiveSpeech: Bool = false
 
+    /// When the recognizer last reported hearing something — i.e. when the silence window that is
+    /// running right now was armed.
+    ///
+    /// Plan CU P1: `stopRecording()` runs when that window *expires*, `silenceThreshold` seconds
+    /// (2.0 s, or 6.0 s after a question-shaped reply) after the wearer actually stopped talking.
+    /// Stamping speech-end there would fold the entire endpointing floor into the start of
+    /// `perceivedLatency` — the headline metric would silently exclude the one stage P2 exists to
+    /// remove, and the before/after would come out flat on a change that worked. Bounded by
+    /// construction: the window is re-armed on every partial, so this is never more than one window
+    /// old.
+    private var lastSpeechObservedAt: Date?
+
     /// Shared audio engine — set by AppState from WakeWordService
     weak var sharedAudioEngineProvider: WakeWordService?
 
@@ -60,7 +72,12 @@ class TranscriptionService: ObservableObject {
         guard !isRecording else { return }
 
         didReceiveSpeech = false
+        lastSpeechObservedAt = nil
         currentTranscription = ""
+        // Plan CU P1: a new utterance means the previous one has been dealt with, whatever became
+        // of it — the turn that answered it has already claimed its stamps, and a voice command
+        // that never became a turn must not leave one behind for the next one to inherit.
+        TurnRecorder.forgetPendingUtterance()
 
         // Pick the recognizer: on-device SenseVoice when selected + its model is ready, else Apple.
         let availability = ASREngineSelector.Availability(
@@ -91,6 +108,14 @@ class TranscriptionService: ObservableObject {
 
     func stopRecording() {
         guard isRecording else { return }
+
+        // Plan CU P1: the mic went quiet when the silence window now expiring was ARMED, not when
+        // it expired — see `lastSpeechObservedAt`. Falls back to now for the stops that never armed
+        // one: the on-device engine (whole-buffer, no partials at all), a recognizer error, or an
+        // external stop before any speech arrived. Stamped before the on-device branch below, whose
+        // SenseVoice decode runs after the mic went quiet and belongs to the wait, not the speech.
+        TurnRecorder.noteSpeechEnd(at: lastSpeechObservedAt ?? Date())
+        lastSpeechObservedAt = nil
 
         silenceTimer?.invalidate()
         silenceTimer = nil
@@ -282,6 +307,9 @@ class TranscriptionService: ObservableObject {
     }
 
     private func resetSilenceTimer() {
+        // Plan CU P1: purely a stamp — the window's length and firing are untouched. Arming it is
+        // the last moment speech was observed, and that is what `stopRecording` records.
+        lastSpeechObservedAt = Date()
         silenceTimer?.invalidate()
         silenceTimer = Timer.scheduledTimer(withTimeInterval: silenceThreshold, repeats: false) { [weak self] _ in
             Task { @MainActor in

--- a/OpenGlassesTests/TurnLedgerTests.swift
+++ b/OpenGlassesTests/TurnLedgerTests.swift
@@ -1,0 +1,367 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan CU P1 — the bounded ring buffer and in-flight bookkeeping wrapped around `TurnTimeline`.
+/// These tests are about the ledger's own invariants (capacity, cohort isolation, drop-harmlessly);
+/// `TurnTimeline`'s derivations are pinned separately in `TurnTimelineTests`.
+@MainActor
+final class TurnLedgerTests: XCTestCase {
+
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+    private func at(_ offset: TimeInterval) -> Date { epoch.addingTimeInterval(offset) }
+
+    /// Starts, marks (`speechEnd` at 0, `firstAudio` at `latency`), and seals one turn in a single
+    /// call, so the aggregate tests below can read as a table of cohort → latency rather than a wall
+    /// of `start`/`mark`/`seal` boilerplate.
+    @discardableResult
+    private func sealTurn(
+        latency: TimeInterval,
+        backend: TurnBackend? = nil,
+        tts: TTSEngine? = nil,
+        mic: MicRoute? = nil,
+        on ledger: TurnLedger
+    ) -> UUID {
+        let id = ledger.start(TurnTimeline(backend: backend, ttsEngine: tts, micRoute: mic))
+        ledger.mark(id, .speechEnd, at: at(0))
+        ledger.mark(id, .firstAudio, at: at(latency))
+        ledger.seal(id)
+        return id
+    }
+
+    // MARK: - Lifecycle: start, mark, seal
+
+    func testStartReturnsTheTimelinesOwnIdAndTracksItInFlight() {
+        let ledger = TurnLedger()
+        let timeline = TurnTimeline(backend: .direct(.anthropic))
+        let id = ledger.start(timeline)
+
+        XCTAssertEqual(id, timeline.id)
+        XCTAssertEqual(ledger.inFlightCount, 1)
+        XCTAssertEqual(ledger.sealed.count, 0)
+        XCTAssertEqual(ledger.turn(id), timeline)
+    }
+
+    func testMarkAndSealRoundTripThroughToSealedHistory() {
+        let ledger = TurnLedger()
+        let id = ledger.start()
+        ledger.mark(id, .speechEnd, at: at(0))
+        ledger.mark(id, .firstAudio, at: at(1.4))
+        ledger.seal(id)
+
+        XCTAssertEqual(ledger.inFlightCount, 0, "sealing must remove the turn from in-flight")
+        XCTAssertEqual(ledger.sealed.count, 1)
+        XCTAssertEqual(ledger.sealed[0].perceivedLatency ?? .nan, 1.4, accuracy: 0.001)
+    }
+
+    func testUpdateAppliesAnArbitraryMutationToTheInFlightTurn() {
+        let ledger = TurnLedger()
+        let id = ledger.start()
+        ledger.update(id) {
+            $0.backend = .direct(.groq)
+            $0.addToolTime(2.0, iterations: 3)
+        }
+        ledger.seal(id)
+
+        let recorded = ledger.sealed[0]
+        XCTAssertEqual(recorded.backend, .direct(.groq))
+        XCTAssertEqual(recorded.toolSeconds, 2.0, accuracy: 0.001)
+        XCTAssertEqual(recorded.toolIterations, 3)
+    }
+
+    // MARK: - Drop-harmlessly: unknown and sealed ids
+
+    /// The core safety property: a mark for a turn the ledger has never heard of must not crash and
+    /// must not conjure a phantom entry into existence.
+    func testMarkForAnUnknownTurnIdIsDroppedHarmlessly() {
+        let ledger = TurnLedger()
+        let strangerID = UUID()
+        ledger.mark(strangerID, .speechEnd, at: at(0))
+
+        XCTAssertEqual(ledger.inFlightCount, 0, "an unknown mark must not create an in-flight entry")
+        XCTAssertEqual(ledger.sealed.count, 0)
+        XCTAssertNil(ledger.turn(strangerID))
+    }
+
+    /// The other half of the contract: a *known* id that has already sealed must also refuse further
+    /// marks. Its story is finished, and a late mark rewriting a sealed entry would corrupt an
+    /// aggregate that already counted it.
+    func testMarkForAnAlreadySealedTurnIsDroppedHarmlessly() {
+        let ledger = TurnLedger()
+        let id = ledger.start()
+        ledger.mark(id, .speechEnd, at: at(0))
+        ledger.mark(id, .firstAudio, at: at(1.0))
+        ledger.seal(id)
+
+        ledger.mark(id, .spokeDone, at: at(99))   // arrives late, after sealing
+
+        XCTAssertNil(ledger.sealed[0].spokeDoneAt, "the late mark must not reach the sealed copy")
+        XCTAssertEqual(ledger.sealed.count, 1, "and it must not resurrect a second entry")
+    }
+
+    func testUpdateForAnUnknownOrAlreadySealedTurnIsDroppedHarmlessly() {
+        let ledger = TurnLedger()
+        let id = ledger.start()
+        ledger.seal(id)
+
+        ledger.update(id) { $0.abandoned = true }        // known, but sealed
+        ledger.update(UUID()) { $0.model = "ghost" }      // never started at all
+
+        XCTAssertFalse(ledger.sealed[0].abandoned)
+        XCTAssertEqual(ledger.sealed.count, 1)
+        XCTAssertEqual(ledger.inFlightCount, 0)
+    }
+
+    func testSealOfAnUnknownIdIsANoOp() {
+        let ledger = TurnLedger()
+        ledger.seal(UUID())
+        XCTAssertEqual(ledger.sealed.count, 0)
+    }
+
+    func testDoubleSealIsANoOpTheSecondTime() {
+        let ledger = TurnLedger()
+        let id = ledger.start()
+        ledger.seal(id)
+        ledger.seal(id)
+        XCTAssertEqual(ledger.sealed.count, 1)
+    }
+
+    // MARK: - Partial (abandoned) turns
+
+    /// An abandoned turn is not a write-off — it still seals, tag and all, and it's still the most
+    /// informative record we have of where that turn stopped.
+    func testAbandonedTurnStillSeals() {
+        let ledger = TurnLedger()
+        let id = ledger.start(TurnTimeline(backend: .direct(.local), micRoute: .glasses))
+        ledger.mark(id, .speechEnd, at: at(0))
+        ledger.mark(id, .commit, at: at(2.0))
+        ledger.update(id) { $0.abandoned = true }
+        ledger.seal(id)
+
+        XCTAssertEqual(ledger.sealed.count, 1)
+        let recorded = ledger.sealed[0]
+        XCTAssertTrue(recorded.abandoned)
+        XCTAssertEqual(recorded.commitAt, at(2.0), "what it did reach is still on the record")
+        XCTAssertNil(recorded.perceivedLatency, "it never reached audio — there is no latency to report")
+    }
+
+    // MARK: - Eviction by count
+
+    func testEvictsOldestSealedTurnsOnceOverTheCountCap() {
+        let ledger = TurnLedger(maxCount: 3, maxBytes: .max)
+        for i in 0..<5 {
+            let id = ledger.start(TurnTimeline(model: "turn-\(i)"))
+            ledger.seal(id)
+        }
+        XCTAssertEqual(ledger.sealed.map(\.model), ["turn-2", "turn-3", "turn-4"],
+                       "only the 3 most recent survive; the oldest are evicted first")
+    }
+
+    func testCountEvictionNeverDropsBelowTheCap() {
+        let ledger = TurnLedger(maxCount: 2, maxBytes: .max)
+        for _ in 0..<10 {
+            let id = ledger.start()
+            ledger.seal(id)
+        }
+        XCTAssertEqual(ledger.sealed.count, 2)
+    }
+
+    // MARK: - Eviction by bytes
+
+    /// Same-size turns throughout, so the arithmetic is exact: two units fit under the cap, a third
+    /// forces the oldest out, and the count cap (100) never binds at all.
+    func testEvictsOldestSealedTurnsOnceOverTheByteCapEvenUnderTheCountCap() {
+        let longModelName = String(repeating: "m", count: 500)
+        let unitSize = TurnLedger.approximateByteSize(of: TurnTimeline(model: longModelName))
+        let ledger = TurnLedger(maxCount: 100, maxBytes: unitSize * 2)
+
+        var ids: [UUID] = []
+        for _ in 0..<3 {
+            let id = ledger.start(TurnTimeline(model: longModelName))
+            ledger.seal(id)
+            ids.append(id)
+        }
+
+        XCTAssertEqual(ledger.sealed.count, 2, "the count cap (100) never binds; the byte cap does")
+        XCTAssertEqual(ledger.sealed.map(\.id), [ids[1], ids[2]], "the oldest is evicted first")
+    }
+
+    /// The byte estimate has to actually track what varies, or this whole cap is theatre. A ledger
+    /// sized for short model names must evict sooner once the names get long.
+    func testByteApproximationGrowsWithTheModelNameLength() {
+        let short = TurnLedger.approximateByteSize(of: TurnTimeline(model: "gpt"))
+        let long = TurnLedger.approximateByteSize(of: TurnTimeline(model: String(repeating: "x", count: 300)))
+        XCTAssertGreaterThan(long, short)
+
+        let empty = TurnLedger.approximateByteSize(of: TurnTimeline())
+        XCTAssertLessThanOrEqual(empty, short, "no model name at all must never cost more than a short one")
+    }
+
+    // MARK: - Aggregates: never pool across backend × ttsEngine × micRoute
+
+    /// The tagging rule made an executable property: turns that differ only in mic route (or TTS
+    /// engine) are two populations, and `stats(for:)` must never blend them into one bucket.
+    func testAggregatesNeverPoolAcrossMicRouteBackendOrTTSEngine() {
+        let ledger = TurnLedger()
+
+        // Phone mic, ElevenLabs — cluster around 1.0 s.
+        for latency in [0.9, 1.0, 1.1] {
+            sealTurn(latency: latency, backend: .direct(.anthropic), tts: .elevenLabs, mic: .phone, on: ledger)
+        }
+        // Same backend and TTS engine, glasses mic — an 8 kHz HFP link is a different population.
+        for latency in [4.8, 5.0, 5.2] {
+            sealTurn(latency: latency, backend: .direct(.anthropic), tts: .elevenLabs, mic: .glasses, on: ledger)
+        }
+        // Same backend and mic as the first group, on-device TTS instead of cloud.
+        for _ in 0..<3 {
+            sealTurn(latency: 2.0, backend: .direct(.anthropic), tts: .kokoro, mic: .phone, on: ledger)
+        }
+
+        let byCohort = ledger.stats(for: \.perceivedLatency)
+        XCTAssertEqual(byCohort.count, 3, "three distinct cohorts must produce three buckets, never one pooled average")
+
+        let phoneEleven = TurnTimeline.Cohort(backend: .direct(.anthropic), ttsEngine: .elevenLabs, micRoute: .phone)
+        let glassesEleven = TurnTimeline.Cohort(backend: .direct(.anthropic), ttsEngine: .elevenLabs, micRoute: .glasses)
+        let phoneKokoro = TurnTimeline.Cohort(backend: .direct(.anthropic), ttsEngine: .kokoro, micRoute: .phone)
+
+        XCTAssertEqual(byCohort[phoneEleven]?.count, 3)
+        XCTAssertEqual(byCohort[phoneEleven]?.mean ?? .nan, 1.0, accuracy: 0.01)
+
+        XCTAssertEqual(byCohort[glassesEleven]?.count, 3)
+        XCTAssertEqual(byCohort[glassesEleven]?.mean ?? .nan, 5.0, accuracy: 0.01,
+                       "the glasses-mic turns must not drag the phone cohort's average toward them")
+
+        XCTAssertEqual(byCohort[phoneKokoro]?.count, 3)
+        XCTAssertEqual(byCohort[phoneKokoro]?.mean ?? .nan, 2.0, accuracy: 0.01)
+    }
+
+    /// Realtime backends carry no TTS engine or mic-route tag of their own (Plan CU: they endpoint
+    /// server-side); they must still land in their own cohort rather than merging with Direct mode.
+    func testRealtimeBackendIsItsOwnCohortSeparateFromDirectMode() {
+        let ledger = TurnLedger()
+        sealTurn(latency: 1.0, backend: .direct(.anthropic), on: ledger)
+        sealTurn(latency: 1.0, backend: .geminiLive, on: ledger)
+
+        let byCohort = ledger.stats(for: \.perceivedLatency)
+        XCTAssertEqual(byCohort.count, 2)
+    }
+
+    func testPerceivedLatencyByCohortConvenienceMatchesGenericStats() {
+        let ledger = TurnLedger()
+        sealTurn(latency: 1.0, backend: .geminiLive, on: ledger)
+        XCTAssertEqual(ledger.perceivedLatencyByCohort, ledger.stats(for: \.perceivedLatency))
+    }
+
+    // MARK: - Median vs mean
+
+    /// The plan's own framing: "one 30 s outlier turn should not move the headline." Five ordinary
+    /// turns plus one very slow one — the mean visibly follows the outlier, the median doesn't.
+    func testMedianResistsAnOutlierThatVisiblyMovesTheMean() {
+        let ledger = TurnLedger()
+        for _ in 0..<5 {
+            sealTurn(latency: 1.0, backend: .direct(.groq), on: ledger)
+        }
+        sealTurn(latency: 30.0, backend: .direct(.groq), on: ledger)
+
+        let cohort = TurnTimeline.Cohort(backend: .direct(.groq), ttsEngine: nil, micRoute: nil)
+        let stat = ledger.stats(for: \.perceivedLatency)[cohort]
+
+        XCTAssertEqual(stat?.count, 6)
+        XCTAssertEqual(stat?.median ?? .nan, 1.0, accuracy: 0.001,
+                       "5 turns at 1.0 s plus one 30 s outlier — the median stays put")
+        XCTAssertEqual(stat?.mean ?? .nan, 35.0 / 6.0, accuracy: 0.001,
+                       "the mean visibly follows the outlier — exactly why the median ships alongside it")
+        XCTAssertGreaterThan(stat?.mean ?? 0, (stat?.median ?? 0) * 4,
+                             "the outlier must move the mean far more than it moves the median")
+    }
+
+    /// Odd sample count, so the median is a single middle value rather than an average of two —
+    /// the other branch of the median calculation from the outlier test above.
+    func testMedianOfAnOddCountIsTheMiddleValue() {
+        let ledger = TurnLedger()
+        for latency in [1.0, 2.0, 9.0] {
+            sealTurn(latency: latency, backend: .direct(.local), on: ledger)
+        }
+        let cohort = TurnTimeline.Cohort(backend: .direct(.local), ttsEngine: nil, micRoute: nil)
+        XCTAssertEqual(ledger.stats(for: \.perceivedLatency)[cohort]?.median ?? .nan, 2.0, accuracy: 0.001)
+    }
+
+    /// A turn missing the metric entirely (never reached first audio) contributes no data point —
+    /// it neither pollutes the bucket nor divides by a phantom zero.
+    func testATurnMissingTheMetricDoesNotContributeToItsCohortsStats() {
+        let ledger = TurnLedger()
+        sealTurn(latency: 1.0, backend: .direct(.anthropic), on: ledger)
+
+        let strandedID = ledger.start(TurnTimeline(backend: .direct(.anthropic)))
+        ledger.mark(strandedID, .speechEnd, at: at(0))
+        ledger.mark(strandedID, .commit, at: at(1.0))   // never reaches firstAudio
+        ledger.update(strandedID) { $0.abandoned = true }
+        ledger.seal(strandedID)
+
+        let cohort = TurnTimeline.Cohort(backend: .direct(.anthropic), ttsEngine: nil, micRoute: nil)
+        XCTAssertEqual(ledger.sealed.count, 2, "both turns are recorded")
+        XCTAssertEqual(ledger.stats(for: \.perceivedLatency)[cohort]?.count, 1,
+                       "only the turn that actually reached audio contributes a latency sample")
+    }
+
+    // MARK: - Housekeeping: ordering, lookup, reset
+
+    func testSealedHistoryIsChronologicalOldestFirst() {
+        let ledger = TurnLedger()
+        let first = ledger.start(TurnTimeline(model: "first"))
+        ledger.seal(first)
+        let second = ledger.start(TurnTimeline(model: "second"))
+        ledger.seal(second)
+        XCTAssertEqual(ledger.sealed.map(\.model), ["first", "second"])
+    }
+
+    func testTurnLooksUpInFlightThenFallsBackToSealed() {
+        let ledger = TurnLedger()
+        let id = ledger.start(TurnTimeline(model: "in flight"))
+        XCTAssertEqual(ledger.turn(id)?.model, "in flight")
+
+        ledger.seal(id)
+        XCTAssertEqual(ledger.turn(id)?.model, "in flight", "still findable after sealing")
+        XCTAssertNil(ledger.turn(UUID()))
+    }
+
+    func testResetClearsBothInFlightAndSealed() {
+        let ledger = TurnLedger()
+        let inFlightID = ledger.start()
+        let sealedID = ledger.start()
+        ledger.seal(sealedID)
+
+        ledger.reset()
+
+        XCTAssertEqual(ledger.inFlightCount, 0)
+        XCTAssertEqual(ledger.sealed.count, 0)
+        XCTAssertNil(ledger.turn(inFlightID))
+        XCTAssertNil(ledger.turn(sealedID))
+    }
+
+    // MARK: - Debug export
+
+    func testDebugExportListsSealedTurnsAndPerCohortStats() {
+        let ledger = TurnLedger()
+        sealTurn(latency: 1.25, backend: .direct(.anthropic), tts: .elevenLabs, mic: .phone, on: ledger)
+
+        let abandonedID = ledger.start(TurnTimeline(backend: .direct(.local)))
+        ledger.mark(abandonedID, .speechEnd, at: at(0))
+        ledger.update(abandonedID) { $0.abandoned = true }
+        ledger.seal(abandonedID)
+
+        let export = ledger.debugExport(now: at(100))
+
+        XCTAssertTrue(export.contains("2 turns sealed"))
+        XCTAssertTrue(export.contains("0 in flight"))
+        XCTAssertTrue(export.contains("ABANDONED"))
+        XCTAssertTrue(export.contains("anthropic/elevenLabs/phone"))
+        XCTAssertTrue(export.contains("perceived=1.25s"))
+    }
+
+    func testDebugExportOnAnEmptyLedgerDoesNotCrashAndSaysSo() {
+        let ledger = TurnLedger()
+        let export = ledger.debugExport(now: at(0))
+        XCTAssertTrue(export.contains("0 turns sealed"))
+        XCTAssertTrue(export.contains("no sealed turn has reached first audio"))
+    }
+}

--- a/OpenGlassesTests/TurnRecorderTests.swift
+++ b/OpenGlassesTests/TurnRecorderTests.swift
@@ -1,0 +1,401 @@
+import AVFoundation
+import XCTest
+@testable import OpenGlasses
+
+/// Plan CU P1 — the seam, not the value type. `TurnTimelineTests` pins the derivations and
+/// `TurnLedgerTests` the store; everything that decides whether those numbers describe the right
+/// turn lives here, and only here: which utterance a turn claims, the staleness ceilings that stop
+/// an unclaimed stamp poisoning a later turn, the hand-off window that keeps a model-switch notice
+/// from claiming `firstAudio`, and the off-turn gate that keeps a background completion out of a
+/// live turn's cohort. Every one of those can be deleted with the rest of the suite still green if
+/// it is not pinned here.
+@MainActor
+final class TurnRecorderTests: XCTestCase {
+
+    /// The recorder's clock, held in a plain class so the closure handed to `TurnRecorder.now` and
+    /// the test body see the same instant — advancing it is how a staleness ceiling is reached
+    /// without sleeping.
+    private final class Clock {
+        var now: Date
+        init(_ now: Date) { self.now = now }
+    }
+
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+    private func at(_ offset: TimeInterval) -> Date { epoch.addingTimeInterval(offset) }
+
+    private var ledger = TurnLedger()
+    private var clock = Clock(Date())
+
+    override func setUp() {
+        super.setUp()
+        ledger = TurnLedger()
+        clock = Clock(at(0))
+        // No input ports by default: the mic-route tests below supply their own, and everything
+        // else falls back to the configured preference rather than to whatever the simulator's
+        // audio session happens to be routed to.
+        TurnRecorder.reset(ledger: ledger, now: { [clock] in clock.now }, micRoutePorts: { [] })
+    }
+
+    override func tearDown() {
+        TurnRecorder.reset()
+        super.tearDown()
+    }
+
+    /// Seal the turn in flight and hand back what it recorded.
+    private func sealAndRead() -> TurnTimeline? {
+        TurnRecorder.endTurn()
+        return ledger.sealed.last
+    }
+
+    // MARK: - Claiming the utterance
+
+    func testTurnClaimsTheSpeechEndStampLeftByTheUtteranceThatStartedIt() {
+        TurnRecorder.noteSpeechEnd(at: at(0))
+        clock.now = at(2.0)
+        TurnRecorder.beginTurn()
+        clock.now = at(3.4)
+        TurnRecorder.handOffToSpeech()
+        TurnRecorder.markPlaybackStart(at: at(3.4))
+
+        let turn = sealAndRead()
+        XCTAssertEqual(turn?.speechEndAt, at(0), "the turn is measured from when the mic went quiet")
+        XCTAssertEqual(turn?.perceivedLatency ?? .nan, 3.4, accuracy: 0.001)
+    }
+
+    /// The stamp is claimed by the turn that answers it — but `handleTranscription` returns several
+    /// times before any turn begins, so a voice command consumed by the pre-LLM chain ("stop",
+    /// "next slide") leaves one nobody will ever claim. Without a ceiling the next turn — possibly
+    /// a typed one, minutes later — inherits it and reports a preposterous perceived latency.
+    func testAnUnclaimedSpeechEndStampGoesStaleRatherThanPoisoningALaterTurn() {
+        TurnRecorder.noteSpeechEnd(at: at(0))          // consumed by the pre-LLM chain; no turn began
+
+        clock.now = at(600)                            // ten minutes later, a fresh turn
+        TurnRecorder.beginTurn()
+        TurnRecorder.handOffToSpeech()
+        TurnRecorder.markPlaybackStart(at: at(601))
+
+        let turn = sealAndRead()
+        XCTAssertNil(turn?.speechEndAt, "a ten-minute-old stamp belongs to no turn")
+        XCTAssertNil(turn?.perceivedLatency, "and no latency is far better than a 601 s one")
+    }
+
+    /// The boundary the ceiling is actually made of — a stamp just inside it is still this turn's.
+    func testASpeechEndStampJustInsideTheCeilingIsStillClaimed() {
+        TurnRecorder.noteSpeechEnd(at: at(0))
+        clock.now = at(29)
+        TurnRecorder.beginTurn()
+        XCTAssertEqual(sealAndRead()?.speechEndAt, at(0))
+    }
+
+    func testCapturingANewUtteranceForgetsBothPendingStamps() {
+        TurnRecorder.noteSpeechEnd(at: at(0))
+        TurnRecorder.noteHeldUtterance(parkedAt: at(-5))
+
+        TurnRecorder.forgetPendingUtterance()
+
+        clock.now = at(1)
+        TurnRecorder.beginTurn()
+        let turn = sealAndRead()
+        XCTAssertNil(turn?.speechEndAt)
+        XCTAssertNil(turn?.heldAt)
+        XCTAssertEqual(turn?.heldSeconds, 0)
+    }
+
+    // MARK: - Held utterances
+
+    /// A parked utterance's turn carries the park time and the wait, but is *measured* from its own
+    /// release — charging the hold to `perceivedLatency` would make every deferred turn read as a
+    /// slow backend when it was a queueing decision.
+    func testHeldUtteranceRecordsTheParkAndTheWaitButStartsItsClockAtTheRelease() {
+        TurnRecorder.noteHeldUtterance(parkedAt: at(0))
+        clock.now = at(7.0)
+        TurnRecorder.beginTurn()
+        TurnRecorder.handOffToSpeech()
+        TurnRecorder.markPlaybackStart(at: at(9.0))
+
+        let turn = sealAndRead()
+        XCTAssertEqual(turn?.heldAt, at(0))
+        XCTAssertEqual(turn?.heldSeconds ?? .nan, 7.0, accuracy: 0.001)
+        XCTAssertEqual(turn?.speechEndAt, at(7.0), "this turn's clock starts at the release")
+        XCTAssertEqual(turn?.perceivedLatency ?? .nan, 2.0, accuracy: 0.001)
+        XCTAssertEqual(turn?.waitIncludingHold ?? .nan, 9.0, accuracy: 0.001,
+                       "the wearer's real wait is reported next to it, never instead of it")
+    }
+
+    /// The sibling of the stale-speech-end case, and the one that bites harder: a held utterance is
+    /// replayed straight into `handleTranscription`, where the pre-LLM chain can consume it exactly
+    /// as it consumes a fresh one. The leftover hold would otherwise rewrite an unrelated later
+    /// turn's speech-end at its own begin instant — destroying that turn's perceived latency — and
+    /// report the intervening hours as `heldSeconds`.
+    func testAnUnclaimedHoldGoesStaleRatherThanRewritingALaterTurnsSpeechEnd() {
+        TurnRecorder.noteHeldUtterance(parkedAt: at(0))   // replayed, then consumed by "next slide"
+
+        clock.now = at(600)                                // an unrelated turn, ten minutes on
+        TurnRecorder.noteSpeechEnd(at: at(598))
+        TurnRecorder.beginTurn()
+        TurnRecorder.handOffToSpeech()
+        TurnRecorder.markPlaybackStart(at: at(601))
+
+        let turn = sealAndRead()
+        XCTAssertNil(turn?.heldAt, "a ten-minute-old park belongs to no turn")
+        XCTAssertEqual(turn?.heldSeconds, 0, "and certainly not to this one, as a ten-minute wait")
+        XCTAssertEqual(turn?.speechEndAt, at(598),
+                       "the stale hold must not displace this turn's own speech-end stamp")
+        XCTAssertEqual(turn?.perceivedLatency ?? .nan, 3.0, accuracy: 0.001)
+    }
+
+    /// The ceiling is measured against the *replay*, not the park: `TurnAdmissionPolicy` allows a
+    /// hold of up to 20 s, and bounding the park itself would refuse a legitimate long one.
+    func testALongButLegitimateHoldIsStillClaimedByItsOwnTurn() {
+        clock.now = at(19)
+        TurnRecorder.noteHeldUtterance(parkedAt: at(0))
+        TurnRecorder.beginTurn()
+
+        let turn = sealAndRead()
+        XCTAssertEqual(turn?.heldAt, at(0))
+        XCTAssertEqual(turn?.heldSeconds ?? .nan, 19.0, accuracy: 0.001)
+    }
+
+    // MARK: - Turn lifecycle
+
+    /// `handleTranscription` has half a dozen early exits and barge-in starts a replacement turn
+    /// from inside the old one's teardown, so "the previous turn always called `endTurn()`" is an
+    /// assumption that would be wrong eventually. A displaced turn seals with the marks it had.
+    func testBeginningATurnSealsOneThatWasStillOpen() {
+        TurnRecorder.beginTurn()
+        TurnRecorder.mark(.commit, at: at(1.0))
+
+        TurnRecorder.beginTurn()
+
+        XCTAssertEqual(ledger.sealed.count, 1, "the displaced turn is sealed, not dropped")
+        XCTAssertEqual(ledger.sealed[0].commitAt, at(1.0), "with exactly the marks it had")
+        XCTAssertEqual(ledger.inFlightCount, 1, "and exactly one turn is left in flight")
+    }
+
+    func testEndTurnIsIdempotent() {
+        TurnRecorder.beginTurn()
+        TurnRecorder.endTurn()
+        TurnRecorder.endTurn()
+        XCTAssertEqual(ledger.sealed.count, 1)
+        XCTAssertEqual(ledger.inFlightCount, 0)
+    }
+
+    func testMarksArrivingAfterTheTurnEndedGoNowhere() {
+        TurnRecorder.beginTurn()
+        TurnRecorder.endTurn()
+        TurnRecorder.mark(.commit, at: at(5.0))
+        TurnRecorder.noteBackend(.direct(.groq), model: "late")
+
+        XCTAssertNil(ledger.sealed[0].commitAt)
+        XCTAssertNil(ledger.sealed[0].backend)
+    }
+
+    func testRecordingDisabledRecordsNothingAtAll() {
+        let defaults = UserDefaults.standard
+        let saved = defaults.object(forKey: "turnLatencyRecordingEnabled")
+        defer { defaults.set(saved, forKey: "turnLatencyRecordingEnabled") }
+
+        TurnRecorder.isEnabled = false
+        TurnRecorder.noteSpeechEnd(at: at(0))
+        TurnRecorder.beginTurn()
+        TurnRecorder.mark(.commit, at: at(1.0))
+        TurnRecorder.endTurn()
+
+        XCTAssertEqual(ledger.sealed.count, 0)
+        XCTAssertEqual(ledger.inFlightCount, 0)
+    }
+
+    // MARK: - Releasing an utterance to whatever answers it next
+
+    /// The tier-0 direct-tool path falls through to the normal LLM path when a tool throws, and the
+    /// LLM turn answers the same words. Without the release, that turn finds the stamp already spent
+    /// and reports no perceived latency at all — on the slowest turn shape the app has (a failed
+    /// tool call *plus* a full round trip), which biases the headline aggregate fast.
+    func testAbandoningATurnHandsItsUtteranceToTheTurnThatAnswersItNext() {
+        TurnRecorder.noteSpeechEnd(at: at(0))
+        clock.now = at(2.0)
+        TurnRecorder.beginTurn()
+
+        clock.now = at(2.5)
+        TurnRecorder.abandonTurnReleasingUtterance()
+
+        XCTAssertEqual(ledger.sealed.count, 1, "the failed attempt is sealed, not left in flight")
+        XCTAssertTrue(ledger.sealed[0].abandoned)
+        XCTAssertEqual(ledger.inFlightCount, 0)
+
+        clock.now = at(2.6)
+        TurnRecorder.beginTurn()
+        TurnRecorder.handOffToSpeech()
+        TurnRecorder.markPlaybackStart(at: at(6.0))
+
+        let replacement = sealAndRead()
+        XCTAssertEqual(replacement?.speechEndAt, at(0),
+                       "the replacement turn inherits the utterance the abandoned one claimed")
+        XCTAssertEqual(replacement?.perceivedLatency ?? .nan, 6.0, accuracy: 0.001,
+                       "which is what the wearer actually waited for the tool that failed")
+    }
+
+    func testAbandoningAHeldTurnHandsBackTheHoldAsWell() {
+        TurnRecorder.noteHeldUtterance(parkedAt: at(0))
+        clock.now = at(5.0)
+        TurnRecorder.beginTurn()
+        TurnRecorder.abandonTurnReleasingUtterance()
+
+        clock.now = at(5.5)
+        TurnRecorder.beginTurn()
+        let replacement = sealAndRead()
+        XCTAssertEqual(replacement?.heldAt, at(0))
+        XCTAssertEqual(replacement?.heldSeconds ?? .nan, 5.5, accuracy: 0.001)
+    }
+
+    // MARK: - First token
+
+    func testFirstTokenIsRecordedOncePerTurnAndReArmsForTheNext() {
+        TurnRecorder.beginTurn()
+        clock.now = at(1.0)
+        TurnRecorder.markFirstToken()
+        clock.now = at(1.1)
+        TurnRecorder.markFirstToken()
+        XCTAssertEqual(sealAndRead()?.firstTokenAt, at(1.0), "every delta calls this; only the first counts")
+
+        TurnRecorder.beginTurn()
+        clock.now = at(9.0)
+        TurnRecorder.markFirstToken()
+        XCTAssertEqual(sealAndRead()?.firstTokenAt, at(9.0), "the next turn gets its own first token")
+    }
+
+    // MARK: - The speech hand-off window
+
+    /// A turn speaks more than its reply: `narrateModelSwitch` says "switching to Groq" while the
+    /// model is still generating. That utterance reaching `markPlaybackStart` would claim
+    /// `firstAudio` — the mark the headline metric *ends* at — and report the turn as far faster
+    /// than the wearer experienced it.
+    func testAModelSwitchNoticeSpokenMidTurnCannotClaimFirstAudio() {
+        TurnRecorder.noteSpeechEnd(at: at(0))
+        TurnRecorder.beginTurn()
+
+        TurnRecorder.markPlaybackStart(at: at(1.0))     // the "switching to Groq" notice
+        TurnRecorder.noteSpeechEngine(.system)
+        TurnRecorder.markPlaybackEnd(at: at(3.0))
+        TurnRecorder.markHUDRendered(at: at(1.2))
+
+        TurnRecorder.handOffToSpeech(at: at(8.0))        // now the reply goes to the engine
+        TurnRecorder.noteSpeechEngine(.elevenLabs)
+        TurnRecorder.markPlaybackStart(at: at(8.4))
+
+        let turn = sealAndRead()
+        XCTAssertEqual(turn?.firstAudioAt, at(8.4), "the reply's audio, not the notice's")
+        XCTAssertEqual(turn?.perceivedLatency ?? .nan, 8.4, accuracy: 0.001)
+        XCTAssertNil(turn?.spokeDoneAt, "the notice's playback end is not this turn's")
+        XCTAssertNil(turn?.hudRenderedAt, "nor is the notice's HUD mirror")
+        XCTAssertEqual(turn?.ttsEngine, .elevenLabs, "nor is the engine that spoke it")
+    }
+
+    /// The window is per-turn: the next turn starts closed, so a stray late callback from the last
+    /// one's playback cannot hand it a first-audio it never had.
+    func testTheHandOffWindowDoesNotSurviveIntoTheNextTurn() {
+        TurnRecorder.beginTurn()
+        TurnRecorder.handOffToSpeech(at: at(1.0))
+        TurnRecorder.endTurn()
+
+        TurnRecorder.beginTurn()
+        TurnRecorder.markPlaybackStart(at: at(2.0))
+        XCTAssertNil(sealAndRead()?.firstAudioAt)
+    }
+
+    // MARK: - Off-turn work
+
+    /// `AgentScheduler`, the notification digest and the OpenClaw triage all reach
+    /// `LLMService.sendMessage` and `runToolLoop` on their own timers, through the very code a voice
+    /// turn is using. Ungated, a scheduled Groq run re-tags a live on-device turn into the Groq
+    /// cohort and adds its tool seconds until `modelSeconds` clamps to zero — "the model took no
+    /// time at all".
+    func testBackgroundWorkCannotRetagOrAccumulateOntoTheLiveTurn() async {
+        TurnRecorder.beginTurn()
+        TurnRecorder.mark(.commit, at: at(0))
+        TurnRecorder.noteBackend(.direct(.local), model: "gemma-on-device")
+
+        await TurnRecorder.offTurn {
+            TurnRecorder.noteBackend(.direct(.groq), model: "llama-in-the-cloud")
+            TurnRecorder.addToolTime(since: at(-4.0))
+            TurnRecorder.addGeneration(tokens: 500, seconds: 1.0)
+            TurnRecorder.markFirstToken()
+        }
+
+        clock.now = at(3.0)
+        TurnRecorder.markFirstToken()
+        TurnRecorder.mark(.generationDone, at: at(10.0))
+
+        let turn = sealAndRead()
+        XCTAssertEqual(turn?.backend, .direct(.local), "the scheduled run must not own this cohort")
+        XCTAssertEqual(turn?.model, "gemma-on-device")
+        XCTAssertEqual(turn?.toolSeconds, 0, "nor charge this turn for its own tool round trips")
+        XCTAssertEqual(turn?.tokenCount, 0)
+        XCTAssertEqual(turn?.firstTokenAt, at(3.0),
+                       "and a suppressed token must not burn the turn's own first-token slot")
+        XCTAssertEqual(turn?.modelSeconds ?? .nan, 10.0, accuracy: 0.001,
+                       "ungated, the background loop's 4 s would come straight out of model time")
+    }
+
+    func testOffTurnSuppressionEndsWithTheWorkThatDeclaredIt() async {
+        TurnRecorder.beginTurn()
+        await TurnRecorder.offTurn { TurnRecorder.mark(.commit, at: self.at(1.0)) }
+        TurnRecorder.mark(.commit, at: at(2.0))
+        XCTAssertEqual(sealAndRead()?.commitAt, at(2.0))
+    }
+
+    // MARK: - Non-model work inside the backend leg
+
+    /// The model-switch notice blocks until it has finished *playing*, inside commit →
+    /// generationDone. Charged to the model, a cascade turn reports ~8 s of "model latency" when 3 s
+    /// of it was the app talking to the wearer.
+    func testAppWorkInsideTheBackendLegIsHeldOutOfModelTime() {
+        TurnRecorder.beginTurn()
+        TurnRecorder.mark(.commit, at: at(0))
+        clock.now = at(3.0)
+        TurnRecorder.addNonModelTime(since: at(0))      // the spoken "switching to Groq"
+        TurnRecorder.mark(.firstToken, at: at(4.0))
+        TurnRecorder.mark(.generationDone, at: at(8.0))
+
+        let turn = sealAndRead()
+        XCTAssertEqual(turn?.nonModelSeconds ?? .nan, 3.0, accuracy: 0.001)
+        XCTAssertEqual(turn?.backendSeconds ?? .nan, 8.0, accuracy: 0.001, "the leg is still reported whole")
+        XCTAssertEqual(turn?.modelSeconds ?? .nan, 5.0, accuracy: 0.001)
+        XCTAssertEqual(turn?.timeToFirstToken ?? .nan, 4.0, accuracy: 0.001)
+        XCTAssertEqual(turn?.modelTimeToFirstToken ?? .nan, 1.0, accuracy: 0.001,
+                       "the model had 1 s of the 4 s; the rest was the app speaking")
+    }
+
+    // MARK: - Mic route
+
+    /// `Config.micRoute` is a preference. `WakeWordService` leaves capture on the phone whenever the
+    /// preferred port is absent — glasses flat, asleep, out of range — so tagging from the
+    /// preference files 48 kHz phone-mic turns in the 8 kHz HFP cohort and reports a median that
+    /// describes neither population.
+    func testTurnIsTaggedWithTheRouteThatActuallyCapturedIt() {
+        TurnRecorder.reset(ledger: ledger,
+                           now: { [clock] in clock.now },
+                           micRoutePorts: { [(name: "Ray-Ban Meta Glasses", type: .bluetoothHFP)] })
+        TurnRecorder.beginTurn()
+        XCTAssertEqual(sealAndRead()?.micRoute, .glasses)
+
+        TurnRecorder.reset(ledger: ledger,
+                           now: { [clock] in clock.now },
+                           micRoutePorts: { [(name: "iPhone Microphone", type: .builtInMic)] })
+        TurnRecorder.beginTurn()
+        XCTAssertEqual(sealAndRead()?.micRoute, .phone,
+                       "the glasses being the preference does not make them the mic")
+
+        TurnRecorder.reset(ledger: ledger,
+                           now: { [clock] in clock.now },
+                           micRoutePorts: { [(name: "AirPods Pro", type: .bluetoothHFP)] })
+        TurnRecorder.beginTurn()
+        XCTAssertEqual(sealAndRead()?.micRoute, .headset)
+    }
+
+    func testASessionWithNoInputPortFallsBackToTheConfiguredPreference() {
+        TurnRecorder.beginTurn()   // setUp supplies no ports
+        XCTAssertEqual(sealAndRead()?.micRoute, Config.micRoute,
+                       "nothing was observed, so the preference is the only answer available")
+    }
+}

--- a/OpenGlassesTests/TurnTimelineTests.swift
+++ b/OpenGlassesTests/TurnTimelineTests.swift
@@ -1,0 +1,356 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan CU P1 — the pure core that has to be right before any latency claim about this app means
+/// anything. Each test below pins one of the derivation invariants; several of them are corrections
+/// that cost a bug to learn elsewhere, so they are written to fail loudly if the invariant is
+/// relaxed rather than to merely exercise the code.
+final class TurnTimelineTests: XCTestCase {
+
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// Marks are injected as offsets from a fixed epoch — the whole point of the type being pure.
+    private func at(_ offset: TimeInterval) -> Date { epoch.addingTimeInterval(offset) }
+
+    // MARK: - Invariant 1: tok/s comes from the reported pair, accumulated
+
+    /// The trap: `firstTokenAt → generationDoneAt` looks like a decode window and is not one. Marks
+    /// are first-wins and get backfilled for non-streaming backends, so a rate taken from them can
+    /// cover a different span than the tokens it divides.
+    func testTokensPerSecondComesFromTheReportedPairNotTheMarks() {
+        var timeline = TurnTimeline()
+        timeline.mark(.firstToken, at: at(1.0))
+        timeline.mark(.generationDone, at: at(1.5))   // a 0.5 s window, if you believed the marks
+        timeline.addGeneration(tokens: 100, seconds: 5.0)
+
+        XCTAssertEqual(timeline.tokensPerSecond ?? 0, 20.0, accuracy: 0.001,
+                       "the reported pair says 100 tokens over 5 s; the marks' 0.5 s window would say 200 tok/s")
+    }
+
+    /// Historical failure mode one: a window that rounds to nothing divides into millions of tok/s,
+    /// and a fictional rate is worse than no rate at all.
+    func testMicrosecondGenerationWindowReportsNoRateRatherThanAFictionalOne() {
+        var timeline = TurnTimeline()
+        timeline.addGeneration(tokens: 512, seconds: 0.000_002)
+
+        XCTAssertNil(timeline.tokensPerSecond,
+                     "a 2 µs window would divide into 256 million tok/s; the guard must return nil instead")
+        XCTAssertEqual(timeline.tokenCount, 512, "the raw counts are still recorded — only the rate is withheld")
+    }
+
+    /// Historical failure mode two: a tool turn runs the model more than once, and pass 2's token
+    /// count paired with pass 1's window produces a plausible-looking lie. Accumulating both halves
+    /// makes that pairing impossible to express.
+    func testGenerationPassesAccumulateSoPassTwoTokensCannotRidePassOnesWindow() {
+        var timeline = TurnTimeline()
+        timeline.addGeneration(tokens: 20, seconds: 4.0)     // pass 1: choose the tool
+        timeline.addGeneration(tokens: 180, seconds: 1.0)    // pass 2: write the answer
+
+        XCTAssertEqual(timeline.tokenCount, 200)
+        XCTAssertEqual(timeline.generationSeconds, 5.0, accuracy: 0.001)
+        XCTAssertEqual(timeline.tokensPerSecond ?? 0, 40.0, accuracy: 0.001,
+                       "200 tokens over 5 s. Overwriting would say 180; pass-2 tokens on pass-1's window, 45")
+    }
+
+    func testAddGenerationAccumulatesRatherThanOverwrites() {
+        var timeline = TurnTimeline()
+        timeline.addGeneration(tokens: 10, seconds: 1.0)
+        timeline.addGeneration(tokens: 10, seconds: 1.0)
+
+        XCTAssertEqual(timeline.tokenCount, 20)
+        XCTAssertEqual(timeline.generationSeconds, 2.0, accuracy: 0.001)
+    }
+
+    func testNoTokensMeansNoRate() {
+        var timeline = TurnTimeline()
+        timeline.addGeneration(tokens: 0, seconds: 3.0)
+        XCTAssertNil(timeline.tokensPerSecond)
+    }
+
+    // MARK: - Invariant 2: TTS lead-in is signed
+
+    /// Negative lead-in is the *good* case — playback began while the model was still generating,
+    /// which is the entire point of sentence-streaming. Clamping it away (as every other span does)
+    /// would delete the metric on exactly the turns it exists to characterise.
+    func testNegativeTTSLeadInIsPreserved() {
+        var timeline = TurnTimeline()
+        timeline.mark(.firstAudio, at: at(8.5))
+        timeline.mark(.generationDone, at: at(10.0))
+
+        XCTAssertEqual(timeline.ttsLeadIn ?? .nan, -1.5, accuracy: 0.001,
+                       "streaming TTS started 1.5 s before generation finished; that must survive as a negative")
+    }
+
+    func testPositiveTTSLeadInIsTheNonStreamingCase() {
+        var timeline = TurnTimeline()
+        timeline.mark(.generationDone, at: at(10.0))
+        timeline.mark(.firstAudio, at: at(10.8))
+        XCTAssertEqual(timeline.ttsLeadIn ?? .nan, 0.8, accuracy: 0.001)
+    }
+
+    /// The asymmetry stated outright. Marks are stamped from several queues and sit on a wall clock
+    /// that can step, so a backwards pair means a late or skewed mark rather than a real ordering —
+    /// everywhere except lead-in, which is allowed to be genuinely negative.
+    func testBackwardsMarksClampToNilEverywhereExceptLeadIn() {
+        var timeline = TurnTimeline()
+        timeline.mark(.speechEnd, at: at(12.0))          // stamped late; everything after reads earlier
+        timeline.mark(.commit, at: at(4.0))
+        timeline.mark(.ttsRequested, at: at(9.0))
+        timeline.mark(.generationDone, at: at(10.0))
+        timeline.mark(.firstAudio, at: at(8.5))
+
+        XCTAssertNil(timeline.endpointingDelay, "a backwards stage span is skew, not a measurement")
+        XCTAssertNil(timeline.perceivedLatency)
+        XCTAssertNil(timeline.ttsTimeToFirstByte)
+        XCTAssertEqual(timeline.ttsLeadIn ?? .nan, -1.5, accuracy: 0.001,
+                       "lead-in is the one span that keeps its sign")
+    }
+
+    // MARK: - Invariant 3: time-to-first-byte is a distinct metric
+
+    /// The streamed-reply shape both metrics exist for: the first sentence reaches the engine long
+    /// before generation ends, so lead-in is negative while synthesis latency is plainly positive.
+    /// One answers "did streaming help?", the other "how slow is the engine?".
+    func testStreamedTurnHasNegativeLeadInAndPositiveTimeToFirstByte() {
+        var timeline = TurnTimeline(ttsEngine: .elevenLabs)
+        timeline.mark(.ttsRequested, at: at(3.0))
+        timeline.mark(.firstAudio, at: at(3.4))
+        timeline.mark(.generationDone, at: at(6.0))
+
+        XCTAssertEqual(timeline.ttsTimeToFirstByte ?? .nan, 0.4, accuracy: 0.001,
+                       "the cloud round trip took 400 ms")
+        XCTAssertEqual(timeline.ttsLeadIn ?? .nan, -2.6, accuracy: 0.001,
+                       "speech started 2.6 s before generation finished")
+        XCTAssertNotEqual(timeline.ttsLeadIn ?? .nan, timeline.ttsTimeToFirstByte ?? .nan,
+                          "the two must never collapse into one number")
+    }
+
+    // MARK: - Invariant 4: frame-grab time is held separately
+
+    /// Vision TTFT contains the wait on the glasses' Bluetooth stream. Raw TTFT keeps it, because
+    /// that is what the turn cost; the model-only derivation removes it, because comparing raw
+    /// vision TTFT against text TTFT blames the model for the radio.
+    func testRawTimeToFirstTokenKeepsTheFrameGrabAndModelTTFTRemovesIt() {
+        var timeline = TurnTimeline()
+        timeline.mark(.commit, at: at(2.0))
+        timeline.mark(.firstToken, at: at(4.0))
+        timeline.addFrameGrabTime(1.2)
+
+        XCTAssertEqual(timeline.timeToFirstToken ?? .nan, 2.0, accuracy: 0.001,
+                       "the raw stage span is never silently corrected")
+        XCTAssertEqual(timeline.modelTimeToFirstToken ?? .nan, 0.8, accuracy: 0.001,
+                       "the model only had 0.8 s of it; the rest was waiting on a frame")
+    }
+
+    func testFrameGrabTimeAccumulatesAcrossGrabs() {
+        var timeline = TurnTimeline()
+        timeline.addFrameGrabTime(0.4)
+        timeline.addFrameGrabTime(0.6)
+        XCTAssertEqual(timeline.frameGrabSeconds, 1.0, accuracy: 0.001,
+                       "a multi-image turn grabs more than one frame")
+    }
+
+    func testModelTimeToFirstTokenIsFlooredRatherThanNegative() {
+        var timeline = TurnTimeline()
+        timeline.mark(.commit, at: at(0))
+        timeline.mark(.firstToken, at: at(0.5))
+        timeline.addFrameGrabTime(2.0)   // accounting overlapped the window
+        XCTAssertEqual(timeline.modelTimeToFirstToken ?? .nan, 0, accuracy: 0.001)
+    }
+
+    // MARK: - Invariant 5: tool time accumulates and stays out of model time
+
+    /// One turn, two tool round trips. Without the split, the six seconds spent inside the tools
+    /// report as model latency and the next afternoon goes into optimising the wrong thing.
+    func testTwoToolTurnKeepsToolExecutionOutOfModelSeconds() {
+        var timeline = TurnTimeline(backend: .direct(.anthropic))
+        timeline.mark(.commit, at: at(0))
+        timeline.addToolTime(2.5)
+        timeline.addToolTime(3.5)
+        timeline.mark(.generationDone, at: at(10.0))
+
+        XCTAssertEqual(timeline.toolIterations, 2)
+        XCTAssertEqual(timeline.toolSeconds, 6.0, accuracy: 0.001)
+        XCTAssertEqual(timeline.backendSeconds ?? .nan, 10.0, accuracy: 0.001,
+                       "the backend leg is reported whole")
+        XCTAssertEqual(timeline.modelSeconds ?? .nan, 4.0, accuracy: 0.001,
+                       "only 4 s of the 10 was the model")
+    }
+
+    func testToolTimeAndIterationsAccumulateRatherThanOverwrite() {
+        var timeline = TurnTimeline()
+        timeline.addToolTime(1.0)
+        timeline.addToolTime(1.0, iterations: 3)
+        XCTAssertEqual(timeline.toolSeconds, 2.0, accuracy: 0.001)
+        XCTAssertEqual(timeline.toolIterations, 4)
+    }
+
+    /// Frame grab and tool time both sit inside the backend leg, so both come out of model time.
+    func testModelSecondsRemovesFrameGrabAsWellAsToolTime() {
+        var timeline = TurnTimeline()
+        timeline.mark(.commit, at: at(0))
+        timeline.mark(.generationDone, at: at(9.0))
+        timeline.addToolTime(3.0)
+        timeline.addFrameGrabTime(1.5)
+        XCTAssertEqual(timeline.modelSeconds ?? .nan, 4.5, accuracy: 0.001)
+    }
+
+    // MARK: - Invariant 6: a held turn is measured from its own speech end
+
+    /// `TurnAdmissionPolicy.deferToQueue` parks an utterance while another turn runs and replays it
+    /// afterwards. Perceived latency must start at *this* turn's speech end — charging the hold to
+    /// the pipeline would make every deferred turn look like a backend problem, and the hold is a
+    /// queueing decision, not a slow model.
+    func testHeldTurnMeasuresPerceivedLatencyFromItsOwnSpeechEnd() {
+        var timeline = TurnTimeline()
+        timeline.mark(.held, at: at(0))
+        timeline.addHoldTime(7.0)
+        timeline.mark(.speechEnd, at: at(7.2))
+        timeline.mark(.firstAudio, at: at(9.2))
+
+        XCTAssertEqual(timeline.perceivedLatency ?? .nan, 2.0, accuracy: 0.001,
+                       "measured from speechEnd, not from heldAt — that would have said 9.2")
+        XCTAssertEqual(timeline.waitIncludingHold ?? .nan, 9.0, accuracy: 0.001,
+                       "the wearer's actual wait is reported next to it, never instead of it")
+    }
+
+    func testHoldTimeAccumulates() {
+        var timeline = TurnTimeline()
+        timeline.addHoldTime(3.0)
+        timeline.addHoldTime(4.0)
+        XCTAssertEqual(timeline.heldSeconds, 7.0, accuracy: 0.001)
+    }
+
+    func testUnheldTurnHasNoHoldAndReportsTheSameWaitEitherWay() {
+        var timeline = TurnTimeline()
+        timeline.mark(.speechEnd, at: at(0))
+        timeline.mark(.firstAudio, at: at(1.4))
+        XCTAssertEqual(timeline.heldSeconds, 0)
+        XCTAssertEqual(timeline.waitIncludingHold ?? .nan, timeline.perceivedLatency ?? .nan, accuracy: 0.001)
+    }
+
+    // MARK: - Invariant 7: perceived latency is the headline, and honest about absence
+
+    func testPerceivedLatencyIsTheSpeechEndToFirstAudioWindow() {
+        var timeline = TurnTimeline()
+        timeline.mark(.speechEnd, at: at(0))
+        timeline.mark(.commit, at: at(2.0))          // the silence window P2 exists to remove
+        timeline.mark(.firstToken, at: at(2.9))
+        timeline.mark(.generationDone, at: at(4.1))
+        timeline.mark(.ttsRequested, at: at(3.1))
+        timeline.mark(.firstAudio, at: at(3.6))
+        timeline.mark(.spokeDone, at: at(7.0))
+
+        XCTAssertEqual(timeline.perceivedLatency ?? .nan, 3.6, accuracy: 0.001)
+        XCTAssertEqual(timeline.endpointingDelay ?? .nan, 2.0, accuracy: 0.001)
+        XCTAssertEqual(timeline.playbackSeconds ?? .nan, 3.4, accuracy: 0.001)
+        XCTAssertEqual(timeline.totalSeconds ?? .nan, 7.0, accuracy: 0.001)
+    }
+
+    /// A turn that errored after commit never reached audio. There is no perceived latency to
+    /// report and inventing one — from generation done, from the last mark — would put a number in
+    /// the aggregate for a turn the wearer never heard.
+    func testPerceivedLatencyIsNilWhenTheTurnNeverReachedAudio() {
+        var timeline = TurnTimeline()
+        timeline.mark(.speechEnd, at: at(0))
+        timeline.mark(.commit, at: at(2.0))
+        timeline.mark(.firstToken, at: at(3.0))
+        timeline.abandoned = true
+
+        XCTAssertNil(timeline.perceivedLatency)
+        XCTAssertNil(timeline.waitIncludingHold)
+        XCTAssertNil(timeline.ttsTimeToFirstByte)
+        XCTAssertNil(timeline.ttsLeadIn)
+    }
+
+    // MARK: - Partial timelines, marks, and the panel's view of them
+
+    /// The abandoned turn is not a write-off: what it did reach is the most informative record we
+    /// have of where it stopped.
+    func testAbandonedTurnStillYieldsAUsablePartialTimeline() {
+        var timeline = TurnTimeline(backend: .direct(.local), micRoute: .glasses)
+        timeline.mark(.speechEnd, at: at(0))
+        timeline.mark(.commit, at: at(2.0))
+        timeline.mark(.firstToken, at: at(6.5))
+        timeline.abandoned = true
+
+        XCTAssertEqual(timeline.timeToFirstToken ?? .nan, 4.5, accuracy: 0.001,
+                       "TTFT is exactly the number that explains why this turn was abandoned")
+        XCTAssertEqual(timeline.startedAt, at(0))
+        XCTAssertNil(timeline.backendSeconds, "generation never finished; no span to report")
+    }
+
+    /// A caller marking `.firstToken` on every streamed delta must not walk the mark forward — the
+    /// metric is about the *first* one.
+    func testMarksAreFirstWins() {
+        var timeline = TurnTimeline()
+        timeline.mark(.firstToken, at: at(3.0))
+        timeline.mark(.firstToken, at: at(3.9))
+        timeline.mark(.firstToken, at: at(4.4))
+        XCTAssertEqual(timeline.firstTokenAt, at(3.0))
+        XCTAssertEqual(timeline[.firstToken], at(3.0))
+    }
+
+    func testUnmarkedStagesReadAsNil() {
+        let timeline = TurnTimeline()
+        for stage in TurnTimeline.Stage.allCases {
+            XCTAssertNil(timeline[stage], stage.rawValue)
+        }
+        XCTAssertNil(timeline.startedAt)
+        XCTAssertEqual(timeline.segments, [])
+    }
+
+    func testStartedAtIsTheFirstMarkInCanonicalOrder() {
+        var held = TurnTimeline()
+        held.mark(.speechEnd, at: at(7.2))
+        held.mark(.held, at: at(0))
+        XCTAssertEqual(held.startedAt, at(0), "a held turn's clock starts when it was parked")
+
+        var direct = TurnTimeline()
+        direct.mark(.speechEnd, at: at(7.2))
+        XCTAssertEqual(direct.startedAt, at(7.2))
+    }
+
+    /// A non-streaming backend has no first token of its own. The breakdown absorbs the missing
+    /// stages into the next segment rather than drawing zero-width bars that would read as
+    /// "instant" when they mean "never observed".
+    func testSegmentsSkipStagesThatNeverLanded() {
+        var timeline = TurnTimeline()
+        timeline.mark(.speechEnd, at: at(0))
+        timeline.mark(.commit, at: at(2.0))
+        timeline.mark(.firstAudio, at: at(5.0))
+
+        XCTAssertEqual(timeline.segments,
+                       [TurnTimeline.Segment(stage: .commit, seconds: 2.0),
+                        TurnTimeline.Segment(stage: .firstAudio, seconds: 3.0)])
+    }
+
+    // MARK: - Cohorts
+
+    /// The tagging rule made structural: two turns that differ only in mic route are two
+    /// populations, and an aggregate that pools them describes neither.
+    func testCohortsSeparateMicRoutesAndTTSEngines() {
+        var phone = TurnTimeline(backend: .direct(.anthropic), ttsEngine: .elevenLabs, micRoute: .phone)
+        var glasses = TurnTimeline(backend: .direct(.anthropic), ttsEngine: .elevenLabs, micRoute: .glasses)
+        var kokoro = TurnTimeline(backend: .direct(.anthropic), ttsEngine: .kokoro, micRoute: .phone)
+
+        XCTAssertNotEqual(phone.cohort, glasses.cohort)
+        XCTAssertNotEqual(phone.cohort, kokoro.cohort)
+        XCTAssertEqual(Set([phone.cohort, glasses.cohort, kokoro.cohort]).count, 3)
+
+        // Marks and spans are not part of the grouping key — two turns of different length still
+        // belong to the same cohort.
+        phone.mark(.speechEnd, at: at(0))
+        glasses.mark(.speechEnd, at: at(0))
+        kokoro.mark(.speechEnd, at: at(0))
+        var otherPhoneTurn = TurnTimeline(backend: .direct(.anthropic), ttsEngine: .elevenLabs, micRoute: .phone)
+        otherPhoneTurn.mark(.speechEnd, at: at(100))
+        XCTAssertEqual(phone.cohort, otherPhoneTurn.cohort)
+    }
+
+    func testRealtimeBackendsAreTheirOwnCohorts() {
+        XCTAssertNotEqual(TurnBackend.geminiLive, TurnBackend.openAIRealtime)
+        XCTAssertNotEqual(TurnBackend.direct(.gemini), TurnBackend.geminiLive)
+        XCTAssertEqual(TurnBackend.direct(.groq).label, "groq")
+    }
+}

--- a/docs/plans/CU-voice-turn-latency.md
+++ b/docs/plans/CU-voice-turn-latency.md
@@ -1,0 +1,325 @@
+# Plan CU — Voice Turn Latency & Instrumentation
+
+**Status: 📝 Drafted 2026-08-22** — no PR yet.
+
+Every Direct-mode turn pays a fixed floor of dead air before the model is even asked.
+`TranscriptionService` commits a turn on a silence timer whose window is
+`SpeechContinuationPolicy.baseWindow` = **2.0 s**, widened to `questionWindow` = 6.0 s when the
+assistant's own reply was question-shaped ([CO](CO-identity-budget-turn-taking.md) Item 4). That
+window is load-bearing and CO was right to widen it — but it is measuring the wrong thing. It asks
+*"has the recognizer been quiet for N seconds"* as a proxy for *"has the wearer finished talking"*,
+and the proxy is bad in both directions at once:
+
+- `SFSpeechRecognizer` delivers partials in **bursts with ~1 s gaps while the user is still
+  speaking**, so any window short enough to feel responsive fires mid-sentence.
+- Every *completed* turn pays the whole window as silence before the backend is touched, so a fast
+  cloud model and a slow local one finish about as far apart as their windows — which is to say,
+  not very.
+
+CO Item 4 already established the cost asymmetry ("waiting too long is mildly awkward, cutting
+someone off mid-thought loses the turn entirely") and resolved it by *lengthening*. **This plan does
+not relitigate that.** It changes the *signal* so the trade-off stops being forced: decide
+end-of-turn from the **audio**, where the question "did speech stop?" is directly answerable, and
+demote the timer to a backstop. Our own code has named this as the intended follow-up since the
+on-device ASR work — `TranscriptionService.swift:54-57`: *"VAD-based endpointing + on-device partial
+results are the staged follow-up."*
+
+Two paths were considered and are **rejected up front**, because both are cheaper than VAD and both
+are known dead ends:
+
+- **Adaptive transcript timing** (shorten the window when partials look settled) — the burst pattern
+  above is not distinguishable from a finished sentence at the timing layer.
+- **Grammatical completeness** of the partial ("does this parse as a whole sentence?") — *"what's the
+  weather"* is both a complete sentence and a prefix of *"what's the weather in London tomorrow"*, so
+  a completeness test commits mid-utterance. This is a semantic dead end, not a tuning problem.
+
+Both rejections have since been **corroborated in the field, twice, independently**: two separate
+builds of comparable apps shipped a transcript-completeness endpointer (dangling-word and filler
+lists shortening the window when the partial "reads finished"), one of them reverted it the same day
+for cutting users off, and the surviving path in both cases is acoustic. That is not a reason to
+change this plan — it is the reason not to spend a week re-discovering it cheaply first.
+
+## Why instrumentation lands first
+
+We cannot currently verify any latency claim about this app. `Diagnostics/SubsystemTestRunner`
+covers cold-start subsystem checks; **nothing measures a live turn**. Perceived slowness is
+attributed by feel, and feel is exactly what gets this wrong — a fixed endpointing window is
+invisible to intuition because it is identical on every turn and therefore reads as "the app's
+speed" rather than as one stage you could remove.
+
+So **P1 is instrumentation and it ships before the fix.** Otherwise P2 is tuned by vibes and P3 is
+guesswork. This ordering is the point of the plan, not an accident of it.
+
+## P1 — `TurnTimeline` (pure core, lands first)
+
+A value type holding the timestamps of one voice turn, with derived durations. Pure — no I/O, no
+`Date()` inside, stages injected — so every derivation is unit-testable against fixture turns.
+Stages are optional throughout: a turn can be abandoned at any point (interrupted, superseded,
+error) and a **partial timeline is still worth recording**.
+
+### Stage taxonomy
+
+| Mark | Meaning |
+|---|---|
+| `heldAt` | utterance parked by `TurnAdmissionPolicy.deferToQueue` (ours) |
+| `speechEndAt` | the mic went quiet — end-of-turn decision point |
+| `commitAt` | handed to a backend |
+| `firstTokenAt` | backend produced first output — *"is the model slow?"* |
+| `generationDoneAt` | model finished the reply |
+| `ttsRequestedAt` | text handed to the speech engine |
+| `firstAudioAt` | **the wearer actually hears something** — perceived latency ends here |
+| `hudRenderedAt` | reply mirrored to the lens (ours) |
+| `spokeDoneAt` | playback finished |
+
+Plus spans that sit *inside* other stages and must be visible separately: `frameGrabSeconds`,
+`toolSeconds`/`toolIterations`, `heldSeconds`. Plus tags: `backend`, `model`, `ttsEngine`,
+`micRoute`, `abandoned`, `interrupted`.
+
+**The headline metric is `perceivedLatency` = `speechEndAt` → `firstAudioAt`.** Everything inside it
+is dead air from the wearer's point of view, and it is the number this whole plan exists to move.
+
+### Meld or adopt wholesale — decided
+
+The taxonomy above is a well-trodden shape for voice agents and there is nothing to gain by
+inventing our own. The decision splits four ways:
+
+1. **Taxonomy and headline metric — adopt wholesale.** speechEnd → commit → firstToken → genDone →
+   firstAudio → spokeDone, with perceived latency as the number that matters.
+2. **The four derivation invariants — adopt wholesale.** These are the expensive part; each one is a
+   correction that costs a bug to learn:
+   - **tok/s comes only from the library-reported pair** (`tokenCount`, `generateTime`), both
+     *accumulated across generation passes*, never from timeline deltas. Timeline stamps are
+     first-wins and get backfilled for non-streaming backends, so a rate derived from them can
+     silently cover a different span than the tokens it divides. Two distinct failure modes live
+     here: a microsecond window dividing into millions of tok/s, and pass-2's token count paired with
+     pass-1's time window. Keep a minimum-window sanity guard; **no rate is better than a fictional
+     one.**
+   - **TTS lead-in is signed on purpose.** `generationDoneAt` → `firstAudioAt` going *negative* means
+     speech started while the model was still generating — the good case, and the entire point of
+     sentence-streaming. Clamping negatives to nil (as every other stage does) deletes the metric on
+     exactly the turns it exists to characterise.
+   - **TTS time-to-first-byte is a distinct metric** from lead-in: `ttsRequestedAt` → `firstAudioAt`.
+     On a streamed reply the first sentence reaches the engine long before generation ends, so
+     lead-in can be negative while TTFB stays positive. This is the one that answers "how slow is
+     synthesis?"
+   - **Frame-grab time is held separately.** It happens between commit and first token, so vision
+     TTFT *includes* it — comparing vision TTFT against text TTFT without subtracting it blames the
+     model for time spent waiting on the glasses' Bluetooth stream.
+3. **Stages — meld, because our turn is structurally bigger.** Four additions are not optional
+   polish; without them the numbers actively lie on our most common turn shapes:
+   - **`toolSeconds` / `toolIterations`.** We have 36+ native tools behind `ToolLoopDriver`, so one
+     turn can be several LLM round trips with execution between them. Without this split, a turn
+     that spent four seconds in a HomeKit call reports four seconds of "model latency" and we go
+     optimise the wrong thing.
+   - **`heldSeconds`.** `TurnAdmissionPolicy.deferToQueue` parks an utterance (up to `maxHoldAge`
+     = 20 s) and replays it when the running turn finishes. That turn's clock starts before its own
+     speech ended; unrecorded, its perceived latency is nonsense.
+   - **`micRoute` tag.** `MicRoute` is three-way (phone / glasses / headset). An 8 kHz Bluetooth HFP
+     link and the phone's 48 kHz mic are two different populations for every acoustic metric in P2 —
+     mixing them produces an average that describes neither.
+   - **`ttsEngine` tag over a three-engine chain.** Ours is ElevenLabs → Kokoro → iOS, and the first
+     is **network** while the second is **on-device Metal**. Those aren't voices, they're three
+     different pipelines: cloud TTFB includes a round trip, and Kokoro synthesising on the GPU
+     measurably slows local decode, so tok/s is only comparable *within* one engine.
+4. **Code — rebuild, don't port.** It's a ~150-line pure struct; the value is the design decisions
+   above, which are now written down here. Porting source would also pull an attribution obligation
+   into About for something we can write in an afternoon.
+5. **Sinks — skip entirely.** No InfluxDB, no Grafana, no `docker-compose`, no push. It lands in the
+   existing Settings → Advanced → Developer diagnostics surface as an on-device ring buffer with a
+   debug export. This is not just scope control: **any push sink becomes an egress question** we then
+   have to answer for HIPAA mode and for `PrivacyFilterScope`'s "every egress is filtered" rule. An
+   on-device ring buffer has no such question, and per-turn latency is a debugging tool for us, not
+   a product surface for the wearer.
+
+### Deliverables
+
+- `TurnTimeline` value type + derivations, with fixture-turn tests covering each invariant above
+  (including a negative-lead-in turn and a two-pass tool turn, since those are the ones prior art
+  got wrong).
+- A bounded in-memory `TurnLedger` (ring buffer, count- and byte-capped) and marking calls threaded
+  through the existing turn path in `OpenGlassesApp`.
+- A Developer-panel view: last N turns, stage breakdown, and the aggregate split by `backend` ×
+  `ttsEngine` × `micRoute` (never pooled — see the tagging rules above).
+
+**Deferred out of P1, deliberately:** the two realtime backends are *modelled* (`TurnBackend`
+carries them, cohorts keep them apart) but not *produced* — neither session manager has turn
+boundaries wired to the recorder, so no realtime turn is recorded and the Direct-vs-realtime
+baseline under Non-goals below cannot be read off the panel yet. Wiring those two managers is the
+first follow-up, not part of P1's diff. Likewise `ttsLeadIn` is signed and will stay signed, but no
+Direct-mode spine can currently produce a negative one: every spine hands the whole reply to the
+speech engine after `generationDone`, so a panel full of positive lead-ins means "no streaming
+hand-off exists to measure", not "sentence streaming is off".
+
+## P2 — Acoustic end-of-turn
+
+### `EndOfTurnPolicy` (pure core)
+
+Arbitrates the acoustic signal against the existing timer, and it is where the CO Item 4 semantics
+get preserved rather than overwritten:
+
+- **Detector unavailable ⇒ byte-for-byte today's behaviour.** The timer path stays exactly as it is.
+  Voice input degrading to "as it was before" is acceptable; breaking it is not.
+- **Speech observed, then ended ⇒ commit after a short grace.** This is the case that removes the
+  2 s floor.
+- **Speech never started ⇒ the timer still owns the decision, at the CO Item 4 window.** This is the
+  subtle half: `questionWindow` exists for a wearer who is *thinking about their answer*, i.e. has
+  not started speaking. Acoustic endpointing has nothing to say about that wearer, so the 6 s window
+  survives untouched as a **no-speech** window. Conflating the two would quietly re-break the exact
+  case CO shipped to fix.
+- **Threshold asymmetry mirrors CO's.** Set the detector's speech threshold *above* the library
+  default: the glasses HFP mic is 8 kHz and noisy, and a false "speech" costs a little latency
+  whereas a false "silence" cuts the wearer off mid-sentence. Same asymmetry, same direction, one
+  layer down.
+
+### `SpeechActivityDetector` (behind a seam)
+
+On-device Silero VAD on the Neural Engine, scoring 16 kHz mono in fixed hops. Soft-fail throughout:
+if the model won't load, `isAvailable` stays false, no events are emitted, and `EndOfTurnPolicy`
+falls through to the timer.
+
+**Where it taps: nowhere new.** `TranscriptionService` already installs a tap
+(`TranscriptionService.swift:164`, `:224`) and accumulates `Float` samples for the on-device ASR
+path. The detector is fed from those same buffers. A second tap would be the wrong move on two
+counts — `WakeWordService` owns the shared engine (`sharedAudioEngineProvider`), and CJ's tap-format
+audit plus AO's audio-session work exist precisely because taps and route changes are where this
+subsystem breaks.
+
+Threading rules, all forced by the fact that `feed(_:)` runs on the **Core Audio render thread**
+~45×/sec:
+
+- Never block, never allocate unpredictably, never hop to the main actor in `feed`. Convert and
+  accumulate under a lock; hand full chunks to an `AsyncStream`; a single consumer task drains it in
+  order (streaming VAD state must be threaded sequentially).
+- **Drop oldest under backpressure**, don't queue. Stale audio is worthless for a liveness decision,
+  and a growing backlog reports speech-end later and later — the failure mode is a slow leak into
+  exactly the latency we're removing.
+- **Rebuild the converter on route change.** A converter built for the old format emits garbage
+  after the route flips, and we flip routes as a matter of course (`MicRoute`, "Hey Meta" stealing
+  the route, glasses connect/disconnect). [CW](CW-realtime-audio-rig-recovery.md) P1 makes the same
+  format-changed test the trigger for rebuilding the *graph*; same hazard, one layer up, and the two
+  should read the format from one place rather than each caching their own idea of it.
+- Callbacks reach the main actor only on speech start/end transitions — a few times per turn.
+
+### Rider: cheaper barge-in
+
+`WakeWordService.onBargeIn` currently fires on recognised *text* during TTS. A VAD speech-start
+event is the same signal several hundred milliseconds earlier and without a recognition round trip.
+Wire it as an additional trigger, not a replacement — the text path also carries the utterance,
+which the barge-in handler uses.
+
+### Rider: per-route input gain
+
+Every threshold in this section is calibrated against a signal level, and that level is not
+comparable across routes — the phone mic at arm's length reads far quieter than a glasses mic at the
+temple, which is the acoustic half of why `micRoute` is a cohort tag in P1 rather than a footnote. A
+clamped per-`MicRoute` input gain, applied before the detector sees the samples, is what makes one
+threshold pair mean the same thing on both routes. It must land **with** the threshold work, not
+after it: tuning a threshold against an un-normalised level and then normalising the level
+invalidates the tuning. [CW](CW-realtime-audio-rig-recovery.md) notes the same rider from the rig
+side and defers it here on purpose, so it is not tuned twice against two different populations.
+
+### Dependency decision
+
+Silero via a maintained Swift package (Apache-2.0, actively developed) versus vendoring the CoreML
+model ourselves. Leaning package, on the CD P3 convention: **pin exactly**, refresh
+`ci_scripts/Package.resolved` per `project_xcode_cloud_resolved`, and attribute in About. Vendoring
+is the fallback if the package pulls in more than the VAD path.
+
+## P3 — Local-model time-to-first-token (gated on P1's numbers)
+
+Two changes that plausibly halve local TTFT:
+
+- **KV prefix cache across turns** — `LocalLLMService` has no prompt cache today, so our
+  `SystemPromptBuilder` prompt (large, and it grows with every tool we add) is prefilled on **every
+  turn** instead of once per session.
+- **Per-model routing-prompt sizing** — a capable model needs a short instruction; a small model
+  needs the fully-worked examples. One prompt for both means either the big model reads an essay or
+  the small one guesses.
+
+**Explicitly gated on P1.** Only worth doing if the timeline shows TTFT is the next-largest stage
+after endpointing, and there is a real cost on the other side: a retained KV cache holds memory that
+`LocalModelBudget` / `MemoryHeadroom` exist to reclaim, and jetsam kills are a documented failure
+mode of this subsystem (per `project_local_model_background` and the CK/local-model history). Do not
+start this before P1 lands.
+
+## P4 — Front-of-turn: wake-word pre-roll
+
+P2 removes dead air at the **end** of an utterance. There is an equal and separate amount at the
+**start**, and it is paid by the wearer in the most annoying currency available: having to say it
+again.
+
+Today the wake word opens the turn and everything spoken *in the same breath* after it is lost —
+`WakeWordService` detects, we tear down its recognition and stand up the turn's own capture, and the
+audio in that gap goes nowhere. So *"Hey Glasses, what time is it"* answers with a listening cue and
+waits, and the wearer repeats the question they already asked. The fix is not faster hand-off; the
+gap is structural. **Keep the audio.**
+
+### `WakePreRollRing` (pure core)
+
+A bounded ring of PCM16 mono at the capture rate holding the last ~2 s, fed from the **same tap the
+recognizer already reads** — a second tap is the wrong move for the reasons P2 gives, and
+`WakeWordService` owns the shared engine either way. Pure, allocation-free after construction,
+oldest-falls-off, unit-tested against fixture writes.
+
+The non-obvious requirement is that a ring of samples is not enough on its own: we need to know
+**where in it the wake phrase ended**, or we replay the wake word itself into the turn and the model
+answers a question that begins with its own name. So the ring carries an **audio clock** — an epoch
+marked per recognition request — and the wake phrase's end is located from the detecting result's
+own segment timing (`segment.timestamp + duration`), not from wall-clock. Wall-clock cannot work
+here: detection latency is variable and the ring is written on the audio thread.
+
+Rules that make it safe rather than clever:
+
+- **Not locatable ⇒ replay nothing.** A bare wake word must open the turn and stay silent. Guessing
+  an offset is worse than the status quo, because a wrong guess feeds a fragment of the wake word in
+  as the user's question.
+- **Stale ⇒ discard.** A pre-roll older than a few seconds describes a different moment; hand back
+  nil and let the turn start clean.
+- **Survives recognizer restarts.** The recognizer is restarted routinely (`WakeWordService` cycles
+  it); the ring is fed by the tap, not the recognizer, so a restart re-marks the epoch and keeps the
+  audio.
+
+### Wiring
+
+- **Direct mode:** the pre-roll tail is prepended to the turn's transcription input, so the
+  utterance the backend sees is the whole breath.
+- **Realtime backends:** bring the mic up **before** the socket, buffer frames through the handshake,
+  and send the pre-roll as the session's first audio append once connected. The handshake is dead
+  time we currently spend deaf; this is the same "keep the audio" move applied to a different gap.
+  Note this is *not* the endpointing work the Non-goals below exclude for realtime — those sessions
+  endpoint server-side and stay that way; this is about what they are given to start with.
+
+Measured, not asserted: P1 gains a `preRollMilliseconds` span, and the win shows up as
+`speechEndAt` → `commitAt` shrinking on wake-initiated turns specifically. If it doesn't, the ring
+is mis-located and the guard above should be firing.
+
+## P5 — Device measurement (deferred)
+
+Needs hardware, and gates the shipped defaults:
+
+- Perceived latency before/after, on **both mic routes** (phone and glasses HFP) — reported
+  separately, never pooled.
+- False-cut rate: how often acoustic endpointing commits mid-sentence at the chosen threshold. This
+  is the metric that can veto the feature; a latency win that cuts people off is not a win.
+- Detector cost: Neural Engine load, battery, thermal over a long session.
+- Route-change behaviour: converter rebuild across a glasses connect/disconnect mid-turn.
+- Pre-roll correctness (P4): the wake word never appears in the transcript, and a one-breath
+  *"<wake word>, <question>"* is answered without a repeat — on both mic routes.
+
+## Non-goals
+
+- **Gemini Live and OpenAI Realtime endpointing.** Both already endpoint server-side and are fine;
+  this is a Direct-mode plan. The *timeline* should still cover realtime turns, because comparing
+  Direct-mode against them is the most useful baseline we have.
+- **A telemetry service.** No server, no push, no consent surface — see P1 item 5.
+- **Reopening CO Item 4.** The question window stays; it changes meaning (no-speech rather than
+  post-speech), it does not shrink.
+
+## Open questions
+
+- Should VAD also replace `noSpeechTimeout` (currently a flat 10 s)? Probably, but it's a different
+  failure mode — nobody spoke at all — and can follow.
+- Does the on-device ASR path (`OnDeviceASREngine`, whole-buffer SenseVoice) want VAD endpointing
+  too? Its own comment says yes. It's the natural second consumer of P2 and would let that path stop
+  depending on the caller's `stopRecording()`.
+- Ring-buffer size and whether the debug export is on by default in Debug builds only.


### PR DESCRIPTION
Instrumentation for the voice turn, landing **before** the fix it exists to enable ([Plan CU](docs/plans/CU-voice-turn-latency.md) P2, acoustic endpointing).

## Why this first

We could not verify any latency claim about this app. `SubsystemTestRunner` covers cold-start checks; nothing measured a live turn. That matters more than it sounds: a fixed endpointing window is invisible to intuition precisely *because* it is identical on every turn, so it reads as "the app's speed" rather than as one stage you could remove. Without this, P2 is tuned by feel and P3 is guesswork.

Headline metric is `perceivedLatency` — `speechEnd → firstAudio`, the wearer's dead air.

## Design decisions worth reviewing

`TurnTimeline` is pure (no I/O, no `Date()` inside), every stage optional, because a turn abandoned partway is still worth recording.

Four derivation rules, each of which costs a bug to learn:

- **tok/s only from the backend-reported `(tokenCount, generateTime)` pair**, both accumulated across passes — never timeline deltas, which are first-wins and backfilled. Guards two distinct failure modes: a microsecond window dividing into millions of tok/s, and pass-2 tokens over a pass-1 window.
- **TTS lead-in is signed on purpose.** Negative means speech started before generation finished — the good case, and the whole point of sentence-streaming. Clamping it (as every other stage does) would delete the metric on exactly the turns it characterises.
- **TTS TTFB is distinct from lead-in.**
- **Frame-grab time held separately**, or vision TTFT blames the model for Bluetooth wait.

Four stages are ours, because without them the numbers actively lie on our common turn shapes: `toolSeconds`/`toolIterations` (else a 4s HomeKit call reports as model latency), `heldSeconds`, `micRoute`, `ttsEngine`.

## What adversarial review caught

- **The blocker:** `speechEnd` was stamped when the silence timer *fires*, so `perceivedLatency` excluded the whole 2–6s endpointing floor. P2's before/after would have come out ≈zero because the number never contained the window. Now stamped where the window is armed.
- **Background work was corrupting live turns.** Schedulers, notification triage and summarisation traverse the same `sendMessage`/`runToolLoop` a turn does — re-tagging the live turn's cohort and charging it tool time until `modelSeconds` clamped to 0.00s. Gated behind a `@TaskLocal`, since a flag cannot separate work that overlaps *in time on the same actor*.
- Cohorts now tag the route that **actually captured** the audio, not the user's preference.
- A tier-0 tool failure hands its utterance back rather than silently dropping the app's slowest turns from the aggregate.

## Scope

No sink — a bounded ring buffer and a developer panel. Any push sink becomes an egress question we'd owe HIPAA mode and `PrivacyFilterScope`.

## Verification

- Debug suite **2980 tests, 0 failures**
- Release clean apart from the documented keychain set that needs code signing (`KeychainServiceTests`, `SecretMigrationTests`, and the two token tests in `ConfigTests`/`OpenClawAgentGateTests`)
- Branch builds standalone (`** TEST BUILD SUCCEEDED **`), independent of the CQ branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)