### PR TITLE
ci: move the Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,10 +13,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/checkout@v7
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: .
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Show toolchain
         run: |
@@ -60,7 +60,7 @@ jobs:
       # libraries exceed GitHub's per-file size limit. Cached so the ~440 MB download
       # doesn't repeat every run; the fetch script is idempotent on a cache hit.
       - name: Cache MediaPipe frameworks
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: Vendor/MediaPipeTasks/Frameworks
           key: mediapipe-frameworks-${{ hashFiles('Scripts/fetch-mediapipe-frameworks.sh') }}
@@ -78,7 +78,7 @@ jobs:
       # stale-artefact failures that look like source bugs. Caching the inputs is safe; caching
       # the outputs is not.
       - name: Cache SPM checkouts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .spm-checkouts
           key: spm-${{ runner.os }}-${{ hashFiles('project.base.yml', 'ci_scripts/Package.resolved') }}
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload result bundle on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: TestResults
           path: TestResults.xcresult


### PR DESCRIPTION
Every run ends with:

> Warning: Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/cache@v4`, `actions/checkout@v4`.

The runner is already executing them on Node 24, so nothing is broken today — this warns about a fallback that will eventually go away. Worth clearing anyway: it prints on every run, and warnings nobody can act on are how the ones that matter get missed.

| Action | Was | Now | Node 24 since |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | v5 |
| `actions/cache` | v4 | **v6** | v5 |
| `actions/upload-artifact` | v4 | **v7** | v6 |
| `actions/configure-pages` | v5 | **v6** | — |
| `actions/deploy-pages` | v4 | **v5** | — |
| `actions/upload-pages-artifact` | v3 | **v5** | — |

All of these require Actions Runner ≥ 2.327.1; our hosted runners (`macos-26` for tests, `ubuntu-latest` for pages) are long past it. No inputs changed — the `cache` key/path API is stable across v4→v6, and `checkout` is used with no inputs in both workflows.

**Coverage:** only `tests.yml` runs on a pull request, so this PR exercises `checkout` and `cache` for real. `upload-artifact` only fires on failure, and `pages.yml` is push-to-main triggered — both are verified on merge.

## One thing found on the way

`.gitignore:43` ignores `.github/` wholesale. `tests.yml` and `pages.yml` predate that rule so they stay tracked, but it means:

- a **new** workflow file needs `git add -f` or it silently never lands;
- `build-ios.yml` and `app-store-upload.yml` exist in my working copy but are **not in the repo** — editing them looks like changing CI and changes nothing.

Not fixed here (a negation cannot re-include files inside an ignored directory — the rule itself has to become specific), but worth a decision separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)