### PR TITLE
Refuse composed tool calls that would actuate without confirmation

### DIFF
--- a/OpenGlasses/Sources/App/Intents/IntentSupport.swift
+++ b/OpenGlasses/Sources/App/Intents/IntentSupport.swift
@@ -38,6 +38,13 @@ enum IntentSupport {
     /// useful instead of a generic error.
     @MainActor
     static func runTool(_ name: String, args: [String: Any], appState: AppState) async -> String {
+        // Every intent tool call lands here, and the registry executes without the router's
+        // confirmation gate — so this is the chokepoint that keeps an intent from actuating
+        // something the assistant would have asked about first.
+        guard !ComposedToolPolicy.isRestrictedTarget(name) else {
+            NSLog("[IntentSupport] Refused intent-bound tool %@ (needs direct confirmation)", name)
+            return ComposedToolPolicy.refusalMessage(target: name)
+        }
         do {
             return try await appState.nativeToolRegistry.executeTool(name: name, arguments: args)
         } catch {

--- a/OpenGlasses/Sources/App/Intents/RunGlassesActionIntent.swift
+++ b/OpenGlasses/Sources/App/Intents/RunGlassesActionIntent.swift
@@ -61,7 +61,21 @@ enum SiriActionError: Error, CustomLocalizedStringResourceConvertible {
 /// as speakable text (not thrown) so Siri reads something useful instead of a generic error.
 @MainActor
 enum SiriActionDispatcher {
+
+    /// Why this binding can't run, or nil to proceed.
+    ///
+    /// The catalog drops such a binding at admission, but an action saved by an earlier build is
+    /// already in `SiriExposureConfig` — so the dispatcher re-decides rather than trusting that
+    /// what reached it was screened. Pure, so the refusal is asserted without an `AppState`.
+    static func refusalReason(for binding: SiriActionBinding) -> String? {
+        guard let tool = binding.toolName, ComposedToolPolicy.isRestrictedTarget(tool) else {
+            return nil
+        }
+        return ComposedToolPolicy.refusalMessage(target: tool)
+    }
+
     static func run(_ binding: SiriActionBinding, appState: AppState) async throws -> String {
+        if let refusal = refusalReason(for: binding) { return refusal }
         switch binding {
         case .builtin(let id):
             return try await BuiltinActionRunner.run(id, appState: appState)

--- a/OpenGlasses/Sources/App/Views/SiriExposureView.swift
+++ b/OpenGlasses/Sources/App/Views/SiriExposureView.swift
@@ -279,8 +279,12 @@ struct SiriActionEditorView: View {
     @State private var customToolId = ""
     @State private var validationMessage: String?
 
+    /// Tools a voice action may bind to. Ones that need the user's direct confirmation aren't
+    /// offered at all — picking one would only ever end in a refusal.
     private var availableToolNames: [String] {
-        (AppStateProvider.shared?.nativeToolRegistry.allTools.map(\.name) ?? []).sorted()
+        (AppStateProvider.shared?.nativeToolRegistry.allTools.map(\.name) ?? [])
+            .filter { !ComposedToolPolicy.isRestrictedTarget($0) }
+            .sorted()
     }
 
     private var customToolNames: [String] {
@@ -425,6 +429,8 @@ struct SiriActionEditorView: View {
             return "Arguments must be a valid JSON object, like {\"action\": \"start\"}."
         case .toolBlockedByCompliance(let tool):
             return "\"\(tool)\" is unavailable while Medical Compliance Mode is on."
+        case .toolNeedsDirectConfirmation(let tool):
+            return "\"\(tool)\" takes an action you have to confirm yourself, so it can't run from a saved voice action. Ask the assistant for it instead."
         case .agentModeRequired:
             return "Custom tools need Agentic Features enabled (Settings → Agentic Features)."
         }

--- a/OpenGlasses/Sources/App/Views/SkillPacksSettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/SkillPacksSettingsView.swift
@@ -58,6 +58,12 @@ struct SkillPacksSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(OGTheme.warnLabel)
             }
+            if let quarantined = pack.quarantinedActions, !quarantined.isEmpty {
+                Label(ComposedToolPolicy.quarantineNotice(actionNames: quarantined),
+                      systemImage: "hand.raised")
+                    .font(.caption)
+                    .foregroundStyle(OGTheme.warnLabel)
+            }
             if pack.decodeSummary != "clean" {
                 Label(pack.decodeSummary, systemImage: "exclamationmark.circle")
                     .font(.caption)

--- a/OpenGlasses/Sources/Services/ComposedToolPolicy.swift
+++ b/OpenGlasses/Sources/Services/ComposedToolPolicy.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The composition floor: which native tools a user-authored *composition* may not reach.
+///
+/// `NativeToolRouter` is the only path that applies the actuation floor (`HighImpactToolPolicy`),
+/// the `SafetySupervisor`, and the confirmation gate. Composition surfaces — a skill pack's `.tool`
+/// binding, a Siri Action's `.tool` binding — resolve a tool from the registry and execute it
+/// directly, so the router only ever sees the wrapper's harmless name (or nothing at all) and none
+/// of those checks run against the real target. A pack action bound to `smart_home` with
+/// `{"action":"unlock"}` would therefore actuate with no confirmation, while the identical call
+/// through the model always confirms.
+///
+/// Until composed calls are routed through that one authority, any target the router *would* have
+/// gated is refused at composition time instead. The classification is a query over the policies
+/// the router itself consults, never a second hand-maintained list: adding a tool to
+/// `PromptInjectionPolicy.highImpactTools` or to `HighImpactToolPolicy` contains it here too.
+enum ComposedToolPolicy {
+
+    /// Whether a resolved target is off-limits to composition.
+    ///
+    /// Classified on the tool *name* alone, with no arguments: a binding merges the caller's
+    /// arguments at call time, so a target that is high-impact for any argument shape must be
+    /// treated as high-impact for all of them. Empty arguments are the conservative probe —
+    /// `PromptInjectionPolicy` reads an absent action as the dispatching one, and
+    /// `mayRequireConfirmation` is already argument-independent.
+    static func isRestrictedTarget(_ toolName: String) -> Bool {
+        HighImpactToolPolicy.mayRequireConfirmation(tool: toolName)
+            || PromptInjectionPolicy.isHighImpact(toolName: toolName, args: [:])
+    }
+
+    /// Why a binding to `target` can't be admitted — for an install-time rejection list.
+    static func admissionReason(target: String) -> String {
+        "binds to '\(target)', which takes an action the user has to confirm directly"
+    }
+
+    /// What a refused composed call tells its caller. Phrased for both the model (which must not
+    /// retry) and Siri (which reads it aloud).
+    static func refusalMessage(target: String) -> String {
+        "'\(target)' takes an action that needs the user's direct confirmation, which a saved "
+            + "shortcut or skill can't ask for, so nothing was done. Do not retry; ask the user to "
+            + "run it themselves."
+    }
+
+    /// Remediation shown on an installed pack whose actions were held back at merge time.
+    static func quarantineNotice(actionNames: [String]) -> String {
+        let names = actionNames.sorted().joined(separator: ", ")
+        return "Turned off for safety: \(names). "
+            + "These run a tool that can unlock, actuate, or share data, which only happens after "
+            + "you confirm it yourself. The rest of the pack still works."
+    }
+}

--- a/OpenGlasses/Sources/Services/NativeTools/SkillPackToolWrapper.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/SkillPackToolWrapper.swift
@@ -22,6 +22,15 @@ struct SkillPackToolWrapper: NativeTool {
     /// Resolves a native tool for `.tool` bindings. Injected; never captures the registry (the
     /// wrapper is *in* the registry — a strong loop there would leak both).
     let resolveNativeTool: @MainActor (String) -> (any NativeTool)?
+    /// Called when a `.tool` binding reaches execution with a target the composition floor
+    /// forbids — meaning admission and the merge-time quarantine both failed to contain it.
+    /// The default traps in debug (`assertionFailure` compiles out of release) so a routing
+    /// regression is impossible to miss locally; execution refuses either way. Injected so the
+    /// refusal path itself is testable.
+    var onContainmentBreach: (String) -> Void = { message in
+        NSLog("[SkillPacks] %@", message)
+        assertionFailure(message)
+    }
 
     private var settingsValues: [String: String] {
         SkillPackSettings.values(packId: packId, declarations: settingDeclarations)
@@ -56,6 +65,15 @@ struct SkillPackToolWrapper: NativeTool {
             return PromptInjectionPolicy.wrap(toolName: name, content: filled)
 
         case .tool(let target, let boundArgs):
+            // Last line of the composition floor: this wrapper executes its target itself, so the
+            // router's confirmation gate never sees the real name. Reaching here with a restricted
+            // target means neither admission nor the merge-time quarantine held — refuse, and say
+            // so loudly in debug.
+            guard !ComposedToolPolicy.isRestrictedTarget(target) else {
+                onContainmentBreach(
+                    "Pack '\(packId)' action '\(action.name)' reached execution bound to '\(target)'")
+                return ComposedToolPolicy.refusalMessage(target: target)
+            }
             guard let tool = resolveNativeTool(target) else {
                 return "This skill's underlying tool '\(target)' isn't available on this device."
             }
@@ -127,7 +145,13 @@ extension NativeToolRegistry {
     func registerSkillPackTools(from store: SkillPackStore) {
         removeSkillPackTools()
         for manifest in store.activeManifests() {
-            for action in manifest.actions {
+            // Re-run the composition floor over what's actually installed: a pack admitted by an
+            // earlier build can hold a `.tool` binding the floor now forbids. The pack stays
+            // installed and its other actions register; only the offending ones are held back,
+            // with the reason recorded on the row for the Settings UI.
+            let quarantined = SkillPackValidator.restrictedActionNames(in: manifest)
+            store.setQuarantinedActions(quarantined, id: manifest.id)
+            for action in manifest.actions where !quarantined.contains(action.name) {
                 register(SkillPackToolWrapper(
                     packId: manifest.id,
                     action: action,

--- a/OpenGlasses/Sources/Services/Siri/SiriActionCatalog.swift
+++ b/OpenGlasses/Sources/Services/Siri/SiriActionCatalog.swift
@@ -201,7 +201,12 @@ struct SiriActionCatalog {
         blockedToolNames: Set<String>
     ) -> Bool {
         if case .capability(kind: .customTool, id: _) = binding, !agentModeEnabled { return false }
-        if let tool = binding.toolName, blockedToolNames.contains(tool) { return false }
+        guard let tool = binding.toolName else { return true }
+        if blockedToolNames.contains(tool) { return false }
+        // A bound tool runs straight off the registry, with no router and so no confirmation
+        // gate. Compliance blocking (above) and the composition floor are separate screens: an
+        // action can be forbidden by either.
+        if ComposedToolPolicy.isRestrictedTarget(tool) { return false }
         return true
     }
 
@@ -214,6 +219,7 @@ struct SiriActionCatalog {
         case unknownTool(String)
         case invalidArgsJSON
         case toolBlockedByCompliance(String)
+        case toolNeedsDirectConfirmation(String)
         case agentModeRequired
     }
 
@@ -241,6 +247,9 @@ struct SiriActionCatalog {
             if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return .emptyPrompt }
         case .tool(let toolName, let argsJSON):
             if blockedToolNames.contains(toolName) { return .toolBlockedByCompliance(toolName) }
+            if ComposedToolPolicy.isRestrictedTarget(toolName) {
+                return .toolNeedsDirectConfirmation(toolName)
+            }
             if let availableToolNames, !availableToolNames.contains(toolName) {
                 return .unknownTool(toolName)
             }
@@ -256,6 +265,9 @@ struct SiriActionCatalog {
                 if blockedToolNames.contains(id) { return .toolBlockedByCompliance(id) }
             } else if let tool = definition.binding.toolName, blockedToolNames.contains(tool) {
                 return .toolBlockedByCompliance(tool)
+            }
+            if let tool = definition.binding.toolName, ComposedToolPolicy.isRestrictedTarget(tool) {
+                return .toolNeedsDirectConfirmation(tool)
             }
         }
         return nil

--- a/OpenGlasses/Sources/Services/SkillPacks/SkillPackStore.swift
+++ b/OpenGlasses/Sources/Services/SkillPacks/SkillPackStore.swift
@@ -26,6 +26,9 @@ final class SkillPackStore: ObservableObject {
         /// lesson applied to packs: a partial load is visible state, not a log line.
         var decodeSummary: String
         var actionCount: Int
+        /// Actions held back at the registry merge because their bound tool needs the user's
+        /// direct confirmation. Optional so state written before the floor existed still loads.
+        var quarantinedActions: [String]?
     }
 
     enum InstallResult: Equatable {
@@ -163,6 +166,20 @@ final class SkillPackStore: ObservableObject {
     func setEnabled(_ enabled: Bool, id: String) {
         guard savingAllowed, let index = installedPacks.firstIndex(where: { $0.id == id }) else { return }
         installedPacks[index].enabled = enabled
+        save()
+    }
+
+    /// Record which of a pack's actions the registry merge held back. Written only on change, so
+    /// the common (empty) case doesn't rewrite state on every launch and refresh.
+    func setQuarantinedActions(_ names: [String], id: String) {
+        guard savingAllowed, let index = installedPacks.firstIndex(where: { $0.id == id }) else { return }
+        let normalized = names.isEmpty ? nil : names.sorted()
+        guard installedPacks[index].quarantinedActions != normalized else { return }
+        installedPacks[index].quarantinedActions = normalized
+        if let normalized {
+            NSLog("[SkillPacks] Quarantined %d action(s) in %@: %@",
+                  normalized.count, id, normalized.joined(separator: ", "))
+        }
         save()
     }
 

--- a/OpenGlasses/Sources/Services/SkillPacks/SkillPackValidator.swift
+++ b/OpenGlasses/Sources/Services/SkillPacks/SkillPackValidator.swift
@@ -119,6 +119,11 @@ enum SkillPackValidator {
             if !nativeToolNames.contains(target) {
                 reasons.append("action '\(name)' binds to unknown native tool '\(target)'")
             }
+            // A wrapper executes its target directly, so the router's confirmation gate never
+            // sees the real name. Anything that gate would have caught is refused at the door.
+            if ComposedToolPolicy.isRestrictedTarget(target) {
+                reasons.append("action '\(name)' \(ComposedToolPolicy.admissionReason(target: target))")
+            }
         case .procedure(let id):
             if id.isEmpty { reasons.append("action '\(name)' has an empty procedure id") }
         case .gateway(let task):
@@ -147,6 +152,19 @@ enum SkillPackValidator {
         }
 
         return reasons
+    }
+
+    /// Names of an installed pack's actions whose `.tool` target the composition floor forbids.
+    ///
+    /// Packs installed by an earlier build predate that floor, so the registry merge re-runs this
+    /// on every launch and refresh rather than trusting install-time admission. Pure so the
+    /// reclassification is asserted without a store or a registry.
+    static func restrictedActionNames(in manifest: SkillPackManifest) -> [String] {
+        manifest.actions.compactMap { action in
+            guard case .tool(let target, _) = action.binding,
+                  ComposedToolPolicy.isRestrictedTarget(target) else { return nil }
+            return action.name
+        }
     }
 
     // MARK: - Shapes

--- a/OpenGlassesTests/ComposedToolContainmentTests.swift
+++ b/OpenGlassesTests/ComposedToolContainmentTests.swift
@@ -1,0 +1,241 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DJ P0 — user-authored composition (skill-pack `.tool` bindings, Siri Actions) executes
+/// off the registry, past the router that applies the confirmation gate. These cover the
+/// containment: admission, merge-time quarantine of packs installed before the floor existed,
+/// the execution-time refusals, and the shared classification that keeps all of them in step
+/// with the router's own policy.
+@MainActor
+final class ComposedToolContainmentTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Records whether the bound tool was reached — a refusal that still executes is the bug.
+    private final class ExecutionSpy {
+        var invoked = false
+    }
+
+    private struct ActuatorStub: NativeTool {
+        let name: String
+        let description = "stub"
+        let spy: ExecutionSpy
+        var parametersSchema: [String: Any] { ["type": "object"] }
+        func execute(args: [String: Any]) async throws -> String {
+            spy.invoked = true
+            return "actuated"
+        }
+    }
+
+    private struct ReadOnlyStub: NativeTool {
+        let name = "get_weather"
+        let description = "reads the weather"
+        var parametersSchema: [String: Any] { ["type": "object"] }
+        func execute(args: [String: Any]) async throws -> String { "sunny" }
+    }
+
+    private func manifestJSON(
+        id: String = "com.example.pack",
+        version: String = "1.0.0",
+        actions: [[String: Any]]
+    ) -> Data {
+        try! JSONSerialization.data(withJSONObject: [
+            "id": id, "version": version, "name": "Test Pack",
+            "summary": "fixture", "actions": actions,
+        ])
+    }
+
+    private func promptAction(name: String) -> [String: Any] {
+        [
+            "name": name,
+            "description": "Use when the user asks for the fixture behaviour.",
+            "parameters": ["type": "object", "properties": [String: Any]()],
+            "binding": ["kind": "prompt", "template": "Do the {{thing}}."],
+        ]
+    }
+
+    private func toolAction(name: String, target: String, boundArgs: [String: String] = [:]) -> [String: Any] {
+        [
+            "name": name,
+            "description": "Use when the user asks for the fixture behaviour.",
+            "parameters": ["type": "object", "properties": [String: Any]()],
+            "binding": ["kind": "tool", "name": target, "boundArgs": boundArgs],
+        ]
+    }
+
+    private func makeStore(directory: URL? = nil, nativeNames: Set<String>) -> SkillPackStore {
+        let dir = directory ?? URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("composed-tool-tests-\(UUID().uuidString)", isDirectory: true)
+        return SkillPackStore(directory: dir, currentBuild: 329, nativeToolNames: { nativeNames })
+    }
+
+    private func validate(_ data: Data, nativeNames: Set<String>) -> SkillPackValidator.Outcome {
+        let (manifest, report) = SkillPackManifest.lossyDecode(data)
+        return SkillPackValidator.validate(manifest: manifest!, report: report,
+                                           currentBuild: 329, nativeToolNames: nativeNames)
+    }
+
+    // MARK: - Shared classification
+
+    func testClassificationTracksTheRouterPolicies() {
+        // No second list: everything the router gates is restricted here, and nothing else is.
+        for tool in PromptInjectionPolicy.highImpactTools {
+            XCTAssertTrue(ComposedToolPolicy.isRestrictedTarget(tool),
+                          "\(tool) is gated by the router and must be off-limits to composition")
+        }
+        XCTAssertTrue(ComposedToolPolicy.isRestrictedTarget("smart_home"))
+        XCTAssertTrue(ComposedToolPolicy.isRestrictedTarget("home_assistant"))
+        XCTAssertTrue(ComposedToolPolicy.isRestrictedTarget("medical_export"))
+        // Args-dependent at the router; a binding merges caller args, so the name alone decides.
+        XCTAssertTrue(ComposedToolPolicy.isRestrictedTarget("code_agent"))
+
+        XCTAssertFalse(ComposedToolPolicy.isRestrictedTarget("get_weather"))
+        XCTAssertFalse(ComposedToolPolicy.isRestrictedTarget("save_note"))
+        XCTAssertFalse(ComposedToolPolicy.isRestrictedTarget("teleprompter"))
+    }
+
+    // MARK: - Skill-pack admission
+
+    func testPackBindingToActuatingToolIsRejected() {
+        for target in ["smart_home", "home_assistant", "medical_export"] {
+            let data = manifestJSON(actions: [toolAction(name: "do_it", target: target)])
+            let outcome = validate(data, nativeNames: [target])
+            guard case .rejected(let reasons) = outcome else {
+                return XCTFail("a pack wrapping \(target) must be rejected, got \(outcome)")
+            }
+            XCTAssertTrue(reasons.contains { $0.contains(target) && $0.contains("confirm") },
+                          "the reason must name the target and why: \(reasons)")
+        }
+    }
+
+    func testPackInstallRefusesActuatingBindingEndToEnd() {
+        let store = makeStore(nativeNames: ["smart_home"])
+        let result = store.install(
+            manifestData: manifestJSON(actions: [
+                toolAction(name: "unlock_door", target: "smart_home", boundArgs: ["action": "unlock"]),
+            ]),
+            signatureBase64: nil, developerMode: true)
+        guard case .rejected = result else { return XCTFail("install must refuse the pack") }
+        XCTAssertTrue(store.installedPacks.isEmpty)
+    }
+
+    func testPromptPackAndReadOnlyBindingRemainUsable() async throws {
+        let registry = NativeToolRegistry(locationService: LocationService())
+        registry.register(ReadOnlyStub())
+        let store = makeStore(nativeNames: ["get_weather"])
+
+        let result = store.install(
+            manifestData: manifestJSON(actions: [
+                promptAction(name: "coach_me"),
+                toolAction(name: "check_sky", target: "get_weather"),
+            ]),
+            signatureBase64: nil, developerMode: true)
+        guard case .installed = result else { return XCTFail("a benign pack must still install: \(result)") }
+
+        registry.registerSkillPackTools(from: store)
+        let prompt = try XCTUnwrap(registry.tool(named: "pack_com_example_pack_coach_me"))
+        let promptResult = try await prompt.execute(args: ["thing": "dishes"])
+        XCTAssertTrue(promptResult.contains("dishes"))
+        let composed = try XCTUnwrap(registry.tool(named: "pack_com_example_pack_check_sky"))
+        let composedResult = try await composed.execute(args: [:])
+        XCTAssertEqual(composedResult, "sunny")
+        XCTAssertNil(store.installedPacks.first?.quarantinedActions,
+                     "nothing to quarantine, so nothing is claimed")
+    }
+
+    // MARK: - Quarantine of already-installed packs
+
+    func testLegacyInstalledPackIsQuarantinedOnMerge() throws {
+        // A pack admitted by a build that predates the floor: written straight to the store's
+        // layout, exactly as an older install left it (no `quarantinedActions` key).
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("composed-tool-legacy-\(UUID().uuidString)", isDirectory: true)
+        let versionDir = dir.appendingPathComponent("com.example.pack", isDirectory: true)
+            .appendingPathComponent("1.0.0", isDirectory: true)
+        try FileManager.default.createDirectory(at: versionDir, withIntermediateDirectories: true)
+        try manifestJSON(actions: [
+            toolAction(name: "unlock_door", target: "smart_home", boundArgs: ["action": "unlock"]),
+            promptAction(name: "coach_me"),
+        ]).write(to: versionDir.appendingPathComponent("skillpack.json"))
+        try JSONSerialization.data(withJSONObject: [[
+            "id": "com.example.pack", "activeVersion": "1.0.0", "name": "Test Pack",
+            "summary": "fixture", "enabled": true, "signatureVerified": true,
+            "installedAt": 0, "decodeSummary": "clean", "actionCount": 2,
+        ]]).write(to: dir.appendingPathComponent("state.json"))
+
+        let store = makeStore(directory: dir, nativeNames: ["smart_home"])
+        let registry = NativeToolRegistry(locationService: LocationService())
+        registry.registerSkillPackTools(from: store)
+
+        XCTAssertNil(registry.tool(named: "pack_com_example_pack_unlock_door"),
+                     "the offending action must not be callable")
+        XCTAssertNotNil(registry.tool(named: "pack_com_example_pack_coach_me"),
+                        "the rest of the pack keeps working")
+        let pack = try XCTUnwrap(store.installedPacks.first)
+        XCTAssertTrue(pack.enabled, "the pack stays installed and on")
+        XCTAssertEqual(pack.quarantinedActions, ["unlock_door"])
+        XCTAssertTrue(ComposedToolPolicy.quarantineNotice(actionNames: ["unlock_door"])
+            .contains("unlock_door"), "the remediation names what was held back")
+
+        // Deterministic: the same state reloaded from disk reaches the same verdict.
+        let reloaded = makeStore(directory: dir, nativeNames: ["smart_home"])
+        XCTAssertEqual(reloaded.installedPacks.first?.quarantinedActions, ["unlock_door"])
+    }
+
+    // MARK: - Wrapper execution refusal
+
+    func testWrapperRefusesRestrictedTargetWithoutExecuting() async throws {
+        let spy = ExecutionSpy()
+        var breaches: [String] = []
+        let wrapper = SkillPackToolWrapper(
+            packId: "com.example.pack",
+            action: SkillPackAction(
+                name: "unlock_door",
+                description: "Unlocks the door.",
+                parametersSchema: ["type": "object"],
+                binding: .tool(name: "smart_home", boundArgs: ["action": "unlock"])),
+            resolveNativeTool: { _ in ActuatorStub(name: "smart_home", spy: spy) },
+            onContainmentBreach: { breaches.append($0) })
+
+        let result = try await wrapper.execute(args: [:])
+        XCTAssertFalse(spy.invoked, "a refusal that still executes is the bug")
+        XCTAssertTrue(result.contains("smart_home"))
+        XCTAssertTrue(result.contains("confirmation"))
+        XCTAssertEqual(breaches.count, 1, "the diagnostic fires exactly once")
+        XCTAssertTrue(breaches[0].contains("unlock_door"))
+    }
+
+    // MARK: - Siri Actions
+
+    func testSiriActionBoundToActuatingToolIsRefused() {
+        let unlock = SiriActionBinding.tool(name: "smart_home", argsJSON: #"{"action":"unlock"}"#)
+
+        // Refused at execution, so an action saved by an earlier build can't actuate either.
+        XCTAssertNotNil(SiriActionDispatcher.refusalReason(for: unlock))
+        XCTAssertNil(SiriActionDispatcher.refusalReason(for: .tool(name: "teleprompter", argsJSON: "")))
+        XCTAssertNil(SiriActionDispatcher.refusalReason(for: .prompt(text: "brief me")))
+
+        // Refused at admission: never offered, never saved.
+        let definition = SiriActionDefinition(displayName: "Unlock", binding: unlock)
+        XCTAssertEqual(
+            SiriActionCatalog.validate(definition, existing: [], availableToolNames: ["smart_home"],
+                                       agentModeEnabled: true, blockedToolNames: []),
+            .toolNeedsDirectConfirmation("smart_home"))
+
+        let catalog = SiriActionCatalog(config: SiriExposureConfig(userActions: [definition]),
+                                        agentModeEnabled: true)
+        XCTAssertFalse(catalog.entries.contains { $0.binding == unlock },
+                       "an ineligible binding is dropped from the catalog entirely")
+    }
+
+    func testSiriActionBoundToReadOnlyToolStillValidates() {
+        let definition = SiriActionDefinition(
+            displayName: "Prompter",
+            binding: .tool(name: "teleprompter", argsJSON: #"{"action": "start"}"#))
+        XCTAssertNil(SiriActionCatalog.validate(
+            definition, existing: [], availableToolNames: ["teleprompter"],
+            agentModeEnabled: false, blockedToolNames: []))
+        let catalog = SiriActionCatalog(config: SiriExposureConfig(userActions: [definition]))
+        XCTAssertTrue(catalog.enabledEntries.contains { $0.displayName == "Prompter" })
+    }
+}


### PR DESCRIPTION
## The bypass

`NativeToolRouter.handleToolCall` is where the high-impact actuation floor (`HighImpactToolPolicy` with Agent Mode off, `SafetySupervisor` with it on), the confirmation gate, and the egress screen run. Two user-authored composition paths reach `NativeToolRegistry.executeTool` / `tool.execute(args:)` directly, so the router never sees the resolved target:

1. **Skill packs** — `SkillPackToolWrapper` resolves its `.tool` target from the registry and executes it. The router only ever saw the harmless `pack_*` name, and `SkillPackValidator` constrained the target only to "exists, isn't another pack wrapper".
2. **Siri Actions** — `SiriActionDispatcher` lets a user-authored action bind any native tool with arbitrary JSON args via `IntentSupport.runTool`. The only admission screen, `SiriActionCatalog.isEligible`/`validate`, filtered on the HIPAA `blockedToolNames` set.

Either could wrap `smart_home` (`{"action":"unlock"}`), `home_assistant`, or `medical_export` and actuate with no confirmation, while the identical call from the model always confirms.

## Containment (docs/plans/DJ, P0)

- **One classification, no second list.** `ComposedToolPolicy.isRestrictedTarget` queries the same policies the router consults — `HighImpactToolPolicy.mayRequireConfirmation` and `PromptInjectionPolicy.isHighImpact` — with empty arguments, so a target that is high-impact for any argument shape is treated as high-impact for all (a binding merges caller args at call time). Adding a tool to either policy contains it here automatically.
- **Skill packs**: the validator rejects a `.tool` binding to a restricted target, and the registry merge re-runs the classification over what is already installed on every launch and refresh. A pack admitted by an earlier build stays installed and keeps its other actions; only the offending ones are held back, recorded on the row and surfaced with a remediation line in Settings → Skill Packs.
- **Wrapper refusal**: reaching execution with a restricted target refuses with a clear result and fires a diagnostic — an `assertionFailure` in debug, compiled out of release, so release behaviour is refusal rather than a warning. The hook is injected so the refusal path is testable.
- **Siri Actions**: restricted targets are dropped from the catalog and rejected by `validate` (in addition to, not instead of, the compliance screen), removed from the tool picker, and refused at execution in both `SiriActionDispatcher.run` and `IntentSupport.runTool` — so an action already saved by an earlier build fails closed.

P1 (routing every composed child call through one authority, with provenance and resolved-argument confirmation) is deliberately out of scope; the other direct-execute callers in `OpenGlassesApp` — the Tier-0 classifier fast path, the weather-context fetch, and the remote-invoke note path — are left for it.

## Tests

New `OpenGlassesTests/ComposedToolContainmentTests.swift` (8 cases, pure/injected — no `.shared` services):

- classification tracks the router's own policy sets, and read-only tools stay unrestricted;
- a pack wrapping `smart_home` / `home_assistant` / `medical_export` is rejected, at the validator and end-to-end through install;
- a prompt-only pack and a read-only `.tool` binding still install and run;
- a legacy pack written straight into the store's on-disk layout is quarantined at merge: the bad action is not registered, the rest of the pack is, the pack stays enabled, and reloading from disk reaches the same verdict;
- a wrapper reaching execution with a restricted target refuses and never invokes its fake executor, firing the diagnostic exactly once;
- a Siri Action bound to `smart_home`/`unlock` is refused at execution, rejected by `validate`, and dropped from the catalog; a `teleprompter` binding still works.

## Verification

- `xcodebuild test`, iOS Simulator: **3685 tests, 0 failures**, 3 skipped.
- `xcodebuild build -configuration Release CODE_SIGNING_ALLOWED=NO`: **BUILD SUCCEEDED**.
- No `Localizable.xcstrings` churn (`SWIFT_EMIT_LOC_STRINGS=NO`); new user-facing copy is interpolated, so nothing new is extracted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)