### PR TITLE
Plan CQ P0+P1+P4 — device tiers, camera backend seam, capture-protocol codec

### DIFF
--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -557,8 +557,50 @@ struct HardwarePrivacyView: View {
     @Binding var isTogglingEncryption: Bool
     @State private var showEncryptionInfo = false
 
+    /// Plan CQ P0: what class of device is connected, resolved from the three things that
+    /// actually determine it. Re-read on each render — this view is cheap and the answer
+    /// changes when glasses connect or drop.
+    private var connectedTier: GlassesTier? {
+        GlassesTierPolicy.resolve(
+            cameraCapabilities: appState.cameraService.activeCapabilities,
+            displayBackendActive: appState.glassesDisplay.isDisplayActive,
+            audioPortNames: (AVAudioSession.sharedInstance().availableInputs ?? []).map(\.portName)
+        )
+    }
+
     var body: some View {
         Form {
+            // Plan CQ P0: "which glasses work with OpenGlasses?" stopped being a product name.
+            // Any glasses that pair as a Bluetooth headset already run the whole voice loop, so
+            // say what the connected pair CAN do rather than letting the user find the limits
+            // one failed feature at a time.
+            Section("Connected Glasses") {
+                if let tier = connectedTier {
+                    LabeledContent("Device class", value: tier.label)
+                    Text(tier.summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    LabeledContent(
+                        "Camera",
+                        value: CameraFeatureGate.summary(given: appState.cameraService.capabilities)
+                    )
+                    let blocked = CameraFeatureGate.unavailableFeatures(
+                        given: appState.cameraService.activeCapabilities ?? .unavailable
+                    )
+                    if !blocked.isEmpty {
+                        Text("Unavailable on these glasses: "
+                             + blocked.map(\.displayName).joined(separator: ", "))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Text("No glasses detected. Pair them in iOS Settings — any glasses that "
+                         + "connect as a Bluetooth headset can run the voice features.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             // Plan CL P3: unified capture route. Headset mode exists because the
             // glasses' hands-free mic link makes Display glasses put their call
             // screen over the lens HUD — earbuds carry mic + voice, lens stays free.

--- a/OpenGlasses/Sources/Services/Audio/MicRoutePolicy.swift
+++ b/OpenGlasses/Sources/Services/Audio/MicRoutePolicy.swift
@@ -36,8 +36,30 @@ enum MicRoute: String, CaseIterable, Identifiable {
 /// Pure route → audio-session decisions, so the selection rules are unit-
 /// testable without an `AVAudioSession`. `WakeWordService` applies them.
 enum MicRoutePolicy {
-    /// Port-name markers that identify the glasses across Meta's lineup.
-    static let glassesNameMarkers = ["meta", "ray-ban", "rayban", "oakley", "glasses"]
+    /// Port-name markers that identify a pair of glasses rather than earbuds.
+    ///
+    /// Plan CQ P0: this list is deliberately **data-only** so a newly supported device is a
+    /// one-line addition, and deliberately **conservative** so it never claims a headset.
+    /// A false positive here is not cosmetic — the `.headset` route skips anything that looks
+    /// like glasses, so a mismatched pair of earbuds would silently stop being selectable, and
+    /// the `.glasses` route would grab them instead. That is why the entries are distinctive
+    /// brand or product tokens ("even g", "camera glasses") and never bare fragments like
+    /// "even", "g2" or "cyan", which appear inside ordinary headset names.
+    ///
+    /// Non-Meta entries are **unverified against hardware** — they are the advertised names
+    /// these devices are reported to use, and matching them only affects which route label the
+    /// user sees and which port the route prefers.
+    static let glassesNameMarkers = [
+        // Meta's lineup.
+        "meta", "ray-ban", "rayban", "oakley", "glasses",
+        // Plan CQ Track B — the OEM capture-to-storage class, sold under many badges.
+        // (Products literally named "Camera Glasses" are already caught by "glasses".)
+        "anko", "heycyan",
+        // Plan CQ Track A — developer camera glasses.
+        "mentra",
+        // Display-tier glasses (Plan AH and the wider display class).
+        "even g", "vuzix",
+    ]
 
     static func looksLikeGlasses(portName: String) -> Bool {
         let name = portName.lowercased()

--- a/OpenGlasses/Sources/Services/Camera/CameraCapabilities.swift
+++ b/OpenGlasses/Sources/Services/Camera/CameraCapabilities.swift
@@ -1,0 +1,214 @@
+import Foundation
+
+/// Plan CQ P1 — what a camera backend can actually do.
+///
+/// The app was written against exactly one camera (Meta's, over DAT), which streams live frames
+/// and captures stills on demand. Every other glasses camera we might support does less than
+/// that, and does less in *different* ways: one class captures stills to a webhook with no local
+/// frame access at all, another captures to onboard storage and needs a network hop to fetch
+/// anything usable, and that same class cannot run its camera and microphone at the same time.
+///
+/// Rather than discover those limits one crashed feature at a time, a backend declares them up
+/// front and `CameraFeatureGate` turns them into an answer a user can read.
+struct CameraCapabilities: Equatable, Sendable {
+
+    /// How long a still capture takes, from request to bytes in hand. This is a *class*, not a
+    /// measurement — it exists to let a caller decide whether a capture is cheap enough to do
+    /// speculatively, or expensive enough that it needs announcing first.
+    enum StillLatency: String, Sendable, Equatable {
+        /// Frames are already flowing; a still is effectively free.
+        case immediate
+        /// A round trip to the device, but fast enough to feel like a shutter.
+        case subSecond
+        /// A network hop, a mode change, or a file transfer. Announce before doing this.
+        case seconds
+    }
+
+    /// Does the backend deliver a continuous stream of frames to the app?
+    ///
+    /// This is the single most consequential flag: everything that watches, tracks, recognises,
+    /// records, or broadcasts is built on `CameraService.framePublisher`. Note that "the glasses
+    /// can stream" is **not** the same question — hardware that pushes video to a remote ingest
+    /// endpoint still gives this app nothing, so this stays false until frames actually arrive
+    /// in-process.
+    var liveFrames: Bool
+
+    /// Can the backend produce a single still image on request?
+    var stillCapture: Bool
+
+    /// Cost class of `stillCapture`. Meaningless when `stillCapture` is false.
+    var stillLatency: StillLatency
+
+    /// Can the camera be used while the device's microphone is in use?
+    ///
+    /// False on hardware where camera and mic are mutually exclusive modes — there, a capture
+    /// makes the glasses deaf for its duration, which the voice loop has to be told about rather
+    /// than discovering as silence.
+    var concurrentWithMic: Bool
+
+    /// Does the backend surface button, touch, or wear events from the hardware?
+    var hardwareEvents: Bool
+
+    /// The Meta/DAT backend: the capability set the whole app was written against.
+    static let meta = CameraCapabilities(
+        liveFrames: true,
+        stillCapture: true,
+        stillLatency: .immediate,
+        concurrentWithMic: true,
+        hardwareEvents: false
+    )
+
+    /// No glasses camera reachable. Distinct from "a backend that can't do much" — this is the
+    /// simulator, an unregistered SDK, or glasses that aren't connected.
+    static let unavailable = CameraCapabilities(
+        liveFrames: false,
+        stillCapture: false,
+        stillLatency: .seconds,
+        concurrentWithMic: true,
+        hardwareEvents: false
+    )
+}
+
+/// Every app feature that needs something from a camera, and which capability it needs.
+///
+/// Deliberately named after the *feature* the user knows, not the plumbing — the whole point is
+/// to be able to say "Sign Language needs a live camera feed, and these glasses don't have one".
+enum CameraDependentFeature: String, CaseIterable, Sendable {
+    case photoCapture
+    case livePreview
+    case faceRecognition
+    case signLanguage
+    case readingCompanion
+    case sceneWatcher
+    case framePinning
+    case videoRecording
+    case broadcast
+    case expertStream
+    case offlineLiveSession
+    case ambientCameraCaptions
+
+    /// Needs frames arriving continuously, not a still on request.
+    var requiresLiveFrames: Bool {
+        switch self {
+        case .photoCapture:
+            return false
+        case .livePreview, .faceRecognition, .signLanguage, .readingCompanion, .sceneWatcher,
+             .framePinning, .videoRecording, .broadcast, .expertStream, .offlineLiveSession,
+             .ambientCameraCaptions:
+            return true
+        }
+    }
+
+    /// User-facing name, used in the reason copy.
+    var displayName: String {
+        switch self {
+        case .photoCapture: return "Photo Capture"
+        case .livePreview: return "Live Preview"
+        case .faceRecognition: return "Face Recognition"
+        case .signLanguage: return "Sign Language"
+        case .readingCompanion: return "Reading Companion"
+        case .sceneWatcher: return "Scene Watcher"
+        case .framePinning: return "Frame Pinning"
+        case .videoRecording: return "Video Recording"
+        case .broadcast: return "Broadcast"
+        case .expertStream: return "Expert Stream"
+        case .offlineLiveSession: return "Offline Live Session"
+        case .ambientCameraCaptions: return "Ambient Captions (camera)"
+        }
+    }
+}
+
+/// Whether a feature can run on the current backend, and if not, what to tell the user.
+enum CameraFeatureAvailability: Equatable, Sendable {
+    case available
+    /// Runs, but not the way the user expects — carries the caveat to surface.
+    case degraded(String)
+    /// Cannot run at all on this hardware.
+    case unavailable(String)
+
+    var isUsable: Bool {
+        switch self {
+        case .available, .degraded: return true
+        case .unavailable: return false
+        }
+    }
+
+    /// The caveat or refusal text, nil when fully available.
+    var note: String? {
+        switch self {
+        case .available: return nil
+        case .degraded(let text), .unavailable(let text): return text
+        }
+    }
+}
+
+/// Pure capability → availability decisions. No hardware, no SDK, no I/O.
+enum CameraFeatureGate {
+
+    /// Whether `feature` can run given the backend's `capabilities`.
+    ///
+    /// `phoneFallbackAvailable` reflects a behaviour that predates this gate and must be
+    /// preserved: `CameraService.capturePhoto()` falls back to the iPhone's own back camera when
+    /// the glasses camera isn't usable. So photo capture stays *available* almost everywhere —
+    /// but degraded, because a phone in a pocket is not pointed where the user is looking, and
+    /// callers already announce that (`CameraService.lastCaptureSource`).
+    ///
+    /// There is no equivalent fallback for live frames: the phone fallback is a one-shot still.
+    static func availability(
+        of feature: CameraDependentFeature,
+        given capabilities: CameraCapabilities,
+        phoneFallbackAvailable: Bool = true
+    ) -> CameraFeatureAvailability {
+        if feature.requiresLiveFrames {
+            guard capabilities.liveFrames else {
+                return .unavailable(
+                    "\(feature.displayName) needs a live camera feed from the glasses, and the "
+                    + "connected glasses don't provide one."
+                )
+            }
+            return .available
+        }
+
+        if capabilities.stillCapture {
+            switch capabilities.stillLatency {
+            case .immediate, .subSecond:
+                return .available
+            case .seconds:
+                return .degraded(
+                    "Captures from these glasses take several seconds — they're fetched from the "
+                    + "glasses rather than streamed."
+                )
+            }
+        }
+
+        guard phoneFallbackAvailable else {
+            return .unavailable("No camera is available.")
+        }
+        return .degraded(
+            "The connected glasses can't capture photos, so the iPhone camera is used instead — "
+            + "point the phone at what you want captured."
+        )
+    }
+
+    /// Features that cannot run at all on this backend. Used for the honest list in Settings,
+    /// rather than making the user find out one failure at a time.
+    static func unavailableFeatures(
+        given capabilities: CameraCapabilities,
+        phoneFallbackAvailable: Bool = true
+    ) -> [CameraDependentFeature] {
+        CameraDependentFeature.allCases.filter {
+            !availability(of: $0, given: capabilities, phoneFallbackAvailable: phoneFallbackAvailable).isUsable
+        }
+    }
+
+    /// A one-line summary for the Settings device row.
+    static func summary(given capabilities: CameraCapabilities) -> String {
+        if capabilities.liveFrames { return "Live video and photo capture" }
+        if capabilities.stillCapture {
+            return capabilities.stillLatency == .seconds
+                ? "Photo capture only (several seconds per photo)"
+                : "Photo capture only"
+        }
+        return "No camera — voice and text features only"
+    }
+}

--- a/OpenGlasses/Sources/Services/Camera/CaptureProtocol/CaptureCommand.swift
+++ b/OpenGlasses/Sources/Services/Camera/CaptureProtocol/CaptureCommand.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// Plan CQ P4 — the command set of the OEM capture protocol.
+///
+/// # What is and isn't attested
+///
+/// This enum lists **only** the commands and payloads that appear in the community
+/// reconstruction. It deliberately does not cover every mode the hardware supports, because the
+/// opcodes for the rest are not documented anywhere we can check, and a guessed byte sent to a
+/// camera on someone's face is not a guess worth making. Where a mode is known to exist but its
+/// encoding is not, it is absent from this type and named in the gaps list below rather than
+/// invented.
+///
+/// Everything here is unverified against hardware.
+///
+/// ## Known gaps (present on the device, encoding unknown)
+/// - Discrete photo mode, video start/stop, audio-recording start/stop as distinct opcodes.
+///   Only the composite AI-capture control payload below is attested.
+/// - Media enumeration and time sync.
+/// - Any command for *leaving* the livestream mode ``startLivestream`` enters. That absence is
+///   the reason livestreaming stays a Plan CQ P7 spike and is not modelled as a normal command.
+enum CaptureCommand: Equatable {
+
+    /// Device control family. Behaviour is selected by the payload, not by a distinct opcode.
+    case control(ControlAction)
+
+    /// Enter livestream mode. **No confirmed exit command exists** — see the gaps list.
+    case startLivestream
+
+    /// An opcode we have not modelled. The escape hatch exists so a capture-log replay can be
+    /// driven through this type without first extending it, not so callers can invent commands.
+    case raw(opcode: UInt8, payload: [UInt8])
+
+    /// Payload-selected behaviours of the ``control(_:)`` family.
+    enum ControlAction: Equatable {
+        /// Take an AI capture and push its thumbnail back over the link.
+        ///
+        /// The thumbnail is on the order of a kilobyte — enough to confirm a capture happened,
+        /// nowhere near enough to read text off. Full resolution needs the network transfer in
+        /// Plan CQ P6.
+        case aiCaptureWithThumbnail
+        /// Put the device's microphone into speech-recognition mode.
+        ///
+        /// Note this is mutually exclusive with the camera on this hardware: the device cannot
+        /// listen and look at once, which is why `CameraCapabilities.concurrentWithMic` exists.
+        case startMicrophone
+        /// Play audio through the device speaker.
+        case speakerPlayback
+
+        /// The attested payload bytes.
+        var payload: [UInt8] {
+            switch self {
+            case .aiCaptureWithThumbnail: return [0x02, 0x01, 0x06, 0x02, 0x02, 0x02]
+            case .startMicrophone:        return [0x02, 0x01, 0x07]
+            case .speakerPlayback:        return [0x02, 0x01, 0x10]
+            }
+        }
+    }
+
+    // MARK: - Opcodes
+
+    /// Device control.
+    static let controlOpcode: UInt8 = 0x41
+    /// Livestream entry.
+    static let livestreamOpcode: UInt8 = 0x67
+
+    var opcode: UInt8 {
+        switch self {
+        case .control: return Self.controlOpcode
+        case .startLivestream: return Self.livestreamOpcode
+        case .raw(let opcode, _): return opcode
+        }
+    }
+
+    var payload: [UInt8] {
+        switch self {
+        case .control(let action): return action.payload
+        case .startLivestream: return []
+        case .raw(_, let payload): return payload
+        }
+    }
+
+    /// The frame to write to the device.
+    var packet: CapturePacket {
+        CapturePacket(command: opcode, payload: payload)
+    }
+}
+
+/// Opcodes the device sends to us, unprompted or in reply.
+enum CaptureNotification: Equatable {
+
+    /// A capture finished and its data can now be requested.
+    case captureReady
+    /// A JPEG thumbnail, delivered inline.
+    case thumbnail(Data)
+    /// One frame of microphone audio: OPUS, 16 kHz mono, roughly 20 ms per frame.
+    ///
+    /// The device stops sending after a few seconds of silence and expects the host to restart
+    /// it — a transport-level behaviour that Plan CQ P5 has to handle, not a stream ending.
+    case microphoneAudio(Data)
+    /// A reply to a control command. May or may not carry a readable status — see
+    /// ``CaptureControlReply``.
+    case controlReply(CaptureControlReply)
+    /// An opcode we do not model.
+    case unrecognised(opcode: UInt8, payload: [UInt8])
+
+    static let captureReadyOpcode: UInt8 = 0x73
+    static let thumbnailOpcode: UInt8 = 0xFD
+    static let microphoneAudioOpcode: UInt8 = 0x59
+
+    /// Interpret a decoded frame.
+    static func from(_ packet: CapturePacket) -> CaptureNotification {
+        switch packet.command {
+        case captureReadyOpcode:
+            return .captureReady
+        case thumbnailOpcode:
+            return .thumbnail(Data(packet.payload))
+        case microphoneAudioOpcode:
+            return .microphoneAudio(Data(packet.payload))
+        case CaptureCommand.controlOpcode:
+            return .controlReply(CaptureControlReply.parse(packet.payload))
+        default:
+            return .unrecognised(opcode: packet.command, payload: packet.payload)
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/Camera/CaptureProtocol/CaptureControlReply.swift
+++ b/OpenGlasses/Sources/Services/Camera/CaptureProtocol/CaptureControlReply.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Plan CQ P4 — a reply to a control command, and the one trap in this protocol worth building
+/// the parser around.
+///
+/// # Why "unreadable" is a first-class outcome
+///
+/// The vendor's own parser fills in the status fields for an allowlist of control sub-types, and
+/// that allowlist excludes several sub-types the device really does accept. For those, the reply
+/// arrives, the command has *executed*, and the status fields still hold their default — which
+/// reads as an error. Anything that treats "no readable success" as "failure" will therefore
+/// report working commands as broken, and, worse, retry them.
+///
+/// So this parser distinguishes three outcomes, not two: it succeeded, it failed, or **we cannot
+/// tell from this reply**. Callers must handle the third explicitly. Collapsing it into failure
+/// is the bug; collapsing it into success is a different bug.
+///
+/// Everything here is a community reconstruction, unverified against hardware.
+struct CaptureControlReply: Equatable {
+
+    enum Status: Equatable {
+        /// Executed, and the reply said so. `workType` is the device's mode indicator.
+        case ok(workType: UInt8)
+        /// Executed and reported a failure code.
+        case failed(code: UInt8)
+        /// Structurally valid, but this reply carries no status we can trust. **Not a failure.**
+        case unreadable
+    }
+
+    /// Which control behaviour this reply is about.
+    let subtype: UInt8
+    let status: Status
+    /// The raw payload, kept so a diagnostics surface or a capture-log replay can show what we
+    /// could not interpret.
+    let payload: [UInt8]
+
+    /// Control sub-types whose replies leave the status fields unpopulated.
+    ///
+    /// This is the allowlist gap described above, expressed as its complement. If a capture log
+    /// ever shows one of these carrying a real status, remove it from the set — that is the only
+    /// change needed, which is why it lives here as data.
+    static let subtypesWithoutStatusFields: Set<UInt8> = [0x09, 0x0A, 0x0D, 0x0E]
+
+    // MARK: - Assumed layout
+    //
+    // Byte offsets within a control reply payload. Grouped and named rather than scattered as
+    // literals because they are the least-verified thing in this file: if the reconstruction is
+    // wrong about the frame body, it is wrong *here*, and this is where a capture log should be
+    // compared first.
+    private static let subtypeOffset = 0
+    private static let errorCodeOffset = 1
+    private static let workTypeOffset = 2
+    /// Shortest payload that could carry sub-type, error code and work type.
+    private static let minimumStatusPayloadLength = 3
+
+    static func parse(_ payload: [UInt8]) -> CaptureControlReply {
+        guard payload.count > subtypeOffset else {
+            return CaptureControlReply(subtype: 0, status: .unreadable, payload: payload)
+        }
+        let subtype = payload[subtypeOffset]
+
+        // Known-gap sub-type: the fields are present but meaningless. Report that we cannot
+        // tell, and never manufacture a failure out of a default value.
+        guard !subtypesWithoutStatusFields.contains(subtype) else {
+            return CaptureControlReply(subtype: subtype, status: .unreadable, payload: payload)
+        }
+
+        // Too short to hold a status. Also unreadable rather than failed — a truncated reply
+        // says nothing about whether the command ran.
+        guard payload.count >= minimumStatusPayloadLength else {
+            return CaptureControlReply(subtype: subtype, status: .unreadable, payload: payload)
+        }
+
+        let code = payload[errorCodeOffset]
+        let status: Status = code == 0
+            ? .ok(workType: payload[workTypeOffset])
+            : .failed(code: code)
+        return CaptureControlReply(subtype: subtype, status: status, payload: payload)
+    }
+
+    /// Whether this reply is positive evidence the command failed.
+    ///
+    /// Named for what it actually means, so a call site cannot accidentally read
+    /// `!isSuccess` as failure — on this protocol those are different questions.
+    var isConfirmedFailure: Bool {
+        if case .failed = status { return true }
+        return false
+    }
+
+    /// Whether the reply confirms success. False for `.unreadable`, which is not a denial.
+    var isConfirmedSuccess: Bool {
+        if case .ok = status { return true }
+        return false
+    }
+}

--- a/OpenGlasses/Sources/Services/Camera/CaptureProtocol/CapturePacket.swift
+++ b/OpenGlasses/Sources/Services/Camera/CaptureProtocol/CapturePacket.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// CRC-16/MODBUS, as used by the OEM capture protocol's frame header.
+///
+/// Written from the published catalogue parameters — reflected polynomial `0xA001`, initial value
+/// `0xFFFF`, no final XOR — and pinned by the catalogue's own check value in the tests, rather
+/// than transcribed from anyone's implementation (Plan CQ licensing rider; same discipline as
+/// `CRC16CCITT` in `EvenPacket`, which is a *different* variant and deliberately not shared).
+enum CRC16Modbus {
+    static func compute(_ bytes: [UInt8]) -> UInt16 {
+        var crc: UInt16 = 0xFFFF
+        for byte in bytes {
+            crc ^= UInt16(byte)
+            for _ in 0..<8 {
+                crc = (crc & 1) != 0 ? (crc >> 1) ^ 0xA001 : crc >> 1
+            }
+        }
+        return crc
+    }
+}
+
+/// Plan CQ P4 — one frame of the OEM capture protocol, encode and decode.
+///
+/// Wire format is a fixed six-byte header followed by the payload:
+///
+/// ```
+/// [0xBC] [command] [len_lo] [len_hi] [crc_lo] [crc_hi] [payload…]
+/// ```
+///
+/// where the length is the payload length little-endian and the CRC is CRC-16/MODBUS over the
+/// payload only (not the header), also little-endian.
+///
+/// **Every byte-level claim here is a community reconstruction and is unverified against
+/// hardware.** This type is pure and ships dark: nothing constructs it until Plan CQ P5 adds a
+/// transport, which itself only runs once a user pairs one of these devices. Treat a decode
+/// failure against a real capture log as evidence the reconstruction is wrong, not as a bug in
+/// the caller.
+struct CapturePacket: Equatable {
+
+    /// Frame start marker.
+    static let sentinel: UInt8 = 0xBC
+
+    /// Header bytes before the payload: sentinel, command, length (2), CRC (2).
+    static let headerLength = 6
+
+    /// Largest chunk the transport will carry in one write. Frames longer than this are split
+    /// across BLE writes and have to be reassembled from the byte stream — see
+    /// ``CaptureFrameAssembler``.
+    static let transportChunkSize = 244
+
+    let command: UInt8
+    let payload: [UInt8]
+
+    init(command: UInt8, payload: [UInt8] = []) {
+        self.command = command
+        self.payload = payload
+    }
+
+    /// The complete on-wire frame.
+    var encoded: [UInt8] {
+        let crc = CRC16Modbus.compute(payload)
+        let length = UInt16(payload.count)
+        var out: [UInt8] = [
+            Self.sentinel,
+            command,
+            UInt8(truncatingIfNeeded: length),
+            UInt8(truncatingIfNeeded: length >> 8),
+            UInt8(truncatingIfNeeded: crc),
+            UInt8(truncatingIfNeeded: crc >> 8),
+        ]
+        out.append(contentsOf: payload)
+        return out
+    }
+
+    /// Split an encoded frame into transport-sized writes.
+    ///
+    /// Fragmentation is a property of the *link*, not the protocol: there are no fragment
+    /// indices or continuation flags to key off, just a byte stream chopped at the MTU. That is
+    /// why reassembly is a stateful stream reader rather than a `reassemble([Packet])`.
+    func chunked(size: Int = CapturePacket.transportChunkSize) -> [[UInt8]] {
+        precondition(size > 0, "chunk size must be positive")
+        let bytes = encoded
+        guard bytes.count > size else { return [bytes] }
+        return stride(from: 0, to: bytes.count, by: size).map {
+            Array(bytes[$0..<min($0 + size, bytes.count)])
+        }
+    }
+
+    /// Decode exactly one frame from the start of `bytes`.
+    ///
+    /// - Returns: the packet and how many bytes it consumed, or nil if `bytes` does not begin
+    ///   with a complete, CRC-valid frame. A nil result does **not** distinguish "not yet
+    ///   complete" from "corrupt" — ``CaptureFrameAssembler`` makes that distinction, because
+    ///   only it knows whether more bytes are coming.
+    static func decode(_ bytes: [UInt8]) -> (packet: CapturePacket, consumed: Int)? {
+        guard bytes.count >= headerLength, bytes[0] == sentinel else { return nil }
+        let length = Int(bytes[2]) | (Int(bytes[3]) << 8)
+        let total = headerLength + length
+        guard bytes.count >= total else { return nil }
+        let payload = Array(bytes[headerLength..<total])
+        let crc = UInt16(bytes[4]) | (UInt16(bytes[5]) << 8)
+        guard crc == CRC16Modbus.compute(payload) else { return nil }
+        return (CapturePacket(command: bytes[1], payload: payload), total)
+    }
+}
+
+/// Reassembles frames from the transport's byte stream.
+///
+/// A BLE notification is not a frame. One write can carry a partial frame, several frames, or a
+/// frame boundary in the middle of it, so the receive path has to buffer and re-scan rather than
+/// parse each notification in isolation.
+///
+/// Resynchronisation matters as much as parsing: a dropped write leaves a partial frame in the
+/// buffer that will never complete, and without a way out the channel is dead for the rest of
+/// the session. On a bad sentinel or a failed CRC the assembler discards one byte and rescans
+/// for the next sentinel — costly per byte, but bounded, and it recovers.
+struct CaptureFrameAssembler {
+
+    /// Bytes received but not yet consumed by a complete frame.
+    private(set) var buffer: [UInt8] = []
+
+    /// How many bytes have been discarded during resynchronisation. Exposed so the cost is
+    /// measurable rather than invisible — a rising count is the signal that the reconstruction
+    /// of the wire format is wrong, or the link is dropping writes.
+    private(set) var discardedBytes = 0
+
+    /// Cap on retained bytes, so a stream that never yields a valid frame cannot grow without
+    /// bound. Sized to comfortably exceed one maximum-length frame.
+    static let maxBufferedBytes = 8 * 1024
+
+    init() {}
+
+    /// Feed one transport write; get back every frame that completed as a result.
+    mutating func append(_ chunk: [UInt8]) -> [CapturePacket] {
+        buffer.append(contentsOf: chunk)
+        var packets: [CapturePacket] = []
+
+        while !buffer.isEmpty {
+            if buffer[0] != CapturePacket.sentinel {
+                // Not a frame start — drop a byte and look again.
+                buffer.removeFirst()
+                discardedBytes += 1
+                continue
+            }
+            if let (packet, consumed) = CapturePacket.decode(buffer) {
+                packets.append(packet)
+                buffer.removeFirst(consumed)
+                continue
+            }
+            // A valid sentinel with no complete frame behind it is either a frame still in
+            // flight or a corrupt header. Tell them apart by whether the declared length could
+            // still arrive; a header that claims a length we already have has a bad CRC and
+            // will never validate, so drop its sentinel and rescan.
+            if buffer.count >= CapturePacket.headerLength {
+                let declared = Int(buffer[2]) | (Int(buffer[3]) << 8)
+                if buffer.count >= CapturePacket.headerLength + declared {
+                    buffer.removeFirst()
+                    discardedBytes += 1
+                    continue
+                }
+            }
+            break  // incomplete — wait for more bytes
+        }
+
+        if buffer.count > Self.maxBufferedBytes {
+            discardedBytes += buffer.count
+            buffer.removeAll(keepingCapacity: true)
+        }
+        return packets
+    }
+
+    /// Drop any partial frame. Call on disconnect so a reconnect starts clean.
+    mutating func reset() {
+        discardedBytes += buffer.count
+        buffer.removeAll(keepingCapacity: true)
+    }
+}

--- a/OpenGlasses/Sources/Services/Camera/GlassesCameraBackend.swift
+++ b/OpenGlasses/Sources/Services/Camera/GlassesCameraBackend.swift
@@ -1,0 +1,75 @@
+import Combine
+import UIKit
+
+/// Plan CQ P1 — the camera seam.
+///
+/// Companion to Plan AH's `GlassesDisplayBackend`, and created for the same reason: the app had
+/// exactly one implementation of a hardware capability, wired directly into the service that
+/// every feature consumes. On the display side that was fixed before a second device arrived.
+/// On the camera side it wasn't, so `CameraService` imported `MWDATCamera` and roughly fifty
+/// files imported `CameraService`.
+///
+/// The split is: a backend owns the *device* (sessions, streams, permissions, recovery), and
+/// `CameraService` owns everything backend-neutral (the published state features observe, the
+/// iPhone-camera fallback, saving to the photo library, the frame cache). Consumers keep talking
+/// to `CameraService` and never learn a backend exists.
+@MainActor
+protocol GlassesCameraBackend: AnyObject {
+
+    /// What this backend can do. Static per backend; `CameraService` republishes it so features
+    /// and Settings can ask without reaching for the backend itself.
+    var capabilities: CameraCapabilities { get }
+
+    /// Everything the backend wants the coordinator to know. One stream rather than a delegate
+    /// so `CameraService` can mirror it into `@Published` state in a single place.
+    var events: PassthroughSubject<CameraBackendEvent, Never> { get }
+
+    /// Whether the backend could serve a capture *right now* — registered, connected, permitted.
+    ///
+    /// This drives the iPhone-camera fallback decision, and it is deliberately a live check
+    /// rather than a cached flag: the failure it exists to prevent is a capture that silently
+    /// photographs a phone lying on a desk while the user is pointing their glasses elsewhere.
+    ///
+    /// - Parameter configuringIfNeeded: whether the backend may do one-time setup in order to
+    ///   answer. The Meta backend configures the SDK on demand here, and **that prompts for
+    ///   Bluetooth** — which is correct at a capture, and wrong from a view body that merely
+    ///   wants to describe the connected device. UI passes `false` and accepts a pessimistic
+    ///   answer; anything about to actually use the camera passes `true`.
+    func isReady(configuringIfNeeded: Bool) -> Bool
+
+    /// Cached permission state. Settable because the app's early-permission path grants it out
+    /// of band and tells the camera about it afterwards.
+    var permissionGranted: Bool { get set }
+
+    func ensurePermission() async throws
+
+    /// Capture a single still. Implementations return encoded image data (JPEG).
+    func capturePhoto() async throws -> Data
+
+    func startStreaming() async throws
+    func stopStreaming() async
+
+    /// Release everything. Called on mode switch and app termination.
+    func tearDown() async
+}
+
+/// Status of a backend's video stream, as the UI understands it.
+enum CameraStreamingStatus: String, Sendable, Equatable {
+    case streaming, waiting, stopped
+}
+
+/// Backend → coordinator notifications.
+enum CameraBackendEvent {
+    /// A new frame, or nil to invalidate the cached frame.
+    ///
+    /// The nil case matters: a torn-down session's last frame must not survive to stand in for
+    /// the next capture. That rule is enforced twice on purpose — here, and by the freshness
+    /// check inside the backend that refuses a stale frame as a photo fallback.
+    case frame(UIImage?)
+    case status(CameraStreamingStatus)
+    case streamingChanged(Bool)
+    case debug(String)
+    /// Actionable compatibility copy ("update the Meta AI app…"), or nil when compatible.
+    case compatibilityNotice(String?)
+    case registrationProgress(Int)
+}

--- a/OpenGlasses/Sources/Services/Camera/MetaCameraBackend.swift
+++ b/OpenGlasses/Sources/Services/Camera/MetaCameraBackend.swift
@@ -1,0 +1,800 @@
+import AVFoundation
+import Combine
+import Foundation
+import MWDATCamera
+import MWDATCore
+import UIKit
+
+/// Plan CQ P1 — the Meta/DAT camera, extracted out of `CameraService` behind
+/// `GlassesCameraBackend`.
+///
+/// This is a **pure extraction**: the DAT session and stream lifecycle, the permission flow, the
+/// stall detection and tiered recovery, the idle teardown and the retry loops are the same code
+/// that shipped, comments and all. The only changes are structural — state that `CameraService`
+/// published is now emitted on `events` for the coordinator to publish, and callbacks became
+/// cases of `CameraBackendEvent`.
+///
+/// Uses a persistent `DeviceSession` + `Stream` pair for both photo capture and video streaming,
+/// following Meta's official sample app pattern (DAT SDK 0.7+).
+@MainActor
+final class MetaCameraBackend: GlassesCameraBackend {
+
+    let capabilities = CameraCapabilities.meta
+    let events = PassthroughSubject<CameraBackendEvent, Never>()
+
+    /// Lazily initialized after Wearables.configure() has been called.
+    private lazy var deviceSelector = AutoDeviceSelector(wearables: Wearables.shared)
+    private var deviceSession: DeviceSession?
+    /// DAT 0.9.0: the `Camera` owns the camera hardware resource; the `Stream` hangs off it.
+    /// Detaching the capability is `camera.stop()` (cascades to the stream) — `stream.stop()`
+    /// alone only pauses streaming and keeps the capability attached for cheap restarts.
+    private var cameraCapability: MWDATCamera.Camera?
+    private var streamSession: MWDATCamera.Stream?
+    /// DAT 0.9.0 `ListenerTokenBag`: the four per-stream listeners (state, video frame,
+    /// photo, error) live and die together, so they're cancelled as one in teardown.
+    private let streamListenerBag = ListenerTokenBag()
+    private var photoContinuation: CheckedContinuation<Data, Error>?
+
+    /// Whether camera permission has been granted (cached to avoid re-checking).
+    var permissionGranted = false
+
+    /// Mirrors of the state the coordinator publishes. Held here too because the recovery,
+    /// teardown and fallback logic below branches on them.
+    private var isStreaming = false
+    private var isCaptureInProgress = false
+    private var latestFrame: UIImage?
+
+    // MARK: - HEVC Decoder Stall Detection
+    /// Timestamp of the last successfully decoded video frame.
+    private var lastFrameTime: Date = .distantPast
+    /// Stall detection timer — fires if no frame arrives for 1.5 seconds.
+    private var stallDetectionTask: Task<Void, Never>?
+    /// Whether we're currently recovering from a stall (prevents re-entrant recovery).
+    private var isRecoveringFromStall = false
+    /// Number of consecutive stall recoveries (for diagnostics).
+    private var stallRecoveryCount = 0
+    /// BR P2: consecutive FAILED recoveries — drives the rebuild-stream-vs-reset-session
+    /// tiering in `StreamRecoveryPolicy`. Reset on any successful recovery.
+    private var consecutiveRecoveryFailures = 0
+    /// BR P2: listener on the DeviceSession's error stream (update-required and terminal
+    /// device errors surface here, not on the camera Stream's errorPublisher).
+    private var sessionErrorTask: Task<Void, Never>?
+
+    /// BR P2: actionable compatibility copy ("update the Meta AI app…") when the DAT layer
+    /// reports an update requirement. Nil when compatible. Read by the retry loop to stop
+    /// churning on a refusal that can never succeed, and emitted for AppState to announce once.
+    private var compatibilityNotice: String? {
+        didSet { events.send(.compatibilityNotice(compatibilityNotice)) }
+    }
+
+    /// Glasses are usable for the camera only once fully registered (state 3). An unconfigured
+    /// SDK is indistinguishable from unregistered glasses as far as this decision goes, and
+    /// falls the same way — reporting not-ready rather than trapping on `Wearables.shared`.
+    ///
+    /// The short-circuit is load-bearing in both modes: reading `registrationState` on an
+    /// unconfigured SDK is a `fatalError`, not a throw.
+    func isReady(configuringIfNeeded: Bool) -> Bool {
+        let configured = configuringIfNeeded
+            ? WearablesBootstrap.ensureConfigured()
+            : WearablesBootstrap.isConfigured
+        return configured && Wearables.shared.registrationState.rawValue >= 3
+    }
+
+    private func debug(_ message: String) { events.send(.debug(message)) }
+
+    // MARK: - Permission
+
+    private func waitForRegistration(minState: Int, timeoutSeconds: Double) async -> Int {
+        guard WearablesBootstrap.ensureConfigured() else { return 0 }
+        let waitStart = ContinuousClock.now
+        while true {
+            let state = Wearables.shared.registrationState.rawValue
+            events.send(.registrationProgress(state))
+            if state >= minState { return state }
+            if ContinuousClock.now - waitStart > .seconds(timeoutSeconds) { return state }
+            try? await Task.sleep(nanoseconds: 500_000_000)
+        }
+    }
+
+    func ensurePermission() async throws {
+        // No SDK, no glasses permission to grant. Throwing here (rather than touching
+        // `Wearables.shared`, which traps when unconfigured) surfaces as the existing
+        // "Meta SDK not registered" state.
+        guard WearablesBootstrap.ensureConfigured() else { throw CameraError.sdkNotRegistered }
+        // The cached flag is only a fast path PAST the iOS prompt + registration wait — the
+        // Meta permission itself is re-verified live every time. Live-traced: the user revoked
+        // the app in the Meta AI app mid-session, and the stale flag sailed straight past the
+        // permission step instead of re-asking.
+        if permissionGranted {
+            if let status = try? await Wearables.shared.checkPermissionStatus(.camera),
+               status == .granted {
+                return
+            }
+            NSLog("[Camera] Cached permission no longer granted — re-running the permission flow")
+            permissionGranted = false
+        }
+
+        let regState = Wearables.shared.registrationState
+        NSLog("[Camera] SDK state: %d (need 3 for camera permissions)", regState.rawValue)
+        events.send(.registrationProgress(regState.rawValue))
+
+        // iOS Camera Permission
+        let iosVideoStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        if iosVideoStatus == .notDetermined {
+            let granted = await AVCaptureDevice.requestAccess(for: .video)
+            if !granted { throw CameraError.permissionDenied }
+        } else if iosVideoStatus == .denied || iosVideoStatus == .restricted {
+            throw CameraError.permissionDenied
+        }
+
+        // Wait for full SDK registration
+        let settledState = await waitForRegistration(minState: 3, timeoutSeconds: 15)
+        if settledState < 3 {
+            NSLog("[Camera] State %d is not fully registered.", settledState)
+            throw CameraError.sdkNotRegistered
+        }
+
+        // Check/request Meta camera permission with retries
+        let maxAttempts = 3
+        for attempt in 0..<maxAttempts {
+            if attempt > 0 {
+                NSLog("[Camera] Permission retry %d/%d...", attempt + 1, maxAttempts)
+                try? await Task.sleep(nanoseconds: 4_000_000_000)
+            }
+
+            do {
+                let readyState = await waitForRegistration(minState: 3, timeoutSeconds: 10)
+                if readyState < 3 { throw CameraError.sdkNotRegistered }
+
+                let status = try await Wearables.shared.checkPermissionStatus(.camera)
+                NSLog("[Camera] checkPermissionStatus: %@", String(describing: status))
+                if status == .granted {
+                    permissionGranted = true
+                    return
+                }
+
+                let requestStatus = try await Wearables.shared.requestPermission(.camera)
+                guard requestStatus == .granted else { throw CameraError.permissionDenied }
+                permissionGranted = true
+                return
+            } catch {
+                NSLog("[Camera] Permission attempt %d/%d failed: %@",
+                      attempt + 1, maxAttempts, error.localizedDescription)
+
+                if let nsError = error as NSError?, nsError.domain == "MWDATCore.PermissionError" {
+                    let currentState = Wearables.shared.registrationState.rawValue
+                    if currentState < 3 { throw CameraError.sdkNotRegistered }
+                }
+                if case .permissionDenied? = error as? CameraError { throw error }
+                if attempt == maxAttempts - 1 { throw CameraError.sdkNotRegistered }
+            }
+        }
+    }
+
+    // MARK: - Persistent Session
+
+    /// Last device id seen on the SDK's devices stream — lets the session bind to THE known
+    /// device (`SpecificDeviceSelector`) instead of asking `AutoDeviceSelector` for any
+    /// "eligible" device, which throws `noEligibleDevice` during the discovery/wake window.
+    private var knownDeviceId: String?
+    private var devicesListenerToken: Any?
+
+    /// True while `startStreaming()`'s continuous mode owns the stream (live voice modes
+    /// put the mic on the glasses concurrently) — drives the low-res contention floor in
+    /// `ensureSession`. Discrete photo sessions leave it false.
+    private var continuousStreamingIntent = false
+    /// Resolution tier the current stream was actually built at (post-policy), so
+    /// `startStreaming` can rebuild a photo-era low-res stream that would starve voice.
+    private var activeStreamResolution: String?
+
+    /// Ensure the persistent stream session exists. Creates it on first call.
+    private func ensureSession() async throws {
+        guard streamSession == nil else { return }
+
+        // First call: start tracking the devices list, and give the listener a beat to
+        // deliver the current snapshot before we pick a selector.
+        if devicesListenerToken == nil {
+            devicesListenerToken = Wearables.shared.addDevicesListener { [weak self] deviceIds in
+                Task { @MainActor in self?.knownDeviceId = deviceIds.first }
+            }
+            try? await Task.sleep(nanoseconds: 200_000_000)
+        }
+
+        // DAT 0.7: DeviceSession owns the connection; Streams hang off it.
+        if deviceSession?.state == .stopped {
+            deviceSession = nil
+        }
+
+        if deviceSession == nil {
+            // Bind to the specific discovered device when we know it — field-proven more
+            // reliable than AutoDeviceSelector for a device whose link is mid-wake.
+            if let id = knownDeviceId {
+                NSLog("[Camera] Creating session bound to device %@", id)
+                deviceSession = try Wearables.shared.createSession(
+                    deviceSelector: SpecificDeviceSelector(device: id))
+            } else {
+                deviceSession = try Wearables.shared.createSession(deviceSelector: deviceSelector)
+            }
+        }
+
+        guard let deviceSession else { throw CameraError.captureFailed }
+
+        // Watch the session's error stream BEFORE starting it — the reason a session dies
+        // during startup (update-required refusal, device drop) arrives there, and attaching
+        // after the state check meant every early stop was an unexplained "stream not ready".
+        watchSessionErrors(on: deviceSession)
+
+        if deviceSession.state != .started {
+            do {
+                try deviceSession.start()
+            } catch {
+                // BR P2: an update-required refusal must read as "go update", not a
+                // generic failure.
+                if let notice = DATCompatibilityMessage.message(for: error) {
+                    compatibilityNotice = notice
+                    debug(notice)
+                }
+                throw error
+            }
+            let deadline = ContinuousClock.now + .seconds(20)
+            let stoppedGraceEnd = ContinuousClock.now + .seconds(2)
+            while ContinuousClock.now < deadline {
+                if deviceSession.state == .started { break }
+                // .stopped inside the first moments can be the pre-transition resting state;
+                // only treat it as terminal once the state machine has had time to move.
+                if deviceSession.state == .stopped && ContinuousClock.now > stoppedGraceEnd { break }
+                try await Task.sleep(nanoseconds: 300_000_000)
+            }
+        }
+
+        guard deviceSession.state == .started else {
+            NSLog("[Camera] Session never reached .started (state: %@)",
+                  String(describing: deviceSession.state))
+            throw CameraError.streamNotReady
+        }
+
+        // Continuous streaming in the live voice modes runs alongside glasses-mic audio;
+        // the policy floors "low" to "medium" there so video can't starve the voice link
+        // off the shared Bluetooth radio (see `StreamConfigPolicy`).
+        let effectiveResolution = StreamConfigPolicy.effectiveResolution(
+            requested: Config.cameraResolution,
+            concurrentGlassesVoice: continuousStreamingIntent
+        )
+        if effectiveResolution != Config.cameraResolution {
+            NSLog("[Camera] Resolution floored to %@ for streaming with glasses voice", effectiveResolution)
+            debug("Camera: low-res floored to medium while voice is on the glasses")
+        }
+        let resolution: StreamingResolution = {
+            switch effectiveResolution {
+            case "low": return .low
+            case "medium": return .medium
+            default: return .high
+            }
+        }()
+        let fps = UInt(Config.cameraFrameRate)
+        guard let camera = try deviceSession.addCamera(
+            config: MWDATCamera.StreamConfiguration(
+                videoCodec: .raw,
+                resolution: resolution,
+                frameRate: fps
+            )
+        ) else {
+            throw CameraError.streamNotReady
+        }
+        cameraCapability = camera
+        streamSession = camera.stream
+        activeStreamResolution = effectiveResolution
+        attachListeners(to: camera.stream)
+        // (session error watcher already attached above, before start)
+        NSLog("[Camera] Created persistent Camera capability (.\(effectiveResolution), \(fps)fps)")
+    }
+
+    /// BR P2: device-level errors (incl. `.datAppOnTheGlassesUpdateRequired`) arrive on the
+    /// DeviceSession's error stream — the camera Stream's errorPublisher never carries them.
+    private func watchSessionErrors(on session: DeviceSession) {
+        sessionErrorTask?.cancel()
+        sessionErrorTask = Task { [weak self] in
+            for await error in session.errorStream() {
+                guard let self, !Task.isCancelled else { return }
+                NSLog("[Camera] DeviceSession error: %@", String(describing: error))
+                if let notice = DATCompatibilityMessage.message(for: error) {
+                    self.compatibilityNotice = notice
+                    self.debug(notice)
+                }
+            }
+        }
+    }
+
+    /// Attach all publishers to the session (state, video frames, photo data, errors).
+    private func attachListeners(to session: MWDATCamera.Stream) {
+        var frameCount = 0
+
+        session.statePublisher.listen { [weak self] state in
+            Task { @MainActor in
+                guard let self else { return }
+                NSLog("[Camera] State changed: %@", String(describing: state))
+                switch state {
+                case .streaming:
+                    self.events.send(.status(.streaming))
+                case .waitingForDevice:
+                    self.events.send(.status(.waiting))
+                case .stopped:
+                    self.events.send(.status(.stopped))
+                    self.isStreaming = false
+                    self.events.send(.streamingChanged(false))
+                case .stopping, .starting, .paused:
+                    self.events.send(.status(.waiting))
+                @unknown default:
+                    break
+                }
+            }
+        }.store(in: streamListenerBag)
+
+        session.videoFramePublisher.listen { [weak self] frame in
+            // Immediate pixel buffer copy: `makeUIImage()` copies the pixel data out of
+            // the VideoToolbox buffer pool right away, preventing VT pool exhaustion
+            // that can occur if the buffer is held across async boundaries.
+            let image = frame.makeUIImage()
+            Task { @MainActor in
+                guard let self, let image else { return }
+                frameCount += 1
+                self.lastFrameTime = Date()
+                self.latestFrame = image
+                if frameCount <= 3 || frameCount % 30 == 0 {
+                    NSLog("[Camera] Video frame #%d (%dx%d)",
+                          frameCount, Int(image.size.width), Int(image.size.height))
+                }
+                self.events.send(.frame(image))
+            }
+        }.store(in: streamListenerBag)
+
+        session.photoDataPublisher.listen { [weak self] photoData in
+            Task { @MainActor in
+                self?.handlePhotoData(photoData)
+            }
+        }.store(in: streamListenerBag)
+
+        session.errorPublisher.listen { [weak self] error in
+            Task { @MainActor in
+                guard let self else { return }
+                let message = CameraErrorPolicy.message(for: error)
+                NSLog("[Camera] Error: %@", message)
+                self.debug("Camera error: \(message)")
+
+                // Fail a pending capture fast on a terminal error (hinges closed, thermal/battery
+                // shutdown, device gone) instead of waiting out the 5s timeout below.
+                if CameraErrorPolicy.abortsCapture(error), let cont = self.photoContinuation {
+                    self.photoContinuation = nil
+                    if let fallback = self.latestFrameAsJPEG() {
+                        NSLog("[Camera] Terminal error during capture — using latest video frame")
+                        cont.resume(returning: fallback)
+                    } else {
+                        cont.resume(throwing: CameraError.captureFailed)
+                    }
+                }
+            }
+        }.store(in: streamListenerBag)
+    }
+
+    /// Wait for the session to reach `.streaming` state, starting it if necessary.
+    private func waitForStreaming(timeout: TimeInterval = 20) async throws {
+        guard let session = streamSession else { throw CameraError.captureFailed }
+
+        // Start the session if not already running
+        if session.state == .stopped {
+            session.start()  // DAT 0.8.0+: Stream.start() is synchronous
+        }
+
+        // Wait for streaming state. During a cold start the stream bounces through .stopped
+        // (device-traced: ~15-18s of .stopped/.waitingForDevice churn before .streaming), so a
+        // transient .stopped is NOT terminal — nudge start() again a few times before giving up.
+        var restartNudges = 0
+        let deadline = ContinuousClock.now + .seconds(timeout)
+        while ContinuousClock.now < deadline {
+            if session.state == .streaming { break }
+            if session.state == .stopped {
+                if restartNudges < 3 {
+                    restartNudges += 1
+                    NSLog("[Camera] Stream stopped while warming up — restart nudge %d/3", restartNudges)
+                    session.start()
+                } else {
+                    NSLog("[Camera] Session stopped unexpectedly while waiting for streaming")
+                    throw CameraError.streamNotReady
+                }
+            }
+            try await Task.sleep(nanoseconds: 500_000_000)
+        }
+
+        if session.state != .streaming {
+            throw CameraError.streamNotReady
+        }
+
+        // Wait for the first video frame to actually arrive — the state becomes
+        // .streaming before data flows, and capturePhoto won't work until then.
+        NSLog("[Camera] Streaming state reached, waiting for first video frame...")
+        while ContinuousClock.now < deadline {
+            if latestFrame != nil { return }
+            try await Task.sleep(nanoseconds: 200_000_000)
+        }
+
+        // Even if no frame arrived, let the caller proceed (fallback will handle it)
+        NSLog("[Camera] No video frame arrived within timeout, proceeding anyway")
+    }
+
+    // MARK: - Photo Capture
+
+    /// Capture a photo from the glasses camera. Returns JPEG data.
+    ///
+    /// NOTE (device-reported, unverified here): `capturePhoto` also works on a stream that
+    /// was added but never `start()`ed, and capturing on a *streaming* stream has been
+    /// reported to race the frame flow and trip the glasses-side frame-stall watchdog.
+    /// Our start-then-capture path is field-traced and carries the frame fallback, so it
+    /// stays; if captures ever start stalling the stream, try the no-start discrete path
+    /// before reaching for bigger hammers.
+    func capturePhoto() async throws -> Data {
+        isCaptureInProgress = true
+        defer { isCaptureInProgress = false }
+        idleTeardownTask?.cancel()   // a capture during the idle grace keeps the session
+
+        try await ensurePermission()
+
+        // The DAT link drops when the glasses idle (battery saving) and discovery lags app
+        // launch by seconds — a session created in that window throws noEligibleDevice
+        // ("all discovered devices are powered off or disconnected") even though the glasses
+        // are registered and on the user's face. Live-traced: discovery failed at +0.3s after
+        // launch, link up at +4.7s. Retry with backoff (~12s window) while the link returns.
+        var sessionError: Error?
+        var firstError: Error?
+        // Fresh cycle, fresh verdict — a stale notice from before a glasses update must not
+        // abort attempts that could now succeed (the watcher re-sets it if still true).
+        compatibilityNotice = nil
+        for attempt in 1...4 {
+            do {
+                try await ensureSession()
+                sessionError = nil
+                break
+            } catch {
+                if firstError == nil { firstError = error }
+                sessionError = error
+                NSLog("[Camera] ensureSession attempt %d/4 failed: %@", attempt, error.localizedDescription)
+                // A compatibility refusal (outdated glasses-side DAT app / firmware) arrives on
+                // the session error stream and kills the session before .started. Retrying can
+                // never succeed — stop churning and surface the actionable update message.
+                if let notice = compatibilityNotice {
+                    NSLog("[Camera] Compatibility refusal — aborting session retries")
+                    throw CameraError.incompatible(notice)
+                }
+                if Self.isSessionAlreadyExists(error) {
+                    // The phantom is a glasses-side session still tearing down — either our
+                    // own previous one, or one LEAKED by a killed/reinstalled app instance
+                    // (nothing ever stops it; the glasses hold it until their own timeout).
+                    // Resetting again re-poisons the window — just wait it out.
+                    if attempt < 4 {
+                        try? await Task.sleep(nanoseconds: UInt64(attempt) * 3_000_000_000)
+                    }
+                } else {
+                    await resetSession()
+                    if attempt < 4 {
+                        try? await Task.sleep(nanoseconds: UInt64(attempt) * 2_000_000_000)
+                    }
+                }
+            }
+        }
+        if let finalError = sessionError {
+            // Surface the FIRST error (the root cause), not the Nth "already exists"
+            // collision that our own retry teardown caused — unless the first error IS the
+            // busy session, which gets the actionable message.
+            let rootError = firstError ?? finalError
+            if Self.isSessionAlreadyExists(rootError) || Self.isSessionAlreadyExists(finalError) {
+                throw CameraError.sessionBusy
+            }
+            throw rootError
+        }
+
+        // Wait for stream to be ready (start if needed)
+        var lastError: Error?
+        for attempt in 1...2 {
+            do {
+                try await waitForStreaming(timeout: attempt == 1 ? 10 : 20)
+                lastError = nil
+                break
+            } catch {
+                NSLog("[Camera] Streaming wait attempt %d failed: %@", attempt, error.localizedDescription)
+                lastError = error
+                if attempt < 2 {
+                    // Reset session and retry
+                    await resetSession()
+                    try await ensureSession()
+                    try await Task.sleep(nanoseconds: 1_000_000_000)
+                }
+            }
+        }
+        if let error = lastError { throw error }
+
+        // Capture using continuation — with video frame fallback
+        let photoData: Data = try await withCheckedThrowingContinuation { continuation in
+            self.photoContinuation = continuation
+
+            NSLog("[Camera] Calling capturePhoto(format: .jpeg)...")
+            let success = streamSession!.capturePhoto(format: .jpeg)
+            if !success {
+                self.photoContinuation = nil
+                // capturePhoto returned false — fall back to latest video frame
+                if let fallback = self.latestFrameAsJPEG() {
+                    NSLog("[Camera] capturePhoto returned false, using latest video frame")
+                    continuation.resume(returning: fallback)
+                } else {
+                    continuation.resume(throwing: CameraError.captureFailed)
+                }
+                return
+            }
+
+            // Timeout after 8 seconds — fall back to latest video frame. (5s was too tight on
+            // a cold WiFi-transport capture; the photo often lands at 5-7s.)
+            Task {
+                try? await Task.sleep(nanoseconds: 8_000_000_000)
+                if let cont = self.photoContinuation {
+                    self.photoContinuation = nil
+                    if let fallback = self.latestFrameAsJPEG() {
+                        NSLog("[Camera] Photo capture timed out, using latest video frame (%d bytes)", fallback.count)
+                        cont.resume(returning: fallback)
+                    } else {
+                        NSLog("[Camera] Photo capture timed out, no video frame available")
+                        cont.resume(throwing: CameraError.timeout)
+                    }
+                }
+            }
+        }
+
+        // Keep the session WARM after capture instead of tearing it down immediately
+        // (device-traced: the glasses-side teardown lags the app-side stop, so the next
+        // capture's createSession collided with the dying session — "A session already
+        // exists for this device" — while long-lived preview sessions never hit it).
+        // Battery is protected by the idle timer: teardown happens after a quiet minute,
+        // and back-to-back photos skip the multi-second session cold-start entirely.
+        if !isStreaming {
+            scheduleIdleTeardown()
+        }
+
+        print("📸 Photo captured: \(photoData.count) bytes")
+        return photoData
+    }
+
+    /// The SDK's one-session-per-device refusal — matched on the message because the thrown
+    /// error type differs between the create and start paths.
+    nonisolated private static func isSessionAlreadyExists(_ error: Error) -> Bool {
+        String(describing: error).localizedCaseInsensitiveContains("already exists")
+            || error.localizedDescription.localizedCaseInsensitiveContains("already exists")
+    }
+
+    /// Tear the session down after a minute of camera idleness (cancelled and re-armed by
+    /// each capture; cancelled outright when explicit streaming starts).
+    private var idleTeardownTask: Task<Void, Never>?
+    private static let sessionIdleGrace: Duration = .seconds(60)
+
+    private func scheduleIdleTeardown() {
+        idleTeardownTask?.cancel()
+        idleTeardownTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.sessionIdleGrace)
+            guard let self, !Task.isCancelled else { return }
+            guard !self.isStreaming, !self.isCaptureInProgress else { return }
+            NSLog("[Camera] Idle grace elapsed — tearing session down")
+            await self.resetSession()
+        }
+    }
+
+    private func handlePhotoData(_ photoData: PhotoData) {
+        guard let continuation = photoContinuation else {
+            NSLog("[Camera] Photo data received but no continuation waiting (timeout may have fired first)")
+            return
+        }
+        photoContinuation = nil
+        NSLog("[Camera] Photo captured via SDK (%d bytes)", photoData.data.count)
+        continuation.resume(returning: photoData.data)
+    }
+
+    /// How old a video frame may be and still stand in for a failed photo capture. Beyond
+    /// this, the frame shows where the camera pointed SECONDS AGO — live-traced: repeated
+    /// capture failures kept donating one stale frame, and the assistant confidently
+    /// described the same scene while the user pointed the glasses at different things.
+    private static let frameFallbackMaxAge: TimeInterval = 10
+
+    /// Convert the latest video frame to JPEG data for use as a photo fallback — but ONLY if
+    /// it's fresh. A stale frame is worse than an honest failure: it hallucinates a scene.
+    private func latestFrameAsJPEG(quality: CGFloat = 0.85) -> Data? {
+        guard let frame = latestFrame,
+              Date().timeIntervalSince(lastFrameTime) < Self.frameFallbackMaxAge else {
+            if latestFrame != nil {
+                NSLog("[Camera] Latest frame is stale (%.0fs old) — refusing frame fallback",
+                      Date().timeIntervalSince(lastFrameTime))
+            }
+            return nil
+        }
+        return frame.jpegData(compressionQuality: quality)
+    }
+
+    // MARK: - Continuous Video Streaming (for Gemini Live)
+
+    /// Start continuous video streaming from the glasses camera.
+    func startStreaming() async throws {
+        guard WearablesBootstrap.ensureConfigured() else { throw CameraError.sdkNotRegistered }
+        guard !isStreaming else { return }
+        idleTeardownTask?.cancel()   // explicit streaming owns the session now
+        continuousStreamingIntent = true
+
+        // A stream left behind by the discrete photo path may sit at the user's "low"
+        // tier; continuous streaming with glasses-mic voice needs the contention floor
+        // (see `StreamConfigPolicy`), so rebuild it at the effective tier first.
+        if let active = activeStreamResolution,
+           StreamConfigPolicy.effectiveResolution(
+               requested: Config.cameraResolution,
+               concurrentGlassesVoice: true) != active {
+            await teardownStreamOnly()
+        }
+
+        do {
+            try await ensurePermission()
+            try await ensureSession()
+            try await waitForStreaming()
+        } catch {
+            continuousStreamingIntent = false
+            throw error
+        }
+
+        isStreaming = true
+        events.send(.streamingChanged(true))
+        startStallDetection()
+        NSLog("[Camera] Streaming started")
+    }
+
+    /// Stop continuous video streaming. Session is kept alive for reuse.
+    func stopStreaming() async {
+        continuousStreamingIntent = false
+        guard isStreaming else { return }
+        stopStallDetection()
+        if let session = streamSession {
+            session.stop()
+        }
+        isStreaming = false
+        events.send(.streamingChanged(false))
+        latestFrame = nil
+        events.send(.frame(nil))
+        NSLog("[Camera] Streaming stopped (session kept alive)")
+    }
+
+    // MARK: - HEVC Decoder Stall Detection & Auto-Recovery
+
+    /// Start monitoring for decoder stalls (no frames for 1.5 seconds).
+    /// If a stall is detected, the session is torn down and recreated.
+    private func startStallDetection() {
+        stopStallDetection()
+        lastFrameTime = Date()
+        stallDetectionTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 500_000_000) // Check every 0.5s
+                guard !Task.isCancelled, let self else { break }
+                guard self.isStreaming, !self.isRecoveringFromStall else { continue }
+
+                // Temple-tap pause is a system hold: no frames is expected, there is no
+                // app-callable resume, and tearing down collapses the channel the next
+                // tap would resume. Sit it out (and keep the clock fresh so recovery
+                // doesn't fire the instant the tap resumes the stream).
+                if !StreamRecoveryPolicy.shouldRecoverFromStall(state: self.streamSession?.state) {
+                    self.lastFrameTime = Date()
+                    continue
+                }
+
+                let elapsed = Date().timeIntervalSince(self.lastFrameTime)
+                if elapsed > 1.5 {
+                    NSLog("[Camera] ⚠️ Decoder stall detected (%.1fs since last frame) — auto-recovering", elapsed)
+                    self.isRecoveringFromStall = true
+                    self.stallRecoveryCount += 1
+                    await self.recoverFromStall()
+                    self.isRecoveringFromStall = false
+                }
+            }
+        }
+    }
+
+    /// Stop stall detection monitoring.
+    private func stopStallDetection() {
+        stallDetectionTask?.cancel()
+        stallDetectionTask = nil
+    }
+
+    /// Recover from a decoder stall. BR P2: tiered — rebuild only the Stream on the
+    /// retained DeviceSession first (the session is the expensive half: BT connection +
+    /// permission state); escalate to a full session reset only after repeated failures.
+    private func recoverFromStall() async {
+        let action = StreamRecoveryPolicy.action(consecutiveFailures: consecutiveRecoveryFailures)
+        NSLog("[Camera] Stall recovery #%d (%@)", stallRecoveryCount, String(describing: action))
+        debug("Camera stall recovery #\(stallRecoveryCount) (\(action))")
+
+        switch action {
+        case .rebuildStream:
+            await teardownStreamOnly()
+        case .resetSession:
+            await resetSession()
+        }
+
+        do {
+            try await ensureSession()
+            try await waitForStreaming()
+            lastFrameTime = Date()
+            consecutiveRecoveryFailures = 0
+            NSLog("[Camera] Stall recovery successful — streaming resumed")
+        } catch {
+            consecutiveRecoveryFailures += 1
+            NSLog("[Camera] Stall recovery failed (%d consecutive): %@",
+                  consecutiveRecoveryFailures, error.localizedDescription)
+            if case .rebuildStream = action {
+                // Stream-only rebuild failed — make the next attempt (or the next stall
+                // tick) escalate rather than looping at the cheap tier.
+                await resetSession()
+            }
+            isStreaming = false
+            events.send(.streamingChanged(false))
+        }
+    }
+
+    /// BR P2: drop the Camera capability and its listeners but keep the DeviceSession alive —
+    /// a failed stream must not strand a half-open session (`ensureSession` re-adds the camera
+    /// on the retained session).
+    private func teardownStreamOnly() async {
+        if let camera = cameraCapability {
+            camera.stop()  // cascades to the stream
+            await awaitCameraStopped(camera)
+        }
+        await streamListenerBag.cancelAll()
+        cameraCapability = nil
+        streamSession = nil
+        activeStreamResolution = nil
+        NSLog("[Camera] Camera capability torn down (session retained)")
+    }
+
+    /// Bounded wait for a stopped Camera to actually reach `.stopped`. The camera
+    /// capability is process-wide and is freed when the Camera finishes stopping — not
+    /// when the session is torn down — so arming a replacement camera before then throws
+    /// `capabilityAlreadyActive`. `stop()` is synchronous but the state transition isn't.
+    private func awaitCameraStopped(_ camera: MWDATCamera.Camera, timeout: Duration = .seconds(2)) async {
+        let deadline = ContinuousClock.now + timeout
+        while ContinuousClock.now < deadline {
+            if camera.state == .stopped { return }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        NSLog("[Camera] Camera did not reach .stopped within %.0fs — proceeding",
+              Double(timeout.components.seconds))
+    }
+
+    /// Reset the session completely (for error recovery).
+    private func resetSession() async {
+        sessionErrorTask?.cancel()
+        sessionErrorTask = nil
+        if let camera = cameraCapability {
+            camera.stop()
+            // Wait for the capability to actually free (see `awaitCameraStopped`) so the
+            // retry loop's next `ensureSession` doesn't collide with the dying camera.
+            await awaitCameraStopped(camera)
+        }
+        deviceSession?.stop()
+        await streamListenerBag.cancelAll()
+        cameraCapability = nil
+        streamSession = nil
+        activeStreamResolution = nil
+        deviceSession = nil
+        // A torn-down session's frames must not survive to serve as "photos" for the next
+        // capture — the staleness gate is belt, this is braces.
+        latestFrame = nil
+        events.send(.frame(nil))
+        lastFrameTime = .distantPast
+        NSLog("[Camera] Session reset")
+    }
+
+    /// Tear down everything — called on mode switch or app termination.
+    func tearDown() async {
+        await stopStreaming()
+        await resetSession()
+        permissionGranted = false
+        NSLog("[Camera] Torn down completely")
+    }
+}

--- a/OpenGlasses/Sources/Services/CameraService.swift
+++ b/OpenGlasses/Sources/Services/CameraService.swift
@@ -1,41 +1,38 @@
-import Foundation
 import AVFoundation
 import Combine
+import Foundation
 import Photos
-import MWDATCore
-import MWDATCamera
 import UIKit
 
-/// Service for capturing photos and streaming video from Ray-Ban Meta smart glasses.
+/// Backend-neutral camera coordinator.
 ///
-/// Uses a persistent `DeviceSession` + `Stream` pair for both photo capture and
-/// video streaming, following Meta's official sample app pattern (DAT SDK 0.7+).
+/// Plan CQ P1 split this in two. Everything that talks to a *device* — sessions, streams,
+/// permissions, stall recovery — moved behind `GlassesCameraBackend` (`MetaCameraBackend` is the
+/// DAT implementation, extracted unchanged). What stayed here is everything that is true no
+/// matter which glasses are connected: the published state features observe, the iPhone-camera
+/// fallback, the photo-library write, and the cached frame.
+///
+/// The public surface is deliberately identical to what it was before the split — roughly fifty
+/// files consume this type, and none of them should have to know a backend exists.
 @MainActor
 class CameraService: ObservableObject {
     @Published var lastPhoto: UIImage?
     @Published var isCaptureInProgress: Bool = false
     @Published var isStreaming: Bool = false
-    @Published var streamingStatus: StreamingStatus = .stopped
+    @Published var streamingStatus: CameraStreamingStatus = .stopped
 
-    enum StreamingStatus: String {
-        case streaming, waiting, stopped
-    }
+    /// Kept as a nested name for the call sites that grew up with it.
+    typealias StreamingStatus = CameraStreamingStatus
 
-    /// Lazily initialized after Wearables.configure() has been called.
-    private lazy var deviceSelector = AutoDeviceSelector(wearables: Wearables.shared)
-    private var deviceSession: DeviceSession?
-    /// DAT 0.9.0: the `Camera` owns the camera hardware resource; the `Stream` hangs off it.
-    /// Detaching the capability is `camera.stop()` (cascades to the stream) — `stream.stop()`
-    /// alone only pauses streaming and keeps the capability attached for cheap restarts.
-    private var cameraCapability: MWDATCamera.Camera?
-    private var streamSession: MWDATCamera.Stream?
-    /// DAT 0.9.0 `ListenerTokenBag`: the four per-stream listeners (state, video frame,
-    /// photo, error) live and die together, so they're cancelled as one in teardown.
-    private let streamListenerBag = ListenerTokenBag()
-    private var photoContinuation: CheckedContinuation<Data, Error>?
+    /// BR P2: actionable compatibility copy ("update the Meta AI app…") when the device layer
+    /// reports an update requirement. Nil when compatible. Observed by AppState for a
+    /// one-time announcement.
+    @Published private(set) var compatibilityNotice: String?
 
-    /// Whether camera permission has been granted (cached to avoid re-checking).
-    var permissionGranted = false
+    /// The device-facing half. Injectable so tests can drive the coordinator without hardware
+    /// (and without touching `Wearables`, which traps in a unit-test process).
+    private let backend: GlassesCameraBackend
+    private var backendEvents: AnyCancellable?
 
     /// Callback for continuous video frames (used by Gemini Live mode)
     var onVideoFrame: ((UIImage) -> Void)?
@@ -52,399 +49,113 @@ class CameraService: ObservableObject {
     /// Optional callback to report SDK registration progress (state 0–3) back to UI.
     var onRegistrationProgress: ((Int) -> Void)?
 
-    // MARK: - HEVC Decoder Stall Detection
-    /// Timestamp of the last successfully decoded video frame.
-    private var lastFrameTime: Date = .distantPast
-    /// Stall detection timer — fires if no frame arrives for 1.5 seconds.
-    private var stallDetectionTask: Task<Void, Never>?
-    /// Whether we're currently recovering from a stall (prevents re-entrant recovery).
-    private var isRecoveringFromStall = false
-    /// Number of consecutive stall recoveries (for diagnostics).
-    private var stallRecoveryCount = 0
-    /// BR P2: consecutive FAILED recoveries — drives the rebuild-stream-vs-reset-session
-    /// tiering in `StreamRecoveryPolicy`. Reset on any successful recovery.
-    private var consecutiveRecoveryFailures = 0
-    /// BR P2: listener on the DeviceSession's error stream (update-required and terminal
-    /// device errors surface here, not on the camera Stream's errorPublisher).
-    private var sessionErrorTask: Task<Void, Never>?
+    /// Whether camera permission has been granted (cached to avoid re-checking).
+    var permissionGranted: Bool {
+        get { backend.permissionGranted }
+        set { backend.permissionGranted = newValue }
+    }
 
-    /// BR P2: actionable compatibility copy ("update the Meta AI app…") when the DAT layer
-    /// reports an update requirement. Nil when compatible. Observed by AppState for a
-    /// one-time announcement.
-    @Published private(set) var compatibilityNotice: String?
-
-    /// iPhone back-camera fallback, used when the glasses camera is unavailable.
-    private let phoneSource = PhoneCameraSource()
+    /// iPhone back-camera fallback, used when the glasses camera is unavailable. Injectable for
+    /// the same reason `backend` is: this is the branch taken whenever the glasses camera can't
+    /// serve a capture, so a test of *that* decision otherwise reaches real AVFoundation and, on
+    /// a simulator with an unresolved camera privacy decision, hangs waiting for a prompt.
+    private let phoneSource: PhoneCameraCapturing
 
     /// Name of the Photos album where glasses photos are saved.
     private nonisolated static let albumName = "Glasses"
 
+    /// `nil` means the default Meta/DAT backend and the real iPhone camera. The backend is built
+    /// here rather than as a default argument because a default argument expression is evaluated
+    /// nonisolated, and the backend is main-actor bound; the phone source takes the same shape so
+    /// both halves of the capture decision are substituted the same way.
+    init(backend: GlassesCameraBackend? = nil, phoneCamera: PhoneCameraCapturing? = nil) {
+        let backend = backend ?? MetaCameraBackend()
+        self.backend = backend
+        self.phoneSource = phoneCamera ?? PhoneCameraSource()
+        backendEvents = backend.events.sink { [weak self] event in
+            self?.handle(event)
+        }
+    }
+
+    // MARK: - Capabilities (Plan CQ P1)
+
+    /// What the current backend can do. Static per backend.
+    var capabilities: CameraCapabilities { backend.capabilities }
+
+    /// Capabilities of the glasses camera *if one is reachable right now*, else nil. This is the
+    /// input `GlassesTierPolicy` wants: "connected but limited" and "not connected" are different
+    /// statements and Settings must not collapse them.
+    ///
+    /// Side-effect-free, because this is read from view bodies — see
+    /// `GlassesCameraBackend.isReady(configuringIfNeeded:)`.
+    var activeCapabilities: CameraCapabilities? {
+        backend.isReady(configuringIfNeeded: false) ? backend.capabilities : nil
+    }
+
+    /// Whether a feature that needs the camera can run on the connected glasses, and if not,
+    /// what to tell the user. Prefer this over discovering the answer as a thrown error.
+    func availability(of feature: CameraDependentFeature) -> CameraFeatureAvailability {
+        CameraFeatureGate.availability(of: feature, given: backend.capabilities)
+    }
+
+    // MARK: - Backend events
+
+    private func handle(_ event: CameraBackendEvent) {
+        switch event {
+        case .frame(let image):
+            latestFrame = image
+            guard let image else { return }
+            onVideoFrame?(image)
+            framePublisher.send(image)
+        case .status(let status):
+            streamingStatus = status
+        case .streamingChanged(let streaming):
+            isStreaming = streaming
+        case .debug(let message):
+            onDebugEvent?(message)
+        case .compatibilityNotice(let notice):
+            compatibilityNotice = notice
+        case .registrationProgress(let state):
+            onRegistrationProgress?(state)
+        }
+    }
+
     // MARK: - Permission
 
-    private func waitForRegistration(minState: Int, timeoutSeconds: Double) async -> Int {
-        guard WearablesBootstrap.ensureConfigured() else { return 0 }
-        let waitStart = ContinuousClock.now
-        while true {
-            let state = Wearables.shared.registrationState.rawValue
-            onRegistrationProgress?(state)
-            if state >= minState { return state }
-            if ContinuousClock.now - waitStart > .seconds(timeoutSeconds) { return state }
-            try? await Task.sleep(nanoseconds: 500_000_000)
-        }
-    }
-
     func ensurePermission() async throws {
-        // No SDK, no glasses permission to grant. Throwing here (rather than touching
-        // `Wearables.shared`, which traps when unconfigured) surfaces as the existing
-        // "Meta SDK not registered" state.
-        guard WearablesBootstrap.ensureConfigured() else { throw CameraError.sdkNotRegistered }
-        // The cached flag is only a fast path PAST the iOS prompt + registration wait — the
-        // Meta permission itself is re-verified live every time. Live-traced: the user revoked
-        // the app in the Meta AI app mid-session, and the stale flag sailed straight past the
-        // permission step instead of re-asking.
-        if permissionGranted {
-            if let status = try? await Wearables.shared.checkPermissionStatus(.camera),
-               status == .granted {
-                return
-            }
-            NSLog("[Camera] Cached permission no longer granted — re-running the permission flow")
-            permissionGranted = false
-        }
-
-        let regState = Wearables.shared.registrationState
-        NSLog("[Camera] SDK state: %d (need 3 for camera permissions)", regState.rawValue)
-        onRegistrationProgress?(regState.rawValue)
-
-        // iOS Camera Permission
-        let iosVideoStatus = AVCaptureDevice.authorizationStatus(for: .video)
-        if iosVideoStatus == .notDetermined {
-            let granted = await AVCaptureDevice.requestAccess(for: .video)
-            if !granted { throw CameraError.permissionDenied }
-        } else if iosVideoStatus == .denied || iosVideoStatus == .restricted {
-            throw CameraError.permissionDenied
-        }
-
-        // Wait for full SDK registration
-        let settledState = await waitForRegistration(minState: 3, timeoutSeconds: 15)
-        if settledState < 3 {
-            NSLog("[Camera] State %d is not fully registered.", settledState)
-            throw CameraError.sdkNotRegistered
-        }
-
-        // Check/request Meta camera permission with retries
-        let maxAttempts = 3
-        for attempt in 0..<maxAttempts {
-            if attempt > 0 {
-                NSLog("[Camera] Permission retry %d/%d...", attempt + 1, maxAttempts)
-                try? await Task.sleep(nanoseconds: 4_000_000_000)
-            }
-
-            do {
-                let readyState = await waitForRegistration(minState: 3, timeoutSeconds: 10)
-                if readyState < 3 { throw CameraError.sdkNotRegistered }
-
-                let status = try await Wearables.shared.checkPermissionStatus(.camera)
-                NSLog("[Camera] checkPermissionStatus: %@", String(describing: status))
-                if status == .granted {
-                    permissionGranted = true
-                    return
-                }
-
-                let requestStatus = try await Wearables.shared.requestPermission(.camera)
-                guard requestStatus == .granted else { throw CameraError.permissionDenied }
-                permissionGranted = true
-                return
-            } catch {
-                NSLog("[Camera] Permission attempt %d/%d failed: %@",
-                      attempt + 1, maxAttempts, error.localizedDescription)
-
-                if let nsError = error as NSError?, nsError.domain == "MWDATCore.PermissionError" {
-                    let currentState = Wearables.shared.registrationState.rawValue
-                    if currentState < 3 { throw CameraError.sdkNotRegistered }
-                }
-                if case .permissionDenied? = error as? CameraError { throw error }
-                if attempt == maxAttempts - 1 { throw CameraError.sdkNotRegistered }
-            }
-        }
-    }
-
-    // MARK: - Persistent Session
-
-    /// Last device id seen on the SDK's devices stream — lets the session bind to THE known
-    /// device (`SpecificDeviceSelector`) instead of asking `AutoDeviceSelector` for any
-    /// "eligible" device, which throws `noEligibleDevice` during the discovery/wake window.
-    private var knownDeviceId: String?
-    private var devicesListenerToken: Any?
-
-    /// True while `startStreaming()`'s continuous mode owns the stream (live voice modes
-    /// put the mic on the glasses concurrently) — drives the low-res contention floor in
-    /// `ensureSession`. Discrete photo sessions leave it false.
-    private var continuousStreamingIntent = false
-    /// Resolution tier the current stream was actually built at (post-policy), so
-    /// `startStreaming` can rebuild a photo-era low-res stream that would starve voice.
-    private var activeStreamResolution: String?
-
-    /// Ensure the persistent stream session exists. Creates it on first call.
-    private func ensureSession() async throws {
-        guard streamSession == nil else { return }
-
-        // First call: start tracking the devices list, and give the listener a beat to
-        // deliver the current snapshot before we pick a selector.
-        if devicesListenerToken == nil {
-            devicesListenerToken = Wearables.shared.addDevicesListener { [weak self] deviceIds in
-                Task { @MainActor in self?.knownDeviceId = deviceIds.first }
-            }
-            try? await Task.sleep(nanoseconds: 200_000_000)
-        }
-
-        // DAT 0.7: DeviceSession owns the connection; Streams hang off it.
-        if deviceSession?.state == .stopped {
-            deviceSession = nil
-        }
-
-        if deviceSession == nil {
-            // Bind to the specific discovered device when we know it — field-proven more
-            // reliable than AutoDeviceSelector for a device whose link is mid-wake.
-            if let id = knownDeviceId {
-                NSLog("[Camera] Creating session bound to device %@", id)
-                deviceSession = try Wearables.shared.createSession(
-                    deviceSelector: SpecificDeviceSelector(device: id))
-            } else {
-                deviceSession = try Wearables.shared.createSession(deviceSelector: deviceSelector)
-            }
-        }
-
-        guard let deviceSession else { throw CameraError.captureFailed }
-
-        // Watch the session's error stream BEFORE starting it — the reason a session dies
-        // during startup (update-required refusal, device drop) arrives there, and attaching
-        // after the state check meant every early stop was an unexplained "stream not ready".
-        watchSessionErrors(on: deviceSession)
-
-        if deviceSession.state != .started {
-            do {
-                try deviceSession.start()
-            } catch {
-                // BR P2: an update-required refusal must read as "go update", not a
-                // generic failure.
-                if let notice = DATCompatibilityMessage.message(for: error) {
-                    compatibilityNotice = notice
-                    onDebugEvent?(notice)
-                }
-                throw error
-            }
-            let deadline = ContinuousClock.now + .seconds(20)
-            let stoppedGraceEnd = ContinuousClock.now + .seconds(2)
-            while ContinuousClock.now < deadline {
-                if deviceSession.state == .started { break }
-                // .stopped inside the first moments can be the pre-transition resting state;
-                // only treat it as terminal once the state machine has had time to move.
-                if deviceSession.state == .stopped && ContinuousClock.now > stoppedGraceEnd { break }
-                try await Task.sleep(nanoseconds: 300_000_000)
-            }
-        }
-
-        guard deviceSession.state == .started else {
-            NSLog("[Camera] Session never reached .started (state: %@)",
-                  String(describing: deviceSession.state))
-            throw CameraError.streamNotReady
-        }
-
-        // Continuous streaming in the live voice modes runs alongside glasses-mic audio;
-        // the policy floors "low" to "medium" there so video can't starve the voice link
-        // off the shared Bluetooth radio (see `StreamConfigPolicy`).
-        let effectiveResolution = StreamConfigPolicy.effectiveResolution(
-            requested: Config.cameraResolution,
-            concurrentGlassesVoice: continuousStreamingIntent
-        )
-        if effectiveResolution != Config.cameraResolution {
-            NSLog("[Camera] Resolution floored to %@ for streaming with glasses voice", effectiveResolution)
-            onDebugEvent?("Camera: low-res floored to medium while voice is on the glasses")
-        }
-        let resolution: StreamingResolution = {
-            switch effectiveResolution {
-            case "low": return .low
-            case "medium": return .medium
-            default: return .high
-            }
-        }()
-        let fps = UInt(Config.cameraFrameRate)
-        guard let camera = try deviceSession.addCamera(
-            config: MWDATCamera.StreamConfiguration(
-                videoCodec: .raw,
-                resolution: resolution,
-                frameRate: fps
-            )
-        ) else {
-            throw CameraError.streamNotReady
-        }
-        cameraCapability = camera
-        streamSession = camera.stream
-        activeStreamResolution = effectiveResolution
-        attachListeners(to: camera.stream)
-        // (session error watcher already attached above, before start)
-        NSLog("[Camera] Created persistent Camera capability (.\(effectiveResolution), \(fps)fps)")
-    }
-
-    /// BR P2: device-level errors (incl. `.datAppOnTheGlassesUpdateRequired`) arrive on the
-    /// DeviceSession's error stream — the camera Stream's errorPublisher never carries them.
-    private func watchSessionErrors(on session: DeviceSession) {
-        sessionErrorTask?.cancel()
-        sessionErrorTask = Task { [weak self] in
-            for await error in session.errorStream() {
-                guard let self, !Task.isCancelled else { return }
-                NSLog("[Camera] DeviceSession error: %@", String(describing: error))
-                if let notice = DATCompatibilityMessage.message(for: error) {
-                    self.compatibilityNotice = notice
-                    self.onDebugEvent?(notice)
-                }
-            }
-        }
-    }
-
-    /// Attach all publishers to the session (state, video frames, photo data, errors).
-    private func attachListeners(to session: MWDATCamera.Stream) {
-        var frameCount = 0
-
-        session.statePublisher.listen { [weak self] state in
-            Task { @MainActor in
-                guard let self else { return }
-                NSLog("[Camera] State changed: %@", String(describing: state))
-                switch state {
-                case .streaming:
-                    self.streamingStatus = .streaming
-                case .waitingForDevice:
-                    self.streamingStatus = .waiting
-                case .stopped:
-                    self.streamingStatus = .stopped
-                    self.isStreaming = false
-                case .stopping, .starting, .paused:
-                    self.streamingStatus = .waiting
-                @unknown default:
-                    break
-                }
-            }
-        }.store(in: streamListenerBag)
-
-        session.videoFramePublisher.listen { [weak self] frame in
-            // Immediate pixel buffer copy: `makeUIImage()` copies the pixel data out of
-            // the VideoToolbox buffer pool right away, preventing VT pool exhaustion
-            // that can occur if the buffer is held across async boundaries.
-            let image = frame.makeUIImage()
-            Task { @MainActor in
-                guard let self, let image else { return }
-                frameCount += 1
-                self.lastFrameTime = Date()
-                self.latestFrame = image
-                if frameCount <= 3 || frameCount % 30 == 0 {
-                    NSLog("[Camera] Video frame #%d (%dx%d)",
-                          frameCount, Int(image.size.width), Int(image.size.height))
-                }
-                self.onVideoFrame?(image)
-                self.framePublisher.send(image)
-            }
-        }.store(in: streamListenerBag)
-
-        session.photoDataPublisher.listen { [weak self] photoData in
-            Task { @MainActor in
-                self?.handlePhotoData(photoData)
-            }
-        }.store(in: streamListenerBag)
-
-        session.errorPublisher.listen { [weak self] error in
-            Task { @MainActor in
-                guard let self else { return }
-                let message = CameraErrorPolicy.message(for: error)
-                NSLog("[Camera] Error: %@", message)
-                self.onDebugEvent?("Camera error: \(message)")
-
-                // Fail a pending capture fast on a terminal error (hinges closed, thermal/battery
-                // shutdown, device gone) instead of waiting out the 5s timeout below.
-                if CameraErrorPolicy.abortsCapture(error), let cont = self.photoContinuation {
-                    self.photoContinuation = nil
-                    if let fallback = self.latestFrameAsJPEG() {
-                        NSLog("[Camera] Terminal error during capture — using latest video frame")
-                        cont.resume(returning: fallback)
-                    } else {
-                        cont.resume(throwing: CameraError.captureFailed)
-                    }
-                }
-            }
-        }.store(in: streamListenerBag)
-    }
-
-    /// Wait for the session to reach `.streaming` state, starting it if necessary.
-    private func waitForStreaming(timeout: TimeInterval = 20) async throws {
-        guard let session = streamSession else { throw CameraError.captureFailed }
-
-        // Start the session if not already running
-        if session.state == .stopped {
-            session.start()  // DAT 0.8.0+: Stream.start() is synchronous
-        }
-
-        // Wait for streaming state. During a cold start the stream bounces through .stopped
-        // (device-traced: ~15-18s of .stopped/.waitingForDevice churn before .streaming), so a
-        // transient .stopped is NOT terminal — nudge start() again a few times before giving up.
-        var restartNudges = 0
-        let deadline = ContinuousClock.now + .seconds(timeout)
-        while ContinuousClock.now < deadline {
-            if session.state == .streaming { break }
-            if session.state == .stopped {
-                if restartNudges < 3 {
-                    restartNudges += 1
-                    NSLog("[Camera] Stream stopped while warming up — restart nudge %d/3", restartNudges)
-                    session.start()
-                } else {
-                    NSLog("[Camera] Session stopped unexpectedly while waiting for streaming")
-                    throw CameraError.streamNotReady
-                }
-            }
-            try await Task.sleep(nanoseconds: 500_000_000)
-        }
-
-        if session.state != .streaming {
-            throw CameraError.streamNotReady
-        }
-
-        // Wait for the first video frame to actually arrive — the state becomes
-        // .streaming before data flows, and capturePhoto won't work until then.
-        NSLog("[Camera] Streaming state reached, waiting for first video frame...")
-        while ContinuousClock.now < deadline {
-            if latestFrame != nil { return }
-            try await Task.sleep(nanoseconds: 200_000_000)
-        }
-
-        // Even if no frame arrived, let the caller proceed (fallback will handle it)
-        NSLog("[Camera] No video frame arrived within timeout, proceeding anyway")
+        try await backend.ensurePermission()
     }
 
     // MARK: - Photo Capture
 
-    /// Capture a photo from the glasses camera. Returns JPEG data.
-    /// Reuses the persistent session — starts it if needed, does NOT stop it after capture.
+    /// Capture a photo. Returns JPEG data.
     /// EVERY captured image is saved to the photo library ("Glasses" album) for later review —
     /// centralized here so no capture path can forget it.
     func capturePhoto() async throws -> Data {
-        // Glasses are usable for the camera only once fully registered (state 3). When
-        // they're offline / not connected / not registered, capture from the iPhone back
-        // camera instead so the vision tools keep working without glasses.
+        // When the glasses camera is offline / not connected / not registered, capture from the
+        // iPhone back camera instead so the vision tools keep working without glasses. This is
+        // also what lets them work on a device (or simulator) where the glasses SDK never came up.
         //
-        // But when glasses ARE registered, a failed glasses capture must FAIL — not silently
+        // But when the glasses ARE usable, a failed glasses capture must FAIL — not silently
         // swap to the phone camera. Live-traced: the phone was on the desk, every "photo"
         // showed the desk, and the assistant confidently described it while the user pointed
         // their glasses at something else. A wrong-camera photo is worse than an error.
+        //
+        // Plan CQ P1: a backend that cannot capture stills at all falls the same way as one that
+        // isn't ready — the phone is the only camera left, and callers announce the swap.
         let data: Data
-        // An unconfigured SDK is indistinguishable from unregistered glasses as far as this
-        // decision goes, and falls the same way: use the phone camera rather than trapping on
-        // `Wearables.shared`. This is what lets vision tools work on a device (or simulator)
-        // where the glasses SDK never came up.
-        if !WearablesBootstrap.ensureConfigured() || Wearables.shared.registrationState.rawValue < 3 {
-            NSLog("[Camera] Glasses not registered (state < 3) — capturing from iPhone back camera")
+        if backend.isReady(configuringIfNeeded: true) && backend.capabilities.stillCapture {
+            isCaptureInProgress = true
+            defer { isCaptureInProgress = false }
+            data = try await backend.capturePhoto()
+            lastCaptureSource = .glasses
+            if let image = UIImage(data: data) {
+                lastPhoto = image
+            }
+        } else {
+            NSLog("[Camera] Glasses camera unavailable — capturing from iPhone back camera")
             data = try await phoneSource.capturePhoto()
             lastCaptureSource = .phone
-        } else {
-            data = try await captureFromGlasses()
-            lastCaptureSource = .glasses
         }
         saveToPhotoLibrary(data)
         return data
@@ -452,382 +163,31 @@ class CameraService: ObservableObject {
 
     /// Which camera actually served the last successful `capturePhoto()`. Callers use this to
     /// ANNOUNCE a phone-camera capture — a silently swapped camera made the assistant describe
-    /// the desk the phone was lying on while the user pointed their glasses elsewhere.
+    /// the desk the phone was lying on while the user pointed the glasses elsewhere.
     enum CaptureSource { case glasses, phone }
     private(set) var lastCaptureSource: CaptureSource = .glasses
 
-    /// Capture a photo from the glasses camera. Returns JPEG data.
-    ///
-    /// NOTE (device-reported, unverified here): `capturePhoto` also works on a stream that
-    /// was added but never `start()`ed, and capturing on a *streaming* stream has been
-    /// reported to race the frame flow and trip the glasses-side frame-stall watchdog.
-    /// Our start-then-capture path is field-traced and carries the frame fallback, so it
-    /// stays; if captures ever start stalling the stream, try the no-start discrete path
-    /// before reaching for bigger hammers.
-    private func captureFromGlasses() async throws -> Data {
-        isCaptureInProgress = true
-        defer { isCaptureInProgress = false }
-        idleTeardownTask?.cancel()   // a capture during the idle grace keeps the session
-
-        try await ensurePermission()
-
-        // The DAT link drops when the glasses idle (battery saving) and discovery lags app
-        // launch by seconds — a session created in that window throws noEligibleDevice
-        // ("all discovered devices are powered off or disconnected") even though the glasses
-        // are registered and on the user's face. Live-traced: discovery failed at +0.3s after
-        // launch, link up at +4.7s. Retry with backoff (~12s window) while the link returns.
-        var sessionError: Error?
-        var firstError: Error?
-        // Fresh cycle, fresh verdict — a stale notice from before a glasses update must not
-        // abort attempts that could now succeed (the watcher re-sets it if still true).
-        compatibilityNotice = nil
-        for attempt in 1...4 {
-            do {
-                try await ensureSession()
-                sessionError = nil
-                break
-            } catch {
-                if firstError == nil { firstError = error }
-                sessionError = error
-                NSLog("[Camera] ensureSession attempt %d/4 failed: %@", attempt, error.localizedDescription)
-                // A compatibility refusal (outdated glasses-side DAT app / firmware) arrives on
-                // the session error stream and kills the session before .started. Retrying can
-                // never succeed — stop churning and surface the actionable update message.
-                if let notice = compatibilityNotice {
-                    NSLog("[Camera] Compatibility refusal — aborting session retries")
-                    throw CameraError.incompatible(notice)
-                }
-                if Self.isSessionAlreadyExists(error) {
-                    // The phantom is a glasses-side session still tearing down — either our
-                    // own previous one, or one LEAKED by a killed/reinstalled app instance
-                    // (nothing ever stops it; the glasses hold it until their own timeout).
-                    // Resetting again re-poisons the window — just wait it out.
-                    if attempt < 4 {
-                        try? await Task.sleep(nanoseconds: UInt64(attempt) * 3_000_000_000)
-                    }
-                } else {
-                    await resetSession()
-                    if attempt < 4 {
-                        try? await Task.sleep(nanoseconds: UInt64(attempt) * 2_000_000_000)
-                    }
-                }
-            }
-        }
-        if let finalError = sessionError {
-            // Surface the FIRST error (the root cause), not the Nth "already exists"
-            // collision that our own retry teardown caused — unless the first error IS the
-            // busy session, which gets the actionable message.
-            let rootError = firstError ?? finalError
-            if Self.isSessionAlreadyExists(rootError) || Self.isSessionAlreadyExists(finalError) {
-                throw CameraError.sessionBusy
-            }
-            throw rootError
-        }
-
-        // Wait for stream to be ready (start if needed)
-        var lastError: Error?
-        for attempt in 1...2 {
-            do {
-                try await waitForStreaming(timeout: attempt == 1 ? 10 : 20)
-                lastError = nil
-                break
-            } catch {
-                NSLog("[Camera] Streaming wait attempt %d failed: %@", attempt, error.localizedDescription)
-                lastError = error
-                if attempt < 2 {
-                    // Reset session and retry
-                    await resetSession()
-                    try await ensureSession()
-                    try await Task.sleep(nanoseconds: 1_000_000_000)
-                }
-            }
-        }
-        if let error = lastError { throw error }
-
-        // Capture using continuation — with video frame fallback
-        let photoData: Data = try await withCheckedThrowingContinuation { continuation in
-            self.photoContinuation = continuation
-
-            NSLog("[Camera] Calling capturePhoto(format: .jpeg)...")
-            let success = streamSession!.capturePhoto(format: .jpeg)
-            if !success {
-                self.photoContinuation = nil
-                // capturePhoto returned false — fall back to latest video frame
-                if let fallback = self.latestFrameAsJPEG() {
-                    NSLog("[Camera] capturePhoto returned false, using latest video frame")
-                    continuation.resume(returning: fallback)
-                } else {
-                    continuation.resume(throwing: CameraError.captureFailed)
-                }
-                return
-            }
-
-            // Timeout after 8 seconds — fall back to latest video frame. (5s was too tight on
-            // a cold WiFi-transport capture; the photo often lands at 5-7s.)
-            Task {
-                try? await Task.sleep(nanoseconds: 8_000_000_000)
-                if let cont = self.photoContinuation {
-                    self.photoContinuation = nil
-                    if let fallback = self.latestFrameAsJPEG() {
-                        NSLog("[Camera] Photo capture timed out, using latest video frame (%d bytes)", fallback.count)
-                        cont.resume(returning: fallback)
-                    } else {
-                        NSLog("[Camera] Photo capture timed out, no video frame available")
-                        cont.resume(throwing: CameraError.timeout)
-                    }
-                }
-            }
-        }
-
-        if let image = UIImage(data: photoData) {
-            lastPhoto = image
-        }
-
-        // Keep the session WARM after capture instead of tearing it down immediately
-        // (device-traced: the glasses-side teardown lags the app-side stop, so the next
-        // capture's createSession collided with the dying session — "A session already
-        // exists for this device" — while long-lived preview sessions never hit it).
-        // Battery is protected by the idle timer: teardown happens after a quiet minute,
-        // and back-to-back photos skip the multi-second session cold-start entirely.
-        if !isStreaming {
-            scheduleIdleTeardown()
-        }
-
-        print("📸 Photo captured: \(photoData.count) bytes")
-        return photoData
-    }
-
-    /// The SDK's one-session-per-device refusal — matched on the message because the thrown
-    /// error type differs between the create and start paths.
-    nonisolated private static func isSessionAlreadyExists(_ error: Error) -> Bool {
-        String(describing: error).localizedCaseInsensitiveContains("already exists")
-            || error.localizedDescription.localizedCaseInsensitiveContains("already exists")
-    }
-
-    /// Tear the session down after a minute of camera idleness (cancelled and re-armed by
-    /// each capture; cancelled outright when explicit streaming starts).
-    private var idleTeardownTask: Task<Void, Never>?
-    private static let sessionIdleGrace: Duration = .seconds(60)
-
-    private func scheduleIdleTeardown() {
-        idleTeardownTask?.cancel()
-        idleTeardownTask = Task { [weak self] in
-            try? await Task.sleep(for: Self.sessionIdleGrace)
-            guard let self, !Task.isCancelled else { return }
-            guard !self.isStreaming, !self.isCaptureInProgress else { return }
-            NSLog("[Camera] Idle grace elapsed — tearing session down")
-            await self.resetSession()
-        }
-    }
-
-    private func handlePhotoData(_ photoData: PhotoData) {
-        guard let continuation = photoContinuation else {
-            NSLog("[Camera] Photo data received but no continuation waiting (timeout may have fired first)")
-            return
-        }
-        photoContinuation = nil
-        NSLog("[Camera] Photo captured via SDK (%d bytes)", photoData.data.count)
-        continuation.resume(returning: photoData.data)
-    }
-
-    /// How old a video frame may be and still stand in for a failed photo capture. Beyond
-    /// this, the frame shows where the camera pointed SECONDS AGO — live-traced: repeated
-    /// capture failures kept donating one stale frame, and the assistant confidently
-    /// described the same scene while the user pointed the glasses at different things.
-    private static let frameFallbackMaxAge: TimeInterval = 10
-
-    /// Convert the latest video frame to JPEG data for use as a photo fallback — but ONLY if
-    /// it's fresh. A stale frame is worse than an honest failure: it hallucinates a scene.
-    private func latestFrameAsJPEG(quality: CGFloat = 0.85) -> Data? {
-        guard let frame = latestFrame,
-              Date().timeIntervalSince(lastFrameTime) < Self.frameFallbackMaxAge else {
-            if latestFrame != nil {
-                NSLog("[Camera] Latest frame is stale (%.0fs old) — refusing frame fallback",
-                      Date().timeIntervalSince(lastFrameTime))
-            }
-            return nil
-        }
-        return frame.jpegData(compressionQuality: quality)
-    }
-
-    // MARK: - Continuous Video Streaming (for Gemini Live)
+    // MARK: - Continuous Video Streaming
 
     /// Start continuous video streaming from the glasses camera.
     func startStreaming() async throws {
-        guard WearablesBootstrap.ensureConfigured() else { throw CameraError.sdkNotRegistered }
-        guard !isStreaming else { return }
-        idleTeardownTask?.cancel()   // explicit streaming owns the session now
-        continuousStreamingIntent = true
-
-        // A stream left behind by the discrete photo path may sit at the user's "low"
-        // tier; continuous streaming with glasses-mic voice needs the contention floor
-        // (see `StreamConfigPolicy`), so rebuild it at the effective tier first.
-        if let active = activeStreamResolution,
-           StreamConfigPolicy.effectiveResolution(
-               requested: Config.cameraResolution,
-               concurrentGlassesVoice: true) != active {
-            await teardownStreamOnly()
+        // Plan CQ P1: refuse with a readable reason on hardware that has no live feed at all,
+        // rather than letting the backend fail in a way the caller has to interpret.
+        if case .unavailable(let reason) = availability(of: .livePreview) {
+            throw CameraError.unsupported(reason)
         }
-
-        do {
-            try await ensurePermission()
-            try await ensureSession()
-            try await waitForStreaming()
-        } catch {
-            continuousStreamingIntent = false
-            throw error
-        }
-
-        isStreaming = true
-        startStallDetection()
-        NSLog("[Camera] Streaming started")
+        try await backend.startStreaming()
     }
 
     /// Stop continuous video streaming. Session is kept alive for reuse.
     func stopStreaming() async {
-        continuousStreamingIntent = false
-        guard isStreaming else { return }
-        stopStallDetection()
-        if let session = streamSession {
-            session.stop()
-        }
-        isStreaming = false
-        latestFrame = nil
-        NSLog("[Camera] Streaming stopped (session kept alive)")
-    }
-
-    // MARK: - HEVC Decoder Stall Detection & Auto-Recovery
-
-    /// Start monitoring for decoder stalls (no frames for 1.5 seconds).
-    /// If a stall is detected, the session is torn down and recreated.
-    private func startStallDetection() {
-        stopStallDetection()
-        lastFrameTime = Date()
-        stallDetectionTask = Task { [weak self] in
-            while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 500_000_000) // Check every 0.5s
-                guard !Task.isCancelled, let self else { break }
-                guard self.isStreaming, !self.isRecoveringFromStall else { continue }
-
-                // Temple-tap pause is a system hold: no frames is expected, there is no
-                // app-callable resume, and tearing down collapses the channel the next
-                // tap would resume. Sit it out (and keep the clock fresh so recovery
-                // doesn't fire the instant the tap resumes the stream).
-                if !StreamRecoveryPolicy.shouldRecoverFromStall(state: self.streamSession?.state) {
-                    self.lastFrameTime = Date()
-                    continue
-                }
-
-                let elapsed = Date().timeIntervalSince(self.lastFrameTime)
-                if elapsed > 1.5 {
-                    NSLog("[Camera] ⚠️ Decoder stall detected (%.1fs since last frame) — auto-recovering", elapsed)
-                    self.isRecoveringFromStall = true
-                    self.stallRecoveryCount += 1
-                    await self.recoverFromStall()
-                    self.isRecoveringFromStall = false
-                }
-            }
-        }
-    }
-
-    /// Stop stall detection monitoring.
-    private func stopStallDetection() {
-        stallDetectionTask?.cancel()
-        stallDetectionTask = nil
-    }
-
-    /// Recover from a decoder stall. BR P2: tiered — rebuild only the Stream on the
-    /// retained DeviceSession first (the session is the expensive half: BT connection +
-    /// permission state); escalate to a full session reset only after repeated failures.
-    private func recoverFromStall() async {
-        let action = StreamRecoveryPolicy.action(consecutiveFailures: consecutiveRecoveryFailures)
-        NSLog("[Camera] Stall recovery #%d (%@)", stallRecoveryCount, String(describing: action))
-        onDebugEvent?("Camera stall recovery #\(stallRecoveryCount) (\(action))")
-
-        switch action {
-        case .rebuildStream:
-            await teardownStreamOnly()
-        case .resetSession:
-            await resetSession()
-        }
-
-        do {
-            try await ensureSession()
-            try await waitForStreaming()
-            lastFrameTime = Date()
-            consecutiveRecoveryFailures = 0
-            NSLog("[Camera] Stall recovery successful — streaming resumed")
-        } catch {
-            consecutiveRecoveryFailures += 1
-            NSLog("[Camera] Stall recovery failed (%d consecutive): %@",
-                  consecutiveRecoveryFailures, error.localizedDescription)
-            if case .rebuildStream = action {
-                // Stream-only rebuild failed — make the next attempt (or the next stall
-                // tick) escalate rather than looping at the cheap tier.
-                await resetSession()
-            }
-            isStreaming = false
-        }
-    }
-
-    /// BR P2: drop the Camera capability and its listeners but keep the DeviceSession alive —
-    /// a failed stream must not strand a half-open session (`ensureSession` re-adds the camera
-    /// on the retained session).
-    private func teardownStreamOnly() async {
-        if let camera = cameraCapability {
-            camera.stop()  // cascades to the stream
-            await awaitCameraStopped(camera)
-        }
-        await streamListenerBag.cancelAll()
-        cameraCapability = nil
-        streamSession = nil
-        activeStreamResolution = nil
-        NSLog("[Camera] Camera capability torn down (session retained)")
-    }
-
-    /// Bounded wait for a stopped Camera to actually reach `.stopped`. The camera
-    /// capability is process-wide and is freed when the Camera finishes stopping — not
-    /// when the session is torn down — so arming a replacement camera before then throws
-    /// `capabilityAlreadyActive`. `stop()` is synchronous but the state transition isn't.
-    private func awaitCameraStopped(_ camera: MWDATCamera.Camera, timeout: Duration = .seconds(2)) async {
-        let deadline = ContinuousClock.now + timeout
-        while ContinuousClock.now < deadline {
-            if camera.state == .stopped { return }
-            try? await Task.sleep(nanoseconds: 100_000_000)
-        }
-        NSLog("[Camera] Camera did not reach .stopped within %.0fs — proceeding",
-              Double(timeout.components.seconds))
-    }
-
-    /// Reset the session completely (for error recovery).
-    private func resetSession() async {
-        sessionErrorTask?.cancel()
-        sessionErrorTask = nil
-        if let camera = cameraCapability {
-            camera.stop()
-            // Wait for the capability to actually free (see `awaitCameraStopped`) so the
-            // retry loop's next `ensureSession` doesn't collide with the dying camera.
-            await awaitCameraStopped(camera)
-        }
-        deviceSession?.stop()
-        await streamListenerBag.cancelAll()
-        cameraCapability = nil
-        streamSession = nil
-        activeStreamResolution = nil
-        deviceSession = nil
-        // A torn-down session's frames must not survive to serve as "photos" for the next
-        // capture — the staleness gate is belt, this is braces.
-        latestFrame = nil
-        lastFrameTime = .distantPast
-        NSLog("[Camera] Session reset")
+        await backend.stopStreaming()
     }
 
     /// Tear down everything — called on mode switch or app termination.
     func tearDown() async {
-        await stopStreaming()
-        await resetSession()
-        permissionGranted = false
-        NSLog("[Camera] Torn down completely")
+        await backend.tearDown()
+        latestFrame = nil
     }
 
     // MARK: - Photo Library
@@ -915,6 +275,9 @@ enum CameraError: LocalizedError {
     /// The session was refused for a compatibility reason (e.g. the glasses-side DAT app is
     /// too old for this SDK). Carries the actionable `DATCompatibilityMessage` copy.
     case incompatible(String)
+    /// Plan CQ P1: the connected glasses simply cannot do this. Carries the gate's reason,
+    /// which is written to be shown to a user as-is.
+    case unsupported(String)
 
     var errorDescription: String? {
         switch self {
@@ -926,6 +289,7 @@ enum CameraError: LocalizedError {
         case .streamNotReady: return "Camera stream not ready — try again"
         case .sessionBusy: return "The glasses are still releasing a previous camera session — try again in about a minute"
         case .incompatible(let message): return message
+        case .unsupported(let message): return message
         }
     }
 }

--- a/OpenGlasses/Sources/Services/Device/GlassesTier.swift
+++ b/OpenGlasses/Sources/Services/Device/GlassesTier.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Plan CQ P0 — what class of device is connected, from the app's point of view.
+///
+/// "Which glasses does OpenGlasses work with?" had one answer for most of this project's life,
+/// and it was a product name. It isn't one any more: the microphone path is plain
+/// `AVAudioSession` routing, so **any** glasses that pair as a Bluetooth headset already carry
+/// the entire voice loop — wake word, transcription, LLM, tools, TTS — with no protocol work at
+/// all. What varies between devices is the camera and the display, not the voice.
+///
+/// So the honest unit is a tier, and the tier is what Settings shows.
+enum GlassesTier: String, Sendable, Equatable, CaseIterable {
+    /// Paired as a Bluetooth headset. The voice loop works; there is no camera or HUD for us.
+    case audioOnly
+    /// A HUD we can render to (Plan AH's `GlassesDisplayBackend`), but no camera.
+    case displayOnly
+    /// A camera backend we can drive. What it can *do* is `CameraCapabilities`, not this.
+    case camera
+
+    var label: String {
+        switch self {
+        case .audioOnly: return "Audio only"
+        case .displayOnly: return "Display"
+        case .camera: return "Camera"
+        }
+    }
+
+    /// One line for the Settings device row — what the user gets, not what they don't.
+    var summary: String {
+        switch self {
+        case .audioOnly:
+            return "Voice, wake word and spoken replies. Camera features use the iPhone camera."
+        case .displayOnly:
+            return "Voice, wake word, spoken replies and the in-lens HUD. No camera."
+        case .camera:
+            return "Voice, wake word, spoken replies and the glasses camera."
+        }
+    }
+}
+
+/// Pure tier resolution. No SDK, no audio session, no I/O — the caller passes in what it
+/// observed and gets back the tier.
+enum GlassesTierPolicy {
+
+    /// Resolve the tier of whatever is currently connected.
+    ///
+    /// - Parameters:
+    ///   - cameraCapabilities: the active camera backend's capabilities, or nil when no camera
+    ///     backend is usable right now (unregistered SDK, glasses offline, simulator).
+    ///   - displayBackendActive: whether a `GlassesDisplayBackend` is connected and rendering.
+    ///   - audioPortNames: names of the currently available Bluetooth audio input ports.
+    /// - Returns: the tier, or nil when nothing glasses-like is connected at all — which is a
+    ///   different statement from "connected but limited" and must not be collapsed into one.
+    ///
+    /// Ordering is most-capable-wins, because a device can legitimately answer to more than one:
+    /// camera glasses are also audio devices, and Meta's Display glasses are all three. The tier
+    /// names the best thing available, and `CameraCapabilities` carries the detail.
+    static func resolve(
+        cameraCapabilities: CameraCapabilities?,
+        displayBackendActive: Bool,
+        audioPortNames: [String]
+    ) -> GlassesTier? {
+        if let capabilities = cameraCapabilities,
+           capabilities.stillCapture || capabilities.liveFrames {
+            return .camera
+        }
+        if displayBackendActive { return .displayOnly }
+        if audioPortNames.contains(where: { MicRoutePolicy.looksLikeGlasses(portName: $0) }) {
+            return .audioOnly
+        }
+        return nil
+    }
+}

--- a/OpenGlasses/Sources/Services/PhoneCameraSource.swift
+++ b/OpenGlasses/Sources/Services/PhoneCameraSource.swift
@@ -11,7 +11,20 @@ import UIKit
 /// Not @MainActor: AVCaptureSession config/start/stop run on `sessionQueue`. The single
 /// in-flight capture continuation is set and resumed on the main queue for thread safety
 /// (same discipline as PhoneCameraController).
-final class PhoneCameraSource: NSObject, @unchecked Sendable {
+/// The phone camera as `CameraService` sees it — one still, on demand.
+///
+/// A seam rather than a concrete reference because this is the branch the coordinator takes
+/// whenever the glasses camera *can't* serve a capture, so any test that exercises that decision
+/// lands in real AVFoundation. On a simulator whose camera privacy decision is still unresolved,
+/// `requestAccess` then waits forever for a prompt no test runner can answer — the test hangs
+/// rather than fails. Injecting the source keeps the fallback decision testable without a camera,
+/// mirroring `GlassesCameraBackend` on the glasses side.
+protocol PhoneCameraCapturing: AnyObject {
+    /// Capture a single still as JPEG data.
+    func capturePhoto() async throws -> Data
+}
+
+final class PhoneCameraSource: NSObject, PhoneCameraCapturing, @unchecked Sendable {
     private let session = AVCaptureSession()
     private let photoOutput = AVCapturePhotoOutput()
     private let sessionQueue = DispatchQueue(label: "com.openglasses.phone-camera.source")

--- a/OpenGlassesTests/CameraCapabilitiesTests.swift
+++ b/OpenGlassesTests/CameraCapabilitiesTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan CQ P1 — the capability model and the gate that turns it into an answer a user can read.
+final class CameraCapabilitiesTests: XCTestCase {
+
+    /// The two device classes Plan CQ targets, as capability fixtures.
+    private let documentedSDKClass = CameraCapabilities(
+        liveFrames: false,          // stills go to a webhook; no local frame access
+        stillCapture: true,
+        stillLatency: .subSecond,   // with camera warm-up
+        concurrentWithMic: true,
+        hardwareEvents: true
+    )
+    private let captureToStorageClass = CameraCapabilities(
+        liveFrames: false,
+        stillCapture: true,
+        stillLatency: .seconds,     // BLE trigger, then a network hop to fetch
+        concurrentWithMic: false,   // camera and mic are exclusive modes
+        hardwareEvents: false
+    )
+
+    // MARK: - Meta backend: the baseline the app was written against
+
+    func testMetaBackendMakesEveryCameraFeatureAvailable() {
+        for feature in CameraDependentFeature.allCases {
+            XCTAssertEqual(
+                CameraFeatureGate.availability(of: feature, given: .meta),
+                .available,
+                "\(feature.rawValue) should be available on the Meta backend"
+            )
+        }
+        XCTAssertTrue(CameraFeatureGate.unavailableFeatures(given: .meta).isEmpty)
+    }
+
+    // MARK: - Live-frame features
+
+    func testLiveFrameFeaturesAreUnavailableWithoutALiveFeed() {
+        // This is the whole reason the gate exists: every one of these is built on
+        // `CameraService.framePublisher`, and neither Plan CQ device class provides it.
+        let liveOnly = CameraDependentFeature.allCases.filter(\.requiresLiveFrames)
+        XCTAssertFalse(liveOnly.isEmpty, "fixture guard — the live-frame set must not be empty")
+
+        for feature in liveOnly {
+            for capabilities in [documentedSDKClass, captureToStorageClass] {
+                let availability = CameraFeatureGate.availability(of: feature, given: capabilities)
+                XCTAssertFalse(availability.isUsable, "\(feature.rawValue) must be refused")
+                XCTAssertTrue(
+                    availability.note?.contains(feature.displayName) == true,
+                    "the refusal should name the feature so the copy is usable as-is"
+                )
+            }
+        }
+    }
+
+    func testPhoneFallbackDoesNotRescueLiveFrameFeatures() {
+        // The iPhone fallback is a one-shot still. It must never make a continuous feature
+        // look available.
+        XCTAssertFalse(
+            CameraFeatureGate.availability(
+                of: .signLanguage, given: .unavailable, phoneFallbackAvailable: true
+            ).isUsable
+        )
+    }
+
+    // MARK: - Still capture
+
+    func testFastStillCaptureIsFullyAvailable() {
+        XCTAssertEqual(
+            CameraFeatureGate.availability(of: .photoCapture, given: documentedSDKClass),
+            .available
+        )
+    }
+
+    func testSlowStillCaptureIsAvailableButFlagged() {
+        let availability = CameraFeatureGate.availability(
+            of: .photoCapture, given: captureToStorageClass
+        )
+        XCTAssertTrue(availability.isUsable)
+        guard case .degraded(let note) = availability else {
+            return XCTFail("a seconds-long capture should be degraded, not silently available")
+        }
+        XCTAssertTrue(note.localizedCaseInsensitiveContains("seconds"))
+    }
+
+    func testNoGlassesCameraFallsBackToThePhoneAndSaysSo() {
+        // Preserves the shipped behaviour that `capturePhoto()` uses the iPhone back camera
+        // when the glasses camera isn't usable — but the caveat has to be surfaced, because a
+        // phone in a pocket is not pointed where the user is looking.
+        let availability = CameraFeatureGate.availability(of: .photoCapture, given: .unavailable)
+        XCTAssertTrue(availability.isUsable)
+        XCTAssertTrue(availability.note?.localizedCaseInsensitiveContains("iPhone camera") == true)
+    }
+
+    func testNoCameraAtAllWhenEvenThePhoneIsUnavailable() {
+        let availability = CameraFeatureGate.availability(
+            of: .photoCapture, given: .unavailable, phoneFallbackAvailable: false
+        )
+        XCTAssertFalse(availability.isUsable)
+    }
+
+    // MARK: - Summaries
+
+    func testSummaryDistinguishesTheThreeCases() {
+        XCTAssertEqual(CameraFeatureGate.summary(given: .meta), "Live video and photo capture")
+        XCTAssertEqual(CameraFeatureGate.summary(given: documentedSDKClass), "Photo capture only")
+        XCTAssertTrue(
+            CameraFeatureGate.summary(given: captureToStorageClass)
+                .localizedCaseInsensitiveContains("several seconds")
+        )
+        XCTAssertTrue(
+            CameraFeatureGate.summary(given: .unavailable)
+                .localizedCaseInsensitiveContains("no camera")
+        )
+    }
+
+    func testUnavailableFeatureListIsExactlyTheLiveFrameSet() {
+        // Photo capture survives on both classes (fast or degraded); everything continuous does not.
+        let expected = Set(CameraDependentFeature.allCases.filter(\.requiresLiveFrames).map(\.rawValue))
+        for capabilities in [documentedSDKClass, captureToStorageClass] {
+            let blocked = Set(CameraFeatureGate.unavailableFeatures(given: capabilities).map(\.rawValue))
+            XCTAssertEqual(blocked, expected)
+        }
+    }
+}

--- a/OpenGlassesTests/CameraServiceCoordinatorTests.swift
+++ b/OpenGlassesTests/CameraServiceCoordinatorTests.swift
@@ -1,0 +1,292 @@
+import Combine
+import UIKit
+import XCTest
+@testable import OpenGlasses
+
+/// Plan CQ P1 — the backend-neutral half of `CameraService`, driven through an injected mock.
+///
+/// The point of the seam is that this is now testable at all: before the split, every one of
+/// these behaviours sat behind `Wearables`, which traps in a unit-test process.
+@MainActor
+final class CameraServiceCoordinatorTests: XCTestCase {
+
+    /// A backend that records what it was asked to do and lets a test emit events by hand.
+    private final class MockCameraBackend: GlassesCameraBackend {
+        var capabilities: CameraCapabilities
+        let events = PassthroughSubject<CameraBackendEvent, Never>()
+        var ready: Bool
+        var permissionGranted = false
+        /// Records whether callers asked for the side-effecting form — the capture path must,
+        /// and UI must not.
+        private(set) var readyQueries: [Bool] = []
+
+        func isReady(configuringIfNeeded: Bool) -> Bool {
+            readyQueries.append(configuringIfNeeded)
+            return ready
+        }
+
+        private(set) var captureCount = 0
+        private(set) var startStreamingCount = 0
+        private(set) var stopStreamingCount = 0
+        private(set) var tearDownCount = 0
+        var captureResult: Result<Data, Error> = .success(Data([0x01, 0x02, 0x03]))
+
+        init(capabilities: CameraCapabilities = .meta, isReady: Bool = true) {
+            self.capabilities = capabilities
+            self.ready = isReady
+        }
+
+        func ensurePermission() async throws { permissionGranted = true }
+
+        func capturePhoto() async throws -> Data {
+            captureCount += 1
+            return try captureResult.get()
+        }
+
+        func startStreaming() async throws { startStreamingCount += 1 }
+        func stopStreaming() async { stopStreamingCount += 1 }
+        func tearDown() async { tearDownCount += 1 }
+    }
+
+    /// The iPhone-camera fallback, faked.
+    ///
+    /// Every test that can reach the fallback branch has to inject this. The real
+    /// `PhoneCameraSource` is AVFoundation, and on a simulator whose camera privacy decision is
+    /// still unresolved it waits forever for a prompt no test runner can answer — so an
+    /// un-injected fallback doesn't fail the suite, it hangs it, and only on machines where the
+    /// permission hasn't already been cached by something else.
+    private final class MockPhoneCamera: PhoneCameraCapturing {
+        private(set) var captureCount = 0
+        /// Not decodable as an image on purpose, same as the backend mock: it keeps the
+        /// photo-library write out of a unit test.
+        var captureResult: Result<Data, Error> = .success(Data([0xBE, 0xEF]))
+
+        func capturePhoto() async throws -> Data {
+            captureCount += 1
+            return try captureResult.get()
+        }
+    }
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - Event mirroring
+
+    func testFrameEventsReachEveryConsumerSurface() {
+        let backend = MockCameraBackend()
+        let service = CameraService(backend: backend)
+
+        var published: [UIImage] = []
+        service.framePublisher.sink { published.append($0) }.store(in: &cancellables)
+        var callbackFrames: [UIImage] = []
+        service.onVideoFrame = { callbackFrames.append($0) }
+
+        let frame = UIImage(systemName: "camera")!
+        backend.events.send(.frame(frame))
+
+        XCTAssertEqual(published.count, 1)
+        XCTAssertEqual(callbackFrames.count, 1)
+        XCTAssertNotNil(service.latestFrame)
+    }
+
+    func testNilFrameClearsTheCacheWithoutPublishing() {
+        // A torn-down session's last frame must not survive to stand in for the next capture.
+        let backend = MockCameraBackend()
+        let service = CameraService(backend: backend)
+        backend.events.send(.frame(UIImage(systemName: "camera")!))
+        XCTAssertNotNil(service.latestFrame)
+
+        var publishedAfterClear = 0
+        service.framePublisher.sink { _ in publishedAfterClear += 1 }.store(in: &cancellables)
+        backend.events.send(.frame(nil))
+
+        XCTAssertNil(service.latestFrame)
+        XCTAssertEqual(publishedAfterClear, 0, "a cache clear is not a frame")
+    }
+
+    func testStatusAndStreamingEventsMirrorIntoPublishedState() {
+        let backend = MockCameraBackend()
+        let service = CameraService(backend: backend)
+
+        backend.events.send(.status(.waiting))
+        XCTAssertEqual(service.streamingStatus, .waiting)
+        backend.events.send(.streamingChanged(true))
+        XCTAssertTrue(service.isStreaming)
+        backend.events.send(.status(.stopped))
+        backend.events.send(.streamingChanged(false))
+        XCTAssertEqual(service.streamingStatus, .stopped)
+        XCTAssertFalse(service.isStreaming)
+    }
+
+    func testDebugCompatibilityAndRegistrationEventsAreForwarded() {
+        let backend = MockCameraBackend()
+        let service = CameraService(backend: backend)
+
+        var debugMessages: [String] = []
+        service.onDebugEvent = { debugMessages.append($0) }
+        var registrationStates: [Int] = []
+        service.onRegistrationProgress = { registrationStates.append($0) }
+
+        backend.events.send(.debug("stall recovery #1"))
+        backend.events.send(.registrationProgress(3))
+        backend.events.send(.compatibilityNotice("Update the Meta AI app"))
+
+        XCTAssertEqual(debugMessages, ["stall recovery #1"])
+        XCTAssertEqual(registrationStates, [3])
+        XCTAssertEqual(service.compatibilityNotice, "Update the Meta AI app")
+    }
+
+    // MARK: - Capture routing
+
+    func testCaptureUsesTheBackendWhenItIsReady() async throws {
+        let backend = MockCameraBackend(isReady: true)
+        // Not decodable as an image on purpose: keeps the photo-library write out of a unit test.
+        backend.captureResult = .success(Data([0xDE, 0xAD]))
+        let phone = MockPhoneCamera()
+        let service = CameraService(backend: backend, phoneCamera: phone)
+
+        let data = try await service.capturePhoto()
+
+        XCTAssertEqual(data, Data([0xDE, 0xAD]))
+        XCTAssertEqual(backend.captureCount, 1)
+        XCTAssertEqual(phone.captureCount, 0, "usable glasses must not be second-guessed")
+        XCTAssertEqual(service.lastCaptureSource, .glasses)
+    }
+
+    func testCaptureSkipsTheBackendWhenItIsNotReady() async throws {
+        // The phone fallback exists so vision tools work without glasses. What matters here is
+        // the absence: an unready backend must not be asked, because a failed glasses capture
+        // silently served by the phone photographs a desk, not what the user is looking at.
+        let backend = MockCameraBackend(isReady: false)
+        let phone = MockPhoneCamera()
+        let service = CameraService(backend: backend, phoneCamera: phone)
+
+        let data = try await service.capturePhoto()
+
+        XCTAssertEqual(backend.captureCount, 0)
+        XCTAssertEqual(phone.captureCount, 1)
+        XCTAssertEqual(data, Data([0xBE, 0xEF]))
+        XCTAssertEqual(service.lastCaptureSource, .phone, "callers announce a phone capture")
+    }
+
+    func testCaptureSkipsABackendThatCannotTakeStills() async throws {
+        let noStills = CameraCapabilities(
+            liveFrames: false,
+            stillCapture: false,
+            stillLatency: .seconds,
+            concurrentWithMic: true,
+            hardwareEvents: false
+        )
+        let backend = MockCameraBackend(capabilities: noStills, isReady: true)
+        let phone = MockPhoneCamera()
+        let service = CameraService(backend: backend, phoneCamera: phone)
+
+        let data = try await service.capturePhoto()
+
+        XCTAssertEqual(backend.captureCount, 0)
+        XCTAssertEqual(phone.captureCount, 1, "the phone is the only camera left")
+        XCTAssertEqual(data, Data([0xBE, 0xEF]))
+        XCTAssertEqual(service.lastCaptureSource, .phone)
+    }
+
+    func testCaptureFailureFromAReadyBackendPropagates() async {
+        // A ready backend that fails must FAIL, not fall through to the phone camera.
+        struct Boom: Error {}
+        let backend = MockCameraBackend(isReady: true)
+        backend.captureResult = .failure(Boom())
+        let phone = MockPhoneCamera()
+        let service = CameraService(backend: backend, phoneCamera: phone)
+
+        do {
+            _ = try await service.capturePhoto()
+            XCTFail("expected the backend failure to propagate")
+        } catch {
+            XCTAssertTrue(error is Boom)
+        }
+        XCTAssertEqual(backend.captureCount, 1)
+        XCTAssertEqual(phone.captureCount, 0, "a wrong-camera photo is worse than an error")
+    }
+
+    // MARK: - Streaming gate
+
+    func testStreamingIsRefusedWithAReadableReasonWhenThereIsNoLiveFeed() async {
+        let stillsOnly = CameraCapabilities(
+            liveFrames: false,
+            stillCapture: true,
+            stillLatency: .subSecond,
+            concurrentWithMic: true,
+            hardwareEvents: true
+        )
+        let backend = MockCameraBackend(capabilities: stillsOnly)
+        let service = CameraService(backend: backend)
+
+        do {
+            try await service.startStreaming()
+            XCTFail("expected the gate to refuse streaming")
+        } catch let error as CameraError {
+            guard case .unsupported(let reason) = error else {
+                return XCTFail("expected .unsupported, got \(error)")
+            }
+            XCTAssertTrue(reason.localizedCaseInsensitiveContains("live camera feed"))
+        } catch {
+            XCTFail("unexpected error \(error)")
+        }
+        XCTAssertEqual(backend.startStreamingCount, 0)
+    }
+
+    func testStreamingProceedsOnABackendWithLiveFrames() async throws {
+        let backend = MockCameraBackend(capabilities: .meta)
+        let service = CameraService(backend: backend)
+
+        try await service.startStreaming()
+        await service.stopStreaming()
+
+        XCTAssertEqual(backend.startStreamingCount, 1)
+        XCTAssertEqual(backend.stopStreamingCount, 1)
+    }
+
+    // MARK: - Pass-through
+
+    func testPermissionFlagAndTearDownDelegateToTheBackend() async {
+        let backend = MockCameraBackend()
+        let service = CameraService(backend: backend)
+
+        service.permissionGranted = true
+        XCTAssertTrue(backend.permissionGranted)
+        XCTAssertTrue(service.permissionGranted)
+
+        backend.events.send(.frame(UIImage(systemName: "camera")!))
+        await service.tearDown()
+
+        XCTAssertEqual(backend.tearDownCount, 1)
+        XCTAssertNil(service.latestFrame)
+    }
+
+    func testActiveCapabilitiesReflectReadiness() {
+        let backend = MockCameraBackend(isReady: false)
+        let service = CameraService(backend: backend)
+        XCTAssertNil(service.activeCapabilities, "an unreachable camera is not a connected one")
+
+        backend.ready = true
+        XCTAssertEqual(service.activeCapabilities, .meta)
+    }
+
+    func testReadinessSideEffectsAreAskedForOnlyOnTheCapturePath() async {
+        // Configuring the Meta SDK prompts for Bluetooth. That is correct at a capture and
+        // wrong from a view body describing the connected device, so the two callers must ask
+        // different questions.
+        let backend = MockCameraBackend(isReady: true)
+        let service = CameraService(backend: backend, phoneCamera: MockPhoneCamera())
+
+        _ = service.activeCapabilities
+        XCTAssertEqual(backend.readyQueries, [false])
+
+        backend.captureResult = .success(Data([0xDE, 0xAD]))
+        _ = try? await service.capturePhoto()
+        XCTAssertEqual(backend.readyQueries, [false, true])
+    }
+}

--- a/OpenGlassesTests/CaptureProtocolTests.swift
+++ b/OpenGlassesTests/CaptureProtocolTests.swift
@@ -1,0 +1,291 @@
+import Foundation
+import XCTest
+@testable import OpenGlasses
+
+/// Plan CQ P4 — the pure capture-protocol core.
+///
+/// The wire format is a community reconstruction, so these tests can only pin what we *believe*
+/// it to be — self-consistency, the published CRC vectors, and the behavioural rules that must
+/// hold whatever the bytes turn out to be. When hardware arrives, a capture log is the thing
+/// that decides whether the reconstruction was right; these tests decide whether our code
+/// implements the reconstruction we wrote down.
+final class CaptureProtocolTests: XCTestCase {
+
+    // MARK: - CRC-16/MODBUS
+
+    func testCRCMatchesThePublishedCheckValue() {
+        // The catalogue's check value for CRC-16/MODBUS: "123456789" → 0x4B37. This is what
+        // makes the implementation ours rather than a transcription — it is validated against
+        // the published algorithm, not against someone else's code.
+        let input = Array("123456789".utf8)
+        XCTAssertEqual(CRC16Modbus.compute(input), 0x4B37)
+    }
+
+    func testCRCOfEmptyInputIsTheInitialValue() {
+        XCTAssertEqual(CRC16Modbus.compute([]), 0xFFFF)
+    }
+
+    func testCRCIsOrderSensitive() {
+        XCTAssertNotEqual(CRC16Modbus.compute([0x01, 0x02]), CRC16Modbus.compute([0x02, 0x01]))
+    }
+
+    // MARK: - Frame encode / decode
+
+    func testHeaderLayoutIsSentinelCommandLengthCRC() {
+        let packet = CapturePacket(command: 0x41, payload: [0xAA, 0xBB])
+        let bytes = packet.encoded
+        let crc = CRC16Modbus.compute([0xAA, 0xBB])
+
+        XCTAssertEqual(bytes[0], 0xBC)
+        XCTAssertEqual(bytes[1], 0x41)
+        XCTAssertEqual(bytes[2], 0x02, "length low byte")
+        XCTAssertEqual(bytes[3], 0x00, "length high byte")
+        XCTAssertEqual(bytes[4], UInt8(truncatingIfNeeded: crc), "CRC low byte")
+        XCTAssertEqual(bytes[5], UInt8(truncatingIfNeeded: crc >> 8), "CRC high byte")
+        XCTAssertEqual(Array(bytes[6...]), [0xAA, 0xBB])
+    }
+
+    func testRoundTrip() {
+        for payloadLength in [0, 1, 6, 255, 256, 1000] {
+            let payload = (0..<payloadLength).map { UInt8($0 % 256) }
+            let packet = CapturePacket(command: 0x59, payload: payload)
+            guard let (decoded, consumed) = CapturePacket.decode(packet.encoded) else {
+                return XCTFail("failed to decode a \(payloadLength)-byte payload")
+            }
+            XCTAssertEqual(decoded, packet)
+            XCTAssertEqual(consumed, packet.encoded.count)
+        }
+    }
+
+    func testMultiByteLengthIsLittleEndian() {
+        // 300 = 0x012C, so low byte 0x2C then high byte 0x01. Getting this backwards would
+        // still round-trip through our own decoder, which is why it is asserted directly.
+        let packet = CapturePacket(command: 0x41, payload: [UInt8](repeating: 0, count: 300))
+        XCTAssertEqual(packet.encoded[2], 0x2C)
+        XCTAssertEqual(packet.encoded[3], 0x01)
+    }
+
+    func testDecodeRejectsBadSentinelTruncationAndCorruptCRC() {
+        let good = CapturePacket(command: 0x41, payload: [0x01, 0x02, 0x03]).encoded
+
+        var badSentinel = good
+        badSentinel[0] = 0x00
+        XCTAssertNil(CapturePacket.decode(badSentinel))
+
+        XCTAssertNil(CapturePacket.decode(Array(good.dropLast())), "truncated frame")
+        XCTAssertNil(CapturePacket.decode([]), "empty input")
+
+        var corrupt = good
+        corrupt[corrupt.count - 1] ^= 0xFF
+        XCTAssertNil(CapturePacket.decode(corrupt), "payload corruption must fail the CRC")
+    }
+
+    func testDecodeIgnoresTrailingBytesAndReportsWhatItConsumed() {
+        let packet = CapturePacket(command: 0x73, payload: [0x09])
+        let stream = packet.encoded + [0xBC, 0x41, 0x00]
+        guard let (decoded, consumed) = CapturePacket.decode(stream) else {
+            return XCTFail("expected the leading frame to decode")
+        }
+        XCTAssertEqual(decoded, packet)
+        XCTAssertEqual(consumed, packet.encoded.count)
+    }
+
+    // MARK: - Transport chunking
+
+    func testShortFramesAreASingleWrite() {
+        let chunks = CapturePacket(command: 0x41, payload: [0x01]).chunked()
+        XCTAssertEqual(chunks.count, 1)
+    }
+
+    func testLongFramesSplitAtTheTransportCeiling() {
+        let packet = CapturePacket(command: 0xFD, payload: [UInt8](repeating: 0x5A, count: 1000))
+        let chunks = packet.chunked()
+        XCTAssertTrue(chunks.allSatisfy { $0.count <= CapturePacket.transportChunkSize })
+        XCTAssertEqual(chunks.flatMap { $0 }, packet.encoded, "chunking must be lossless")
+    }
+
+    // MARK: - Stream reassembly
+
+    func testFrameSplitAcrossWritesIsReassembled() {
+        // A thumbnail is the realistic case: ~1 KB across five BLE writes.
+        let packet = CapturePacket(command: 0xFD, payload: (0..<1024).map { UInt8($0 % 256) })
+        var assembler = CaptureFrameAssembler()
+
+        var received: [CapturePacket] = []
+        for chunk in packet.chunked() {
+            received.append(contentsOf: assembler.append(chunk))
+        }
+
+        XCTAssertEqual(received, [packet])
+        XCTAssertTrue(assembler.buffer.isEmpty)
+        XCTAssertEqual(assembler.discardedBytes, 0)
+    }
+
+    func testSeveralFramesInOneWriteAllSurface() {
+        let a = CapturePacket(command: 0x73, payload: [])
+        let b = CapturePacket(command: 0x59, payload: [0x01, 0x02])
+        let c = CapturePacket(command: 0xFD, payload: [0xFF])
+        var assembler = CaptureFrameAssembler()
+
+        let packets = assembler.append(a.encoded + b.encoded + c.encoded)
+
+        XCTAssertEqual(packets, [a, b, c])
+    }
+
+    func testFrameBoundaryInTheMiddleOfAWrite() {
+        let a = CapturePacket(command: 0x73, payload: [0x01])
+        let b = CapturePacket(command: 0x59, payload: [0x02, 0x03])
+        let stream = a.encoded + b.encoded
+        var assembler = CaptureFrameAssembler()
+
+        let first = assembler.append(Array(stream[0..<(a.encoded.count + 2)]))
+        XCTAssertEqual(first, [a])
+        let second = assembler.append(Array(stream[(a.encoded.count + 2)...]))
+        XCTAssertEqual(second, [b])
+    }
+
+    func testAssemblerResynchronisesAfterGarbage() {
+        // A dropped write leaves bytes that will never form a frame. Without resync the channel
+        // is dead for the rest of the session, so recovery is the behaviour under test.
+        let good = CapturePacket(command: 0x41, payload: [0x0A, 0x0B])
+        var assembler = CaptureFrameAssembler()
+
+        let packets = assembler.append([0x00, 0x11, 0x22] + good.encoded)
+
+        XCTAssertEqual(packets, [good])
+        XCTAssertEqual(assembler.discardedBytes, 3, "the cost of resync must be counted, not hidden")
+    }
+
+    func testAssemblerRecoversFromACorruptFrameFollowedByAGoodOne() {
+        var corrupt = CapturePacket(command: 0x41, payload: [0x01, 0x02, 0x03]).encoded
+        corrupt[corrupt.count - 1] ^= 0xFF        // breaks the CRC, length still consistent
+        let good = CapturePacket(command: 0x73, payload: [0x07])
+        var assembler = CaptureFrameAssembler()
+
+        let packets = assembler.append(corrupt + good.encoded)
+
+        XCTAssertEqual(packets, [good], "a corrupt frame must not swallow the next good one")
+        XCTAssertGreaterThan(assembler.discardedBytes, 0)
+    }
+
+    func testAssemblerDoesNotGrowWithoutBound() {
+        var assembler = CaptureFrameAssembler()
+        // A header promising far more than will ever arrive: the buffer must not retain it
+        // forever.
+        let header: [UInt8] = [0xBC, 0x41, 0xFF, 0xFF, 0x00, 0x00]
+        _ = assembler.append(header)
+        for _ in 0..<40 {
+            _ = assembler.append([UInt8](repeating: 0x00, count: 1000))
+        }
+        XCTAssertLessThanOrEqual(assembler.buffer.count, CaptureFrameAssembler.maxBufferedBytes)
+    }
+
+    func testResetDropsAPartialFrame() {
+        var assembler = CaptureFrameAssembler()
+        _ = assembler.append(Array(CapturePacket(command: 0x41, payload: [1, 2, 3]).encoded.prefix(4)))
+        XCTAssertFalse(assembler.buffer.isEmpty)
+        assembler.reset()
+        XCTAssertTrue(assembler.buffer.isEmpty)
+    }
+
+    // MARK: - Commands
+
+    func testAttestedControlPayloads() {
+        XCTAssertEqual(
+            CaptureCommand.control(.aiCaptureWithThumbnail).payload,
+            [0x02, 0x01, 0x06, 0x02, 0x02, 0x02]
+        )
+        XCTAssertEqual(CaptureCommand.control(.startMicrophone).payload, [0x02, 0x01, 0x07])
+        XCTAssertEqual(CaptureCommand.control(.speakerPlayback).payload, [0x02, 0x01, 0x10])
+
+        for action in [CaptureCommand.ControlAction.aiCaptureWithThumbnail, .startMicrophone, .speakerPlayback] {
+            XCTAssertEqual(CaptureCommand.control(action).opcode, 0x41)
+        }
+        XCTAssertEqual(CaptureCommand.startLivestream.opcode, 0x67)
+    }
+
+    func testCommandsEncodeToDecodableFrames() {
+        let command = CaptureCommand.control(.aiCaptureWithThumbnail)
+        guard let (decoded, _) = CapturePacket.decode(command.packet.encoded) else {
+            return XCTFail("a command must produce a decodable frame")
+        }
+        XCTAssertEqual(decoded.command, command.opcode)
+        XCTAssertEqual(decoded.payload, command.payload)
+    }
+
+    // MARK: - Inbound notifications
+
+    func testNotificationRouting() {
+        XCTAssertEqual(
+            CaptureNotification.from(CapturePacket(command: 0x73, payload: [])),
+            .captureReady
+        )
+        XCTAssertEqual(
+            CaptureNotification.from(CapturePacket(command: 0xFD, payload: [0x01, 0x02])),
+            .thumbnail(Data([0x01, 0x02]))
+        )
+        XCTAssertEqual(
+            CaptureNotification.from(CapturePacket(command: 0x59, payload: [0x03])),
+            .microphoneAudio(Data([0x03]))
+        )
+        XCTAssertEqual(
+            CaptureNotification.from(CapturePacket(command: 0x12, payload: [0x04])),
+            .unrecognised(opcode: 0x12, payload: [0x04])
+        )
+    }
+
+    // MARK: - Control replies (the trap)
+
+    func testReadableReplyReportsSuccessAndFailure() {
+        let ok = CaptureControlReply.parse([0x01, 0x00, 0x05])
+        XCTAssertEqual(ok.status, .ok(workType: 0x05))
+        XCTAssertTrue(ok.isConfirmedSuccess)
+        XCTAssertFalse(ok.isConfirmedFailure)
+
+        let failed = CaptureControlReply.parse([0x01, 0x03, 0x00])
+        XCTAssertEqual(failed.status, .failed(code: 0x03))
+        XCTAssertTrue(failed.isConfirmedFailure)
+    }
+
+    /// The defect this parser exists to avoid: for these sub-types the device executes the
+    /// command and the reply's status fields are never populated, so a non-zero byte in the
+    /// error position is a *default*, not a failure. Reporting it as failure makes working
+    /// commands look broken — and makes the caller retry them.
+    func testSubtypesWithoutStatusFieldsAreNeverReportedAsFailures() {
+        for subtype in CaptureControlReply.subtypesWithoutStatusFields {
+            // Byte 1 looks exactly like an error code, and must still not be read as one.
+            let reply = CaptureControlReply.parse([subtype, 0xFF, 0xFF])
+            XCTAssertEqual(reply.status, .unreadable, "sub-type \(subtype) must be unreadable")
+            XCTAssertFalse(reply.isConfirmedFailure,
+                           "sub-type \(subtype) must never be a confirmed failure")
+            XCTAssertFalse(reply.isConfirmedSuccess,
+                           "…and must not be manufactured into a success either")
+        }
+    }
+
+    /// Positive control for the test above: the same bytes on a status-bearing sub-type DO read
+    /// as a failure. Without this, the assertion above would pass on a parser that called
+    /// everything unreadable.
+    func testPositiveControlAStatusBearingSubtypeStillReportsFailure() {
+        let statusBearing: UInt8 = 0x01
+        XCTAssertFalse(CaptureControlReply.subtypesWithoutStatusFields.contains(statusBearing))
+        XCTAssertTrue(CaptureControlReply.parse([statusBearing, 0xFF, 0xFF]).isConfirmedFailure)
+    }
+
+    func testTruncatedRepliesAreUnreadableNotFailed() {
+        // A truncated reply says nothing about whether the command ran.
+        for payload in [[], [0x01], [0x01, 0x00]] as [[UInt8]] {
+            let reply = CaptureControlReply.parse(payload)
+            XCTAssertEqual(reply.status, .unreadable)
+            XCTAssertFalse(reply.isConfirmedFailure)
+        }
+    }
+
+    func testControlReplyArrivesThroughTheNotificationPath() {
+        let packet = CapturePacket(command: 0x41, payload: [0x0A, 0xFF, 0xFF])
+        guard case .controlReply(let reply) = CaptureNotification.from(packet) else {
+            return XCTFail("a 0x41 frame should route to a control reply")
+        }
+        XCTAssertEqual(reply.status, .unreadable, "0x0A is one of the known-gap sub-types")
+    }
+}

--- a/OpenGlassesTests/GlassesTierTests.swift
+++ b/OpenGlassesTests/GlassesTierTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan CQ P0 — the device-tier model, and the widened glasses-name markers it rests on.
+final class GlassesTierTests: XCTestCase {
+
+    // MARK: - Tier resolution
+
+    func testNoDeviceResolvesToNil() {
+        // "Not connected" and "connected but limited" are different statements. Collapsing
+        // them into `.audioOnly` would tell a user with nothing paired that their glasses
+        // work for voice.
+        XCTAssertNil(GlassesTierPolicy.resolve(
+            cameraCapabilities: nil,
+            displayBackendActive: false,
+            audioPortNames: ["iPhone Microphone", "AirPods Pro"]
+        ))
+    }
+
+    func testBluetoothGlassesWithoutCameraOrDisplayAreAudioOnly() {
+        XCTAssertEqual(
+            GlassesTierPolicy.resolve(
+                cameraCapabilities: nil,
+                displayBackendActive: false,
+                audioPortNames: ["Anko Camera Glasses"]
+            ),
+            .audioOnly
+        )
+    }
+
+    func testDisplayBackendBeatsAudioOnly() {
+        XCTAssertEqual(
+            GlassesTierPolicy.resolve(
+                cameraCapabilities: nil,
+                displayBackendActive: true,
+                audioPortNames: ["Even G2"]
+            ),
+            .displayOnly
+        )
+    }
+
+    func testCameraBackendWins() {
+        // Most-capable-wins: camera glasses are also audio devices, and Meta's Display
+        // glasses are all three. The tier names the best thing available.
+        XCTAssertEqual(
+            GlassesTierPolicy.resolve(
+                cameraCapabilities: .meta,
+                displayBackendActive: true,
+                audioPortNames: ["Ray-Ban Meta"]
+            ),
+            .camera
+        )
+    }
+
+    func testStillOnlyBackendStillCountsAsCamera() {
+        // A backend with no live feed is still a camera tier — what it can't do is
+        // `CameraCapabilities`' job to say, not the tier's.
+        let stillsOnly = CameraCapabilities(
+            liveFrames: false,
+            stillCapture: true,
+            stillLatency: .seconds,
+            concurrentWithMic: false,
+            hardwareEvents: false
+        )
+        XCTAssertEqual(
+            GlassesTierPolicy.resolve(
+                cameraCapabilities: stillsOnly,
+                displayBackendActive: false,
+                audioPortNames: []
+            ),
+            .camera
+        )
+    }
+
+    func testUnreachableCameraBackendDoesNotClaimCameraTier() {
+        // `.unavailable` is what `CameraService.activeCapabilities` reports when nothing is
+        // reachable; it must not read as a connected camera.
+        XCTAssertNil(GlassesTierPolicy.resolve(
+            cameraCapabilities: .unavailable,
+            displayBackendActive: false,
+            audioPortNames: ["AirPods Pro"]
+        ))
+    }
+
+    // MARK: - Name markers (Plan CQ P0 widening)
+
+    func testWidenedMarkersMatchTheNewDeviceClasses() {
+        let names = [
+            "Ray-Ban Meta",           // pre-existing
+            "Oakley Meta HSTN",       // pre-existing
+            "Anko Camera Glasses",    // Track B, retail badge
+            "HeyCyan M02S",           // Track B, OEM platform
+            "Mentra Live",            // Track A
+            "Even G2",                // display tier
+            "Vuzix Z100",             // display tier
+        ]
+        for name in names {
+            XCTAssertTrue(MicRoutePolicy.looksLikeGlasses(portName: name),
+                          "\(name) should be recognised as glasses")
+        }
+    }
+
+    /// False-positive corpus. A marker that matches a headset is not cosmetic: the `.headset`
+    /// route skips anything glasses-like, so a mismatched pair of earbuds silently stops being
+    /// selectable and the `.glasses` route grabs them instead.
+    func testOrdinaryHeadsetsAreNotMistakenForGlasses() {
+        let names = [
+            "AirPods Pro",
+            "AirPods Max",
+            "Beats Studio Buds",
+            "WH-1000XM5",
+            "Bose QuietComfort Earbuds",
+            "Jabra Elite 7",
+            "Pixel Buds Pro",
+            "Galaxy Buds3",
+            "Soundcore Liberty 4",
+            "iPhone Microphone",
+            "Headphones",
+            "Steven's Earbuds",       // would match a bare "even"
+            "G2 Speaker",             // would match a bare "g2"
+            "Cyan Speaker",           // would match a bare "cyan"
+        ]
+        for name in names {
+            XCTAssertFalse(MicRoutePolicy.looksLikeGlasses(portName: name),
+                           "\(name) must not be treated as glasses")
+        }
+    }
+
+    func testMarkerMatchingIsCaseInsensitive() {
+        XCTAssertTrue(MicRoutePolicy.looksLikeGlasses(portName: "ANKO CAMERA GLASSES"))
+        XCTAssertTrue(MicRoutePolicy.looksLikeGlasses(portName: "mentra live"))
+    }
+}

--- a/docs/plans/CQ-third-party-glasses-backends.md
+++ b/docs/plans/CQ-third-party-glasses-backends.md
@@ -1,0 +1,379 @@
+# Plan CQ — Third-Party Glasses Backends (camera seam + two device classes)
+
+**Status:** 🚧 P0 + P1 built (2026-08-09) — the shared foundation, both fully headless.
+
+**P0 ✅** `GlassesTier` + pure `GlassesTierPolicy` (most-capable-wins; "not connected" stays
+distinct from "connected but limited"), widened `MicRoutePolicy.glassesNameMarkers` guarded by a
+false-positive corpus, and a "Connected Glasses" section in Settings → Hardware & Privacy that
+states the tier, what the camera can do, and which features are unavailable — instead of letting
+the user find the limits one failure at a time.
+
+**P1 ✅** `GlassesCameraBackend` seam. `MetaCameraBackend` is a pure extraction of the DAT half —
+session/stream lifecycle, permission flow, stall detection, tiered recovery, idle teardown, retry
+loops, comments and all — and `CameraService` keeps its public surface exactly, so none of the ~50
+consuming files changed. `CameraCapabilities` + pure `CameraFeatureGate` turn a backend's limits
+into copy a user can read; `startStreaming()` now refuses with that copy rather than failing
+obscurely. Readiness is asked as `isReady(configuringIfNeeded:)` because the Meta backend
+configures the SDK on demand to answer, and that prompts for Bluetooth — correct at a capture,
+wrong from a view body.
+
+**P4 ✅** the Track B protocol core, also headless: `CRC16Modbus` (written from the published
+catalogue parameters, pinned by the catalogue's own check value), `CapturePacket` (six-byte header,
+little-endian length and CRC, MTU chunking) and `CaptureFrameAssembler` — a *stateful stream*
+reader, because fragmentation here is a property of the link with no fragment indices to key off,
+so a write can carry half a frame, three frames, or a boundary in the middle. Resynchronisation is
+tested as a first-class behaviour: a dropped write would otherwise leave a partial frame that never
+completes and a channel dead for the session. `CaptureCommand`/`CaptureNotification` model **only**
+the attested opcodes and payloads, with the known gaps named rather than guessed.
+`CaptureControlReply` is built around the one real trap — several control sub-types execute while
+their reply's status fields stay unpopulated, so "failed" and "we cannot tell" are distinct
+outcomes, and the test that proves it carries a positive control (the same bytes on a
+status-bearing sub-type *do* read as a failure).
+
+**Ordering deviation, stated:** the plan puts Track A first and that recommendation stands on the
+merits. It was not followed because there is no hardware, which blocks Track A's P2/P3 entirely
+and makes adding a beta third-party SPM dependency unverifiable. P4 is the only remaining phase
+that can be *finished* rather than started. It ships dark and dead — nothing constructs a
+`CapturePacket` until P5 adds a transport.
+
+Still unstarted: **A/P2, A/P3** (vendor SDK dependency + hardware), **B/P5, B/P6, B/P7** (hardware,
+and P6/P7 additionally gated on the cellular experiment).
+
+**Companion to:** Plan AH, which did this for the *display* half (`GlassesDisplayBackend`, EVEN G2
+as the first second-renderer). This plan does it for the *camera* half, and generalises "which
+glasses can OpenGlasses drive?" into a stated device-tier model.
+**Shape:** P0 and P1 are shared foundations. Then two tracks — **Track A** a documented, MIT-licensed
+vendor SDK; **Track B** a reconstructed OEM protocol on ~NZ$100 retail hardware. One PR per phase.
+
+---
+
+## Why this matters now
+
+Two things landed at once. A ~NZ$100 OEM camera-glasses platform is on retail shelves under a dozen
+brand names, with an AI service its own listing says expires **six months after activation** — a
+dated, well-defined population of people with working camera glasses and no assistant. And a
+developer-oriented camera-glasses vendor now ships an **MIT-licensed native iOS Bluetooth SDK** for
+direct phone-to-glasses connection: no vendor cloud, no account, and critically **no permission
+gate** of the kind that has blocked our own Meta on-glasses testing for months
+(`reference_dat_glasses_gotchas`).
+
+Between them they cover both ends of the market. What they have in common is the reason this plan
+exists: neither can be supported today, because unlike the display half, the camera half of the app
+has no backend seam at all.
+
+## Hard scope limit (state up front, applies to BOTH classes)
+
+**Neither device class delivers live camera frames to the app.**
+
+- The documented-SDK class captures stills to a **webhook URL** and streams by *pushing* to a remote
+  RTMP / SRT / WHIP ingest endpoint. The vendor documentation is explicit that the SDK does not
+  expose local frame buffers or continuous camera access to the host app.
+- The OEM class captures to **onboard storage**; the phone must then fetch. Over BLE you get a
+  thumbnail on the order of a kilobyte — useless for OCR, labels, serial plates, or any of the
+  dense-visual work Plans CN/BT/AD exist to serve. Full resolution means joining the glasses' own
+  WiFi access point and pulling files over HTTP. That class additionally has **camera and microphone
+  as mutually exclusive modes** — it cannot listen and look at the same time.
+
+So on both, every `framePublisher` consumer is unavailable out of the box: face recognition, CK sign
+language, BT reading companion, scene watcher, camera-sourced ambient captions, CE frame pinning,
+BU/CC live modes, L WebRTC, RTMP broadcast, video recording, CP's outbound relay.
+
+The difference is that on the documented-SDK class there is a **credible route back** — see P3 — and
+on the OEM class there is only an unverified one. That asymmetry drives the ordering.
+
+| | Documented-SDK class | OEM capture-to-storage class |
+|---|---|---|
+| Voice loop, wake word, TTS, agent, text features | ✅ today, zero code (P0) | ✅ today, zero code (P0) |
+| Still capture → vision tools | ✅ P2, sub-second with warm-up | 🟡 P6, seconds + network hop |
+| Live frames → `framePublisher` | 🟡 P3 loopback spike — plausible | 🟡 P7 spike — unverified, may not exist |
+| Button / touch / wear events | ✅ P2, richer than DAT | ❌ not exposed |
+| Mic PCM into our ASR | ✅ P2 (16 kHz PCM or LC3 + VAD) | ❌ mode-exclusive with camera |
+| Licence | MIT, actively maintained | none detectable — clean-room only |
+| Entitlements / store paperwork | none | Hotspot Configuration |
+
+## The blocking device experiment (Track B only)
+
+**Do not start P6 before answering this.** When an iPhone joins the glasses' access point via
+`NEHotspotConfiguration`, that network has no route to the internet. Does iOS keep cellular data
+alive for our URLSession traffic, or does the app go dark until we leave the AP?
+
+If it does not, every cloud-backed capture becomes join → download → leave → wait for reassociation
+→ *then* call the model: a multi-second stall with a visible connectivity blip, on a device that
+also cannot hear the user while its camera is engaged. At that point P6 is not worth building and
+Track B stops at thumbnails.
+
+Twenty minutes with hardware and a debug button. It gates most of Track B's cost.
+
+---
+
+## Shared foundation
+
+### P0 — Audio-tier support (no protocol work at all) ✅
+
+Our microphone and speaker path is not DAT-bound. `MicRoutePolicy` matches on
+`AVAudioSession.Port` (`.bluetoothHFP` / `.bluetoothLE` / `.headsetMic`) and on port-name markers
+(`MicRoutePolicy.swift:40`). Both device classes pair as ordinary Bluetooth headsets, so **both
+already carry the full voice loop today** — wake word → transcription → LLM → tools → TTS. The only
+reason it feels unsupported is cosmetic: the port name won't match `meta`/`ray-ban`/`oakley`, so the
+app labels them "Headset Mic (AirPods etc.)" and the user has no reason to believe the glasses are
+involved.
+
+1. Widen `glassesNameMarkers` to cover both classes' naming, keeping the list data-only so it grows
+   without a code change.
+2. A `GlassesTier` descriptor (`audioOnly` / `displayOnly` / `camera`) surfaced in Settings, so the
+   app says *"Connected as an audio device — camera features need a supported camera backend"*
+   instead of failing feature by feature.
+3. Settings + README copy: supported devices become a tier table, not a single product name.
+4. Tests: marker matching, tier resolution.
+
+Fully headless. An afternoon. **This is the highest value-per-hour in the plan by a wide margin.**
+
+### P1 — `GlassesCameraBackend` seam ✅
+
+The display half is backend-agnostic because Plan AH made it so. The camera half is not:
+`CameraService` is a concrete `@MainActor class` importing `MWDATCamera` directly
+(`CameraService.swift:14`), and ~50 files reach into it.
+
+Two things keep this tractable. Consumers use only a narrow slice — `capturePhoto()`,
+`framePublisher`, `latestFrame`, `isStreaming`, `startStreaming`/`stopStreaming` — and Plan CP is
+already inserting `OutboundFrameRelay` between the publisher and every outbound consumer, so the
+fan-out side has a single chokepoint by construction.
+
+1. Extract `GlassesCameraBackend` with `MetaCameraBackend` as a **pure** extraction — DAT session
+   and stream lifecycle, stall detection, recovery policy move wholesale; existing camera tests stay
+   green untouched. Same discipline as `MetaDisplayBackend`.
+2. `CameraCapabilities`: `liveFrames`, `stillCapture`, `stillLatency` (immediate / sub-second /
+   seconds), `concurrentWithMic`, `hardwareEvents`. This is the type honest degradation hangs off,
+   and the table above is its test fixture.
+3. A pure capability gate consulted at feature entry points, so unsupported features grey out with a
+   reason instead of throwing at the moment of use.
+4. `CameraService` keeps its name and published properties; it becomes the backend-neutral
+   coordinator, exactly as `GlassesDisplayService` did.
+
+Fully headless. **Worth doing even if both tracks are abandoned** — it is what lets any future
+camera device in (including Plan BA's Android DAT) without touching 50 call sites.
+
+**As built**, three notes worth carrying forward:
+
+- The backend talks to the coordinator over a single `CameraBackendEvent` stream rather than a
+  set of callbacks, so all the `@Published` mirroring lands in one `handle(_:)`. `.frame(nil)`
+  doubles as "invalidate the cache", which is how a torn-down session's last frame is stopped
+  from standing in for the next capture.
+- Readiness became `isReady(configuringIfNeeded:)`. A plain property was wrong: the Meta backend
+  configures the SDK on demand in order to answer, and configuration prompts for Bluetooth — fine
+  at a capture, not fine from the Settings view body that describes the connected device. UI
+  passes `false` and takes a pessimistic answer.
+- The seam paid for itself immediately in testability. The coordinator's routing rules — phone
+  fallback, the refusal to silently swap cameras on a *ready* backend's failure, event mirroring,
+  the streaming gate — are now unit-tested against a mock, where before they sat behind
+  `Wearables`, which traps in a unit-test process.
+
+---
+
+## Track A — documented-SDK camera glasses (do this first)
+
+The vendor ships `mentra-bluetooth-sdk-ios` via SwiftPM, MIT, iOS 15.1+, currently beta and actively
+pushed. Direct BLE from our app to the glasses; no vendor app, cloud, or account in the path.
+
+### P2 — Backend over the vendor SDK
+
+The API surface is richer than DAT's in the places that matter to us:
+
+- **Stills:** `requestPhoto(...)` with size tier, compression, and manual exposure/ISO;
+  `warmUpCamera(...)` pre-opens the session (capped ~60 s) so a subsequent capture is fast.
+  Delivery is by webhook — so we run a **loopback receiver**: a localhost HTTP endpoint on the phone,
+  passed as the webhook URL, whose upload handler resolves the pending `capturePhoto()` continuation.
+  That is the whole trick, and it makes this backend's `stillCapture` genuinely competitive with
+  Meta's.
+- **Microphone:** `mic_pcm` emits continuous 16 kHz / 16-bit / mono / signed-LE PCM — the exact
+  shape our ASR path wants — with `mic_lc3` and VAD/loudness gating as alternatives. This is a
+  better mic route than routing through `AVAudioSession`, and it is independent of the camera.
+- **Hardware events:** `button_press` (with press type), `touch_event`, and `head_up` wear detection,
+  delivered through `MentraBluetoothSDKDelegate`. These feed **Plan CH** (media-button trigger),
+  **Plan W** (presence), and **Plan CM P1**'s doff-aware auto-pause — on hardware we can actually
+  buy, without waiting on Meta's rollout.
+- Battery, RSSI, WiFi/hotspot status, RGB LED, gallery mode, OTA.
+
+Work: `MentraCameraBackend` conforming to P1's protocol; a pure `PhotoWebhookReceiver` (request
+routing, multipart parse, continuation correlation, timeout) tested headlessly against synthetic
+uploads; a warm-up policy (when to pre-open, when to let it lapse) as a pure core, wired to Plan BV's
+`PowerPolicyService` so warm-up backs off under `conserve`/`reserve`; hardware-event bridging into
+the existing trigger surfaces.
+
+Capabilities declared: `liveFrames: false`, `stillCapture: true`, `stillLatency: .subSecond`,
+`concurrentWithMic: true`, `hardwareEvents: true`.
+
+Headless except the BLE edge and the on-device latency numbers. Ships dark behind backend selection,
+same as EVEN.
+
+### P3 — Live-frame loopback spike (the phase that decides how much of ❌ reopens)
+
+`startStream(...)` pushes camera video to an RTMP, SRT, or **WHIP/WebRTC** ingest endpoint, with
+keep-alive maintained by the SDK. Nothing says that endpoint has to be remote.
+
+Point it at a receiver we run, and the frames come back to us. We are unusually well-placed to try
+this: Plans L and M already built WebRTC transport, signalling, and `WebRTCStreamingService`, so a
+WHIP ingest is closer to a rearrangement of existing parts than new infrastructure. Two candidate
+shapes, in order of preference:
+
+1. **On-device WHIP receiver** — glasses → phone directly over the local network. Lowest latency, no
+   hosting, works offline. Highest uncertainty: whether the glasses can reach a phone-hosted ingest
+   on the same network, and what the SDP/ICE path looks like when both peers are local.
+2. **LAN or self-hosted relay** — glasses → relay → phone. Falls back on Plan M's existing
+   deployment story; adds a hop and a dependency, but is a known quantity.
+
+Deliverable is a decision with numbers, not a feature: achievable frame rate, end-to-end latency,
+decode cost, thermal behaviour, and battery drain over ten minutes. If it lands, `liveFrames` flips
+true for this backend and most of the ❌ column reopens through the existing `framePublisher` — with
+CP's privacy relay already sitting in the right place. If it doesn't, we lose a spike and Track A
+still ships as a strong stills-plus-events backend.
+
+Hard timebox. Nothing downstream may assume the outcome.
+
+---
+
+## Track B — OEM capture-to-storage glasses (do this second, if at all)
+
+Same hardware class as the retail ~NZ$100 glasses and most of the sub-$150 AliExpress camera
+glasses, which are largely the same OEM platform rebadged.
+
+### P4 — Capture-protocol core (pure) ✅
+
+The BLE protocol has been reconstructed by the community. Framing is a one-byte sentinel, a command
+id, a little-endian length, a CRC-16/MODBUS over the payload, then the payload; anything past the
+ATT payload ceiling fragments. Commands cover mode selection (photo / video start-stop / audio
+start-stop / AI capture), battery and charging state, media counts, time sync and version queries.
+Completion arrives as a notification; a thumbnail can be pulled over the same channel.
+
+All of it a pure codec with no CoreBluetooth in sight, mirroring `EvenPacket`:
+
+1. `CapturePacket` encode/decode — framing, length, fragmentation, reassembly.
+2. CRC-16/MODBUS implemented **from the published algorithm and validated against published test
+   vectors** — no community bytes copied, per the licensing rider below.
+3. Command enum and response parser, including the case where a response is structurally valid but
+   the parser's allowlist doesn't populate the status fields — a known trap in this protocol family,
+   where a command executes while the parsed reply still reads as its default error. Our parser must
+   distinguish **failed** from **unparsed**; conflating them makes working commands look broken.
+4. Golden fixtures for every command round-trip.
+
+Fully headless.
+
+**As built**, two departures from the sketch above worth recording:
+
+- Reassembly is a **stateful stream reader** (`CaptureFrameAssembler`), not a
+  `reassemble([Packet])`. The described format has no fragment index or continuation flag —
+  fragmentation is just the MTU chopping a byte stream — so frames have to be recovered by
+  buffering and rescanning. That made *resynchronisation* the interesting behaviour rather than
+  an afterthought: a single dropped write leaves a partial frame that will never complete, and
+  with no way out the channel is dead for the rest of the session. The assembler drops a byte and
+  rescans, counts what it discarded so the cost is measurable, and caps its buffer.
+- The command set models **only what is attested** and names the gaps in the type's own
+  documentation instead of filling them: discrete photo/video/audio opcodes, media enumeration and
+  time sync are absent, as is any command for *leaving* livestream mode. A guessed byte sent to a
+  camera on someone's face is not a guess worth making, and an invented constant would read as
+  fact to the next person.
+
+### P5 — Transport + backend, shipping dark
+
+`CaptureBLETransport` (CoreBluetooth, foreground-only v1, no state restoration — consistent with
+`EvenBLETransport`'s decisions and the app's other lifecycle constraints), plus the
+`GlassesCameraBackend` conformance mapping our calls onto P4's commands. Pairing UI beside the
+existing EVEN pairing surface.
+
+Ships dark. Every byte-level claim is a community reconstruction awaiting hardware validation, in
+the same words Plan AH used for the same reason. `stillCapture` here means the **thumbnail** —
+enough to prove the round trip, not enough to answer a question about what the user is looking at.
+
+Capabilities declared: `liveFrames: false`, `stillCapture: true`, `stillLatency: .seconds`,
+`concurrentWithMic: false`, `hardwareEvents: false`. That last pair is what the P1 gate exists for.
+
+### P6 — Media transfer (gated on the device experiment above)
+
+`NEHotspotConfiguration` join, candidate-IP probe, manifest fetch, concurrent HTTP file pull, rejoin.
+Needs the **Hotspot Configuration entitlement** — real App Store paperwork and a new capability on
+the App ID, which per `project_xcode_cloud_new_target_signing` is exactly the kind of change that
+breaks the Xcode Cloud archive on signing until registered upstream. Budget for that, not just code.
+
+The pure part worth isolating: an ordering policy guaranteeing we are back on a routable network
+*before* any model call is attempted, and that a capture interrupted mid-transfer degrades to the
+thumbnail rather than to nothing.
+
+### P7 — RTSP live-preview spike (speculative, may not exist)
+
+Traces of an RTSP-over-WiFi path exist in this hardware family — a BLE command entering a streaming
+mode, then a standard RTSP URL on the device's own network. The reconstruction is explicitly
+unverified at runtime, addressing differs per hardware variant, one variant's route is WiFi-Direct
+which iOS does not expose at all, and there is **no confirmed command for leaving streaming mode
+safely**. Run only if P6 came back green and a device is in hand. Expect nothing.
+
+---
+
+## Licensing rider
+
+Two different regimes, and the plan must not blur them.
+
+- **Track A** depends on a real MIT-licensed vendor SwiftPM package. Normal dependency hygiene
+  applies: pin it exactly (per Plan CD P3's lesson — `from:` admits breaking minors, and this package
+  is pre-1.0 *and* beta), refresh `ci_scripts/Package.resolved` per
+  `project_xcode_cloud_resolved`, and attribute in About.
+- **Track B** has no licensed source anywhere in the space — one community README claims a permissive
+  licence its repository does not actually contain. Treat all of it as **documentation of a wire
+  format, never as source to port.** Swift written from the described format, validated against
+  independently published algorithm vectors, exactly as `EvenPacket` was. The vendor SDK for that
+  platform is proprietary; we do not link, vendor, or wrap it.
+
+## Non-goals
+
+- Wrapping or shipping any proprietary vendor SDK binary.
+- Supporting any vendor's own cloud AI, subscription, or account system.
+- A generic "any BLE glasses" abstraction. Two concrete camera backends is the bar for generalising;
+  a speculative third is not.
+- Firmware modification, OTA-side work, or debug-mode unlocks on Track B hardware.
+- Display support on either class — neither has a display. Track A's vendor sells display glasses
+  too, but those route through a cloud SDK, which is a different plan.
+
+## Open questions
+
+1. **The Track B cellular experiment.** Gates P6 and P7.
+2. **Does the loopback receiver in P2 survive backgrounding?** A localhost HTTP endpoint during a
+   capture is fine in the foreground; the app's other lifecycle constraints say assume not otherwise.
+   If it doesn't, `stillCapture` is foreground-only on Track A and the gate must say so.
+3. Does Track B's thumbnail have any legitimate use? ~1 KB is hopeless for reading, but might carry a
+   coarse scene classifier or a "did the capture frame the thing at all" check before paying for a
+   full transfer. Measure before dismissing.
+4. Given Track B's camera/mic exclusivity: does a capture duck the wake word for its duration, or
+   refuse while a live conversation runs? Leaning duck-with-narration — silently going deaf is the
+   failure mode users report as a crash.
+5. Should P1's capability gate retro-fit the EVEN display backend's unavailable-feature list, which
+   Plan AH documents but does not enforce in code? Probably yes; same mechanism.
+6. Track A is **beta software** (pre-1.0, actively churning). Do we ship it user-visible, or keep it
+   behind the developer panel until it stabilises? Leaning developer-panel first.
+
+## Device landscape (why a tier model, not a device list)
+
+Sorting the market by *what OpenGlasses needs from it* produces three tiers, and nearly every device
+on sale falls cleanly into one:
+
+| Tier | Needs from us | Cost to support |
+|---|---|---|
+| **Audio-only** | nothing — already works | **zero** (P0 is labelling) |
+| **Display** | a `GlassesDisplayBackend` | seam exists (Plan AH); per-device protocol work |
+| **Camera** | a `GlassesCameraBackend` | **seam does not exist — that is P1** |
+
+Two observations that shape the effort:
+
+- **Live frames to a phone are the line between ~$100 and ~$300+ hardware**, and even above it the
+  vendor answer is "push to an ingest endpoint", not "here are your buffers". Power, thermals and
+  bandwidth make it genuinely hard. We should stop expecting to find local frame access on anything
+  but Meta, and design the app to degrade honestly instead — which is precisely what P1 buys.
+- **The cheap end is one OEM platform wearing many badges.** Supporting Track B supports most of the
+  sub-$150 camera-glasses market at once. That is the argument for Track B despite everything above:
+  not one product, a category.
+
+## Rider — a cheaper unlock than either track
+
+Plan AH's `EvenBLETransport` ships dark with its **auth handshake stubbed pending capture logs**. A
+community reconstruction of that handshake — seven packets, reported working — now exists
+independently of us. That is the single blocker between Plan AH step 5 and our HUD rendering on real
+shipping hardware. Same Track B licensing rider applies. It is cheaper than anything here and should
+be scheduled ahead of both tracks.


### PR DESCRIPTION
Everything in [Plan CQ](docs/plans/CQ-third-party-glasses-backends.md) that can be finished without hardware. What Plan AH did for the display half, done for the camera half.

## P0 — device tiers

"Which glasses work with OpenGlasses?" stops being a single product name. Our mic path is `AVAudioSession`-based rather than DAT-bound, so **any glasses that pair as a Bluetooth headset already run the whole voice loop today**. `GlassesTier`/`GlassesTierPolicy` say what a connected pair *can* do (most-capable-wins; "not connected" stays distinct from "connected but limited") instead of letting the user find the limits one failed feature at a time.

The marker list is data-only and deliberately conservative — a false positive is not cosmetic: the `.headset` route skips anything that looks like glasses, so mismatched earbuds would silently stop being selectable. Hence distinctive brand tokens, never bare fragments.

## P1 — camera backend seam

`GlassesCameraBackend`, with `MetaCameraBackend` as a pure extraction. Worth doing on its own merits — ~50 files reach into `CameraService`.

- One `CameraBackendEvent` stream replaces scattered callbacks. `.frame(nil)` doubles as cache-invalidate, which is what stops a torn-down session's last frame standing in for the next capture.
- Readiness is `isReady(configuringIfNeeded:)` because the Meta backend configures the SDK to answer — **and that prompts for Bluetooth**: right at a capture, wrong from a view body.
- The coordinator's routing rules are unit-tested for the first time, having previously sat behind `Wearables`, which traps in a test process.

## P4 — Track B capture-protocol codec

CRC16/Modbus pinned by the catalogue check value, plus a **stateful** frame assembler: the format carries no fragment index, so resynchronisation is the load-bearing behaviour — one dropped write would otherwise leave a partial frame that never completes and a dead channel for the session. Only attested opcodes are modelled; gaps are named in the type rather than guessed. Ships dark until a transport exists.

## Rider

`PhoneCameraSource` gains a `PhoneCameraCapturing` seam. The coordinator takes that branch whenever the glasses camera can't serve a capture, so an untested fallback lands in real AVFoundation — and on a simulator with an unresolved camera privacy decision, `requestAccess` waits forever for a prompt no test runner can answer, **hanging rather than failing**.

## Verification

- Debug suite **2980 tests, 0 failures**
- Release clean apart from the documented keychain set that needs code signing
- Branch builds standalone (`** TEST BUILD SUCCEEDED **`), independent of the CU branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)