### PR TITLE
Announce phone-camera fallback on remote capture, de-flake display tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ xcuserdata/
 # MediaPipe Tasks binaries — fetched by Scripts/fetch-mediapipe-frameworks.sh (too large
 # to commit: the graph static libraries exceed GitHub's 100 MB per-file limit)
 Vendor/MediaPipeTasks/Frameworks/
+
+# Local TLS material — never commit private keys
+*.crt
+*.key

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -4334,6 +4334,15 @@ class AppState: ObservableObject, AppStateProtocol {
                 // remote caller only needs the capture to have happened.
                 _ = try await self.cameraService.capturePhoto()
                 self.cameraService.restoreAudioForWakeWord()
+                // A phone-camera capture must SAY so (see `captureAndAnalyzePhoto`). The
+                // executor's pre-capture "Remote photo" announcement promises a glasses photo;
+                // if the fallback fired, the wearer just had their phone's view — of whatever
+                // pocket or desk it was on — sent off at a remote agent's request, and only
+                // this correction tells them.
+                if self.cameraService.lastCaptureSource == .phone {
+                    await self.speechService.speak(
+                        "That photo came from the phone camera — the glasses weren't available.")
+                }
             },
             startAudioRecording: { [weak self] in
                 guard let self else { throw RemoteInvokeError.unavailable }

--- a/OpenGlasses/Sources/App/Views/GatewaySettingsView.swift
+++ b/OpenGlasses/Sources/App/Views/GatewaySettingsView.swift
@@ -22,7 +22,7 @@ struct GatewaySettingsView: View {
                             .foregroundStyle(.secondary)
                         Text("No Gateways Configured")
                             .font(.headline)
-                        Text("A gateway is a small server (e.g. running on your Mac or a Raspberry Pi) that gives the AI access to more capabilities — smart-home control, local automations, custom tools. Run OpenClaw, NanoClaw, NemoClaw, or any compatible server and point this app at it.")
+                        Text("A gateway is a small server (e.g. running on your computer or a Raspberry Pi) that gives the AI access to more capabilities — smart-home control, local automations, custom tools. Run OpenClaw, NanoClaw, NemoClaw, or any compatible server and point this app at it.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
@@ -111,7 +111,7 @@ struct GatewaySettingsView: View {
             } header: {
                 Text("Agent Bridge")
             } footer: {
-                Text("Gateways add tools the assistant can call. The Hermes Bridge goes further: when enabled, an agent on your Mac answers whole conversations with its own tools and memory.")
+                Text("Gateways add tools the assistant can call. The Hermes Bridge goes further: when enabled, an agent on your computer answers whole conversations with its own tools and memory.")
             }
 
             // Remote invoke (Plan BH): per-class consent for gateway-initiated device commands.

--- a/OpenGlassesTests/GlassesDisplayInteractiveTests.swift
+++ b/OpenGlassesTests/GlassesDisplayInteractiveTests.swift
@@ -35,6 +35,22 @@ final class GlassesDisplayInteractiveTests: XCTestCase {
         try? await Task.sleep(nanoseconds: ms * 1_000_000)
     }
 
+    /// Poll until `condition` holds, up to `timeout` seconds. Frames driven by the
+    /// service's own wall-clock timers (flash auto-clear, screen restore) must be waited
+    /// on this way rather than with a fixed `settle`: on a loaded machine the timer can
+    /// overshoot its nominal duration by seconds, and a fixed sleep then asserts on the
+    /// pre-timer state. Callers still assert afterwards, so a timeout surfaces as the
+    /// real assertion failure with its frame diff.
+    @discardableResult
+    private func waitFor(timeout: TimeInterval = 5, until condition: () -> Bool) async -> Bool {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while !condition() {
+            guard Date() < deadline else { return false }
+            await settle(5)
+        }
+        return true
+    }
+
     private func card(_ key: String, items: [String] = ["done"]) -> HUDScreen {
         HUDScreen(title: key, items: items.map { id in HUDItem(id: id, label: id.capitalized) {} })
     }
@@ -78,7 +94,7 @@ final class GlassesDisplayInteractiveTests: XCTestCase {
         // A caption (default showText) stays suppressed; an AI reply flashes over the card.
         svc.showText("a caption line")                          // suppressed
         svc.showText("the AI answer", flashWhileInteractive: true)  // flashes
-        await settle()
+        await waitFor { !self.frames.isEmpty }
         XCTAssertEqual(frames, [.content(body: "the AI answer", title: nil, icon: .none)])
     }
 
@@ -89,10 +105,10 @@ final class GlassesDisplayInteractiveTests: XCTestCase {
         frames.removeAll()
 
         svc.showNotification(title: nil, body: "ping", icon: .message, duration: 0.05)
-        await settle(25)                     // before the flash auto-clears
-        XCTAssertEqual(frames, [.content(body: "ping", title: nil, icon: .message)])
+        await waitFor { !self.frames.isEmpty }
+        XCTAssertEqual(frames.first, .content(body: "ping", title: nil, icon: .message))
 
-        await settle(120)                    // after the flash duration
+        await waitFor { self.frames.last == .screen(renderKey: screen.renderKey) }
         XCTAssertEqual(frames.last, .screen(renderKey: screen.renderKey))   // screen restored
     }
 
@@ -106,9 +122,9 @@ final class GlassesDisplayInteractiveTests: XCTestCase {
 
     func testNonInteractiveFlashAutoClears() async {
         svc.flash("brief", duration: 0.05)
-        await settle(25)
-        XCTAssertEqual(frames, [.content(body: "brief", title: nil, icon: .none)])
-        await settle(120)
+        await waitFor { !self.frames.isEmpty }
+        XCTAssertEqual(frames.first, .content(body: "brief", title: nil, icon: .none))
+        await waitFor { self.frames.last == .clear }
         XCTAssertEqual(frames.last, .clear)
     }
 


### PR DESCRIPTION
Rescues three unlanded edits stranded in finished worktrees, applied onto main:

- **Phone-fallback disclosure:** a remote-requested photo capture now speaks a correction when `CameraService` silently fell back to the phone camera — the executor's pre-capture announcement promises a glasses photo, and without this the wearer never learns their phone's view (of a pocket, a desk) was captured and sent at a remote agent's request. (The related `_ =` discards and file-handle re-seek had already landed via #356; only this disclosure was still missing.)
- **Display test de-flaking:** `GlassesDisplayInteractiveTests` polls for the expected frame (`waitFor`) instead of sleeping fixed durations, so flash auto-clear / screen-restore timers overshooting on a loaded machine can't assert against the pre-timer state.
- **Copy:** gateway settings say "your computer" instead of "your Mac".
- **Hygiene:** `.gitignore` now excludes `*.crt`/`*.key` (no such files are tracked) so local TLS key material can't be committed by accident.

Verification: full suite — 3677 tests, 3 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)