### PR TITLE
Stop the glasses SDK sending telemetry to Meta

### DIFF
--- a/.claude/rules/dat-conventions.md
+++ b/.claude/rules/dat-conventions.md
@@ -106,6 +106,14 @@ Notes from the field:
 - **WiFi transport** is transparent — no app-facing API; the SDK negotiates it.
 - The DAT App Model (DAM) is always enabled as of 0.9.0 — the `MWDAT.DAMEnabled` Info.plist opt-out
   key is ignored. Crash-reporting opt-out: `MWDAT > CrashReporting > OptOut` (Bool, default `false`).
+- **Data collection is opt-out, and this app opts out.** `MWDATCore` POSTs `ar_wearables_sdk_*`
+  event batches (session, stream, permission, display, crash) to a hard-coded
+  `api2.ar.meta.com/mwsdk/telemetry`. Both `MWDAT > Analytics > OptOut` and
+  `MWDAT > CrashReporting > OptOut` are `YES` in `OpenGlasses/Info.plist` and must stay that way —
+  absent or `NO` means opted **in**. `MetaTelemetryBlock` is the backstop: it registers a
+  `URLProtocol` before `Wearables.configure()` that answers that endpoint locally and counts what
+  it stopped. Attestation (`/wearables/attestation/challenge`) shares the host and is deliberately
+  **not** blocked — it gates device access.
 
 ## Links
 

--- a/OpenGlasses/Info.plist
+++ b/OpenGlasses/Info.plist
@@ -91,6 +91,21 @@
 	<true/>
 	<key>MWDAT</key>
 	<dict>
+		<!-- Opt out of Meta's SDK data collection. Both dictionaries are read by
+		     MWDATCore at configure() time: Analytics/OptOut suppresses the event
+		     uploader that posts to api2.ar.meta.com/mwsdk/telemetry, and
+		     CrashReporting/OptOut suppresses the SDK's own crash reporter. Absent
+		     or NO means opted in, so these must stay explicitly YES. -->
+		<key>Analytics</key>
+		<dict>
+			<key>OptOut</key>
+			<true/>
+		</dict>
+		<key>CrashReporting</key>
+		<dict>
+			<key>OptOut</key>
+			<true/>
+		</dict>
 		<key>AppLinkURLScheme</key>
 		<string>openglasses://</string>
 		<key>ClientToken</key>

--- a/OpenGlasses/Sources/App/Views/DeveloperPanelView.swift
+++ b/OpenGlasses/Sources/App/Views/DeveloperPanelView.swift
@@ -192,6 +192,22 @@ struct DeveloperPanelView: View {
                 await appState.speechService.speak("Test okay", urgency: .low, mirrorToHUD: false)
                 return .pass("Spoken")
             },
+            SubsystemTest(id: "telemetry", name: "SDK Telemetry", icon: "antenna.radiowaves.left.and.right.slash") { @MainActor in
+                // Verifies on-device what only a packet capture could otherwise tell us: that the
+                // glasses SDK's data collection is off in the *shipped* bundle, and that nothing
+                // has had to be blocked at the network layer to keep it that way.
+                let optOut = MetaTelemetryBlock.bundleOptOut
+                let blocked = MetaTelemetryBlock.blockedCount
+                if !optOut.analytics || !optOut.crashReporting {
+                    let missing = [optOut.analytics ? nil : "Analytics",
+                                   optOut.crashReporting ? nil : "CrashReporting"].compactMap { $0 }
+                    return .fail("Opt-out missing from Info.plist: \(missing.joined(separator: ", "))")
+                }
+                if blocked > 0 {
+                    return .fail("Opt-out set but ignored — \(blocked) upload(s) blocked at the network layer")
+                }
+                return .pass("Opt-out set · no uploads attempted")
+            },
             SubsystemTest(id: "wakeword", name: "Wake Word", icon: "waveform.badge.mic") { @MainActor in
                 appState.wakeWordService.isListening
                     ? .pass("Listening for “\(Config.wakePhrase.capitalized)”")

--- a/OpenGlasses/Sources/App/Views/SettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsView.swift
@@ -831,10 +831,15 @@ struct HardwarePrivacyView: View {
                     ),
                     info: "Off by default. When on, the fitness coach may read your Apple Health workout history and send it to your configured AI provider (Anthropic, OpenAI, Google, etc.) so it can discuss your progress. Your Health data leaves the device only while this is enabled. On-device workout tracking, form analysis, and saving workouts to Apple Health work either way."
                 )
+                InfoStatusRow(
+                    title: "Glasses Analytics",
+                    status: MetaTelemetryBlock.disclosureState.summary,
+                    info: "The glasses SDK collects its own usage analytics — connection sessions, camera streams, permission checks, crashes — and uploads them to Meta. This app opts out, and additionally blocks those uploads from leaving your phone. There is nothing to turn on: it is off in every build. Pairing your glasses still contacts Meta once to verify the app is allowed to talk to them, which is what makes the connection work and carries no usage data."
+                )
             } header: {
                 Text("Privacy")
             } footer: {
-                Text("Bystander Face Blur runs entirely on-device — no images leave your phone. Share Health Data with AI is off by default: Apple Health data is sent to your AI provider only when you turn it on.")
+                Text("Bystander Face Blur runs entirely on-device — no images leave your phone. Share Health Data with AI is off by default: Apple Health data is sent to your AI provider only when you turn it on. The glasses SDK's own analytics are disabled and blocked.")
             }
 
             Section {
@@ -883,6 +888,41 @@ struct HardwarePrivacyView: View {
             }
         }
         .navigationTitle("Hardware & Privacy")
+    }
+}
+
+// MARK: - Info Status Row
+
+/// A read-only counterpart to ``InfoToggle``: states a privacy fact and explains it, with
+/// nothing for the user to switch. For guarantees that are compiled in rather than configured —
+/// presenting one as a toggle would imply an "on" state the app does not offer.
+struct InfoStatusRow: View {
+    let title: String
+    let status: String
+    let info: String
+
+    @State private var showInfo = false
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(title)
+            Button {
+                showInfo = true
+            } label: {
+                Image(systemName: "info.circle")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            Spacer()
+            Text(status)
+                .foregroundStyle(.secondary)
+        }
+        .alert(title, isPresented: $showInfo) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(info)
+        }
     }
 }
 

--- a/OpenGlasses/Sources/Services/Device/MetaTelemetryBlock.swift
+++ b/OpenGlasses/Sources/Services/Device/MetaTelemetryBlock.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// Stops the Meta wearables SDK from phoning home.
+///
+/// # Why this exists
+///
+/// `MWDATCore` ships an analytics pipeline that POSTs SDK event batches
+/// (`ar_wearables_sdk_*` — session, stream, permission, display, crash) to a hard-coded
+/// endpoint on `api2.ar.meta.com`. The supported way to switch that off is the
+/// `MWDAT/Analytics/OptOut` and `MWDAT/CrashReporting/OptOut` Info.plist keys, which this
+/// app sets. Those keys are the primary control and this type is *not* a substitute for them.
+///
+/// This is the backstop. The opt-out is a plist flag read by a closed-source binary we ship
+/// but do not build: a stale personal plist, a missed key after an SDK bump, or a change in
+/// how that flag is honoured would silently restore the uploads, and nothing in a build log
+/// would say so. Registering a `URLProtocol` puts the guarantee in code we own — the request
+/// cannot leave the process regardless of what the SDK decides — and gives us a counter that
+/// makes a regression visible instead of silent.
+///
+/// # Scope
+///
+/// Only the telemetry endpoint is intercepted. Attestation
+/// (`/wearables/attestation/challenge`) is how the SDK proves the app is entitled to talk to
+/// the glasses; blocking that would break device access, not privacy, so it is deliberately
+/// left alone. Nothing else in the app routes through here.
+enum MetaTelemetryBlock {
+
+    /// Host that serves both the telemetry and attestation endpoints.
+    static let telemetryHost = "api2.ar.meta.com"
+
+    /// Path prefix of the SDK's analytics/crash upload endpoint.
+    static let telemetryPathPrefix = "/mwsdk/telemetry"
+
+    /// Number of uploads stopped this process. Non-zero means the plist opt-out did not take —
+    /// worth surfacing in diagnostics rather than leaving to a packet capture to discover.
+    private(set) nonisolated(unsafe) static var blockedCount = 0
+
+    private nonisolated(unsafe) static var isInstalled = false
+
+    /// Whether `url` is the SDK's telemetry upload endpoint.
+    ///
+    /// Matched on host + path prefix rather than the full string: the SDK appends its own
+    /// query/segments, and matching the whole URL would fail open on the first change.
+    static func isTelemetryURL(_ url: URL?) -> Bool {
+        guard let url, let host = url.host?.lowercased() else { return false }
+        guard host == telemetryHost else { return false }
+        return url.path.hasPrefix(telemetryPathPrefix)
+    }
+
+    // MARK: - Info.plist opt-out (the primary control)
+
+    /// Whether the SDK's two data-collection opt-outs are set in an Info dictionary.
+    ///
+    /// Pure and dictionary-injected so the Developer panel can assert the *shipped* bundle
+    /// really carries them. The keys live at `MWDAT/Analytics/OptOut` and
+    /// `MWDAT/CrashReporting/OptOut`, and absent means opted **in** — so a missing key has to
+    /// read as `false` here, never as a benign default.
+    static func plistOptOut(in infoDictionary: [String: Any]?) -> (analytics: Bool, crashReporting: Bool) {
+        let mwdat = infoDictionary?["MWDAT"] as? [String: Any]
+        func optOut(_ section: String) -> Bool {
+            ((mwdat?[section] as? [String: Any])?["OptOut"] as? Bool) ?? false
+        }
+        return (optOut("Analytics"), optOut("CrashReporting"))
+    }
+
+    /// The running app's opt-out state.
+    static var bundleOptOut: (analytics: Bool, crashReporting: Bool) {
+        plistOptOut(in: Bundle.main.infoDictionary)
+    }
+
+    // MARK: - Disclosure
+
+    /// What Settings tells the user about the glasses SDK's data collection.
+    ///
+    /// Deliberately has an honest failure case. `.off` is only claimed when the opt-out is
+    /// present *and* nothing has had to be intercepted — a privacy claim the app cannot back
+    /// up is worse than no claim.
+    enum Disclosure: Equatable {
+        /// Opt-out set and no upload ever attempted.
+        case off
+        /// Opt-out set but ignored; `count` uploads were stopped at the network layer.
+        case blocked(Int)
+        /// Opt-out missing from the bundle — the SDK's default, which is opted in.
+        case on
+
+        var summary: String {
+            switch self {
+            case .off: return "Off"
+            case .blocked: return "Blocked"
+            case .on: return "On"
+            }
+        }
+    }
+
+    /// Pure form, so the disclosure can be tested without a bundle or a live process.
+    static func disclosure(optOut: (analytics: Bool, crashReporting: Bool),
+                           blockedCount: Int) -> Disclosure {
+        guard optOut.analytics && optOut.crashReporting else { return .on }
+        return blockedCount == 0 ? .off : .blocked(blockedCount)
+    }
+
+    /// The running app's disclosure state.
+    static var disclosureState: Disclosure {
+        disclosure(optOut: bundleOptOut, blockedCount: blockedCount)
+    }
+
+    /// Register the interceptor. Idempotent; call before `Wearables.configure()`.
+    static func install() {
+        guard !isInstalled else { return }
+        isInstalled = true
+        URLProtocol.registerClass(Interceptor.self)
+    }
+
+    /// One-line state for diagnostics surfaces.
+    static var statusDescription: String {
+        guard isInstalled else { return "not installed" }
+        return blockedCount == 0 ? "installed" : "installed — \(blockedCount) upload(s) blocked"
+    }
+
+    fileprivate static func recordBlock(_ url: URL?) {
+        blockedCount += 1
+        if blockedCount == 1 {
+            NSLog("[MetaTelemetryBlock] blocked SDK telemetry upload to %@ (plist opt-out did not take)",
+                  url?.absoluteString ?? "?")
+        }
+    }
+
+    /// Answers the upload locally instead of letting it reach the network.
+    final class Interceptor: URLProtocol {
+
+        override class func canInit(with request: URLRequest) -> Bool {
+            isTelemetryURL(request.url)
+        }
+
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            MetaTelemetryBlock.recordBlock(request.url)
+            // 204 rather than an error: the uploader treats a failure as "retry later" and keeps
+            // the batch on disk, so failing it would leave a growing local queue and a retry loop
+            // for uploads that can never succeed. A success drops the batch — the payload is
+            // discarded here and never sent.
+            let response = HTTPURLResponse(url: request.url ?? URL(string: "https://\(MetaTelemetryBlock.telemetryHost)")!,
+                                           statusCode: 204,
+                                           httpVersion: "HTTP/1.1",
+                                           headerFields: nil)
+            if let response {
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    #if DEBUG
+    /// Reset counters for tests. Registration itself is process-wide and is left in place.
+    static func resetCountForTesting() {
+        blockedCount = 0
+    }
+    #endif
+}

--- a/OpenGlasses/Sources/Services/WearablesBootstrap.swift
+++ b/OpenGlasses/Sources/Services/WearablesBootstrap.swift
@@ -50,6 +50,10 @@ enum WearablesBootstrap {
     static func ensureConfigured() -> Bool {
         if didAttempt { return isConfigured }
         didAttempt = true
+        // Before configure(), so the SDK's analytics uploader can never win a race with it.
+        // The Info.plist opt-out is what should stop those uploads; this is the backstop that
+        // makes it true in code we own. See MetaTelemetryBlock.
+        MetaTelemetryBlock.install()
         do {
             try Wearables.configure()
             isConfigured = true

--- a/OpenGlassesTests/MetaTelemetryBlockTests.swift
+++ b/OpenGlassesTests/MetaTelemetryBlockTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import OpenGlasses
+
+/// The glasses SDK uploads `ar_wearables_sdk_*` analytics batches to a hard-coded Meta endpoint
+/// unless the app opts out. These cover both halves of switching that off: the Info.plist keys
+/// that are supposed to do it, and the `URLProtocol` backstop that makes it true regardless.
+final class MetaTelemetryBlockTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        MetaTelemetryBlock.resetCountForTesting()
+    }
+
+    // MARK: - Endpoint matching
+
+    func testMatchesTheSDKTelemetryEndpoint() {
+        XCTAssertTrue(MetaTelemetryBlock.isTelemetryURL(URL(string: "https://api2.ar.meta.com/mwsdk/telemetry")))
+    }
+
+    /// The SDK owns the tail of this URL. Matching host + prefix rather than the exact string is
+    /// what keeps an appended path segment or query from silently reopening the upload.
+    func testMatchesTelemetryURLsWithExtraPathOrQuery() {
+        XCTAssertTrue(MetaTelemetryBlock.isTelemetryURL(URL(string: "https://api2.ar.meta.com/mwsdk/telemetry/batch")))
+        XCTAssertTrue(MetaTelemetryBlock.isTelemetryURL(URL(string: "https://api2.ar.meta.com/mwsdk/telemetry?v=2")))
+    }
+
+    func testHostMatchIsCaseInsensitive() {
+        XCTAssertTrue(MetaTelemetryBlock.isTelemetryURL(URL(string: "https://API2.AR.META.COM/mwsdk/telemetry")))
+    }
+
+    /// Attestation shares the host and is how the SDK proves the app may talk to the glasses.
+    /// Blocking it would break device access, not protect privacy — this is the line that keeps
+    /// the interceptor from being widened to the whole host by accident.
+    func testDoesNotMatchAttestationOnTheSameHost() {
+        XCTAssertFalse(MetaTelemetryBlock.isTelemetryURL(
+            URL(string: "https://api2.ar.meta.com/wearables/attestation/challenge")))
+    }
+
+    func testDoesNotMatchOtherHostsOrNil() {
+        XCTAssertFalse(MetaTelemetryBlock.isTelemetryURL(URL(string: "https://api.anthropic.com/mwsdk/telemetry")))
+        XCTAssertFalse(MetaTelemetryBlock.isTelemetryURL(URL(string: "https://evil.api2.ar.meta.com/mwsdk/telemetry")))
+        XCTAssertFalse(MetaTelemetryBlock.isTelemetryURL(nil))
+    }
+
+    // MARK: - Interception
+
+    /// The claim worth testing: a telemetry POST issued the way the SDK issues one
+    /// (`URLSession.shared`) is answered locally and never leaves the process.
+    func testTelemetryUploadIsAnsweredLocallyAndNeverSent() async throws {
+        MetaTelemetryBlock.install()
+
+        var request = URLRequest(url: URL(string: "https://api2.ar.meta.com/mwsdk/telemetry")!)
+        request.httpMethod = "POST"
+        request.httpBody = Data("{\"events\":[]}".utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 204,
+                       "a success drops the SDK's cached batch; a failure would leave it retrying forever")
+        XCTAssertTrue(data.isEmpty)
+        XCTAssertEqual(MetaTelemetryBlock.blockedCount, 1,
+                       "the counter is how a regression becomes visible without a packet capture")
+    }
+
+    func testInstallIsIdempotent() {
+        MetaTelemetryBlock.install()
+        MetaTelemetryBlock.install()
+        XCTAssertEqual(MetaTelemetryBlock.statusDescription, "installed")
+    }
+
+    // MARK: - Info.plist opt-out
+
+    func testReadsBothOptOutKeys() {
+        let info: [String: Any] = [
+            "MWDAT": [
+                "Analytics": ["OptOut": true],
+                "CrashReporting": ["OptOut": true],
+            ]
+        ]
+        let state = MetaTelemetryBlock.plistOptOut(in: info)
+        XCTAssertTrue(state.analytics)
+        XCTAssertTrue(state.crashReporting)
+    }
+
+    /// Absent means opted **in** — the SDK's default. A missing key must not read as a safe
+    /// default here, or the Developer-panel probe would report privacy we don't have.
+    func testMissingKeysReadAsOptedIn() {
+        XCTAssertFalse(MetaTelemetryBlock.plistOptOut(in: nil).analytics)
+        XCTAssertFalse(MetaTelemetryBlock.plistOptOut(in: [:]).crashReporting)
+        XCTAssertFalse(MetaTelemetryBlock.plistOptOut(in: ["MWDAT": ["Analytics": [:]]]).analytics)
+        XCTAssertFalse(MetaTelemetryBlock.plistOptOut(in: ["MWDAT": ["Analytics": ["OptOut": false]]]).analytics)
+    }
+
+    // MARK: - Settings disclosure
+
+    /// "Off" is the strongest claim, and it is only made when both halves hold. The app should
+    /// never tell a user their data is not being collected on the strength of a flag alone.
+    func testDisclosureClaimsOffOnlyWhenOptedOutAndNothingWasBlocked() {
+        XCTAssertEqual(
+            MetaTelemetryBlock.disclosure(optOut: (analytics: true, crashReporting: true), blockedCount: 0),
+            .off)
+    }
+
+    func testDisclosureReportsBlockedWhenTheOptOutWasIgnored() {
+        XCTAssertEqual(
+            MetaTelemetryBlock.disclosure(optOut: (analytics: true, crashReporting: true), blockedCount: 3),
+            .blocked(3),
+            "an opt-out that is set but not honoured must not read as \"Off\" in Settings")
+    }
+
+    /// Either key missing means the SDK is collecting by default — Settings has to say so rather
+    /// than round it down to the reassuring answer.
+    func testDisclosureReportsOnWhenEitherKeyIsMissing() {
+        XCTAssertEqual(
+            MetaTelemetryBlock.disclosure(optOut: (analytics: false, crashReporting: true), blockedCount: 0),
+            .on)
+        XCTAssertEqual(
+            MetaTelemetryBlock.disclosure(optOut: (analytics: true, crashReporting: false), blockedCount: 0),
+            .on)
+    }
+
+    func testDisclosureSummariesAreTheUserFacingWords() {
+        XCTAssertEqual(MetaTelemetryBlock.Disclosure.off.summary, "Off")
+        XCTAssertEqual(MetaTelemetryBlock.Disclosure.blocked(2).summary, "Blocked")
+        XCTAssertEqual(MetaTelemetryBlock.Disclosure.on.summary, "On")
+    }
+
+    /// Guards the shipped bundle, not just the parser: this fails if anyone drops the keys from
+    /// `OpenGlasses/Info.plist`.
+    func testShippedBundleOptsOutOfBothAnalyticsAndCrashReporting() throws {
+        // These tests are hosted by the app (TEST_HOST), so `Bundle.main` is the app bundle —
+        // this reads the plist that actually ships, not the test bundle's generated one.
+        let state = MetaTelemetryBlock.bundleOptOut
+        XCTAssertTrue(state.analytics, "MWDAT/Analytics/OptOut must be YES in the app's Info.plist")
+        XCTAssertTrue(state.crashReporting, "MWDAT/CrashReporting/OptOut must be YES in the app's Info.plist")
+    }
+}

--- a/project.base.yml
+++ b/project.base.yml
@@ -121,7 +121,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "360"
+        CURRENT_PROJECT_VERSION: "361"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -236,7 +236,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "360"
+        CURRENT_PROJECT_VERSION: "361"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -274,7 +274,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "360"
+        CURRENT_PROJECT_VERSION: "361"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "360"
+        CURRENT_PROJECT_VERSION: "361"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "360"
+        CURRENT_PROJECT_VERSION: "361"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## The problem

`MWDATCore` ships an analytics pipeline that POSTs `ar_wearables_sdk_*` event batches to a hard-coded endpoint on `api2.ar.meta.com`. Extracted from the framework binary, the events are:

`session_event`, `stream_session_event`, `display_event`, `register_event`, `check_permission_event`, `crash_event`, `device_analytics_event` — carrying fields including `device_identifier`, `device_soc_build_version`, `third_party_app_name`, session ids, durations and payload sizes. Batches are cached on disk and retried.

Collection is **opt-out**, and this app had never opted out. Every glasses session was reporting usage to Meta.

## The fix — two layers

**1. The supported switch (`Info.plist`)**

```xml
<key>MWDAT</key>
<dict>
    <key>Analytics</key><dict><key>OptOut</key><true/></dict>
    <key>CrashReporting</key><dict><key>OptOut</key><true/></dict>
```

This is what actually stops the uploads. Absent or `NO` means opted **in**, so both must stay explicitly `YES`.

**2. A backstop we own (`MetaTelemetryBlock`)**

The plist flag is read by a closed-source binary we ship but do not build. A stale personal plist, a missed key after an SDK bump, or a change in how that flag is honoured would silently restore the uploads, and nothing in a build log would say so. A `URLProtocol` registered before `Wearables.configure()` answers the telemetry endpoint locally and counts what it stopped — the guarantee moves into code we own, and a regression becomes countable instead of invisible.

It answers **204 rather than failing**: the uploader treats a failure as "retry later" and keeps the batch on disk, so failing the request would leave a growing local queue retrying forever. The payload is discarded.

## What is deliberately *not* blocked

`/wearables/attestation/challenge` shares the host but is how the SDK proves the app may talk to the glasses. Blocking it would break device access, not protect privacy. There's a test pinning that line so the interceptor can't be widened to the whole host by accident.

## Surfaces

- **Settings → Hardware & Privacy** — a read-only "Glasses Analytics: Off" row. Not a toggle: the guarantee is compiled in, and presenting it as a switch would imply an "on" state the app doesn't offer. New `InfoStatusRow` component for exactly this shape of fact.
- **Developer panel** — an "SDK Telemetry" probe that fails loudly if a key is missing from the shipped bundle, or if the opt-out is set *but ignored*.

The disclosure only claims "Off" when the opt-out is present **and** nothing has had to be intercepted — it reads "Blocked" if the opt-out was ignored, "On" if a key is missing. A privacy claim the app can't back up would be worse than no claim.

## Tests

14 new tests. Endpoint matching (host + path prefix, so an appended segment or query can't reopen the upload), attestation exclusion, end-to-end interception through `URLSession.shared` (the API the SDK links), the plist parser treating a missing key as opted **in**, and the disclosure's honest failure modes. One reads the **shipped bundle**, so dropping the keys from `Info.plist` fails CI.

## Verification status

- Full suite green (**3199 tests**) and **Release build green** — but on the commit *before* the Settings disclosure was added. The delta not yet covered by a full run is `SettingsView` / `InfoStatusRow` / `Disclosure` + their 4 tests; a targeted run was still compiling when this PR went up. **I'll post the result as a comment.**
- Build bumped 360 → 361; calendar version unchanged (this is a fix, not a feature).

## Not covered — needs a device session

Whether the SDK's uploader uses `URLSession.shared` is inferred from binary symbols, not proven, so a blocked count of **0** is consistent with "nothing sent" but is not proof of it. The discriminating check is a proxy or Console.app filtered on `api2.ar.meta.com` during a real glasses session: expect the attestation call and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
