### PR TITLE
Say what failed, and stop failing silently

### DIFF
--- a/OpenGlasses/Info.plist
+++ b/OpenGlasses/Info.plist
@@ -151,7 +151,7 @@
 	<key>NSHomeKitUsageDescription</key>
 	<string>OpenGlasses controls your smart home devices hands-free through your glasses.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-		<string>OpenGlasses scans your local network to find self-hosted AI servers (Ollama, LM Studio, vLLM, LocalAI) so you can connect without typing an address.</string>
+		<string>OpenGlasses uses your local network to find self-hosted AI servers (Ollama, LM Studio, vLLM, LocalAI) without typing an address, and to stream video to a server on your own network.</string>
 		<key>NSBonjourServices</key>
 		<array>
 			<string>_http._tcp</string>

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -1644,6 +1644,23 @@ class AppState: ObservableObject, AppStateProtocol {
         // which picks its own source. Turning listening off mid-stream hands the capture over to a
         // standalone engine instead of silently going video-only.
         broadcastService.audioProvider = captureAudioRouter
+
+        // Persistence and capture-audio diagnostics. A field report of a recording that vanished
+        // used to contain nothing but the launch trace, because none of these paths said anything
+        // the in-app log could carry — only NSLog, which a wearer cannot send.
+        captureAudioRouter.onDebugEvent = { [weak self] message in
+            self?.addDebugEvent(message)
+        }
+        videoRecorder.onDebugEvent = { [weak self] message in
+            self?.addDebugEvent(message)
+        }
+        broadcastService.onDebugEvent = { [weak self] message in
+            self?.addDebugEvent(message)
+        }
+        GlassesPhotoAlbum.onDebugEvent = { [weak self] message in
+            Task { @MainActor in self?.addDebugEvent(message) }
+        }
+
         let captureListeningToken = wakeWordService.$isListening
             .removeDuplicates()
             .sink { [weak self] listening in

--- a/OpenGlasses/Sources/Models/ModelConfig.swift
+++ b/OpenGlasses/Sources/Models/ModelConfig.swift
@@ -27,8 +27,11 @@ struct ModelConfig: Codable, Identifiable, Equatable {
         case .anthropic, .gemini, .geminiVertex, .openai:
             return true
         case .chatgpt:
-            // Codex models accept image input over the Responses backend (BW P4 verifies live).
-            return true
+            // The subscription catalog is coding-tuned, and image acceptance on it was never
+            // actually confirmed on device. Claiming vision here is what put a camera button in
+            // front of a model that cannot use it, so the honest answer is no until a photo turn
+            // is confirmed working against that backend. `ChatGPTVisionGate` is the backstop.
+            return false
         case .groq, .local, .appleOnDevice:
             return false
         case .qwen:

--- a/OpenGlasses/Sources/Services/AudioCapture/CaptureAudioNormalizer.swift
+++ b/OpenGlasses/Sources/Services/AudioCapture/CaptureAudioNormalizer.swift
@@ -1,0 +1,168 @@
+import AVFoundation
+import Foundation
+
+/// Compares two audio formats the way the consumers downstream of capture actually compare them:
+/// by stream description, which is what `CMAudioFormatDescription` is built from and what an
+/// `AVAssetWriterInput` locks itself to.
+enum CaptureAudioFormatMatch {
+
+    /// Whether two formats describe the same stream — same rate, layout, packing and width.
+    ///
+    /// Deliberately stricter than "same sample rate and channel count": interleaved and
+    /// non-interleaved float32 at 48 kHz mono are the same audio and two different
+    /// `AudioStreamBasicDescription`s, and it is the description that decides whether an asset
+    /// writer accepts the next sample buffer.
+    static func matches(_ lhs: AudioStreamBasicDescription, _ rhs: AudioStreamBasicDescription) -> Bool {
+        lhs.mSampleRate == rhs.mSampleRate
+            && lhs.mFormatID == rhs.mFormatID
+            && lhs.mFormatFlags == rhs.mFormatFlags
+            && lhs.mBytesPerPacket == rhs.mBytesPerPacket
+            && lhs.mFramesPerPacket == rhs.mFramesPerPacket
+            && lhs.mBytesPerFrame == rhs.mBytesPerFrame
+            && lhs.mChannelsPerFrame == rhs.mChannelsPerFrame
+            && lhs.mBitsPerChannel == rhs.mBitsPerChannel
+    }
+
+    static func matches(_ lhs: AVAudioFormat, _ rhs: AVAudioFormat) -> Bool {
+        matches(lhs.streamDescription.pointee, rhs.streamDescription.pointee)
+    }
+}
+
+/// Holds capture audio to one format for the life of a capture, whatever source is feeding it.
+///
+/// The two mic sources behind `CaptureAudioRouter` are two separate `AVAudioEngine`s, and each
+/// takes its tap format from `inputNode.outputFormat(forBus: 0)` — whatever the route happens to be
+/// when *that* engine starts. Handing over mid-capture can therefore change the sample rate,
+/// channel count or packing under consumers that cannot survive it:
+///
+///  - `AVAssetWriterInput` locks its audio format to the first sample buffer it is given. The next
+///    buffer that disagrees is rejected and the whole `AVAssetWriter` moves to `.failed` — which
+///    takes the *video* track down with it. The recording does not lose its audio, it dies, and
+///    `finishWriting` then has no file to hand back. That is the device symptom this exists for:
+///    enable the always-on listener a minute into a recording and the recording ends a second later.
+///  - The broadcast's audio PTS runs off a sample-count clock read at `buffer.format.sampleRate`,
+///    so a rate change shifts A/V sync for the rest of the session.
+///
+/// So the first buffer of a capture fixes the canonical format and every later buffer is converted
+/// into it. Buffers that already match — the entire steady state, and every capture that never sees
+/// a handover — are passed through untouched, so nothing is resampled that doesn't have to be.
+///
+/// A conversion that fails yields silence of the right duration rather than `nil`: dropping the
+/// slot would shift the broadcast's sample clock permanently, and passing the original through
+/// would be the format change all over again.
+final class CaptureAudioNormalizer: @unchecked Sendable {
+
+    /// `NSLock` rather than `OSAllocatedUnfairLock` because the guarded work has to *return* an
+    /// `AVAudioPCMBuffer`, and `withLock` constrains its result to `Sendable`. Contention is
+    /// negligible either way: one audio thread calls `normalize`, and only a capture ending calls
+    /// `reset` from the main actor.
+    private let lock = NSLock()
+
+    private var canonical: AVAudioFormat?
+    private var converter: AVAudioConverter?
+    private var convertingFrom: AVAudioFormat?
+    private var conversionFailures = 0
+
+    /// The format consumers are currently being fed, or nil before this capture's first buffer.
+    var canonicalFormat: AVAudioFormat? {
+        lock.lock()
+        defer { lock.unlock() }
+        return canonical
+    }
+
+    /// How many buffers this capture could not convert (diagnostics only).
+    var conversionFailureCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return conversionFailures
+    }
+
+    /// Forget the canonical format. Called when a capture ends so the next one adopts the route it
+    /// actually starts on, rather than one fixed by a recording that finished an hour ago.
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        canonical = nil
+        converter = nil
+        convertingFrom = nil
+        conversionFailures = 0
+    }
+
+    /// Called from the audio render thread. Returns the buffer consumers should see: the input
+    /// itself when it already matches the canonical format, a converted copy when it doesn't.
+    func normalize(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let canonical else {
+            canonical = buffer.format
+            return buffer
+        }
+        if CaptureAudioFormatMatch.matches(buffer.format, canonical) { return buffer }
+
+        if converter == nil || !(convertingFrom.map { CaptureAudioFormatMatch.matches($0, buffer.format) } ?? false) {
+            converter = AVAudioConverter(from: buffer.format, to: canonical)
+            convertingFrom = buffer.format
+        }
+        guard let converter,
+              let converted = Self.convert(buffer, with: converter, to: canonical) else {
+            conversionFailures += 1
+            return Self.silence(matching: buffer, in: canonical)
+        }
+        return converted
+    }
+
+    // MARK: - Conversion
+
+    private static func convert(_ buffer: AVAudioPCMBuffer,
+                                with converter: AVAudioConverter,
+                                to format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        guard buffer.frameLength > 0, buffer.format.sampleRate > 0 else { return nil }
+        let ratio = format.sampleRate / buffer.format.sampleRate
+        // Headroom: a resampler's output length for a given input block is not exactly the ratio.
+        let capacity = AVAudioFrameCount((Double(buffer.frameLength) * ratio).rounded(.up)) + 64
+        guard let output = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else { return nil }
+
+        var supplied = false
+        var error: NSError?
+        let status = converter.convert(to: output, error: &error) { _, outStatus in
+            // One block of input per call. Claiming `.haveData` forever makes a resampling
+            // converter spin; `.noDataNow` is how it is told this block is all there is.
+            if supplied {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            supplied = true
+            outStatus.pointee = .haveData
+            return buffer
+        }
+
+        switch status {
+        case .haveData, .inputRanDry:
+            return output.frameLength > 0 ? output : nil
+        case .endOfStream, .error:
+            if let error { NSLog("[CaptureAudio] Conversion failed: %@", error.localizedDescription) }
+            return nil
+        @unknown default:
+            return nil
+        }
+    }
+
+    /// Silence in `format` lasting as long as `buffer` did — the duration is what the broadcast's
+    /// sample clock and the writer's timeline care about.
+    private static func silence(matching buffer: AVAudioPCMBuffer, in format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        let sourceRate = buffer.format.sampleRate > 0 ? buffer.format.sampleRate : format.sampleRate
+        let ratio = format.sampleRate / sourceRate
+        let frames = AVAudioFrameCount(max(1, (Double(buffer.frameLength) * ratio).rounded()))
+        guard let silent = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames) else { return nil }
+        silent.frameLength = frames
+        // Zero the whole buffer list rather than a typed channel pointer: the canonical format
+        // follows the hardware route and a Bluetooth link does not always hand us float32.
+        let list = UnsafeMutableAudioBufferListPointer(silent.mutableAudioBufferList)
+        for audioBuffer in list {
+            guard let data = audioBuffer.mData else { continue }
+            memset(data, 0, Int(audioBuffer.mDataByteSize))
+        }
+        return silent
+    }
+}

--- a/OpenGlasses/Sources/Services/AudioCapture/CaptureAudioRouter.swift
+++ b/OpenGlasses/Sources/Services/AudioCapture/CaptureAudioRouter.swift
@@ -28,8 +28,16 @@ final class CaptureAudioRouter: ObservableObject, BroadcastAudioProviding {
     private let isPhoneSpeakerOutput: @MainActor () -> Bool
     private let includeAssistantVoice: @MainActor () -> Bool
 
+    /// Reported to the on-screen diagnostics log so a handover shows up in a bug report. Optional;
+    /// nothing here depends on it being wired.
+    var onDebugEvent: ((String) -> Void)?
+
     private var consumers: [String: @Sendable (AVAudioPCMBuffer) -> Void] = [:]
     private let fanout = CaptureAudioFanout()
+    /// Holds every source's buffers to one format for the life of a capture. Without this a
+    /// handover changes the sample format under the recorder's asset writer, which fails the
+    /// writer outright — video track included.
+    private let normalizer = CaptureAudioNormalizer()
     private var arbiter = AudioSourceArbiter()
     private var wakeListening = false
     private var assistantSpeaking = false
@@ -92,6 +100,7 @@ final class CaptureAudioRouter: ObservableObject, BroadcastAudioProviding {
         publishConsumers()
         run(arbiter.reset())
         activeSource = arbiter.source
+        normalizer.reset()
     }
 
     /// Await any in-flight source change. Test seam — production never needs to wait.
@@ -109,9 +118,15 @@ final class CaptureAudioRouter: ObservableObject, BroadcastAudioProviding {
         let commands = arbiter.apply(conditions)
         guard !commands.isEmpty else { return }
         activeSource = arbiter.source
-        NSLog("[CaptureAudio] Source → %@ (listening: %@, capturing: %@)",
-              arbiter.source.rawValue, wakeListening ? "yes" : "no",
-              conditions.captureActive ? "yes" : "no")
+        // A capture that has ended releases the canonical format, so the next one adopts whatever
+        // route it actually starts on. While a capture is live the format is held across every
+        // handover — that is the whole point of it.
+        if arbiter.source == .none { normalizer.reset() }
+        let summary = "Capture audio source → \(arbiter.source.rawValue) "
+                    + "(listening: \(wakeListening ? "on" : "off"), "
+                    + "capturing: \(conditions.captureActive ? "yes" : "no"))"
+        NSLog("[CaptureAudio] %@", summary)
+        onDebugEvent?(summary)
         run(commands)
     }
 
@@ -125,28 +140,36 @@ final class CaptureAudioRouter: ObservableObject, BroadcastAudioProviding {
         }
     }
 
-    private func execute(_ command: CaptureAudioCommand) async {
+    /// The block every source hands its buffers to. Normalise first, then fan out: consumers must
+    /// see one unbroken single-format stream no matter which engine is currently producing it.
+    private func makeSourceHandler() -> @Sendable (AVAudioPCMBuffer) -> Void {
         let fanout = self.fanout
+        let normalizer = self.normalizer
+        return { buffer in
+            guard let normalized = normalizer.normalize(buffer) else { return }
+            fanout.dispatch(normalized)
+        }
+    }
+
+    private func execute(_ command: CaptureAudioCommand) async {
         switch command {
         case .attachToWakeTap:
-            wakeTap?.addAudioBufferConsumer(id: Self.sourceConsumerId) { buffer in
-                fanout.dispatch(buffer)
-            }
+            wakeTap?.addAudioBufferConsumer(id: Self.sourceConsumerId, handler: makeSourceHandler())
         case .detachFromWakeTap:
             wakeTap?.removeAudioBufferConsumer(id: Self.sourceConsumerId)
         case .startStandalone:
             guard let standalone else {
                 NSLog("[CaptureAudio] No standalone engine — capture stays video-only while listening is off")
+                onDebugEvent?("Capture audio: no standalone engine — video-only while listening is off")
                 return
             }
-            standalone.addAudioBufferConsumer(id: Self.sourceConsumerId) { buffer in
-                fanout.dispatch(buffer)
-            }
+            standalone.addAudioBufferConsumer(id: Self.sourceConsumerId, handler: makeSourceHandler())
             do {
                 try await standalone.start()
             } catch {
                 standalone.removeAudioBufferConsumer(id: Self.sourceConsumerId)
                 NSLog("[CaptureAudio] Standalone engine failed to start: %@", error.localizedDescription)
+                onDebugEvent?("Capture audio engine failed to start: \(error.localizedDescription)")
             }
         case .stopStandalone:
             standalone?.removeAudioBufferConsumer(id: Self.sourceConsumerId)

--- a/OpenGlasses/Sources/Services/BroadcastResilience.swift
+++ b/OpenGlasses/Sources/Services/BroadcastResilience.swift
@@ -429,9 +429,18 @@ struct BroadcastHealth: Equatable {
     /// Frames that never reached the wire since this broadcast started.
     var droppedFrameCount: Int = 0
     var duration: TimeInterval = 0
+    /// Anything at all has left the device on this connection.
+    ///
+    /// The readout used to fall back to the *target* bitrate whenever the transport hadn't
+    /// reported, which reads as flow. A session that connected and then sent nothing showed
+    /// "3.7 Mbps · 0 fps" — a number that described an intention, next to the measurement proving
+    /// it never happened.
+    var hasSentAnything: Bool = false
 
-    /// "2.4 Mbps" / "820 kbps" — measured if the transport has told us, target otherwise.
+    /// "2.4 Mbps" / "820 kbps" — measured if the transport has told us, the target it is aiming
+    /// for once something has actually gone out, and nothing at all before that.
     var bitrateLabel: String {
+        guard hasSentAnything else { return "—" }
         let bits = measuredBitrate > 0 ? measuredBitrate : targetBitrate
         guard bits > 0 else { return "—" }
         if bits >= 1_000_000 {
@@ -445,14 +454,88 @@ struct BroadcastHealth: Equatable {
         "\(Int(achievedFrameRate.rounded())) fps"
     }
 
-    /// Short status word for the badge. Never names an attempt count it does not have.
+    /// Short status word for the badge. Never names an attempt count it does not have, and never
+    /// says "Live" for a connection that has yet to put a byte on the wire.
     var stateLabel: String {
         switch state {
         case .idle: return "Idle"
         case .connecting: return "Connecting"
-        case .live: return "Live"
+        case .live: return hasSentAnything ? "Live" : "Nothing sent yet"
         case .reconnecting(let attempt): return "Reconnecting \(attempt)"
         case .failed: return "Failed"
         }
+    }
+}
+
+/// Whether a broadcast that believes it is connected has actually put anything on the wire.
+///
+/// From the field: an RTMP ingest on the same network logged connection after connection opening
+/// and timing out with **zero bytes received** — no handshake, no publish — while the app showed a
+/// target bitrate and an ever-growing reconnect backoff. The reconnect machinery worked perfectly;
+/// what was missing was anybody noticing that the first publish never happened, and saying so.
+///
+/// The most common cause on a phone is iOS's local-network privacy gate, which is per-install and
+/// per-user and produces exactly this shape: the app believes it is connected, and nothing arrives.
+/// So the message names that when the target is a private address, and stays generic when it isn't.
+enum BroadcastStallPolicy {
+
+    /// How long a connected session may send nothing before it is worth saying so. Long enough to
+    /// clear a slow handshake and the encoder priming, short enough to beat a wearer's patience.
+    static let stallSeconds: TimeInterval = 8
+
+    enum Verdict: Equatable {
+        /// Bytes have gone out; nothing to say.
+        case flowing
+        /// Nothing yet, but not long enough to mean anything.
+        case tooEarly
+        /// Connected, past the grace period, and still nothing on the wire.
+        case stalled
+    }
+
+    static func verdict(secondsSinceStart: TimeInterval,
+                        hasSentAnything: Bool,
+                        stallSeconds: TimeInterval = stallSeconds) -> Verdict {
+        if hasSentAnything { return .flowing }
+        return secondsSinceStart >= stallSeconds ? .stalled : .tooEarly
+    }
+
+    /// Whether a host sits on the local network, where iOS's privacy gate applies. Accepts a bare
+    /// host, or a full `rtmp://host:port/app` URL.
+    static func isPrivateNetworkHost(_ hostOrURL: String) -> Bool {
+        let host = self.host(from: hostOrURL).lowercased()
+        guard !host.isEmpty else { return false }
+        if host == "localhost" || host.hasSuffix(".local") { return true }
+
+        let parts = host.split(separator: ".").map(String.init)
+        guard parts.count == 4, let first = Int(parts[0]), let second = Int(parts[1]),
+              parts.allSatisfy({ Int($0) != nil }) else { return false }
+        switch first {
+        case 10, 127: return true
+        case 192: return second == 168
+        case 172: return (16...31).contains(second)
+        case 169: return second == 254        // link-local
+        default: return false
+        }
+    }
+
+    /// The host out of an RTMP URL, or the input itself when it is already bare.
+    static func host(from hostOrURL: String) -> String {
+        var rest = hostOrURL
+        if let schemeEnd = rest.range(of: "://") { rest = String(rest[schemeEnd.upperBound...]) }
+        if let at = rest.firstIndex(of: "@") { rest = String(rest[rest.index(after: at)...]) }
+        if let slash = rest.firstIndex(of: "/") { rest = String(rest[..<slash]) }
+        if let colon = rest.firstIndex(of: ":") { rest = String(rest[..<colon]) }
+        return rest.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// What to tell the wearer about a connection that is sending nothing.
+    static func stalledMessage(target: String) -> String {
+        guard isPrivateNetworkHost(target) else {
+            return "Connected to the streaming server, but nothing is reaching it. Check the "
+                 + "stream key and that the server is accepting a publish."
+        }
+        return "Connected to the streaming server, but nothing is reaching it. If that server is "
+             + "on your own network, allow OpenGlasses to use it in Settings, under Privacy & "
+             + "Security, Local Network."
     }
 }

--- a/OpenGlasses/Sources/Services/BroadcastService.swift
+++ b/OpenGlasses/Sources/Services/BroadcastService.swift
@@ -104,6 +104,16 @@ class BroadcastService: ObservableObject {
     private var streamName = ""
     private var currentTargetBitrate = 0
     private var measuredBitrate = 0
+    /// Anything has actually left the device on this connection, from the transport's own
+    /// cumulative byte count. Drives both the honest readout and the stall check — a target bitrate
+    /// next to 0 fps described an intention, not a stream.
+    private var hasSentAnything = false
+    /// When the current connection finished publishing, or nil when there isn't a live one. The
+    /// stall clock runs from here, per attempt.
+    private var liveSince: Date?
+
+    /// Reported to the on-screen diagnostics log. Optional; nothing here depends on it.
+    var onDebugEvent: ((String) -> Void)?
     private var droppedFrameBaseline = 0
 
     /// CY: supplies the outbound pipeline's own dropped-frame count (`OutboundFrameRelay` discards
@@ -296,11 +306,18 @@ class BroadcastService: ObservableObject {
         let controller = BroadcastBitRateController(
             ceiling: ceiling,
             floor: VideoBitratePolicy.Profile.rtmp.minimum
-        ) { [weak self] target, measured in
-            Task { @MainActor in self?.recordBitrate(target: target, measured: measured) }
+        ) { [weak self] target, measured, totalBytesOut in
+            Task { @MainActor in
+                self?.recordBitrate(target: target, measured: measured, totalBytesOut: totalBytesOut)
+            }
         }
         await stream.setBitRateStrategy(controller)
         bitRateController = controller
+
+        // This attempt's own silence clock. Per attempt, not per broadcast: a reconnect builds a
+        // fresh connection with fresh byte counters, and each one has to prove itself.
+        hasSentAnything = false
+        liveSince = Date()
 
         observeStatus(connection: connection, stream: stream)
     }
@@ -388,6 +405,10 @@ class BroadcastService: ObservableObject {
         guard machine.apply(.dropped) else { return }
 
         NSLog("[Broadcast] Connection lost (%@) — reconnecting", reason)
+        // Whatever killed it, this attempt's silence clock stops with it; the next attempt sets
+        // its own when it publishes.
+        liveSince = nil
+        hasSentAnything = false
         cancelStatusObservation()
         teardownConnectionObjects()
 
@@ -583,13 +604,45 @@ class BroadcastService: ObservableObject {
         }
         frameRateMeter.record(frames: pushedFrameCount, at: Date())
         pushedFrameCount = 0
+        checkForStall()
         publishHealth()
     }
 
+    /// A connection that believes it is publishing but has never put a byte on the wire is dead,
+    /// and is treated as dead.
+    ///
+    /// This is the swallowed-handshake case: the socket opens, the RTMP handshake never reaches it,
+    /// and the ingest sits there until its own timeout while the app shows a bitrate. Nothing in
+    /// the status streams reports it, because from the transport's point of view nothing went
+    /// wrong — so the silence itself has to be the signal.
+    ///
+    /// It routes into `handleConnectionLoss` rather than only setting an error, so the existing
+    /// reconnect machinery gets its shot: a fresh connection may well come up writable, and if none
+    /// ever does, the reconnect policy's own give-up budget ends the session honestly. Saying so in
+    /// the UI without retrying would leave a stream idling that could have recovered itself.
+    private func checkForStall() {
+        guard let liveSince else { return }
+        let verdict = BroadcastStallPolicy.verdict(
+            secondsSinceStart: Date().timeIntervalSince(liveSince),
+            hasSentAnything: hasSentAnything)
+        guard verdict == .stalled else { return }
+        self.liveSince = nil   // this attempt is spent; the next one starts its own clock
+        let message = BroadcastStallPolicy.stalledMessage(target: connectionURL)
+        NSLog("[Broadcast] Nothing sent after %.0fs — %@", BroadcastStallPolicy.stallSeconds, message)
+        onDebugEvent?("Broadcast published but wrote 0 bytes in \(Int(BroadcastStallPolicy.stallSeconds))s — reconnecting")
+        broadcastError = message
+        handleConnectionLoss(reason: "published but nothing reached the server")
+    }
+
     /// The bitrate controller applied a new target (or just measured the link).
-    private func recordBitrate(target: Int, measured: Int) {
+    ///
+    /// `totalBytesOut` is the transport's cumulative count, which is what proves the handshake
+    /// actually went out. The per-second measurement can legitimately read zero on a healthy
+    /// stream between keyframes, so it cannot carry this.
+    private func recordBitrate(target: Int, measured: Int, totalBytesOut: Int) {
         currentTargetBitrate = target
         measuredBitrate = measured
+        if totalBytesOut > 0 { hasSentAnything = true }
         publishHealth()
     }
 
@@ -604,7 +657,8 @@ class BroadcastService: ObservableObject {
             // Both counts are "a frame that did not reach the wire": one discarded by the privacy
             // relay keeping up, one dropped because there was no connection to push it to.
             droppedFrameCount: relayDrops + unsentFrameCount,
-            duration: broadcastDuration
+            duration: broadcastDuration,
+            hasSentAnything: hasSentAnything
         )
         sessionState = machine.state
     }
@@ -748,6 +802,8 @@ class BroadcastService: ObservableObject {
         rtmpConnection = nil
         mediaMixer = nil
         bitRateController = nil
+        liveSince = nil
+        hasSentAnything = false
     }
 }
 
@@ -764,9 +820,13 @@ final actor BroadcastBitRateController: StreamBitRateStrategy {
     let mamimumAudioBitRate: Int = 0
 
     private var policy: AdaptiveBitratePolicy
-    private let onSample: @Sendable (Int, Int) -> Void
+    /// `(target, measured, totalBytesOut)`. The third is cumulative bytes the transport has
+    /// actually written to the socket — the only number here that can tell "connected and
+    /// streaming" apart from "connected and silent", which is the state a swallowed handshake
+    /// leaves the session in.
+    private let onSample: @Sendable (Int, Int, Int) -> Void
 
-    init(ceiling: Int, floor: Int, onSample: @escaping @Sendable (Int, Int) -> Void) {
+    init(ceiling: Int, floor: Int, onSample: @escaping @Sendable (Int, Int, Int) -> Void) {
         self.mamimumVideoBitRate = ceiling
         self.policy = AdaptiveBitratePolicy(ceiling: ceiling, floor: floor)
         self.onSample = onSample
@@ -780,7 +840,7 @@ final actor BroadcastBitRateController: StreamBitRateStrategy {
             var settings = await stream.videoSettings
             settings.bitRate = mamimumVideoBitRate
             try? await stream.setVideoSettings(settings)
-            onSample(mamimumVideoBitRate, 0)
+            onSample(mamimumVideoBitRate, 0, 0)
         case .status(let report):
             await apply(report, insufficientBandwidth: false, to: stream)
         case .publishInsufficientBWOccured(let report):
@@ -800,13 +860,13 @@ final actor BroadcastBitRateController: StreamBitRateStrategy {
         )
         switch policy.evaluate(sample) {
         case .hold:
-            onSample(settings.bitRate, sample.measuredBitrate)
+            onSample(settings.bitRate, sample.measuredBitrate, report.totalBytesOut)
         case .stepDown(let bitrate), .stepUp(let bitrate):
             settings.bitRate = bitrate
             try? await stream.setVideoSettings(settings)
             NSLog("[Broadcast] Bitrate → %d bps (measured %d bps, queue %d B)",
                   bitrate, sample.measuredBitrate, sample.queuedBytes)
-            onSample(bitrate, sample.measuredBitrate)
+            onSample(bitrate, sample.measuredBitrate, report.totalBytesOut)
         }
     }
 }

--- a/OpenGlasses/Sources/Services/CameraService.swift
+++ b/OpenGlasses/Sources/Services/CameraService.swift
@@ -266,8 +266,12 @@ class CameraService: ObservableObject {
     func saveToPhotoLibrary(_ data: Data) {
         guard let image = UIImage(data: data) else { return }
         Task {
-            if await GlassesPhotoAlbum.saveImage(image) {
-                print("📸 Photo saved to \(GlassesPhotoAlbum.albumName) album")
+            let result = await GlassesPhotoAlbum.saveImage(image)
+            if case .notPermitted(let status) = result {
+                // Not an error to swallow: on a fresh install this is the whole reason a capture
+                // is nowhere to be found afterwards.
+                NSLog("[Camera] Photo not saved — library %@",
+                      GlassesPhotoAlbumPolicy.describe(status))
             }
         }
     }

--- a/OpenGlasses/Sources/Services/GlassesPhotoAlbum.swift
+++ b/OpenGlasses/Sources/Services/GlassesPhotoAlbum.swift
@@ -55,6 +55,36 @@ enum GlassesPhotoAlbumPolicy {
         let nsError = error as NSError
         return nsError.domain == PHPhotosErrorDomain && nsError.code == albumAlreadyExistsCode
     }
+
+    /// A word for an authorization status, for the diagnostics log. "Photo library access denied"
+    /// was the only thing a failed save ever said, which cannot tell apart a wearer who declined,
+    /// a device where the library is restricted, and a prompt that was never presented at all —
+    /// the three cases that look identical from the outside and need completely different answers.
+    static func describe(_ status: PHAuthorizationStatus) -> String {
+        switch status {
+        case .authorized: return "authorized"
+        case .limited: return "limited"
+        case .denied: return "denied"
+        case .restricted: return "restricted"
+        case .notDetermined: return "not determined"
+        @unknown default: return "unknown"
+        }
+    }
+}
+
+/// How a save to the photo library ended.
+///
+/// Three outcomes rather than a Bool, because "it didn't save" is not one thing: a library the
+/// wearer has never been asked about, one they said no to, and a change request that failed all
+/// need to be told apart — the first two are answered in Settings and the third is not.
+enum PhotoLibrarySaveResult: Equatable {
+    case saved
+    /// Authorization does not allow adding — carries the status seen so the caller can say which.
+    case notPermitted(PHAuthorizationStatus)
+    /// Authorized, but the asset did not land.
+    case failed
+
+    var didSave: Bool { self == .saved }
 }
 
 /// Every write this app makes to the photo library goes through here.
@@ -77,19 +107,26 @@ enum GlassesPhotoAlbum {
 
     private static let albumIDKey = "GlassesPhotoAlbumLocalIdentifier"
 
+    /// Reported to the on-screen diagnostics log. Set once at app start; nothing here depends on
+    /// it being wired. `nonisolated(unsafe)` because this type is a namespace of statics reached
+    /// from every capture path — it is assigned exactly once, before any capture can run.
+    nonisolated(unsafe) static var onDebugEvent: (@Sendable (String) -> Void)?
+
     /// Serialises the synchronous PhotoKit work off the main thread. Serial rather than concurrent
     /// so two saves racing the first-ever create cannot both create an album.
     private static let queue = DispatchQueue(label: "openglasses.photo-album", qos: .utility)
 
     // MARK: - Saving
 
-    /// Save a still image into the Glasses album. Returns whether the asset landed — a denied
-    /// library is a normal outcome here, not an error.
+    /// Save a still image into the Glasses album. A library that has not been granted is a normal
+    /// outcome here rather than an error, and it comes back distinguishable from a save that was
+    /// allowed and still failed.
     @discardableResult
-    static func saveImage(_ image: UIImage) async -> Bool {
-        guard await ensureCanSave() else {
-            NSLog("[PhotoAlbum] Photo library access denied — image not saved")
-            return false
+    static func saveImage(_ image: UIImage) async -> PhotoLibrarySaveResult {
+        let status = await ensureCanSave()
+        guard GlassesPhotoAlbumPolicy.canSave(status) else {
+            report("Photo library \(GlassesPhotoAlbumPolicy.describe(status)) — image not saved")
+            return .notPermitted(status)
         }
         let saved = await saveTargetingAlbum {
             PHAssetChangeRequest.creationRequestForAsset(from: image)
@@ -98,29 +135,47 @@ enum GlassesPhotoAlbum {
         // point at the next capability. Recorded here rather than at any one call
         // site because every route into the album passes through this function.
         if saved { SettingsJourneyStore.note(.firstPhotoCaptured) }
-        return saved
+        report(saved ? "Photo saved to the \(albumName) album" : "Photo library save failed")
+        return saved ? .saved : .failed
     }
 
-    /// Save a video file into the Glasses album. Returns whether the asset landed; callers keep
-    /// their on-disk copy either way (`RecordingFiler` files to Documents before this runs).
+    /// Save a video file into the Glasses album. Callers keep their on-disk copy whatever this
+    /// returns (`RecordingFiler` files to Documents before this runs).
     @discardableResult
-    static func saveVideo(at url: URL) async -> Bool {
-        guard await ensureCanSave() else {
-            NSLog("[PhotoAlbum] Photo library access denied — video not saved")
-            return false
+    static func saveVideo(at url: URL) async -> PhotoLibrarySaveResult {
+        let status = await ensureCanSave()
+        guard GlassesPhotoAlbumPolicy.canSave(status) else {
+            report("Photo library \(GlassesPhotoAlbumPolicy.describe(status)) — recording not saved")
+            return .notPermitted(status)
         }
-        return await saveTargetingAlbum {
+        let saved = await saveTargetingAlbum {
             PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: url)
         }
+        report(saved ? "Recording saved to the \(albumName) album" : "Photo library save failed")
+        return saved ? .saved : .failed
     }
 
     // MARK: - Authorization (the one prompt)
 
-    private static func ensureCanSave() async -> Bool {
+    /// The authorization status a save may proceed on, asking for it if it has never been asked.
+    ///
+    /// Runs on the main actor. Presenting the system prompt is UI work, and a request made from a
+    /// background context is exactly the shape of failure the field report showed: no prompt ever
+    /// appeared on a fresh install, every save declined, nothing said. The status seen is returned
+    /// rather than a Bool so the caller can be specific about why nothing landed.
+    @MainActor
+    private static func ensureCanSave() async -> PHAuthorizationStatus {
         let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
-        guard status == .notDetermined else { return GlassesPhotoAlbumPolicy.canSave(status) }
+        guard status == .notDetermined else { return status }
+        report("Asking for photo library access")
         let requested = await PHPhotoLibrary.requestAuthorization(for: .readWrite)
-        return GlassesPhotoAlbumPolicy.canSave(requested)
+        report("Photo library access \(GlassesPhotoAlbumPolicy.describe(requested))")
+        return requested
+    }
+
+    private static func report(_ message: String) {
+        NSLog("[PhotoAlbum] %@", message)
+        onDebugEvent?(message)
     }
 
     // MARK: - The change request

--- a/OpenGlasses/Sources/Services/LLM/ChatGPTVisionGate.swift
+++ b/OpenGlasses/Sources/Services/LLM/ChatGPTVisionGate.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Vision honesty for the ChatGPT (Codex/Responses) subscription provider.
+///
+/// `LLMProvider.chatgpt` authenticates against the ChatGPT Codex backend and serves a
+/// coding-tuned model catalog (`ChatGPTOAuth.modelCatalog`: `gpt-5.1-codex`,
+/// `gpt-5.1-codex-mini`, `gpt-5.3-codex-spark`). Whether that backend accepts image input
+/// (`input_image`) at all was never actually confirmed on device —
+/// docs/plans/BW-chatgpt-subscription-provider.md's P4 checklist still has "One image turn
+/// (photo question) — confirms `input_image` acceptance on codex models" unchecked, and every
+/// catalog model is a "codex" (coding) variant with no documented vision sibling. Sending a
+/// photo down this path anyway, behind a system prompt that insists "You CAN see it — never
+/// deny vision", produces either an odd denial or (worse) a hallucinated description of a
+/// scene the model never saw.
+///
+/// This mirrors the on-device Vision honesty gate in `LLMService.sendMessage`: when we don't
+/// know a model can see, we say so plainly instead of asserting it can. Pure and state-free so
+/// the routing decision is unit-testable without touching the network, `.shared` services, or
+/// Config.
+enum ChatGPTVisionGate {
+    enum Decision: Equatable {
+        /// Proceed normally — either there's no image this turn, or the provider isn't ChatGPT.
+        case sendWithImage
+        /// Refuse the image turn: speak `message` instead of building a vision-insisting system
+        /// prompt or sending any image bytes to the backend.
+        case declineVision(message: String)
+    }
+
+    /// Spoken/shown when a photo turn reaches the ChatGPT subscription provider. Matches the
+    /// app's existing not-configured/can't-see copy: plain, spoken-friendly, names the real
+    /// alternatives rather than just failing.
+    static let declineMessage =
+        "This ChatGPT sign-in can't see photos — add an OpenAI API key, switch to Gemini, or use the on-device model instead."
+
+    /// Decide whether a turn's image should reach the ChatGPT provider. Only ever declines for
+    /// `.chatgpt` with an image attached; every other provider, and every ChatGPT turn without
+    /// an image, is a no-op so nothing else changes.
+    static func decide(provider: LLMProvider, hasImage: Bool) -> Decision {
+        guard provider == .chatgpt, hasImage else { return .sendWithImage }
+        return .declineVision(message: declineMessage)
+    }
+}

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -552,6 +552,14 @@ class LLMService: ObservableObject {
             return "I can't look at photos with the current on-device model. Switch to a vision-capable local model like SmolVLM2, or a cloud model, and try again."
         }
 
+        // Vision honesty (ChatGPT/Codex subscription provider): whether the codex catalog
+        // accepts image input was never actually confirmed on device (see
+        // `ChatGPTVisionGate`), so treat it like the on-device gate above — decline honestly
+        // before a vision-insisting system prompt is ever built or an image byte is sent.
+        if case .declineVision(let message) = ChatGPTVisionGate.decide(provider: provider, hasImage: imageData != nil) {
+            return message
+        }
+
         let smallContext = !isOnDevice && Config.llmImageLightweightPromptEnabled
         let effectiveIncludeTools = smallContext ? false : includeTools
 

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -664,16 +664,28 @@ final class LocalLLMService: ObservableObject {
 
         let effectiveSystem: String
         let effectiveHistory: [(role: String, content: String)]
+        // Long edge the photo may reach the processor at; 0 on a text turn.
+        var imageLongEdge = 0
         if let photo = imageData {
+            // Measured now, not at launch: the binding constraint on a photo turn is what this
+            // process may still allocate, and with the model resident and the camera live that
+            // is a completely different number from the device's RAM.
+            let headroom = MemoryHeadroom.availableBytes()
             let plan = LocalModelBudget.multimodalTurnPlan(
-                for: loadedModelId, marketingRAMGB: Self.marketingRAMGB)
+                for: loadedModelId, marketingRAMGB: Self.marketingRAMGB, availableBytes: headroom)
+            NSLog("🔬 LocalLLM.generateGemma4Turn model=%@ image=%dKB ram=%.0fGB headroom=%dMB footprint=%dMB fullPrompt=%@ refuse=%@",
+                  loadedModelId ?? "?", photo.count / 1024, Self.marketingRAMGB,
+                  headroom / 1_048_576, MemoryHeadroom.appFootprintBytes() / 1_048_576,
+                  plan.keepsFullSystemPrompt ? "yes" : "no", plan.refusesImage ? "yes" : "no")
+            // Say so rather than starting a prefill that ends as a process kill. A photo turn on
+            // an already-resident multi-gigabyte model crossed the per-process cap on a 12 GB
+            // phone and took the app to the home screen with no error and no recording of why.
+            guard !plan.refusesImage else { throw LocalLLMError.insufficientMemoryForPhoto }
             effectiveSystem = plan.keepsFullSystemPrompt
                 ? systemPrompt
                 : Config.compactVisionTurnPrompt(from: systemPrompt)
             effectiveHistory = plan.keepsHistory ? Array(history.suffix(4)) : []
-            NSLog("🔬 LocalLLM.generateGemma4Turn model=%@ image=%dKB ram=%.0fGB fullPrompt=%@ history=%d",
-                  loadedModelId ?? "?", photo.count / 1024, Self.marketingRAMGB,
-                  plan.keepsFullSystemPrompt ? "yes" : "no", effectiveHistory.count)
+            imageLongEdge = plan.imageLongEdge
         } else {
             effectiveSystem = systemPrompt
             effectiveHistory = history
@@ -688,19 +700,28 @@ final class LocalLLMService: ObservableObject {
             for turn in effectiveHistory {
                 chat.append(turn.role == "assistant" ? .assistant(turn.content) : .user(turn.content))
             }
+            var resize: CGSize?
             if let imageData {
                 guard let ciImage = CIImage(data: imageData) else {
                     throw LocalLLMError.generationFailed("Couldn't decode the photo.")
                 }
                 chat.append(.user(userMessage, images: [.ciImage(ciImage)]))
+                // Bounded, not squashed. There was no cap here at all, on the reasoning that
+                // Gemma's processor picks its own canvas and its own soft-token count — true of
+                // the *token* count, and beside the point for memory: preprocessing a
+                // full-resolution frame materialises it as float pixels on top of a resident
+                // multi-gigabyte model, which is where the per-process cap was crossed. The size
+                // is computed aspect-preserving rather than passed as a square, so the crop the
+                // old comment was defending is still intact.
+                resize = LocalModelBudget.imageSize(width: Int(ciImage.extent.width),
+                                                    height: Int(ciImage.extent.height),
+                                                    maxLongEdge: imageLongEdge)
             } else {
                 chat.append(.user(userMessage))
             }
 
-            // No forced resize: Gemma's processor picks an aspect-preserving canvas and its own
-            // per-image token count, and pre-squashing to 896² neither shrinks that count nor
-            // improves the crop — it just spends preprocessing on a phone photo twice.
-            let userInput = UserInput(chat: chat)
+            let userInput = resize.map { UserInput(chat: chat, processing: .init(resize: $0)) }
+                ?? UserInput(chat: chat)
             let lmInput: LMInput
             do {
                 lmInput = try await context.processor.prepare(input: userInput)
@@ -777,7 +798,16 @@ final class LocalLLMService: ObservableObject {
         }
         defer { NotificationCenter.default.removeObserver(bgObserver) }
 
-        NSLog("🔬 LocalLLM.generateVisionTurn model=%@ image=%dKB", loadedModelId ?? "?", imageData.count / 1024)
+        // Same turn-time headroom gate as the Gemma path: a smaller VLM is still a resident model
+        // plus an unchunked multimodal prefill, and the per-process cap does not care which
+        // factory loaded it.
+        let visionPlan = LocalModelBudget.multimodalTurnPlan(
+            for: loadedModelId, marketingRAMGB: Self.marketingRAMGB,
+            availableBytes: MemoryHeadroom.availableBytes())
+        guard !visionPlan.refusesImage else { throw LocalLLMError.insufficientMemoryForPhoto }
+        let visionLongEdge = visionPlan.imageLongEdge
+        NSLog("🔬 LocalLLM.generateVisionTurn model=%@ image=%dKB longEdge=%d", loadedModelId ?? "?",
+              imageData.count / 1024, visionLongEdge)
         // `UserInput` (and the `CIImage` inside it) isn't `Sendable`, so it's built *inside* the
         // `@Sendable` closure from Sendable ingredients only — the image data, the prompt strings
         // and the history — rather than constructed out here and captured across the boundary.
@@ -791,10 +821,14 @@ final class LocalLLMService: ObservableObject {
                 chat.append(turn.role == "assistant" ? .assistant(turn.content) : .user(turn.content))
             }
             chat.append(.user(userMessage, images: [.ciImage(ciImage)]))
-            // 896² is Gemma's native vision resolution and a sane cap for every supported VLM —
-            // a full-resolution glasses photo through the image pipeline is a pure memory spike.
-            let userInput = UserInput(chat: chat,
-                                      processing: .init(resize: CGSize(width: 896, height: 896)))
+            // Capped, because a full-resolution glasses photo through the image pipeline is a
+            // pure memory spike — but aspect-preserving now rather than squashed into a square,
+            // and at the long edge this turn's headroom actually allows.
+            let resize = LocalModelBudget.imageSize(width: Int(ciImage.extent.width),
+                                                    height: Int(ciImage.extent.height),
+                                                    maxLongEdge: visionLongEdge)
+                ?? CGSize(width: ciImage.extent.width, height: ciImage.extent.height)
+            let userInput = UserInput(chat: chat, processing: .init(resize: resize))
             let lmInput = try await context.processor.prepare(input: userInput)
             let stream = try MLXLMCommon.generate(input: lmInput, parameters: parameters, context: context)
             var iterator = stream.makeAsyncIterator()
@@ -1019,6 +1053,10 @@ enum LocalLLMError: LocalizedError {
     case generationFailed(String)
     case backgrounded
     case insufficientMemory(neededBytes: Int64, availableBytes: Int64)
+    /// Not enough process allocation left to prefill a photo on the loaded model. Distinct from
+    /// `insufficientMemory`, which is about *loading*: here the model is loaded and working, and
+    /// only the image turn is out of reach.
+    case insufficientMemoryForPhoto
     case promptTooLong(tokens: Int, limit: Int)
     case alreadyGenerating
     case alreadyDownloading
@@ -1034,6 +1072,8 @@ enum LocalLLMError: LocalizedError {
         case .insufficientMemory(let needed, let available):
             let gb = { (bytes: Int64) in String(format: "%.1f", Double(bytes) / 1_073_741_824) }
             return "Not enough memory to load the on-device model — it needs about \(gb(needed)) GB but only \(gb(available)) GB is available. Free up about \(gb(needed - available)) GB by closing other apps, or switch to a cloud model."
+        case .insufficientMemoryForPhoto:
+            return "There isn't enough memory to look at a photo with the on-device model right now. Ask me without the picture, or switch to a cloud model."
         case .promptTooLong(let tokens, let limit):
             return "Prompt is too long for the on-device model (\(tokens) tokens; limit \(limit)). Switch to a cloud model for this request."
         case .alreadyGenerating:

--- a/OpenGlasses/Sources/Services/LocalModelBudget.swift
+++ b/OpenGlasses/Sources/Services/LocalModelBudget.swift
@@ -1,3 +1,4 @@
+import CoreGraphics
 import Foundation
 
 /// Pure prompt-budget logic for on-device (MLX) generation (BK P2).
@@ -103,6 +104,13 @@ enum LocalModelBudget {
         let keepsFullSystemPrompt: Bool
         /// Tokenized-prompt ceiling for the turn.
         let promptBudget: Int
+        /// Longest edge (pixels) the photo may reach the processor at. The image is resampled to
+        /// fit, aspect preserved — the preprocessing of a full-resolution frame is itself a
+        /// multi-hundred-megabyte spike on top of an already-resident multi-gigabyte model.
+        let imageLongEdge: Int
+        /// There is not enough headroom to attempt an image turn at all. The caller must refuse
+        /// out loud rather than start a prefill that ends as a process kill.
+        let refusesImage: Bool
     }
 
     /// Marketing RAM (GB) at or above which a phone carries a full multimodal turn. Below it,
@@ -115,17 +123,70 @@ enum LocalModelBudget {
     /// room for them.
     static let constrainedMultimodalBudgetFraction = 0.25
 
-    /// Per-device plan for an image turn. Pure — the caller supplies the device's RAM, so this
-    /// is exercised headlessly at both tiers.
-    static func multimodalTurnPlan(for modelId: String?, marketingRAMGB: Double) -> MultimodalTurnPlan {
+    /// Remaining process allocation below which an image turn is refused rather than attempted.
+    ///
+    /// Sized from a device kill: a 12 GB iPhone, on the "roomy" tier, with Gemma 4 loaded and the
+    /// camera pipeline live, took a photo turn to a 6.2 GB footprint and was terminated for
+    /// exceeding the **per-process** limit while frontmost. Marketing RAM never saw it coming,
+    /// because marketing RAM is not the constraint — iOS's per-process cap is, and it does not
+    /// scale with the box on the shelf.
+    static let multimodalRefusalHeadroomBytes: Int64 = 1_024 * 1024 * 1024
+
+    /// Remaining process allocation below which an image turn is trimmed even on a roomy phone.
+    static let multimodalFullPromptHeadroomBytes: Int64 = 2_048 * 1024 * 1024
+
+    /// Long edge for a photo on the roomy tier, and on the constrained tier.
+    static let fullImageLongEdge = 1_344
+    static let constrainedImageLongEdge = 896
+
+    /// Per-turn plan for an image turn.
+    ///
+    /// Pure — the caller supplies both the device's RAM and the headroom measured *at turn time*,
+    /// so every tier including the refusal is exercised headlessly. Headroom leads: a roomy device
+    /// with nothing left to allocate is a constrained device, whatever the spec sheet says.
+    ///
+    /// `availableBytes <= 0` means "no per-process budget on this platform" (simulator, Mac) and
+    /// skips the headroom gate entirely rather than refusing — the same rule `MemoryHeadroom`
+    /// follows, for the same reason: refusing on unknown bricks the environments that don't need
+    /// the guard.
+    static func multimodalTurnPlan(for modelId: String?,
+                                   marketingRAMGB: Double,
+                                   availableBytes: Int64 = 0) -> MultimodalTurnPlan {
         let full = promptBudget(for: modelId)
-        guard marketingRAMGB < multimodalFullPromptRAMGB else {
-            return MultimodalTurnPlan(keepsHistory: true, keepsFullSystemPrompt: true, promptBudget: full)
+        let headroomKnown = availableBytes > 0
+
+        if headroomKnown, availableBytes < multimodalRefusalHeadroomBytes {
+            return MultimodalTurnPlan(keepsHistory: false, keepsFullSystemPrompt: false,
+                                      promptBudget: minimumBudget,
+                                      imageLongEdge: constrainedImageLongEdge,
+                                      refusesImage: true)
+        }
+
+        let roomyDevice = marketingRAMGB >= multimodalFullPromptRAMGB
+        let roomyRightNow = !headroomKnown || availableBytes >= multimodalFullPromptHeadroomBytes
+        if roomyDevice && roomyRightNow {
+            return MultimodalTurnPlan(keepsHistory: true, keepsFullSystemPrompt: true,
+                                      promptBudget: full,
+                                      imageLongEdge: fullImageLongEdge,
+                                      refusesImage: false)
         }
         return MultimodalTurnPlan(
             keepsHistory: false,
             keepsFullSystemPrompt: false,
-            promptBudget: max(minimumBudget, Int(Double(full) * constrainedMultimodalBudgetFraction)))
+            promptBudget: max(minimumBudget, Int(Double(full) * constrainedMultimodalBudgetFraction)),
+            imageLongEdge: constrainedImageLongEdge,
+            refusesImage: false)
+    }
+
+    /// Aspect-preserving size for an image whose long edge must not exceed `maxLongEdge`, or nil
+    /// when it already fits and re-sampling would only spend memory to change nothing.
+    static func imageSize(width: Int, height: Int, maxLongEdge: Int) -> CGSize? {
+        guard width > 0, height > 0, maxLongEdge > 0 else { return nil }
+        let longEdge = max(width, height)
+        guard longEdge > maxLongEdge else { return nil }
+        let scale = Double(maxLongEdge) / Double(longEdge)
+        return CGSize(width: max(1, Int((Double(width) * scale).rounded())),
+                      height: max(1, Int((Double(height) * scale).rounded())))
     }
 
     /// Trim conversation history so the tokenized prompt fits `budget`, dropping the **oldest**

--- a/OpenGlasses/Sources/Services/ModelFallbackChain.swift
+++ b/OpenGlasses/Sources/Services/ModelFallbackChain.swift
@@ -60,6 +60,9 @@ enum ModelFallbackChain {
             case .promptTooLong: return .needsBiggerWindow
             case .backgrounded: return .retryOtherModel   // a cloud candidate can still run
             case .insufficientMemory: return .retryOtherModel   // cloud (or a smaller local model) still fits
+            // The model is loaded and working; only this turn's photo is out of reach on it. A
+            // cloud candidate has no such ceiling, so cascade rather than end the turn.
+            case .insufficientMemoryForPhoto: return .retryOtherModel
             case .modelNotLoaded, .generationFailed, .alreadyGenerating, .alreadyDownloading:
                 return .retryOtherModel
             }

--- a/OpenGlasses/Sources/Services/RecordingFiler.swift
+++ b/OpenGlasses/Sources/Services/RecordingFiler.swift
@@ -65,6 +65,11 @@ struct RecordingFiler {
         var folderRequested: Bool
         /// Where the user-folder copy landed, if one was made.
         var folderCopyURL: URL?
+        /// The Photos save was refused by authorization rather than failing on its own merits.
+        /// Worth its own flag because it is the only failure here the wearer can actually fix,
+        /// and telling them "couldn't save" when the answer is one switch in Settings is not
+        /// honest reporting — it is a dead end.
+        var photosNotPermitted: Bool = false
 
         /// True when at least one copy survives outside the temporary directory.
         var isPersisted: Bool {
@@ -93,6 +98,11 @@ struct RecordingFiler {
                      + "storage and may not survive. Free up some space and try again."
             }
             if photosRequested && !savedToPhotos {
+                if photosNotPermitted {
+                    return "OpenGlasses doesn't have permission to add to your photo library, so "
+                         + "the recording isn't in Photos. You can turn that on in Settings. It is "
+                         + "safe in \(location) — nothing was lost."
+                }
                 return "Couldn't save the recording to Photos. The recording is safe in "
                      + "\(location) — nothing was lost."
             }

--- a/OpenGlasses/Sources/Services/VideoRecordingService.swift
+++ b/OpenGlasses/Sources/Services/VideoRecordingService.swift
@@ -40,6 +40,28 @@ class VideoRecordingService: ObservableObject {
     // Accessed from background audio callback — must be nonisolated(unsafe)
     private nonisolated(unsafe) var audioInput: AVAssetWriterInput?
 
+    /// The writer, reachable from the background append callbacks so they can stop feeding one
+    /// that has already failed. An `AVAssetWriter` in `.failed` rejects every further append on
+    /// every track, so continuing to push at it only buries the first error.
+    private nonisolated(unsafe) var appendWriter: AVAssetWriter?
+
+    /// The stream description the audio input locked onto with its first sample buffer.
+    ///
+    /// An asset writer's audio input takes its format from the first buffer it accepts and fails
+    /// the whole writer — video track included — on the next one that disagrees. Capture audio is
+    /// normalised upstream (`CaptureAudioNormalizer`) precisely so this cannot happen, and this is
+    /// the belt to that pair of braces: a buffer in an unexpected format is dropped, loudly, rather
+    /// than allowed to kill the recording.
+    private nonisolated(unsafe) var audioStreamDescription: AudioStreamBasicDescription?
+    /// Reused for every buffer once the format is known — building one per buffer was pure waste.
+    private nonisolated(unsafe) var audioFormatDescription: CMAudioFormatDescription?
+    /// Buffers refused because their format didn't match the locked one. Reported at stop.
+    private nonisolated(unsafe) var mismatchedAudioBuffers: Int = 0
+
+    /// Reported to the on-screen diagnostics log: where a finished recording actually landed, and
+    /// why anything that didn't land, didn't. Optional; nothing here depends on it being wired.
+    var onDebugEvent: ((String) -> Void)?
+
     /// ID used to register as an audio buffer consumer on the capture audio router.
     private static let audioConsumerId = "video_recording_audio"
 
@@ -251,8 +273,12 @@ class VideoRecordingService: ObservableObject {
         writer.startSession(atSourceTime: .zero)
 
         self.writer = writer
+        self.appendWriter = writer
         self.videoInput = videoInput
         self.audioInput = audioInput
+        self.audioStreamDescription = nil
+        self.audioFormatDescription = nil
+        self.mismatchedAudioBuffers = 0
         self.adaptor = adaptor
         self.outputURL = url
         self.videoStartTime = nil
@@ -362,15 +388,33 @@ class VideoRecordingService: ObservableObject {
         // Stop meeting assistant
         meetingAssistant?.stop()
 
-        guard let writer, let videoInput else { return nil }
+        /// Non-nil when the encode itself went wrong — reported alongside wherever the bytes landed.
+        var writerFailure: String?
 
-        videoInput.markAsFinished()
-        audioInput?.markAsFinished()
+        // Whatever state the writer is in, everything below still runs: a recording that ended
+        // abnormally has bytes on disk that must be filed out of `tmp/` exactly like a clean one.
+        // Returning early here used to skip the filing step entirely (Plan DA's "never delete
+        // until a persistent copy exists" applies to abnormal ends too).
+        if let writer, let videoInput {
+            videoInput.markAsFinished()
+            audioInput?.markAsFinished()
 
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            writer.finishWriting {
-                cont.resume()
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                writer.finishWriting {
+                    cont.resume()
+                }
             }
+            if writer.status == .failed {
+                writerFailure = writer.error?.localizedDescription ?? "the recording could not be finished"
+                NSLog("[Recording] Writer failed: %@", writerFailure ?? "unknown")
+            }
+        } else {
+            writerFailure = "the recording could not be finished"
+            NSLog("[Recording] Stopped with no writer — filing whatever reached disk")
+        }
+        if mismatchedAudioBuffers > 0 {
+            NSLog("[Recording] Dropped %d audio buffer(s) in an unexpected format", mismatchedAudioBuffers)
+            onDebugEvent?("Recording dropped \(mismatchedAudioBuffers) mis-formatted audio buffer(s)")
         }
 
         let temporaryURL = outputURL
@@ -381,6 +425,14 @@ class VideoRecordingService: ObservableObject {
         // — the transcript sidecar, file protection, the URL handed back for sharing — works
         // against the filed location, not the temporary one.
         let url = await fileFinishedRecording(temporaryURL)
+
+        // A broken encode is worth saying out loud even when the bytes were filed: a playable
+        // prefix and an unplayable file look identical from the outside.
+        if let writerFailure {
+            let note = "Something went wrong while finishing the recording — \(writerFailure)."
+            lastSaveNote = [note, lastSaveNote].compactMap { $0 }.joined(separator: " ")
+            onDebugEvent?("Recording writer failed: \(writerFailure)")
+        }
 
         // Final caption collection
         if autoTranscribe {
@@ -425,8 +477,11 @@ class VideoRecordingService: ObservableObject {
         autoTranscribe = false
 
         self.writer = nil
+        self.appendWriter = nil
         self.videoInput = nil
         self.audioInput = nil
+        self.audioStreamDescription = nil
+        self.audioFormatDescription = nil
         self.adaptor = nil
         self.outputURL = nil
         self.videoStartTime = nil
@@ -482,8 +537,15 @@ class VideoRecordingService: ObservableObject {
                                  date: recordingStartDate ?? Date(),
                                  saveToPhotos: wantsPhotos)
 
-        if wantsPhotos {
-            outcome.savedToPhotos = await saveVideoToPhotos(outcome.primaryURL)
+        // Only offer Photos a file that is actually there — a failed encode leaves nothing behind,
+        // and asking the library to ingest a missing file reads as a save failure rather than as
+        // the encode failure it is.
+        if wantsPhotos, FileManager.default.fileExists(atPath: outcome.primaryURL.path) {
+            let result = await GlassesPhotoAlbum.saveVideo(at: outcome.primaryURL)
+            outcome.savedToPhotos = result.didSave
+            if case .notPermitted = result { outcome.photosNotPermitted = true }
+        } else if wantsPhotos {
+            NSLog("[Recording] Nothing on disk to hand to Photos")
         }
 
         if let copyURL = outcome.folderCopyURL {
@@ -491,28 +553,18 @@ class VideoRecordingService: ObservableObject {
         }
         lastSaveNote = outcome.message
         lastSaveSummary = outcome.summary
+        let photosState = outcome.savedToPhotos
+            ? "yes"
+            : (outcome.photosNotPermitted ? "not permitted" : (wantsPhotos ? "failed" : "off"))
         NSLog("[Recording] Filed → %@ (photos: %@, folder copy: %@)",
-              outcome.primaryURL.path,
-              outcome.savedToPhotos ? "yes" : (wantsPhotos ? "failed" : "off"),
+              outcome.primaryURL.path, photosState,
               outcome.folderCopyURL == nil ? (outcome.folderRequested ? "failed" : "none") : "yes")
+        // The chokepoint every recording passes through, so the next diagnostics report of this
+        // class carries the answer instead of a launch trace.
+        onDebugEvent?("Recording filed — app folder: \(outcome.savedToLibrary ? "yes" : "no"), "
+                      + "photos: \(photosState), "
+                      + "chosen folder: \(outcome.folderCopyURL == nil ? (outcome.folderRequested ? "failed" : "none") : "yes")")
         return outcome.primaryURL
-    }
-
-    // MARK: - Photos Library
-
-    /// Save the video file to the "Glasses" album in the Photos library.
-    /// Returns whether the save landed — a denied library or a failed change request is a normal
-    /// outcome here, not an error, because the on-disk copy has already been written.
-    ///
-    /// The album resolution and the single authorization prompt behind it live in
-    /// `GlassesPhotoAlbum`; this used to be one of two private copies of both.
-    @discardableResult
-    private func saveVideoToPhotos(_ url: URL) async -> Bool {
-        let saved = await GlassesPhotoAlbum.saveVideo(at: url)
-        if saved {
-            NSLog("[Recording] Video saved to %@ album", GlassesPhotoAlbum.albumName)
-        }
-        return saved
     }
 
     // MARK: - Transcript Persistence
@@ -556,6 +608,12 @@ class VideoRecordingService: ObservableObject {
     // MARK: - Frame Appending
 
     private nonisolated func appendFrame(_ image: UIImage) {
+        // A writer that has already failed rejects every further append on every track, so pushing
+        // at it only buries the first error. Deliberately *before* the watchdog stamp: with the
+        // writer dead nothing is reaching the file, and letting the stall watchdog notice is how a
+        // silently-dead recording gets stopped, saved and announced instead of running for ten
+        // minutes producing nothing.
+        guard appendWriter?.status == .writing else { return }
         lastFrameAt = Date()   // feeds the stream-death watchdog
         guard let cgImage = image.cgImage else { return }
 
@@ -614,9 +672,28 @@ class VideoRecordingService: ObservableObject {
     /// Append an audio buffer from the shared audio engine into the recording.
     private nonisolated func appendAudioBuffer(_ buffer: AVAudioPCMBuffer) {
         guard let audioInput, audioInput.isReadyForMoreMediaData else { return }
+        guard appendWriter?.status == .writing else { return }
 
         let format = buffer.format
         let frameCount = buffer.frameLength
+        guard frameCount > 0 else { return }
+
+        // The audio input locks to the first format it accepts; a later buffer that disagrees
+        // fails the writer and takes the video track down with it. Capture audio is normalised
+        // upstream so every buffer of a recording arrives in one format — if one somehow doesn't,
+        // drop it. A recording missing 20 ms of audio beats a recording that does not exist.
+        let incoming = format.streamDescription.pointee
+        if let locked = audioStreamDescription {
+            guard CaptureAudioFormatMatch.matches(incoming, locked) else {
+                mismatchedAudioBuffers += 1
+                if mismatchedAudioBuffers == 1 {
+                    NSLog("[Recording] Audio format changed mid-file (%.0fHz/%uch → %.0fHz/%uch) — dropping buffers rather than failing the writer",
+                          locked.mSampleRate, locked.mChannelsPerFrame,
+                          incoming.mSampleRate, incoming.mChannelsPerFrame)
+                }
+                return
+            }
+        }
 
         // Convert AVAudioPCMBuffer → CMSampleBuffer for AVAssetWriter
         var sampleBuffer: CMSampleBuffer?
@@ -636,19 +713,26 @@ class VideoRecordingService: ObservableObject {
             timing.presentationTimeStamp = .zero
         }
 
-        var formatDescription: CMAudioFormatDescription?
-        CMAudioFormatDescriptionCreate(
-            allocator: kCFAllocatorDefault,
-            asbd: format.streamDescription,
-            layoutSize: 0,
-            layout: nil,
-            magicCookieSize: 0,
-            magicCookie: nil,
-            extensions: nil,
-            formatDescriptionOut: &formatDescription
-        )
+        // Built once per recording, not once per buffer: the format is fixed by the first buffer
+        // and every later one is checked against it above.
+        if audioFormatDescription == nil {
+            var created: CMAudioFormatDescription?
+            CMAudioFormatDescriptionCreate(
+                allocator: kCFAllocatorDefault,
+                asbd: format.streamDescription,
+                layoutSize: 0,
+                layout: nil,
+                magicCookieSize: 0,
+                magicCookie: nil,
+                extensions: nil,
+                formatDescriptionOut: &created
+            )
+            guard created != nil else { return }
+            audioFormatDescription = created
+            audioStreamDescription = incoming
+        }
 
-        guard let desc = formatDescription else { return }
+        guard let desc = audioFormatDescription else { return }
 
         CMSampleBufferCreate(
             allocator: kCFAllocatorDefault,
@@ -677,7 +761,10 @@ class VideoRecordingService: ObservableObject {
             bufferList: audioBufferList
         )
 
-        audioInput.append(sb)
+        if !audioInput.append(sb) {
+            NSLog("[Recording] Audio append rejected: %@",
+                  appendWriter?.error?.localizedDescription ?? "unknown")
+        }
     }
 
     // MARK: - Pixel Buffer Pool

--- a/OpenGlassesTests/BroadcastResilienceTests.swift
+++ b/OpenGlassesTests/BroadcastResilienceTests.swift
@@ -375,19 +375,36 @@ final class BroadcastResilienceTests: XCTestCase {
                                      targetBitrate: 3_000_000,
                                      measuredBitrate: 2_400_000,
                                      droppedFrameCount: 4,
-                                     duration: 61)
+                                     duration: 61,
+                                     hasSentAnything: true)
         XCTAssertEqual(health.stateLabel, "Live")
         XCTAssertEqual(health.bitrateLabel, "2.4 Mbps")
         XCTAssertEqual(health.frameRateLabel, "29 fps")
     }
 
-    func testHealthFallsBackToTheTargetBeforeAnythingIsMeasured() {
-        let health = BroadcastHealth(state: .connecting, targetBitrate: 3_100_000)
+    func testHealthShowsTheTargetOnceSomethingIsActuallyFlowing() {
+        // Between "the first bytes went out" and "the transport has reported a rate", the target
+        // is the honest thing to show: it is what the encoder is aiming for, and something is
+        // moving.
+        let health = BroadcastHealth(state: .live, targetBitrate: 3_100_000, hasSentAnything: true)
         XCTAssertEqual(health.bitrateLabel, "3.1 Mbps")
     }
 
+    func testAConnectionThatHasSentNothingShowsNoBitrateAtAll() {
+        // The device readout that started this: "3.7 Mbps · 0 fps" on a connection the ingest
+        // never received a byte from. The target described an intention; printing it next to the
+        // measurement that disproved it is the bug.
+        let health = BroadcastHealth(state: .live,
+                                     achievedFrameRate: 0,
+                                     targetBitrate: 3_700_000,
+                                     hasSentAnything: false)
+        XCTAssertEqual(health.bitrateLabel, "—")
+        XCTAssertEqual(health.stateLabel, "Nothing sent yet")
+    }
+
     func testHealthRendersSubMegabitRatesInKilobits() {
-        let health = BroadcastHealth(state: .live, targetBitrate: 0, measuredBitrate: 820_000)
+        let health = BroadcastHealth(state: .live, targetBitrate: 0, measuredBitrate: 820_000,
+                                     hasSentAnything: true)
         XCTAssertEqual(health.bitrateLabel, "820 kbps")
     }
 
@@ -398,5 +415,67 @@ final class BroadcastResilienceTests: XCTestCase {
     func testReconnectingLabelNamesTheAttempt() {
         let health = BroadcastHealth(state: .reconnecting(attempt: 3))
         XCTAssertEqual(health.stateLabel, "Reconnecting 3")
+    }
+
+    // MARK: - Connected, and sending nothing
+
+    func testFlowingIsNeverCalledStalledHoweverLongItRuns() {
+        XCTAssertEqual(
+            BroadcastStallPolicy.verdict(secondsSinceStart: 600, hasSentAnything: true), .flowing)
+    }
+
+    func testTheGracePeriodCoversAHandshakeAndThePriming() {
+        XCTAssertEqual(
+            BroadcastStallPolicy.verdict(secondsSinceStart: 3, hasSentAnything: false), .tooEarly)
+    }
+
+    func testSilencePastTheGracePeriodIsAStall() {
+        XCTAssertEqual(
+            BroadcastStallPolicy.verdict(secondsSinceStart: 9, hasSentAnything: false), .stalled)
+    }
+
+    func testPrivateAddressesAreRecognisedAsLocalNetwork() {
+        for target in ["rtmp://192.168.1.103:1935/live", "10.0.0.4", "172.20.3.9",
+                       "rtmp://mediaserver.local/live", "localhost", "169.254.1.1"] {
+            XCTAssertTrue(BroadcastStallPolicy.isPrivateNetworkHost(target), target)
+        }
+    }
+
+    func testPublicIngestsAreNotTreatedAsLocalNetwork() {
+        for target in ["rtmp://a.rtmp.youtube.com/live2", "203.0.113.7", "172.32.0.1",
+                       "192.169.1.1", ""] {
+            XCTAssertFalse(BroadcastStallPolicy.isPrivateNetworkHost(target), target)
+        }
+    }
+
+    func testHostIsTakenOutOfAFullRTMPURL() {
+        XCTAssertEqual(BroadcastStallPolicy.host(from: "rtmp://192.168.1.103:1935/live"),
+                       "192.168.1.103")
+        XCTAssertEqual(BroadcastStallPolicy.host(from: "rtmp://user:pw@host.example/app"),
+                       "host.example")
+        XCTAssertEqual(BroadcastStallPolicy.host(from: "192.168.1.103"), "192.168.1.103")
+    }
+
+    func testAStalledLocalTargetNamesTheLocalNetworkSetting() {
+        let message = BroadcastStallPolicy.stalledMessage(target: "rtmp://192.168.1.103:1935/live")
+        XCTAssertTrue(message.contains("Local Network"), message)
+    }
+
+    func testAStallIsADropSoTheReconnectMachineryGetsItsShot() {
+        // A session that published and then wrote nothing is dead, and the session machine has to
+        // agree — otherwise the stall is a message next to a stream that idles forever instead of
+        // retrying. A fresh connection may well come up writable.
+        var machine = BroadcastSessionMachine()
+        machine.apply(.start)
+        XCTAssertTrue(machine.apply(.connected))
+        XCTAssertTrue(machine.apply(.dropped),
+                      "a zero-bytes stall must be accepted as a drop from live")
+        XCTAssertEqual(machine.state, .reconnecting(attempt: 1))
+    }
+
+    func testAStalledPublicTargetDoesNotBlameAPermissionItCannotHaveHit() {
+        let message = BroadcastStallPolicy.stalledMessage(target: "rtmp://a.rtmp.youtube.com/live2")
+        XCTAssertFalse(message.contains("Local Network"), message)
+        XCTAssertTrue(message.contains("stream key"), message)
     }
 }

--- a/OpenGlassesTests/CaptureAudioTests.swift
+++ b/OpenGlassesTests/CaptureAudioTests.swift
@@ -465,4 +465,178 @@ final class CaptureAudioRouterTests: XCTestCase {
         await router.settleForTesting()
         XCTAssertEqual(tap.consumerIds, [CaptureAudioRouter.sourceConsumerId])
     }
+
+    // MARK: - One format across a handover
+
+    /// A source-shaped buffer: the two engines take their format from whatever route they start
+    /// on, so a handover can change the sample rate under consumers.
+    private func buffer(sampleRate: Double, channels: AVAudioChannelCount = 1,
+                        frames: AVAudioFrameCount = 256, level: Float = 0.8) -> AVAudioPCMBuffer {
+        let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: channels)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames)!
+        buffer.frameLength = frames
+        for channel in 0..<Int(channels) {
+            let data = buffer.floatChannelData![channel]
+            for frame in 0..<Int(frames) { data[frame] = level }
+        }
+        return buffer
+    }
+
+    /// Records the format of everything it is handed.
+    private final class FormatSink: @unchecked Sendable {
+        private(set) var rates: [Double] = []
+        private(set) var channels: [AVAudioChannelCount] = []
+        func receive(_ buffer: AVAudioPCMBuffer) {
+            rates.append(buffer.format.sampleRate)
+            channels.append(buffer.format.channelCount)
+        }
+    }
+
+    func testHandoverDoesNotChangeTheFormatConsumersSee() async {
+        // The device defect: enabling the listener mid-recording swapped a 48 kHz phone-mic engine
+        // for a 16 kHz glasses tap, the asset writer rejected the first buffer of the new format,
+        // and the whole writer — video track included — went to .failed a second later.
+        let router = makeRouter()
+        let sink = FormatSink()
+        router.addAudioBufferConsumer(id: "recording") { sink.receive($0) }
+        await router.settleForTesting()
+
+        standalone.push(buffer(sampleRate: 48_000))
+        router.setWakeListening(true)
+        await router.settleForTesting()
+        tap.push(buffer(sampleRate: 16_000))
+        tap.push(buffer(sampleRate: 16_000))
+
+        XCTAssertEqual(sink.rates.count, 3, "no buffer may be dropped at the handover")
+        XCTAssertEqual(Set(sink.rates), [48_000],
+                       "consumers must keep seeing the format the capture started on")
+    }
+
+    func testHandoverBackAlsoHoldsTheFormat() async {
+        // The fix has to hold in both directions: listening on → off mid-capture is the same swap.
+        let router = makeRouter()
+        let sink = FormatSink()
+        router.setWakeListening(true)
+        router.addAudioBufferConsumer(id: "broadcast") { sink.receive($0) }
+        await router.settleForTesting()
+
+        tap.push(buffer(sampleRate: 16_000, channels: 1))
+        router.setWakeListening(false)
+        await router.settleForTesting()
+        standalone.push(buffer(sampleRate: 48_000, channels: 2))
+
+        XCTAssertEqual(sink.rates.count, 2)
+        XCTAssertEqual(Set(sink.rates), [16_000])
+        XCTAssertEqual(Set(sink.channels), [1])
+    }
+
+    func testANewCaptureAdoptsTheRouteItStartsOn() async {
+        // The canonical format is held for the life of a *capture*, not for the life of the app:
+        // a recording made an hour ago must not pin the next one to a route that has since gone.
+        let router = makeRouter()
+        let first = FormatSink()
+        router.addAudioBufferConsumer(id: "recording") { first.receive($0) }
+        await router.settleForTesting()
+        standalone.push(buffer(sampleRate: 48_000))
+        router.removeAudioBufferConsumer(id: "recording")
+        await router.settleForTesting()
+
+        let second = FormatSink()
+        router.addAudioBufferConsumer(id: "recording") { second.receive($0) }
+        await router.settleForTesting()
+        standalone.push(buffer(sampleRate: 16_000))
+
+        XCTAssertEqual(first.rates, [48_000])
+        XCTAssertEqual(second.rates, [16_000])
+    }
+}
+
+// MARK: - Normalizer
+
+final class CaptureAudioNormalizerTests: XCTestCase {
+
+    private func buffer(sampleRate: Double, channels: AVAudioChannelCount = 1,
+                        frames: AVAudioFrameCount = 480, level: Float = 0.5) -> AVAudioPCMBuffer {
+        let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: channels)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames)!
+        buffer.frameLength = frames
+        for channel in 0..<Int(channels) {
+            let data = buffer.floatChannelData![channel]
+            for frame in 0..<Int(frames) { data[frame] = level }
+        }
+        return buffer
+    }
+
+    func testTheFirstBufferFixesTheFormatAndIsPassedThroughUntouched() {
+        let normalizer = CaptureAudioNormalizer()
+        let source = buffer(sampleRate: 48_000)
+        let out = normalizer.normalize(source)
+        XCTAssertTrue(out === source, "a capture's first buffer must not be copied or resampled")
+        XCTAssertEqual(normalizer.canonicalFormat?.sampleRate, 48_000)
+    }
+
+    func testMatchingBuffersAreNotCopied() {
+        // The steady state, and every capture that never sees a handover: no conversion at all.
+        let normalizer = CaptureAudioNormalizer()
+        _ = normalizer.normalize(buffer(sampleRate: 48_000))
+        let next = buffer(sampleRate: 48_000)
+        XCTAssertTrue(normalizer.normalize(next) === next)
+    }
+
+    func testADifferentRateIsResampledIntoTheCanonicalFormat() {
+        let normalizer = CaptureAudioNormalizer()
+        _ = normalizer.normalize(buffer(sampleRate: 48_000, frames: 480))
+        let converted = normalizer.normalize(buffer(sampleRate: 16_000, frames: 160))
+        XCTAssertNotNil(converted)
+        XCTAssertEqual(converted?.format.sampleRate, 48_000)
+        XCTAssertEqual(converted?.format.channelCount, 1)
+        XCTAssertGreaterThan(converted?.frameLength ?? 0, 0)
+        XCTAssertEqual(normalizer.conversionFailureCount, 0)
+    }
+
+    func testADifferentChannelCountIsMixedIntoTheCanonicalFormat() {
+        let normalizer = CaptureAudioNormalizer()
+        _ = normalizer.normalize(buffer(sampleRate: 48_000, channels: 1))
+        let converted = normalizer.normalize(buffer(sampleRate: 48_000, channels: 2))
+        XCTAssertEqual(converted?.format.channelCount, 1)
+        XCTAssertEqual(converted?.format.sampleRate, 48_000)
+    }
+
+    func testConvertedAudioIsNotSilence() {
+        // A conversion that "succeeds" into zeroes would look fine to the writer and sound like a
+        // dead mic, which is the failure mode this whole path exists to avoid.
+        let normalizer = CaptureAudioNormalizer()
+        _ = normalizer.normalize(buffer(sampleRate: 48_000, level: 0.5))
+        // Several blocks, because a resampler's first output block rises out of its own priming.
+        var peak: Float = 0
+        for _ in 0..<4 {
+            let converted = normalizer.normalize(buffer(sampleRate: 16_000, frames: 160, level: 0.5))!
+            let data = converted.floatChannelData![0]
+            for frame in 0..<Int(converted.frameLength) { peak = max(peak, abs(data[frame])) }
+        }
+        XCTAssertGreaterThan(peak, 0.1)
+        XCTAssertEqual(normalizer.conversionFailureCount, 0)
+    }
+
+    func testResetLetsTheNextCapturePickItsOwnFormat() {
+        let normalizer = CaptureAudioNormalizer()
+        _ = normalizer.normalize(buffer(sampleRate: 48_000))
+        normalizer.reset()
+        XCTAssertNil(normalizer.canonicalFormat)
+        _ = normalizer.normalize(buffer(sampleRate: 16_000))
+        XCTAssertEqual(normalizer.canonicalFormat?.sampleRate, 16_000)
+    }
+
+    func testFormatMatchIsByStreamDescription() {
+        let mono48 = AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 1)!
+        let mono16 = AVAudioFormat(standardFormatWithSampleRate: 16_000, channels: 1)!
+        let stereo48 = AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 2)!
+        let interleaved48 = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 48_000,
+                                          channels: 1, interleaved: true)!
+        XCTAssertTrue(CaptureAudioFormatMatch.matches(mono48, mono48))
+        XCTAssertFalse(CaptureAudioFormatMatch.matches(mono48, mono16))
+        XCTAssertFalse(CaptureAudioFormatMatch.matches(mono48, stereo48))
+        // Same audio, different packing — and it is the packing an asset writer locks onto.
+        XCTAssertFalse(CaptureAudioFormatMatch.matches(mono48, interleaved48))
+    }
 }

--- a/OpenGlassesTests/ChatGPTVisionGateTests.swift
+++ b/OpenGlassesTests/ChatGPTVisionGateTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import OpenGlasses
+
+/// The ChatGPT (Codex/Responses) subscription provider's image-input acceptance was never
+/// actually confirmed on device (docs/plans/BW P4's image-turn checklist item is still
+/// unchecked), so `ChatGPTVisionGate` refuses a photo turn instead of sending it behind a
+/// system prompt that insists the model can see. Pure decision logic — no network, no
+/// `.shared` services, no `LLMService` instance required.
+final class ChatGPTVisionGateTests: XCTestCase {
+
+    func testChatGPTWithImageDeclinesVision() {
+        let decision = ChatGPTVisionGate.decide(provider: .chatgpt, hasImage: true)
+        guard case .declineVision(let message) = decision else {
+            return XCTFail("expected .declineVision, got \(decision)")
+        }
+        XCTAssertEqual(message, ChatGPTVisionGate.declineMessage)
+    }
+
+    func testChatGPTWithoutImageIsUnaffected() {
+        XCTAssertEqual(ChatGPTVisionGate.decide(provider: .chatgpt, hasImage: false), .sendWithImage)
+    }
+
+    func testNonChatGPTProvidersWithImageAreUnaffected() {
+        // Representative of the other paths this fix must not touch: API-key OpenAI, an
+        // on-device local model, and Gemini all still get their image sent normally.
+        for provider: LLMProvider in [.openai, .gemini, .geminiVertex, .anthropic, .local, .appleOnDevice] {
+            XCTAssertEqual(ChatGPTVisionGate.decide(provider: provider, hasImage: true), .sendWithImage,
+                           "\(provider) must not be affected by the ChatGPT-only vision gate")
+        }
+    }
+
+    func testDeclineMessageIsHonestAndPointsAtAlternativesWithoutJargon() {
+        let message = ChatGPTVisionGate.declineMessage
+        XCTAssertTrue(message.contains("can't see photos"), "must be honest about the limitation")
+        XCTAssertTrue(message.contains("OpenAI API key"), "must name the API-key alternative")
+        XCTAssertTrue(message.contains("Gemini"), "must name the Gemini alternative")
+        XCTAssertTrue(message.contains("on-device"), "must name the on-device alternative")
+        // No internal plan letters or codenames leaking into user-visible copy.
+        XCTAssertFalse(message.lowercased().contains("plan "), "must not reference internal plan docs")
+        XCTAssertFalse(message.lowercased().contains("codex"), "must not use internal/jargon model-family names")
+    }
+}

--- a/OpenGlassesTests/Gemma4ChatPromptTests.swift
+++ b/OpenGlassesTests/Gemma4ChatPromptTests.swift
@@ -171,6 +171,86 @@ final class Gemma4ChatPromptTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(plan.promptBudget, LocalModelBudget.minimumBudget)
     }
 
+    // MARK: - Headroom, not marketing RAM
+
+    private static let gemma = "mlx-community/gemma-4-e2b-it-4bit"
+    private static let gigabyte: Int64 = 1_073_741_824
+
+    /// The device kill this gate exists for: a 12 GB iPhone on the roomy tier, Gemma resident and
+    /// the camera live, taken to a 6.2 GB footprint by a photo turn and terminated for exceeding
+    /// the *per-process* limit while frontmost. Marketing RAM said "roomy" the whole way down.
+    func testTheMeasuredCrashScenarioIsRefusedNotAttempted() {
+        // ~0.3 GB left to allocate on a 12 GB phone at the moment the photo turn began.
+        let plan = LocalModelBudget.multimodalTurnPlan(
+            for: Self.gemma, marketingRAMGB: 12, availableBytes: Int64(0.3 * Double(Self.gigabyte)))
+        XCTAssertTrue(plan.refusesImage,
+                      "a turn with no headroom must be refused out loud, never attempted")
+    }
+
+    func testARoomyDeviceRunningLowIsTreatedAsConstrained() {
+        // Headroom leads: 12 GB on the box, 1.5 GB left in the process — that is the small-device
+        // case, and it gets the small-device plan rather than the full prompt and history.
+        let plan = LocalModelBudget.multimodalTurnPlan(
+            for: Self.gemma, marketingRAMGB: 12, availableBytes: Int64(1.5 * Double(Self.gigabyte)))
+        XCTAssertFalse(plan.refusesImage)
+        XCTAssertFalse(plan.keepsHistory)
+        XCTAssertFalse(plan.keepsFullSystemPrompt)
+        XCTAssertEqual(plan.imageLongEdge, LocalModelBudget.constrainedImageLongEdge)
+    }
+
+    func testARoomyDeviceWithRealHeadroomKeepsTheWholeTurn() {
+        let plan = LocalModelBudget.multimodalTurnPlan(
+            for: Self.gemma, marketingRAMGB: 12, availableBytes: 4 * Self.gigabyte)
+        XCTAssertFalse(plan.refusesImage)
+        XCTAssertTrue(plan.keepsHistory)
+        XCTAssertTrue(plan.keepsFullSystemPrompt)
+        XCTAssertEqual(plan.imageLongEdge, LocalModelBudget.fullImageLongEdge)
+    }
+
+    func testUnknownHeadroomSkipsTheGateRatherThanRefusing() {
+        // `os_proc_available_memory()` returns 0 where no per-process budget applies (simulator,
+        // Mac). Refusing on unknown would brick exactly the environments that don't need this.
+        let plan = LocalModelBudget.multimodalTurnPlan(
+            for: Self.gemma, marketingRAMGB: 12, availableBytes: 0)
+        XCTAssertFalse(plan.refusesImage)
+        XCTAssertTrue(plan.keepsHistory)
+    }
+
+    func testASmallDeviceWithHeadroomIsStillTrimmedNotRefused() {
+        let plan = LocalModelBudget.multimodalTurnPlan(
+            for: Self.gemma, marketingRAMGB: 8, availableBytes: 4 * Self.gigabyte)
+        XCTAssertFalse(plan.refusesImage)
+        XCTAssertFalse(plan.keepsHistory)
+        XCTAssertEqual(plan.imageLongEdge, LocalModelBudget.constrainedImageLongEdge)
+    }
+
+    // MARK: - Bounding the image itself
+
+    func testAFullResolutionPhotoIsBoundedWithItsAspectKept() {
+        // A glasses frame, not a square: squashing it to 896² was the old cap's cost, and having
+        // no cap at all was the memory spike that replaced it.
+        let size = LocalModelBudget.imageSize(width: 4032, height: 3024, maxLongEdge: 1344)
+        XCTAssertEqual(size?.width, 1344)
+        XCTAssertEqual(size?.height, 1008)
+    }
+
+    func testAPortraitPhotoIsBoundedOnItsLongEdge() {
+        let size = LocalModelBudget.imageSize(width: 1080, height: 1920, maxLongEdge: 896)
+        XCTAssertEqual(size?.height, 896)
+        XCTAssertEqual(size?.width, 504)
+    }
+
+    func testAnImageAlreadyWithinBudgetIsNotResampled() {
+        // Re-sampling a small image spends memory to change nothing, which is the opposite of
+        // what this is for.
+        XCTAssertNil(LocalModelBudget.imageSize(width: 640, height: 480, maxLongEdge: 1344))
+    }
+
+    func testDegenerateSizesAreLeftAlone() {
+        XCTAssertNil(LocalModelBudget.imageSize(width: 0, height: 0, maxLongEdge: 1344))
+        XCTAssertNil(LocalModelBudget.imageSize(width: 4032, height: 3024, maxLongEdge: 0))
+    }
+
     /// Text turns are unaffected by the tiering — their prefill is chunked, so a fat prompt
     /// costs time rather than a resident-memory spike.
     func testTextBudgetIsUnchangedByDeviceRAM() {

--- a/OpenGlassesTests/GlassesPhotoAlbumPolicyTests.swift
+++ b/OpenGlassesTests/GlassesPhotoAlbumPolicyTests.swift
@@ -93,4 +93,22 @@ final class GlassesPhotoAlbumPolicyTests: XCTestCase {
         XCTAssertFalse(GlassesPhotoAlbumPolicy.isAlbumAlreadyExists(otherCode))
         XCTAssertFalse(GlassesPhotoAlbumPolicy.isAlbumAlreadyExists(otherDomain))
     }
+
+    // MARK: - Telling the three "not saved" cases apart
+
+    func testEveryStatusHasItsOwnWord() {
+        // A field report that says only "access denied" cannot distinguish a wearer who declined
+        // from a prompt that was never presented — the two need completely different answers.
+        let described: [PHAuthorizationStatus] = [.authorized, .limited, .denied, .restricted, .notDetermined]
+        let words = described.map(GlassesPhotoAlbumPolicy.describe)
+        XCTAssertEqual(words, ["authorized", "limited", "denied", "restricted", "not determined"])
+        XCTAssertEqual(Set(words).count, words.count)
+    }
+
+    func testSaveResultDistinguishesRefusalFromFailure() {
+        XCTAssertTrue(PhotoLibrarySaveResult.saved.didSave)
+        XCTAssertFalse(PhotoLibrarySaveResult.failed.didSave)
+        XCTAssertFalse(PhotoLibrarySaveResult.notPermitted(.notDetermined).didSave)
+        XCTAssertNotEqual(PhotoLibrarySaveResult.notPermitted(.denied), .failed)
+    }
 }

--- a/OpenGlassesTests/RecordingFilerTests.swift
+++ b/OpenGlassesTests/RecordingFilerTests.swift
@@ -305,6 +305,35 @@ final class RecordingFilerTests: XCTestCase {
                        + "the app's Recordings folder — nothing was lost.")
     }
 
+    func testADeniedLibrarySaysSoAndPointsAtSettings() throws {
+        // Field report: a fresh install saved nothing to Photos and said nothing about it. "Couldn't
+        // save" is a dead end when the answer is one switch — the copy has to name it.
+        let source = try makeSourceFile()
+        let filer = RecordingFiler(recordingsDirectory: recordings)
+
+        var outcome = filer.file(source, date: date("2026-08-24 14:30:12"), saveToPhotos: true)
+        outcome.savedToPhotos = false
+        outcome.photosNotPermitted = true
+
+        XCTAssertEqual(outcome.message,
+                       "OpenGlasses doesn't have permission to add to your photo library, so the "
+                       + "recording isn't in Photos. You can turn that on in Settings. It is safe "
+                       + "in the app's Recordings folder — nothing was lost.")
+    }
+
+    func testAFailedPhotosSaveStillReadsAsAFailureNotAPermissionProblem() throws {
+        let source = try makeSourceFile()
+        let filer = RecordingFiler(recordingsDirectory: recordings)
+
+        var outcome = filer.file(source, date: date("2026-08-24 14:30:12"), saveToPhotos: true)
+        outcome.savedToPhotos = false
+        outcome.photosNotPermitted = false
+
+        XCTAssertEqual(outcome.message,
+                       "Couldn't save the recording to Photos. The recording is safe in "
+                       + "the app's Recordings folder — nothing was lost.")
+    }
+
     func testEverythingLandingSaysNothing() throws {
         let folder = root.appendingPathComponent("Chosen")
         let source = try makeSourceFile()

--- a/docs/plans/BW-chatgpt-subscription-provider.md
+++ b/docs/plans/BW-chatgpt-subscription-provider.md
@@ -95,7 +95,15 @@ confirmed covered. **Live half: pending, needs the phone + a real ChatGPT accoun
 - [ ] One streamed text turn (Chat tab), one buffered voice turn.
 - [ ] One tool turn (a native tool AND an MCP tool) — watch the `ChatGPT turn: N tool
       call(s) parsed` log line.
-- [ ] One image turn (photo question) — confirms `input_image` acceptance on codex models.
+- [ ] One image turn (photo question) — would confirm `input_image` acceptance on codex models.
+      **Closed in the negative for now (2026-08-27).** This was never run, yet the provider was
+      marked vision-capable and photo turns were handed the image *and* a system prompt insisting
+      "You CAN see it — never deny vision" — which invites a described scene the model never saw.
+      Every catalog entry is a coding variant with no vision sibling, so the honest default is no:
+      `ModelConfig.inferredSupportsVision` reports `false` for this provider, and
+      `ChatGPTVisionGate` declines a photo turn out loud (pointing at an API key, Gemini, or the
+      on-device model) before an image byte is sent. If a live turn ever *does* prove acceptance,
+      the gate is the one place to reopen, per model.
 - [ ] Token refresh across an expiry (leave the app overnight, ask again).
 - [ ] Verify the endpoint constants against the live service (the P1 constants block is
       captured-at-implementation and unverified until this runs).

--- a/docs/plans/CY-broadcast-resilience-and-quality.md
+++ b/docs/plans/CY-broadcast-resilience-and-quality.md
@@ -163,7 +163,89 @@ throttling. "30 configured, 6 achieved" is a diagnosis; a lit LIVE badge is not.
   achieved frame rate, and dropped frames when there are any. Deliberately subtle and monospaced,
   matching the recording-duration capsule above it.
 
-## P4 — Device/network verification (deferred, needs hardware)
+## P4 — Device/network verification (first hardware run, 2026-08-27)
+
+Broadcast to an RTMP ingest on the same network was run on hardware. **The reconnect machinery
+works** — the backoff grew exactly as designed, and the session-state machine behaved. What it was
+faithfully reconnecting *from* is the finding: the ingest logged connection after connection
+opening and timing out after ten seconds having received **zero bytes** — no handshake, no publish.
+The initial publish never happened, and nothing in the app noticed or said so.
+
+Two things were wrong on our side of that, independent of whatever the transport was doing:
+
+- **The readout implied flow that did not exist.** `bitrateLabel` fell back to the *target* bitrate
+  whenever the transport hadn't reported, so the health bar read "3.7 Mbps · 0 fps" for a connection
+  the server never received a byte from. A target is an intention; printing it beside the
+  measurement that disproves it is worse than printing nothing. `BroadcastHealth.hasSentAnything`
+  now gates it, and the badge says "Nothing sent yet" rather than "Live".
+- **Nothing watched for the silence.** `BroadcastStallPolicy` calls a connection stalled when it is
+  past a grace period with nothing measured, and the tick reports it once, with copy that names
+  iOS's local-network permission when the target is a private address (the most common cause with
+  exactly this shape on a fresh install: the app believes it is connected and nothing arrives) and
+  stays generic — stream key, server accepting a publish — when it isn't. It does not tear the
+  session down; the reconnect may still succeed.
+
+The `NSLocalNetworkUsageDescription` copy also only described discovering AI servers, so the prompt
+made no sense in a streaming context; it now covers both.
+
+### What the simulator ruled out
+
+The permission theory was disproved on hardware: the wearer granted Local Network, force-restarted,
+went live again, and two fresh attempts showed the identical signature — TCP opened, zero bytes,
+server timeout at ten seconds.
+
+So the connect sequence itself was put under a byte-level probe from the simulator: a listener that
+records the first bytes of any connection, and two paths driven against it — a bare
+`RTMPConnection().connect()`, and our exact order (stream created against the connection, video and
+audio codec settings applied, mixer built and wired, then connect). **Both wrote the C0/C1
+handshake, byte-identical in shape** (`03 00 00 00 00 …`). Driven against a real RTMP ingest the same
+sequence went further still: connect returned, and the publish was accepted — the session went live.
+
+So the publish path, never once proven against a live ingest in the original work, is now proven
+from the simulator. It is not what fails.
+
+That refutes the three obvious candidates for our side of it: no deadlock between the main actor
+and the status-consumption tasks, no wrong-actor invocation, and no malformed connect URL. Our call
+sequence is not what stops the handshake.
+
+**The trigger is therefore device-specific, and the mechanism is most likely below us.** In
+HaishinKit's `RTMPSocket`, `send(_:)` returns early when `connected` is false — silently, no throw,
+no log:
+
+```swift
+func send(_ data: Data) {
+    guard connected else { return }
+    …
+}
+```
+
+`RTMPConnection.connect` writes the handshake immediately after the socket reports ready. `connected`
+is set true in `stateDidChange(.ready)`, but `viabilityUpdateHandler` runs through a *separate*,
+unordered actor hop, and `viabilityDidChange(false)` calls `close()` — which clears `connected` and
+`outputs`. A viability flap landing after ready leaves the socket TCP-open with the handshake write
+discarded and the receive loop (`while connected`) exiting immediately: precisely the observed
+signature, and precisely the kind of flap a phone's local-network machinery can produce and a
+simulator never will.
+
+This is **not** proven, and the fix does not depend on it being right.
+
+### What the fix is
+
+Detection, not diagnosis. `NetworkMonitorReport.totalBytesOut` — the transport's own cumulative
+count of bytes written — is plumbed through the bitrate controller, per connection attempt. A
+connection that has published and still written nothing past a grace period is treated as **dropped**
+and routed into `handleConnectionLoss`, so the reconnect machinery gets its shot; if no attempt ever
+comes up writable, the reconnect policy's give-up budget ends the session honestly. The per-second
+measured bitrate cannot carry this — it legitimately reads zero between keyframes on a healthy
+stream — which is why the cumulative count is the signal.
+
+The guard is unconditional rather than gated on the mechanism above, so it holds whatever the real
+trigger turns out to be. Nothing in the dependency is forked or patched; the upstream silent-drop is
+noted for a report.
+
+### Still owed on hardware
+
+- **A successful publish to a LAN ingest**, once the cause is known.
 
 Everything above is decision logic or wiring and is covered headlessly. What is not:
 

--- a/docs/plans/CZ-independent-capture-audio.md
+++ b/docs/plans/CZ-independent-capture-audio.md
@@ -126,7 +126,60 @@ says the audio behaviour plainly. The stale "streams are silent while listening 
 comments in `BroadcastService` and in the [BS](BS-transcript-guard-and-broadcast-breadth.md) plan
 doc are corrected rather than deleted, so the history stays legible.
 
-## P5 — Device verification (owed)
+## P5 — Device verification (partly done, 2026-08-27)
+
+### What the device found
+
+The mid-stream handover was run on hardware for the first time, and it broke the recording rather
+than the audio. Repro: listening off → start a video recording from the UI → turn listening on
+mid-recording → about a second later the recording ends.
+
+Root cause, and it is one the headless suite could not have caught because both fakes pushed the
+same format: **the two sources are two `AVAudioEngine`s, and each takes its tap format from
+`inputNode.outputFormat(forBus: 0)` — whatever route that engine starts on.** A handover therefore
+changes the sample format under the consumers. `VideoRecordingService` built a fresh
+`CMAudioFormatDescription` per buffer and appended it, so the first buffer of the new format was
+rejected by the audio input and moved the whole `AVAssetWriter` to `.failed` — which takes the
+*video* track down with it. Not "the recording lost its audio": the recording died, `finishWriting`
+had nothing to hand back, and nothing on that path checked `writer.status` or said a word.
+
+That also explains the recording never appearing in Photos on those attempts: there was no file.
+
+### What the fix is
+
+- **`CaptureAudioNormalizer`** at the router boundary. The first buffer of a capture fixes the
+  canonical format; every later buffer is converted into it with a per-source `AVAudioConverter`,
+  and matching buffers (the whole steady state, and every capture that never sees a handover) pass
+  through untouched. A conversion that fails yields silence of the same duration rather than `nil`,
+  because dropping the slot would shift the broadcast's sample-count clock permanently. The format
+  is released when a capture ends, so the next one adopts the route it actually starts on.
+- **Recorder hardening**, as the second brace: the audio format description is built once and later
+  buffers are checked against it and dropped if they disagree; both append paths bail when the
+  writer is already `.failed`; a failed writer is reported on `lastSaveNote` instead of passing as a
+  successful stop; and `stopRecording` files whatever reached disk even when it is torn down with no
+  writer at all (Plan DA's "never delete before a persistent copy exists" applies to abnormal ends
+  too, and that path used to return early and skip filing entirely).
+- **Diagnostics.** Source handovers, the filer's per-destination outcome and the photo-library
+  authorization status now reach the in-app debug log, not just `NSLog`. A field report of exactly
+  this class arrived containing nothing but a launch trace, because none of these paths said
+  anything a wearer could send.
+
+Covered by new headless tests: sources pushing *different* formats across a handover in both
+directions, no buffer dropped, one format out; a new capture adopting its own format; and the
+normalizer's conversion, pass-through and reset behaviour directly.
+
+### Still owed on hardware
+
+- **A handover mid-stream, both directions** — now with the fix in place: toggle listening off and
+  on during a live broadcast and a recording; assert the finished artefact plays end to end and has
+  continuous audio across both switches, by listening to it rather than by counting buffers.
+- The rest of the list below is unchanged and still unverified.
+
+### Follow-up, deliberately not taken here
+
+The in-app debug log is per-launch and in-memory, so a report filed after a relaunch misses the
+window entirely. Persisting a small ring across launches is the obvious next step and is a separate
+change from a bug fix.
 
 Everything above is decision logic or engine construction, and only the first can be tested
 headlessly. What cannot:

--- a/docs/plans/DH-local-gemma-keyless-tier.md
+++ b/docs/plans/DH-local-gemma-keyless-tier.md
@@ -59,6 +59,32 @@ model) through Gemma's VLM where it beats the current local option — measured,
 decode latency and the Metal contention constraint (VLM decode vs on-device TTS synthesis) are
 the deciders, per the CV plan's duty-cycle reasoning.
 
+### P3 correction from the device (2026-08-27)
+
+A photo turn to the loaded Gemma killed the app to the home screen. The Jetsam event: terminated
+for **per-process-limit** while frontmost, at a 6.2 GB footprint, on a 12 GB iPhone.
+
+Two decisions in P1/P3 were wrong together, and each was defensible alone:
+
+1. **The tier was decided on marketing RAM.** `multimodalTurnPlan` gave anything ≥ 12 GB the full
+   prompt, full history and no image cap. But device RAM is not the constraint — iOS's per-process
+   allocation cap is, and it does not scale with the box on the shelf. With multi-gigabyte weights
+   resident and the camera pipeline live, a 12 GB phone had a few hundred megabytes left to
+   allocate and was still on the "roomy" tier. The plan now takes the headroom measured at *turn
+   time* (`os_proc_available_memory()` via `MemoryHeadroom`), treats a roomy-but-full device as
+   constrained, and refuses the image outright below a floor — spoken honestly
+   (`LocalLLMError.insufficientMemoryForPhoto`) rather than as a process kill.
+2. **The forced 896² pre-resize was removed** on the reasoning that Gemma's processor picks its own
+   canvas and its own soft-token count. That is true of the *token* count and beside the point for
+   memory: preprocessing a full-resolution frame materialises it as float pixels on top of an
+   already-resident model. The cap is back, but computed aspect-preserving from the frame's own
+   dimensions rather than passed as a square — so the crop the removal was defending survives, and
+   the long edge follows the tier.
+
+Both are pure decisions and are tested against injected headroom values, including the measured
+crash scenario. The performance matrix in P4 should now record headroom alongside tok/s, since
+headroom is what decides whether a photo turn happens at all.
+
 ## P4 — Deferred device work
 
 The performance matrix this plan exists for: which phones run it acceptably (decode tok/s,


### PR DESCRIPTION
Five defects found in one afternoon of testing on a physical iPhone with the glasses connected. They are here together because three of them turned out to be the same story told from different angles: something failed, and nothing said so.

## 1. Enabling wake-word listening mid-recording killed the recording

**Repro:** listening off → start a video recording → turn listening on → about a second later it stops.

**Root cause.** Capture audio rides two sources behind `CaptureAudioRouter`, and they are two separate `AVAudioEngine`s. Each takes its tap format from `inputNode.outputFormat(forBus: 0)` — whatever route *that* engine starts on. A handover therefore changes the sample format under every consumer.

`VideoRecordingService.appendAudioBuffer` built a fresh `CMAudioFormatDescription` from each incoming buffer and appended it. An `AVAssetWriterInput` locks its audio format to the first sample buffer it accepts and rejects the next one that disagrees — moving the whole `AVAssetWriter` to `.failed`, which takes the **video** track with it. So this was never "the recording lost its audio": the recording died, `finishWriting` had nothing to hand back, and nothing on that path checked `writer.status`.

The existing headless suite could not have caught it: both fakes pushed the same format.

**Fix.**
- `CaptureAudioNormalizer` at the router boundary. The first buffer of a capture fixes the canonical format; later buffers are converted into it through a per-source `AVAudioConverter`. Matching buffers — the whole steady state, and every capture that never sees a handover — pass through untouched. A failed conversion yields silence of the same duration rather than `nil`, because dropping the slot would shift the broadcast's sample-count clock permanently. The format is released when a capture ends. This holds in both directions and covers broadcast as well as recording, since both ride the same router.
- Recorder hardening as the second brace: the format description is built once and later buffers checked against it and dropped if they disagree; both append paths bail when the writer has already failed; a failed writer is reported on `lastSaveNote` instead of passing as a clean stop.

## 2. A recording that ended abnormally was never filed

`stopRecording` returned early — before the filing step — whenever the writer or video input was gone. Plan DA's "never delete before a persistent copy exists" applies to abnormal ends too. It now files whatever reached disk on every path, and Photos is only offered a file that actually exists.

## 3. Nothing ever reached Photos, and nothing said why

Device evidence: a fresh install, and no photo-library permission prompt had ever appeared. Every save died silently, on the photo path and the recording path alike.

- The authorization request now runs on the main actor. Presenting the system prompt is UI work, and a request made from a background context is exactly the shape of "no prompt ever appeared".
- `saveImage`/`saveVideo` return a typed `PhotoLibrarySaveResult` instead of a Bool. "It didn't save" was three different situations — never asked, asked and declined, authorized but the change request failed — and they need completely different answers. The status is logged with a word for each.
- `RecordingFiler.Outcome` carries `photosNotPermitted`, so the message can name the one failure the wearer can actually fix: "OpenGlasses doesn't have permission to add to your photo library… You can turn that on in Settings."

**Not settled:** whether the main-actor request is *the* cause. The evidence pins the symptom, not the mechanism, so this also ships the instrument for the next run (below).

## 4. A photo turn to the on-device model crashed the app to the home screen

**Highest severity here.** The Jetsam event: terminated for **per-process-limit** while frontmost, 6.2 GB footprint, on a 12 GB iPhone.

**Root cause.** `LocalModelBudget.multimodalTurnPlan` decided the tier from *marketing RAM* — ≥ 12 GB got the full prompt, full history and no image cap. But device RAM is not the constraint. iOS's per-process allocation cap is, and it does not scale with the box on the shelf. With multi-gigabyte weights resident and the camera pipeline live, a 12 GB phone had a few hundred megabytes left to allocate and was still on the "roomy" tier.

Compounding it: the forced 896² pre-resize had been removed on the reasoning that Gemma's processor picks its own canvas and soft-token count. True of the *token* count, and beside the point for memory — preprocessing a full-resolution frame materialises it as float pixels on top of an already-resident model.

**Fix.**
- The plan now takes the headroom measured **at turn time** (`os_proc_available_memory()` via `MemoryHeadroom`). A roomy-but-full device is treated as constrained; below a floor the image is refused out loud (`LocalLLMError.insufficientMemoryForPhoto` — "There isn't enough memory to look at a photo with the on-device model right now. Ask me without the picture, or switch to a cloud model.") rather than attempted. Unknown headroom (simulator, Mac) skips the gate rather than refusing — the same rule `MemoryHeadroom` already follows.
- The image cap is back on both VLM paths, computed **aspect-preserving** from the frame's own dimensions rather than passed as a square, so the crop the removal was defending survives. The long edge follows the tier.
- The cascade classifies the new error as retry-other-model: a cloud candidate has no such ceiling.

## 5. Broadcast connected to a LAN ingest and sent zero bytes

The ingest logged connection after connection opening and timing out after ten seconds having received **no bytes at all** — no handshake, no publish, while the app showed "Live" and a bitrate. Granting Local Network permission and restarting changed nothing: two fresh attempts, identical signature. So this is not the permission gate.

**What was ruled out.** The connect sequence was put under a byte-level probe from the simulator — a listener recording the first bytes of any connection, driven by two paths: a bare `RTMPConnection().connect()`, and our exact order (stream created against the connection, codec settings applied, mixer built and wired, then connect). **Both wrote the C0/C1 handshake** (`03 00 00 00 00 …`), byte-identical in shape. Driven against a real RTMP ingest the same sequence went further: connect returned and the publish was accepted — the session went live. The publish path, which the original CY work never proved against a live ingest anywhere, is now proven from the simulator.

That refutes a deadlock between the main actor and the status-consumption tasks, a wrong-actor invocation, and a malformed connect URL. Our call sequence is not what stops the handshake.

**Most likely mechanism, not proven.** In HaishinKit's `RTMPSocket`, `send(_:)` returns early when `connected` is false — silently, no throw, no log. `RTMPConnection.connect` writes the handshake immediately after the socket reports ready; `connected` is set in `stateDidChange(.ready)`, but `viabilityUpdateHandler` runs through a *separate, unordered* actor hop and `viabilityDidChange(false)` calls `close()`, clearing `connected` and `outputs`. A viability flap landing after ready leaves the socket TCP-open with the handshake write discarded and the receive loop (`while connected`) exiting instantly — exactly the observed signature, and exactly the kind of flap a phone's local-network machinery can produce and a simulator never will. **Upstream issue, not forked or patched here.**

**The fix is detection, not diagnosis, and does not depend on that being right.**

- `NetworkMonitorReport.totalBytesOut` — the transport's own cumulative count of bytes written — is plumbed through the bitrate controller, tracked **per connection attempt** (a reconnect builds a fresh connection with fresh counters, so each attempt proves itself). The per-second measured bitrate cannot carry this: it legitimately reads zero between keyframes on a healthy stream.
- A connection that has published and still written nothing past a grace period is treated as **dropped** and routed into `handleConnectionLoss`, so the reconnect machinery gets its shot. If no attempt ever comes up writable, the reconnect policy's give-up budget ends the session honestly. Saying so in the UI without retrying would leave a stream idling that could have recovered itself.
- `BroadcastHealth.bitrateLabel` fell back to the **target** bitrate whenever the transport hadn't reported, so the bar read "3.7 Mbps · 0 fps" for a connection nothing had left the device on. A target is an intention; printing it beside the measurement that disproves it is worse than printing nothing. Gated on `hasSentAnything`; the badge says "Nothing sent yet" rather than "Live".
- `NSLocalNetworkUsageDescription` described only discovering AI servers, so the prompt made no sense in a streaming context. It now covers both.

## 6. Vision honesty for the ChatGPT subscription provider

The subscription provider serves a coding-tuned catalog, and whether that backend accepts image input was never actually confirmed — the plan's own device checklist still has the line unchecked. It was nonetheless marked vision-capable, and photo turns were handed the image *plus* a system prompt insisting "You CAN see it — never deny vision", which invites a described scene the model never saw. The codebase already solved this class for on-device models; this mirrors it.

`ChatGPTVisionGate` is a pure decision consulted before any prompt is built or byte sent, and `ModelConfig.inferredSupportsVision` now reports `false` for the provider so the camera button isn't offered for a model that cannot use it. If a live turn ever proves acceptance, the gate is the one place to reopen, per model.

## Diagnostics

An in-app diagnostics report of exactly this class arrived containing nothing but a launch trace, because none of these paths said anything the in-app log could carry — only `NSLog`, which a wearer cannot send. Capture-audio source handovers, the filer's per-destination outcome, the photo-library authorization status encountered at save time, and the broadcast stall now all reach the debug log.

Deliberately **not** taken here: the log is per-launch and in-memory, so a report filed after a relaunch still misses the window. Persisting a small ring across launches is the obvious next step and is a separate change from a bug fix. Noted in the CZ plan.

## Tests

All headless — pure seams and fakes, no `AVAudioEngine`, no `.shared` service, no Wearables, no network.

- **Capture audio:** sources pushing *different* formats across a handover in both directions, no buffer dropped and one format out; a new capture adopting its own format rather than the last one's; the normalizer's pass-through, resample, channel-mix, reset and stream-description matching directly.
- **Filer:** the permission-denied message and the plain-failure message, kept distinct.
- **Photo album policy:** a distinct word per authorization status; refusal distinguished from failure.
- **Local model budget:** the measured crash scenario (~0.3 GB headroom on a 12 GB phone) refused; a roomy-but-full device treated as constrained; unknown headroom skipping the gate; the aspect-preserving image bound including portrait and already-small frames.
- **Broadcast:** the stall verdict across its grace period; private vs public target classification; host extraction from a full RTMP URL; a zero-bytes stall being accepted as a drop by the session machine (so it reconnects rather than idling); and the readout no longer claiming a bitrate for a connection that has sent nothing.
- **ChatGPT vision gate:** declines with an image, unaffected without one, every other provider unaffected.

## What needs confirming on device

None of the five root causes can be proved fixed in a simulator.

1. **Recording across a handover** — record, toggle listening on mid-recording, keep recording, toggle it off, stop. The recording must survive both switches, play end to end, and appear in Photos and in the app's Recordings folder. Same for a broadcast.
2. **The photo-library prompt** — on a fresh install, the first capture or recording must actually present the system prompt. If it is declined, the app must say so in words that name Settings.
3. **A photo turn to the on-device model** — must either answer or refuse out loud. It must not take the app to the home screen.
4. **Broadcast to the LAN ingest** — if it still sends nothing, the app must now say why within about eight seconds instead of showing a bitrate and reconnecting forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
