### PR TITLE
ci: cancel superseded test runs and cache the SPM checkouts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,16 @@ on:
       - '**.md'
       - 'docs/**'
 
+# A PR run is obsolete the moment a newer commit lands on the same branch, but without a
+# concurrency group the superseded run still bills a full ~17-minute macOS slot. Twelve August
+# runs (227 macOS minutes) were already stale when they finished; one branch queued eleven.
+#
+# main is deliberately exempt: `cancel-in-progress` is false for push events, because a run on
+# main is the record of what main does and must not be cancelled by the next merge.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: macos-26
@@ -57,6 +67,23 @@ jobs:
 
       - name: Fetch MediaPipe frameworks
         run: ./Scripts/fetch-mediapipe-frameworks.sh
+
+      # Every run re-clones the full SPM graph — WebRTC, HaishinKit, mlx-swift-lm and the
+      # HuggingFace packages — before a line of app code compiles. The checkouts are identical
+      # between runs unless the pins move, so -clonedSourcePackagesDirPath (set on the xcodebuild
+      # invocation below) puts them at a stable path this can cache.
+      #
+      # DerivedData is deliberately NOT cached. A restored build directory carries absolute paths
+      # and module timestamps from another machine, and this repo has already lost time to
+      # stale-artefact failures that look like source bugs. Caching the inputs is safe; caching
+      # the outputs is not.
+      - name: Cache SPM checkouts
+        uses: actions/cache@v4
+        with:
+          path: .spm-checkouts
+          key: spm-${{ runner.os }}-${{ hashFiles('project.base.yml', 'ci_scripts/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
 
       - name: Skip Watch targets
         run: printf 'OPENGLASSES_SKIP_WATCH=1\n' > .openglasses-generate.env
@@ -92,6 +119,7 @@ jobs:
             -resultBundlePath TestResults.xcresult \
             -skipPackagePluginValidation \
             -skipMacroValidation \
+            -clonedSourcePackagesDirPath .spm-checkouts \
             SWIFT_EMIT_LOC_STRINGS=NO \
             2>&1 | tee xcodebuild.log | grep -E "Test Suite|Test Case.*(passed|failed)|error:|\*\* TEST" \
             || { tail -100 xcodebuild.log; exit 1; }

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ DerivedData
 
 # Swift Package Manager
 .build/
+# xcodebuild -clonedSourcePackagesDirPath target (CI caches this; see .github/workflows/tests.yml)
+.spm-checkouts/
 .swiftpm/
 Packages/
 Package.pins


### PR DESCRIPTION
Two changes to `.github/workflows/tests.yml`. No test coverage changes.

## Context

`Unit Tests` accounts for **every macOS-runner minute** metered against this repo — 98 runs in August, ~17.5 min each, 1,746 minutes total. The `Deploy to GitHub Pages` job is Linux and contributes 22 minutes.

One thing to be clear about up front: **this is not a cost fix.** OpenGlasses is a public repo, so those minutes are discounted in full — every macOS line on the August statement bills `$0`, including on days when private-repo Linux minutes were being charged. The gross figure is what the usage *would* cost.

What it does fix is a 17-minute feedback loop, and the fact that the same workload becomes a real ~$108/month bill the day this repo goes private.

## 1. Concurrency group

There was none, so a PR run continued after a newer commit had already superseded it. In August, **12 runs (227 macOS minutes) finished with a result nobody could act on**; `claude/plan-cl-ui-refresh` alone triggered 11 runs.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

`main` is deliberately exempt — a run on `main` is the record of what `main` does, and shouldn't be cancelled by the next merge.

## 2. Cache the SPM checkouts

Every run re-cloned the full graph — WebRTC, HaishinKit, mlx-swift-lm, the HuggingFace packages — before compiling any app code. `-clonedSourcePackagesDirPath .spm-checkouts` moves the checkouts to a stable path that `actions/cache` can hold, keyed on `project.base.yml` + `ci_scripts/Package.resolved` with a prefix fallback so a pin change degrades to a partial hit rather than a miss.

**DerivedData is deliberately not cached.** A restored build directory carries another machine's absolute paths and module timestamps, and stale artefacts in this repo have already cost time by presenting as source bugs. Caching the inputs is safe; caching the outputs is not.

## Verification

`actionlint` reports clean. The real proof is this PR's own run — and the cache only pays off from the *second* run onward, so expect the first one to be no faster than usual.

## Not included

- **The duplicate post-merge run.** `tests.yml` fires on both `pull_request` and `push: [main]`; given how fast PRs merge here, that re-tests an already-green commit 38 times a month (669 minutes). Worth cutting or moving to a nightly schedule, but it's a real change in safety posture rather than pure waste, so it should be a decision, not a drive-by.
- **A build-number bump.** This touches no app code and produces no build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)