### PR TITLE
Route every composed and direct tool call through one authorization authority

### DIFF
--- a/OpenGlasses/Sources/App/Intents/IntentSupport.swift
+++ b/OpenGlasses/Sources/App/Intents/IntentSupport.swift
@@ -38,17 +38,14 @@ enum IntentSupport {
     /// useful instead of a generic error.
     @MainActor
     static func runTool(_ name: String, args: [String: Any], appState: AppState) async -> String {
-        // Every intent tool call lands here, and the registry executes without the router's
-        // confirmation gate — so this is the chokepoint that keeps an intent from actuating
-        // something the assistant would have asked about first.
-        guard !ComposedToolPolicy.isRestrictedTarget(name) else {
-            NSLog("[IntentSupport] Refused intent-bound tool %@ (needs direct confirmation)", name)
-            return ComposedToolPolicy.refusalMessage(target: name)
-        }
-        do {
-            return try await appState.nativeToolRegistry.executeTool(name: name, arguments: args)
-        } catch {
-            return "That action isn't available right now: \(error.localizedDescription)"
+        // Every intent tool call lands here, and goes through the same authority a model tool call
+        // does — a user-authored Siri Action is a saved binding replayed by a machine, so the
+        // composition floor applies to it exactly as it does to a skill pack.
+        let call = ResolvedToolCall.root(name: name, arguments: ToolArguments(args),
+                                         origin: .siriAction)
+        switch await appState.nativeToolRouter.execute(call) {
+        case .success(let text): return text
+        case .failure(let message): return message
         }
     }
 }

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -834,16 +834,18 @@ class AppState: ObservableObject, AppStateProtocol {
         // before any pack merge, so a previously installed pack can't launder a name past the
         // validator for the next install.
         let registryForPacks = nativeToolRegistry
+        let routerForPacks = nativeToolRouter
         skillPackStore = SkillPackStore(nativeToolNames: {
             Set(registryForPacks.allTools.compactMap { $0 is SkillPackToolWrapper ? nil : $0.name })
         })
-        nativeToolRegistry.registerSkillPackTools(from: skillPackStore)
+        nativeToolRegistry.registerSkillPackTools(from: skillPackStore, authority: nativeToolRouter)
         let storeForSideload = skillPackStore
         skillPackSideload = SkillPackSideloadService(
             store: storeForSideload,
-            onInstalled: { [weak registryForPacks] in
+            onInstalled: { [weak registryForPacks, weak routerForPacks] in
                 guard let registryForPacks else { return }
-                registryForPacks.registerSkillPackTools(from: storeForSideload)
+                registryForPacks.registerSkillPackTools(from: storeForSideload,
+                                                       authority: routerForPacks)
             })
 
         // Wire "still working" updates for long-running tool executions (Plan CB). Direct mode
@@ -3341,7 +3343,7 @@ class AppState: ObservableObject, AppStateProtocol {
 
     /// Rebuild the registry's skill-pack tools after an install/remove/enable change (Plan BX).
     func refreshSkillPackTools() {
-        nativeToolRegistry.registerSkillPackTools(from: skillPackStore)
+        nativeToolRegistry.registerSkillPackTools(from: skillPackStore, authority: nativeToolRouter)
     }
 
     /// Resolve a command candidate, logging any demotion so a field miss is traceable to the clause
@@ -3834,11 +3836,13 @@ class AppState: ObservableObject, AppStateProtocol {
             // described the slow turns.
             TurnRecorder.beginTurn()
             let toolStartedAt = Date()
-            do {
-                let result = try await router.registry.executeTool(
-                    name: directCall.toolName,
-                    arguments: directCall.arguments
-                )
+            // Tier-0 skips the model, never the authorization boundary: the classifier's allowlist
+            // is a routing shortcut, not a permission to act unchecked.
+            let outcome = await router.execute(.root(
+                name: directCall.toolName,
+                arguments: ToolArguments(directCall.arguments),
+                origin: .user))
+            if case .success(let result) = outcome {
                 TurnRecorder.addToolTime(since: toolStartedAt)
                 lastResponse = result
                 print("⚡ Direct tool call: \(directCall.toolName) → \(result)")
@@ -3856,9 +3860,10 @@ class AppState: ObservableObject, AppStateProtocol {
                 TurnRecorder.handOffToSpeech()
                 await speechService.speak(result)
                 stopStopListener()
-            } catch {
-                // Fall through to normal LLM path if direct call fails
-                print("⚠️ Direct tool call failed, falling back to LLM: \(error)")
+            } else if case .failure(let message) = outcome {
+                // Fall through to normal LLM path if direct call fails. A policy refusal lands here
+                // too, and re-reaches the same gate through the model — never around it.
+                print("⚠️ Direct tool call failed, falling back to LLM: \(message)")
                 // Plan CU P1: the LLM turn below answers this same utterance, so seal this attempt
                 // as its own abandoned record and hand back the stamps it claimed. Sealed here
                 // rather than at the gate below, which `isProcessing = false` is about to skip.
@@ -3988,9 +3993,10 @@ class AppState: ObservableObject, AppStateProtocol {
                         // phrasings (live-traced); handed the data, it just answers. ~200ms,
                         // local path only — cloud models tool-call fine on their own.
                         var weatherCtx: String?
-                        if classification.relevantSections.contains(.weather) {
-                            weatherCtx = try? await nativeToolRegistry.executeTool(
-                                name: "get_weather", arguments: [:])
+                        if classification.relevantSections.contains(.weather),
+                           case .success(let forecast) = await nativeToolRouter.execute(
+                               .root(name: "get_weather", origin: .appInternal)) {
+                            weatherCtx = forecast
                         }
                         // Fast path: on-device Gemma 4 agent — but spill to the cloud cascade if it
                         // can't serve the turn (BK P2b: prefer local for cost, fall over to cloud).
@@ -4411,8 +4417,13 @@ class AppState: ObservableObject, AppStateProtocol {
             },
             addNote: { [weak self] text in
                 guard let self else { throw RemoteInvokeError.unavailable }
-                return try await self.nativeToolRouter.registry.executeTool(
-                    name: "save_note", arguments: ["content": text])
+                // A remote caller's note still goes through the authority; the remote-invoke
+                // consent gate above it decides *who* may ask, not what may run unchecked.
+                switch await self.nativeToolRouter.execute(
+                    .root(name: "save_note", arguments: ["content": text], origin: .appInternal)) {
+                case .success(let confirmation): return confirmation
+                case .failure: throw RemoteInvokeError.unavailable
+                }
             },
             getTranscript: { [weak self] in
                 guard let self else { return "" }

--- a/OpenGlasses/Sources/Models/ToolInvocation.swift
+++ b/OpenGlasses/Sources/Models/ToolInvocation.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+// MARK: - Arguments
+
+/// One tool argument, restricted to the JSON shapes a tool call can actually carry.
+///
+/// The point is `Sendable` by construction. A composed call is built by one object (a skill-pack
+/// wrapper), authorized by another (the router), and executed inside a task the router spawns for
+/// the timeout race — `[String: Any]` cannot cross those boundaries safely, and annotating it
+/// `@unchecked` would only hide that.
+enum ToolArgumentValue: Sendable, Equatable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+    case null
+    indirect case array([ToolArgumentValue])
+    indirect case object([String: ToolArgumentValue])
+
+    /// Classify an arbitrary argument value.
+    ///
+    /// `NSNumber` is matched before `Bool`/`Int`/`Double` because a bridged Swift `Bool` *is* an
+    /// `NSNumber` and `as? Int` would happily claim it; the CoreFoundation type id is the only
+    /// reliable discriminator. Anything outside the JSON shapes (no provider or internal caller
+    /// produces one today) degrades to its string form rather than vanishing.
+    init(_ value: Any) {
+        switch value {
+        case let existing as ToolArgumentValue:
+            self = existing
+        case let string as String:
+            self = .string(string)
+        case is NSNull:
+            self = .null
+        case let number as NSNumber:
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                self = .bool(number.boolValue)
+            } else if let type = String(cString: number.objCType).first, type == "d" || type == "f" {
+                self = .double(number.doubleValue)
+            } else {
+                self = .int(number.intValue)
+            }
+        case let array as [Any]:
+            self = .array(array.map(ToolArgumentValue.init))
+        case let object as [String: Any]:
+            self = .object(object.mapValues(ToolArgumentValue.init))
+        default:
+            self = .string(String(describing: value))
+        }
+    }
+
+    /// The value a `NativeTool` sees in its `args` dictionary.
+    ///
+    /// Numbers and booleans come back as `NSNumber` so that a tool's `as? Int` / `as? Double` /
+    /// `as? Bool` type-checks behave exactly as they do for provider-parsed JSON, which is already
+    /// `NSNumber`-backed. A call assembled from Swift literals therefore becomes *more* permissive,
+    /// never less.
+    var anyValue: Any {
+        switch self {
+        case .string(let value): return value
+        case .int(let value): return NSNumber(value: value)
+        case .double(let value): return NSNumber(value: value)
+        case .bool(let value): return NSNumber(value: value)
+        case .null: return NSNull()
+        case .array(let values): return values.map(\.anyValue)
+        case .object(let values): return values.mapValues(\.anyValue)
+        }
+    }
+}
+
+/// A tool call's arguments — a `Sendable` dictionary with lossless conversion to and from the
+/// `[String: Any]` shape the `NativeTool` protocol and the provider wires speak.
+struct ToolArguments: Sendable, Equatable, ExpressibleByDictionaryLiteral {
+    private(set) var values: [String: ToolArgumentValue]
+
+    init(_ raw: [String: Any] = [:]) {
+        values = raw.mapValues(ToolArgumentValue.init)
+    }
+
+    init(values: [String: ToolArgumentValue]) {
+        self.values = values
+    }
+
+    init(dictionaryLiteral elements: (String, Any)...) {
+        values = Dictionary(uniqueKeysWithValues: elements.map { ($0.0, ToolArgumentValue($0.1)) })
+    }
+
+    var rawValues: [String: Any] { values.mapValues(\.anyValue) }
+    var isEmpty: Bool { values.isEmpty }
+
+    subscript(key: String) -> ToolArgumentValue? { values[key] }
+
+    mutating func set(_ key: String, to value: Any) {
+        values[key] = ToolArgumentValue(value)
+    }
+}
+
+// MARK: - Provenance
+
+/// Where a tool call entered the app. Provenance is additive: a child call keeps its caller's
+/// identity in `ToolInvocationContext.parent` rather than replacing it.
+enum ToolInvocationOrigin: String, Sendable, Equatable {
+    /// An LLM tool call inside a turn (direct mode, a live session, or an agent plan step).
+    case model
+    /// A person acting through the app — a tapped control or a deterministically classified
+    /// utterance that skips the model.
+    case user
+    /// Composed by an installed skill pack's `.tool` binding.
+    case skillPack
+    /// Composed by a user-authored Siri Action's `.tool` binding.
+    case siriAction
+    /// App-initiated plumbing (context pre-fetch, remote-invoke plumbing) with no composition.
+    case appInternal = "internal"
+
+    /// User-authored composition: a binding a person saved once and a machine replays later. These
+    /// are the origins the composition floor governs — the person isn't present to be asked.
+    var isComposition: Bool {
+        self == .skillPack || self == .siriAction
+    }
+}
+
+/// The call that composed a child call.
+struct ToolCallParent: Sendable, Equatable {
+    let invocationID: String
+    let toolName: String
+    /// The composition that bound the child — a skill-pack id, or a Siri Action id. Nil when the
+    /// parent composed the child itself with no third-party template involved.
+    let composerID: String?
+}
+
+/// Everything the authorization authority needs to know about *how* a call was reached.
+struct ToolInvocationContext: Sendable, Equatable {
+    /// A composition deeper than this is refused. Nothing legitimate today goes past one level;
+    /// the ceiling exists so aliases and procedures can't grow an unbounded chain later.
+    static let maxDepth = 4
+
+    let invocationID: String
+    let rootInvocationID: String
+    let origin: ToolInvocationOrigin
+    let parent: ToolCallParent?
+    let depth: Int
+    /// Tool names from the root down to and including the parent. Cycle detection needs the whole
+    /// chain and `parent` only reaches one level up.
+    let ancestry: [String]
+
+    static func root(origin: ToolInvocationOrigin,
+                     invocationID: String = UUID().uuidString) -> ToolInvocationContext {
+        ToolInvocationContext(invocationID: invocationID, rootInvocationID: invocationID,
+                              origin: origin, parent: nil, depth: 0, ancestry: [])
+    }
+
+    /// True when dispatching `target` would re-enter a call already on the stack.
+    func wouldCycle(_ target: String) -> Bool {
+        ancestry.contains(target)
+    }
+}
+
+/// A tool call resolved to its real target and final arguments — what the authority decides on and
+/// what actually executes. There is no shape in which a wrapper name or a pre-substitution template
+/// reaches a safety check.
+struct ResolvedToolCall: Sendable {
+    let name: String
+    let arguments: ToolArguments
+    let context: ToolInvocationContext
+
+    static func root(name: String, arguments: ToolArguments = ToolArguments(),
+                     origin: ToolInvocationOrigin,
+                     invocationID: String = UUID().uuidString) -> ResolvedToolCall {
+        ResolvedToolCall(name: name, arguments: arguments,
+                         context: .root(origin: origin, invocationID: invocationID))
+    }
+
+    /// A call this one composes. The child keeps the root invocation id, names this call as its
+    /// parent, and carries the composing pack/action id — no layer may drop what came before it.
+    func child(name: String, arguments: ToolArguments, composerID: String?,
+               origin: ToolInvocationOrigin = .skillPack,
+               invocationID: String = UUID().uuidString) -> ResolvedToolCall {
+        ResolvedToolCall(
+            name: name,
+            arguments: arguments,
+            context: ToolInvocationContext(
+                invocationID: invocationID,
+                rootInvocationID: context.rootInvocationID,
+                origin: origin,
+                parent: ToolCallParent(invocationID: context.invocationID, toolName: self.name,
+                                       composerID: composerID),
+                depth: context.depth + 1,
+                ancestry: context.ancestry + [self.name]))
+    }
+}
+
+/// The call currently executing, so a tool that composes another one can name its own invocation as
+/// the parent. A task-local rather than a parameter because `NativeTool.execute(args:)` is the
+/// registry-wide signature and only the composing wrappers need this.
+enum ToolInvocationScope {
+    @TaskLocal static var current: ResolvedToolCall?
+}

--- a/OpenGlasses/Sources/Services/ComposedToolPolicy.swift
+++ b/OpenGlasses/Sources/Services/ComposedToolPolicy.swift
@@ -2,19 +2,29 @@ import Foundation
 
 /// The composition floor: which native tools a user-authored *composition* may not reach.
 ///
-/// `NativeToolRouter` is the only path that applies the actuation floor (`HighImpactToolPolicy`),
-/// the `SafetySupervisor`, and the confirmation gate. Composition surfaces — a skill pack's `.tool`
-/// binding, a Siri Action's `.tool` binding — resolve a tool from the registry and execute it
-/// directly, so the router only ever sees the wrapper's harmless name (or nothing at all) and none
-/// of those checks run against the real target. A pack action bound to `smart_home` with
-/// `{"action":"unlock"}` would therefore actuate with no confirmation, while the identical call
-/// through the model always confirms.
+/// A composition — a skill pack's `.tool` binding, a Siri Action's `.tool` binding — is a target
+/// and arguments a person authored once and a machine replays later, with nobody present to answer
+/// for it. Composed calls reach the same authority a model call does ([[ToolAuthorizationPolicy]]),
+/// carrying their resolved target and merged arguments, so the actuation floor
+/// (`HighImpactToolPolicy`), the `SafetySupervisor`, and the confirmation gate *can* run on the real
+/// action rather than on a harmless `pack_*` name.
 ///
-/// Until composed calls are routed through that one authority, any target the router *would* have
-/// gated is refused at composition time instead. The classification is a query over the policies
-/// the router itself consults, never a second hand-maintained list: adding a tool to
+/// What a composition may reach is nonetheless narrowed by `Mode`. The shipping default refuses any
+/// target the router would have gated: admission-time rejection and merge-time quarantine already
+/// keep such a binding out of the registry, and a refusal nobody has to answer is safer than a
+/// prompt raised by a replayed binding. The classification is a query over the policies the router
+/// itself consults, never a second hand-maintained list — adding a tool to
 /// `PromptInjectionPolicy.highImpactTools` or to `HighImpactToolPolicy` contains it here too.
 enum ComposedToolPolicy {
+
+    /// What the authority does with a composition whose resolved target the router would gate.
+    enum Mode: Equatable {
+        /// Refuse it outright. The shipping default.
+        case refuse
+        /// Route it: the resolved target and merged arguments go to the same confirmation gate a
+        /// direct call gets, with the composing pack named in the copy.
+        case confirmResolved
+    }
 
     /// Whether a resolved target is off-limits to composition.
     ///
@@ -39,6 +49,32 @@ enum ComposedToolPolicy {
         "'\(target)' takes an action that needs the user's direct confirmation, which a saved "
             + "shortcut or skill can't ask for, so nothing was done. Do not retry; ask the user to "
             + "run it themselves."
+    }
+
+    /// A composition reaching another composition. Chaining stays forbidden: each link would widen
+    /// what a single authored binding can reach, and nothing legitimate needs it.
+    static func chainingRefusal(target: String) -> String {
+        "'\(target)' is itself a skill, and one skill can't call another, so nothing was done. "
+            + "Do not retry."
+    }
+
+    /// A composed call that would re-enter something already running above it.
+    static func cycleRefusal(target: String) -> String {
+        "'\(target)' is already running further up this request, so it was not started again. "
+            + "Do not retry."
+    }
+
+    /// The composition depth ceiling — a guard for future aliases and procedures, not a limit
+    /// anything legitimate reaches today.
+    static func depthRefusal(target: String) -> String {
+        "'\(target)' was reached through too many chained skills, so it was not run. Do not retry."
+    }
+
+    /// What a composed call is told when no execution authority is wired up — a misconfigured or
+    /// headless build. Composed calls fail closed there rather than executing unchecked.
+    static func unroutedRefusal(target: String) -> String {
+        "'\(target)' couldn't be checked for safety right now, so it was not run. Do not retry; "
+            + "ask the user to try again with the app in the foreground."
     }
 
     /// Remediation shown on an installed pack whose actions were held back at merge time.

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
@@ -329,22 +329,11 @@ final class NativeToolRegistry {
         }
     }
 
-    /// Execute a tool by name with the given arguments.
-    /// Used by the ConversationClassifier for direct (LLM-free) tool calls.
-    func executeTool(name: String, arguments: [String: Any]) async throws -> String {
-        guard let tool = tool(named: name) else {
-            throw NativeToolError.toolNotFound(name)
-        }
-        return try await tool.execute(args: arguments)
-    }
-}
-
-enum NativeToolError: LocalizedError {
-    case toolNotFound(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .toolNotFound(let name): return "Tool '\(name)' not found or disabled"
-        }
-    }
+    // There is deliberately no `executeTool(name:arguments:)` here.
+    //
+    // A lookup-and-execute helper on the registry is how every bypass in this app started: a Siri
+    // Action, a skill-pack binding, and an LLM-free fast path each reached one and ran an acting
+    // tool without the confirmation gate, the safety supervisor, or the egress screen. Execution
+    // belongs to `NativeToolRouter.execute(_:)` and to nothing else; this type resolves and lists
+    // tools. New callers take a `ToolExecutionAuthority`, not a tool instance.
 }

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
@@ -1,9 +1,17 @@
 import Foundation
 import os.lock
 
+/// The one object allowed to dispatch an acting tool. Composition surfaces (a skill pack's `.tool`
+/// binding, a Siri Action) hold this rather than a `NativeTool` instance, so there is no shape in
+/// which they can resolve a target and execute it themselves.
+@MainActor
+protocol ToolExecutionAuthority: AnyObject {
+    func execute(_ call: ResolvedToolCall) async -> ToolResult
+}
+
 /// Routes tool calls: native tools → MCP servers → OpenClaw fallback.
 @MainActor
-final class NativeToolRouter {
+final class NativeToolRouter: ToolExecutionAuthority {
     let registry: NativeToolRegistry
     var openClawBridge: OpenClawBridge?
     var mcpClient: MCPClient?
@@ -33,6 +41,14 @@ final class NativeToolRouter {
     /// Tool execution timeout in seconds (prevents hung tools from blocking forever).
     var toolTimeoutSeconds: TimeInterval = 30
 
+    /// What a composition may reach. Defaults to refusing any target the router would have gated —
+    /// admission and merge-time quarantine already keep such bindings out of the registry, so the
+    /// routed confirmation path is proven by tests before it is anything's default.
+    var composedTargetPolicy: ComposedToolPolicy.Mode = .refuse
+
+    /// Content-free record of refusals, for diagnostics and for tests to assert against.
+    let authorizationEvents = ToolAuthorizationEventLog()
+
     /// Names of tools routed since the last `takeTurnToolNames()` — lets the memory loop
     /// (Memory & Recall Phase 3) see which tools a turn used, to spot repeated multi-step
     /// requests worth saving as a skill.
@@ -50,83 +66,87 @@ final class NativeToolRouter {
         self.openClawBridge = openClawBridge
     }
 
-    /// Handle a tool call by name. Routing order: native → MCP → OpenClaw → error.
+    /// Handle a root tool call from a model turn. A thin adapter over `execute(_:)` so the provider
+    /// integrations keep one signature; everything below the adapter sees the same resolved call a
+    /// composed child does.
     func handleToolCall(name: String, args: [String: Any]) async -> ToolResult {
-        turnToolNames.append(name)   // Phase 3: track tools used this turn for skill detection
+        await execute(.root(name: name, arguments: ToolArguments(args), origin: .model))
+    }
 
-        // 0a. Actuation floor (Plan BC): confirmation before irreversible, security-relevant
-        // physical actions (unlock a door, open a garage, disarm an alarm) even when agent mode is
-        // OFF — so a prompt-injected sign/web result can't silently actuate. When agent mode is on,
-        // the SafetySupervisor below (0b) already confirms these high-impact tools, so this floor
-        // only needs to cover the agent-mode-off default and would otherwise double-prompt.
-        if !Config.agentModeEnabled,
-           HighImpactToolPolicy.mayRequireConfirmation(tool: name),
-           case .requiresConfirmation(let summary) = HighImpactToolPolicy.evaluate(tool: name, args: args) {
-            if let coordinator = confirmationCoordinator {
-                NSLog("[NativeToolRouter] Actuation floor requires confirmation for %@: %@", name, summary)
-                let approved = await coordinator.requestConfirmation(toolName: name, summary: summary)
-                guard approved else {
-                    NSLog("[NativeToolRouter] User declined %@ (actuation floor)", name)
-                    return .failure("The user did NOT approve this action, so '\(name)' was not performed. Do not retry it; tell the user it was cancelled unless they explicitly ask again.")
-                }
-            } else {
+    /// Authorize and dispatch one resolved call. Routing order: native → MCP → OpenClaw → error.
+    ///
+    /// Every acting path in the app funnels through here — a model tool call, a deterministically
+    /// classified utterance, a Siri Action, and a skill pack's `.tool` binding — so the policy
+    /// ladder is evaluated exactly once against the *real* target and its final arguments.
+    func execute(_ call: ResolvedToolCall) async -> ToolResult {
+        let name = call.name
+        let args = call.arguments.rawValues
+        // Phase 3: track tools used this turn for skill detection. A composed child records its
+        // resolved target *and* keeps the pack action its parent already recorded — the pair is the
+        // useful signal; only the user-visible progress reporting below is de-duplicated.
+        turnToolNames.append(name)
+
+        let safetyContext = safetyContextProvider?() ?? SafetyContext.live(now: Date(), location: nil)
+        let decision = ToolAuthorizationPolicy.evaluate(.init(
+            call: call,
+            agentModeEnabled: Config.agentModeEnabled,
+            safetyContext: safetyContext,
+            composedTargets: composedTargetPolicy))
+
+        switch decision {
+        case .allow:
+            break
+
+        case .refuse(let reason, let message):
+            authorizationEvents.record(call: call, verdict: reason.rawValue)
+            return .failure(message)
+
+        case .block(let message):
+            NSLog("[NativeToolRouter] Safety supervisor BLOCKED %@", name)
+            return .failure(message)
+
+        case .hold(let summary, let message):
+            onActionHeld?(summary)
+            NSLog("[NativeToolRouter] Held %@ for re-engagement (autonomy=%@)", name,
+                  safetyContext.autonomy.rawValue)
+            return .failure(message)
+
+        case .confirm(let summary):
+            guard let coordinator = confirmationCoordinator else {
                 // No confirmation UI wired (e.g. headless): fail closed rather than actuate blind.
-                NSLog("[NativeToolRouter] No confirmation coordinator; refusing high-impact %@", name)
-                return .failure("'\(name)' requires user confirmation, which isn't available right now, so it was not performed. Tell the user to try again with the app in the foreground.")
+                NSLog("[NativeToolRouter] No confirmation coordinator; refusing %@", name)
+                return .failure(ToolAuthorizationPolicy.unavailableConfirmationMessage(name))
+            }
+            NSLog("[NativeToolRouter] Confirmation required for %@: %@", name, summary)
+            let approved = await coordinator.requestConfirmation(toolName: name, summary: summary)
+            guard approved else {
+                NSLog("[NativeToolRouter] User declined %@", name)
+                return .failure(ToolAuthorizationPolicy.declineMessage(name))
             }
         }
 
-        // 0b. Deterministic safety supervisor (Plan S): the single pre-execution safety gate when
-        // agent mode is on. It subsumes the high-impact confirmation backstop — its
-        // `needsVoiceApproval` rule reproduces it — and adds deterministic block/confirm rules
-        // (geofence, quiet hours, irreversible floor). A `.block` veto short-circuits with no
-        // execution; a `.confirm` routes through the same human-in-the-loop gate. Even if
-        // untrusted content talked the model into a destructive tool, nothing runs without this.
-        if Config.agentModeEnabled {
-            let context = safetyContextProvider?() ?? SafetyContext.live(now: Date(), location: nil)
-            switch SafetySupervisor.evaluate(tool: name, args: args, context: context) {
-            case .allow:
-                break
-            case .block(let reason):
-                NSLog("[NativeToolRouter] Safety supervisor BLOCKED %@: %@", name, reason)
-                // Plan W: when the block is the presence autonomy ceiling on an acting tool (the
-                // user is idle/away), hold it for re-engagement instead of reporting a hard safety
-                // block — the action was deferred, not forbidden.
-                if context.autonomy != .autoAct,
-                   PromptInjectionPolicy.isHighImpact(toolName: name, args: args) {
-                    let summary = PromptInjectionPolicy.actionSummary(toolName: name, args: args)
-                    onActionHeld?(summary)
-                    NSLog("[NativeToolRouter] Held %@ for re-engagement (autonomy=%@)", name, context.autonomy.rawValue)
-                    return .failure("'\(name)' wasn't run because you've been away from the glasses; I've held it to raise when you're back. Do not retry automatically.")
-                }
-                return .failure("'\(name)' was blocked by a safety rule (\(reason)). Do not retry; tell the user it was blocked for safety.")
-            case .confirm(let reason):
-                guard let coordinator = confirmationCoordinator else {
-                    // No confirmation UI wired (e.g. headless): fail closed rather than actuate
-                    // blind, exactly as the agent-mode-off floor above does. Falling through here
-                    // would make the *more* autonomous mode the one that skips the gate.
-                    NSLog("[NativeToolRouter] No confirmation coordinator; refusing %@ (%@)", name, reason)
-                    return .failure("'\(name)' requires user confirmation, which isn't available right now, so it was not performed. Tell the user to try again with the app in the foreground.")
-                }
-                // High-impact tools get the richer action summary; other rules use their reason.
-                let summary = PromptInjectionPolicy.isHighImpact(toolName: name, args: args)
-                    ? PromptInjectionPolicy.actionSummary(toolName: name, args: args)
-                    : reason
-                NSLog("[NativeToolRouter] Safety supervisor requires confirmation for %@: %@", name, reason)
-                let approved = await coordinator.requestConfirmation(toolName: name, summary: summary)
-                guard approved else {
-                    NSLog("[NativeToolRouter] User declined %@", name)
-                    return .failure("The user did NOT approve this action, so '\(name)' was not performed. Do not retry it; tell the user it was cancelled unless they explicitly ask again.")
-                }
-            }
-        }
+        // Only a model's own root call speaks "still working" — a composed child runs inside its
+        // parent's execution, which is already reporting, and the non-model origins have no turn to
+        // narrate.
+        let reportProgress = call.context.origin == .model && call.context.depth == 0
 
-        // 1. Check native tools first
+        // 1. Check native tools first.
         if let tool = registry.tool(named: name) {
             NSLog("[NativeToolRouter] Executing native tool: %@", name)
-            return await executeWithTimeout(name: name) {
-                try await tool.execute(args: args)
+            return await executeWithTimeout(name: name, reportProgress: reportProgress) {
+                // The executing call is task-local so a tool that composes another one names its
+                // own invocation as the parent instead of inventing a fresh root.
+                try await ToolInvocationScope.$current.withValue(call) {
+                    try await tool.execute(args: args)
+                }
             }
+        }
+
+        // A composition binds a native tool by name and nothing else. Falling through to MCP or the
+        // gateway here would let an authored binding reach a third-party server the user never
+        // pointed it at.
+        guard !call.context.origin.isComposition else {
+            return .failure("This skill's underlying tool '\(name)' isn't available on this device.")
         }
 
         // 2. Check MCP servers for the tool (matched on its fully-qualified, namespace-isolated
@@ -147,7 +167,7 @@ final class NativeToolRouter {
             }
             let outboundArgs = verdict.redactedArgs ?? args
             NSLog("[NativeToolRouter] Executing MCP tool: %@", name)
-            return await executeWithTimeout(name: name) {
+            return await executeWithTimeout(name: name, reportProgress: reportProgress) {
                 await mcp.performCall(tool: tool, server: server, arguments: outboundArgs)
             }
         }
@@ -166,7 +186,8 @@ final class NativeToolRouter {
     // MARK: - Timeout + "Still Working" Updates
 
     /// Execute a tool with a timeout and periodic "still working" TTS updates.
-    private func executeWithTimeout(name: String, work: @escaping () async throws -> String) async -> ToolResult {
+    private func executeWithTimeout(name: String, reportProgress: Bool = true,
+                                    work: @escaping () async throws -> String) async -> ToolResult {
         let startTime = Date()
 
         // "Still working" timer: fires every 10 seconds during long operations
@@ -177,7 +198,7 @@ final class NativeToolRouter {
                 guard !Task.isCancelled else { break }
                 elapsed += 10
                 NSLog("[NativeToolRouter] Tool %@ still running after %ds", name, elapsed)
-                self?.onLongRunningUpdate?(elapsed)
+                if reportProgress { self?.onLongRunningUpdate?(elapsed) }
             }
         }
 

--- a/OpenGlasses/Sources/Services/NativeTools/SkillPackToolWrapper.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/SkillPackToolWrapper.swift
@@ -19,25 +19,27 @@ struct SkillPackToolWrapper: NativeTool {
     /// The pack's declared settings, so `{{setting.key}}` substitutions resolve the user's
     /// configured values (P2).
     var settingDeclarations: [SkillPackManifest.SettingDeclaration] = []
-    /// Resolves a native tool for `.tool` bindings. Injected; never captures the registry (the
-    /// wrapper is *in* the registry — a strong loop there would leak both).
-    let resolveNativeTool: @MainActor (String) -> (any NativeTool)?
-    /// Called when a `.tool` binding reaches execution with a target the composition floor
-    /// forbids — meaning admission and the merge-time quarantine both failed to contain it.
-    /// The default traps in debug (`assertionFailure` compiles out of release) so a routing
-    /// regression is impossible to miss locally; execution refuses either way. Injected so the
-    /// refusal path itself is testable.
-    var onContainmentBreach: (String) -> Void = { message in
-        NSLog("[SkillPacks] %@", message)
-        assertionFailure(message)
+    /// Hands a resolved child call to the one execution authority. Injected as a closure rather
+    /// than a reference so the wrapper never captures the registry or the router (the wrapper is
+    /// *in* the registry — a strong loop there would leak both).
+    ///
+    /// The wrapper does template substitution and type coercion and nothing else: it holds no tool
+    /// instance and has no way to execute one. The default fails closed, so a wrapper built without
+    /// an authority refuses instead of finding another route.
+    var dispatchChild: @MainActor (ResolvedToolCall) async -> ToolResult = { call in
+        .failure(ComposedToolPolicy.unroutedRefusal(target: call.name))
     }
+
+    /// Every wrapper's registered name begins with this, which is what makes a pack tool unable to
+    /// shadow a native one — and what lets the authority spot pack-to-pack chaining.
+    static let namePrefix = "pack_"
 
     private var settingsValues: [String: String] {
         SkillPackSettings.values(packId: packId, declarations: settingDeclarations)
     }
 
     static func toolName(packId: String, actionName: String) -> String {
-        "pack_" + packId.replacingOccurrences(of: ".", with: "_").replacingOccurrences(of: "-", with: "_")
+        namePrefix + packId.replacingOccurrences(of: ".", with: "_").replacingOccurrences(of: "-", with: "_")
             + "_" + actionName
     }
 
@@ -65,30 +67,27 @@ struct SkillPackToolWrapper: NativeTool {
             return PromptInjectionPolicy.wrap(toolName: name, content: filled)
 
         case .tool(let target, let boundArgs):
-            // Last line of the composition floor: this wrapper executes its target itself, so the
-            // router's confirmation gate never sees the real name. Reaching here with a restricted
-            // target means neither admission nor the merge-time quarantine held — refuse, and say
-            // so loudly in debug.
-            guard !ComposedToolPolicy.isRestrictedTarget(target) else {
-                onContainmentBreach(
-                    "Pack '\(packId)' action '\(action.name)' reached execution bound to '\(target)'")
-                return ComposedToolPolicy.refusalMessage(target: target)
-            }
-            guard let tool = resolveNativeTool(target) else {
-                return "This skill's underlying tool '\(target)' isn't available on this device."
-            }
             // Bound args are templates over the caller's args; caller args pass through
             // underneath, bound keys win — the pack author's contract, not the model's.
             // Substitution yields strings, but native tools type-check their args (`as? Int`),
             // so a purely numeric/boolean result is coerced — without this, a `tool` binding
             // could never satisfy a required integer parameter like set_timer's `seconds`
             // (found authoring the first real pack, not in review).
-            var merged = args
+            var merged = ToolArguments(args)
             for (key, template) in boundArgs {
                 let substituted = Self.substitute(template: template, args: args, settings: settingsValues)
-                merged[key] = Self.coerce(substituted)
+                merged.set(key, to: Self.coerce(substituted))
             }
-            return try await tool.execute(args: merged)
+            // The full child call — real target, final merged arguments — is resolved *before* any
+            // safety decision, then handed to the authority. Nothing here can execute it.
+            let parent = ToolInvocationScope.current
+                ?? .root(name: name, arguments: ToolArguments(args), origin: .skillPack)
+            let child = parent.child(name: target, arguments: merged, composerID: packId,
+                                     origin: .skillPack)
+            switch await dispatchChild(child) {
+            case .success(let text): return text
+            case .failure(let message): return message
+            }
 
         case .procedure(let id):
             // Parsed and validated in P1; runnable when P2 lands the content pipeline.
@@ -142,7 +141,11 @@ extension NativeToolRegistry {
     /// registry and the store exist; re-call after install/remove/enable changes — the previous
     /// merge is removed first, so this is a rebuild, and a pack that left the store leaves the
     /// registry with it.
-    func registerSkillPackTools(from store: SkillPackStore) {
+    /// `authority` is what a `.tool` binding's child call is dispatched to. Without one (or once it
+    /// goes away) a merged pack's prompt bindings keep working and its composed bindings refuse —
+    /// composition with no authorization boundary is not a supported mode.
+    func registerSkillPackTools(from store: SkillPackStore,
+                                authority: (any ToolExecutionAuthority)? = nil) {
         removeSkillPackTools()
         for manifest in store.activeManifests() {
             // Re-run the composition floor over what's actually installed: a pack admitted by an
@@ -156,14 +159,11 @@ extension NativeToolRegistry {
                     packId: manifest.id,
                     action: action,
                     settingDeclarations: manifest.settings,
-                    resolveNativeTool: { [weak self] target in
-                        guard let self else { return nil }
-                        // .tool bindings compose over native tools only — resolving another
-                        // pack's wrapper here would enable pack chaining, which v1 refuses.
-                        guard let tool = self.tool(named: target), !(tool is SkillPackToolWrapper) else {
-                            return nil
+                    dispatchChild: { [weak authority] call in
+                        guard let authority else {
+                            return .failure(ComposedToolPolicy.unroutedRefusal(target: call.name))
                         }
-                        return tool
+                        return await authority.execute(call)
                     }))
             }
         }

--- a/OpenGlasses/Sources/Services/NativeTools/ToolAuthorizationEventLog.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/ToolAuthorizationEventLog.swift
@@ -1,0 +1,54 @@
+import Foundation
+import CryptoKit
+
+/// A content-free record of one authorization verdict.
+///
+/// Ids are fingerprints, never the values: an invocation id correlates a refusal with the turn that
+/// caused it, and a pack id is user-installed content that has no business sitting in a log. The
+/// tool name is kept in the clear deliberately — it comes from a fixed, app-defined vocabulary and
+/// is the one field that makes the record actionable. No argument, template, or result ever lands
+/// here.
+struct ToolAuthorizationEvent: Sendable, Equatable {
+    let at: Date
+    let toolName: String
+    let origin: ToolInvocationOrigin
+    let depth: Int
+    let verdict: String
+    let invocationFingerprint: String
+    let rootFingerprint: String
+    let composerFingerprint: String?
+}
+
+/// Bounded in-memory security event ring for authorization refusals. Owned by the router rather
+/// than a singleton so a test observes exactly the calls it made.
+@MainActor
+final class ToolAuthorizationEventLog {
+    /// Enough to see a pattern in a session; small enough that it can't become a data store.
+    static let capacity = 50
+
+    private(set) var events: [ToolAuthorizationEvent] = []
+
+    func record(call: ResolvedToolCall, verdict: String, at: Date = Date()) {
+        let context = call.context
+        let event = ToolAuthorizationEvent(
+            at: at,
+            toolName: call.name,
+            origin: context.origin,
+            depth: context.depth,
+            verdict: verdict,
+            invocationFingerprint: Self.fingerprint(context.invocationID),
+            rootFingerprint: Self.fingerprint(context.rootInvocationID),
+            composerFingerprint: context.parent?.composerID.map(Self.fingerprint))
+        events.insert(event, at: 0)
+        if events.count > Self.capacity {
+            events.removeLast(events.count - Self.capacity)
+        }
+        NSLog("[ToolAuthorization] %@ refused for %@ (origin=%@ depth=%d invocation=%@)",
+              verdict, call.name, context.origin.rawValue, context.depth, event.invocationFingerprint)
+    }
+
+    /// Short, stable, one-way. Correlates records within a session without carrying the value.
+    static func fingerprint(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8)).prefix(8).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/OpenGlasses/Sources/Services/NativeTools/ToolAuthorizationPolicy.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/ToolAuthorizationPolicy.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Why a call was refused outright — recorded on the security event, never shown to the user.
+enum ToolRefusalReason: String, Sendable, Equatable {
+    case packChaining
+    case parentCycle
+    case depthLimit
+    case restrictedTarget
+}
+
+/// What the authority decided about one resolved call. Carrying the model-facing text here (rather
+/// than building it at the dispatch site) is what lets a test assert a verdict without executing a
+/// tool or presenting a confirmation.
+enum ToolAuthorizationDecision: Equatable {
+    case allow
+    /// The composition floor refused it: nothing executes, nothing is confirmed.
+    case refuse(reason: ToolRefusalReason, message: String)
+    /// A deterministic safety rule vetoed it.
+    case block(message: String)
+    /// The presence autonomy ceiling held an acting call for re-engagement.
+    case hold(summary: String, message: String)
+    /// Requires human approval before it runs; `summary` is the confirmation copy.
+    case confirm(summary: String)
+}
+
+/// The single policy evaluation behind every tool call, split out from dispatch so a decision can
+/// be asserted in isolation — no registry, no confirmation UI, no global `Config`.
+///
+/// Order matches the ladder the router has always applied: the composition floor first (a
+/// user-authored binding replayed by a machine), then the agent-mode-off actuation floor
+/// ([[HighImpactToolPolicy]]), then the deterministic supervisor ([[SafetySupervisor]]) when agent
+/// mode is on. The two build-mode halves stay mutually exclusive so a high-impact call is never
+/// confirmed twice.
+enum ToolAuthorizationPolicy {
+
+    struct Input {
+        let call: ResolvedToolCall
+        let agentModeEnabled: Bool
+        /// Supervisor context; only consulted when agent mode is on.
+        let safetyContext: SafetyContext
+        /// How a composition whose resolved target the router would gate is handled.
+        let composedTargets: ComposedToolPolicy.Mode
+
+        /// The default context has no rules enabled and reads no settings — the router always
+        /// passes a live one, so this keeps a policy assertion free of global state.
+        init(call: ResolvedToolCall, agentModeEnabled: Bool,
+             safetyContext: SafetyContext = SafetyContext(
+                now: Date(), location: nil, homeRegion: nil, enabledRules: [],
+                quietHoursStart: 0, quietHoursEnd: 0),
+             composedTargets: ComposedToolPolicy.Mode = .refuse) {
+            self.call = call
+            self.agentModeEnabled = agentModeEnabled
+            self.safetyContext = safetyContext
+            self.composedTargets = composedTargets
+        }
+    }
+
+    static func evaluate(_ input: Input) -> ToolAuthorizationDecision {
+        let call = input.call
+        let name = call.name
+        let args = call.arguments.rawValues
+        let context = call.context
+
+        // 0. Composition floor. A binding is authored once and replayed by a machine, so the
+        //    structural limits apply before any argument is looked at.
+        if context.depth > 0, name.hasPrefix(SkillPackToolWrapper.namePrefix) {
+            return .refuse(reason: .packChaining, message: ComposedToolPolicy.chainingRefusal(target: name))
+        }
+        if context.depth > 0, context.wouldCycle(name) {
+            return .refuse(reason: .parentCycle, message: ComposedToolPolicy.cycleRefusal(target: name))
+        }
+        if context.depth > ToolInvocationContext.maxDepth {
+            return .refuse(reason: .depthLimit, message: ComposedToolPolicy.depthRefusal(target: name))
+        }
+        if context.origin.isComposition, input.composedTargets == .refuse,
+           ComposedToolPolicy.isRestrictedTarget(name) {
+            return .refuse(reason: .restrictedTarget, message: ComposedToolPolicy.refusalMessage(target: name))
+        }
+
+        // 1. Actuation floor (Plan BC): confirmation before irreversible, security-relevant physical
+        //    actions even when agent mode is OFF, so a prompt-injected sign or web result can't
+        //    silently actuate. With agent mode on, the supervisor below already covers these tools
+        //    and this floor would only double-prompt.
+        if !input.agentModeEnabled, HighImpactToolPolicy.mayRequireConfirmation(tool: name),
+           case .requiresConfirmation(let summary) = HighImpactToolPolicy.evaluate(tool: name, args: args) {
+            return .confirm(summary: attributed(summary, call: call))
+        }
+
+        // 2. Deterministic safety supervisor (Plan S) — the single pre-execution gate when agent
+        //    mode is on. Even if untrusted content talked the model into a destructive tool, nothing
+        //    runs without this.
+        guard input.agentModeEnabled else { return .allow }
+        switch SafetySupervisor.evaluate(tool: name, args: args, context: input.safetyContext) {
+        case .allow:
+            return .allow
+        case .block(let reason):
+            // Plan W: when the block is the presence autonomy ceiling on an acting tool (the user
+            // is idle or away), the action was deferred, not forbidden — hold it for re-engagement.
+            if input.safetyContext.autonomy != .autoAct,
+               PromptInjectionPolicy.isHighImpact(toolName: name, args: args) {
+                return .hold(summary: PromptInjectionPolicy.actionSummary(toolName: name, args: args),
+                             message: holdMessage(name))
+            }
+            return .block(message: blockMessage(name, reason: reason))
+        case .confirm(let reason):
+            // High-impact tools get the richer action summary; other rules speak their reason.
+            let summary = PromptInjectionPolicy.isHighImpact(toolName: name, args: args)
+                ? PromptInjectionPolicy.actionSummary(toolName: name, args: args)
+                : reason
+            return .confirm(summary: attributed(summary, call: call))
+        }
+    }
+
+    // MARK: - Model-facing copy
+
+    /// Confirmation copy names the real action; a composed call also names what asked for it, so
+    /// approving is a decision about the action *and* its source.
+    private static func attributed(_ summary: String, call: ResolvedToolCall) -> String {
+        guard let composer = call.context.parent?.composerID else { return summary }
+        return "\(summary) — requested by the ‘\(composer)’ skill"
+    }
+
+    static func declineMessage(_ name: String) -> String {
+        "The user did NOT approve this action, so '\(name)' was not performed. Do not retry it; tell the user it was cancelled unless they explicitly ask again."
+    }
+
+    static func unavailableConfirmationMessage(_ name: String) -> String {
+        "'\(name)' requires user confirmation, which isn't available right now, so it was not performed. Tell the user to try again with the app in the foreground."
+    }
+
+    static func blockMessage(_ name: String, reason: String) -> String {
+        "'\(name)' was blocked by a safety rule (\(reason)). Do not retry; tell the user it was blocked for safety."
+    }
+
+    static func holdMessage(_ name: String) -> String {
+        "'\(name)' wasn't run because you've been away from the glasses; I've held it to raise when you're back. Do not retry automatically."
+    }
+}

--- a/OpenGlassesTests/ComposedToolContainmentTests.swift
+++ b/OpenGlassesTests/ComposedToolContainmentTests.swift
@@ -132,7 +132,8 @@ final class ComposedToolContainmentTests: XCTestCase {
             signatureBase64: nil, developerMode: true)
         guard case .installed = result else { return XCTFail("a benign pack must still install: \(result)") }
 
-        registry.registerSkillPackTools(from: store)
+        let router = NativeToolRouter(registry: registry)
+        registry.registerSkillPackTools(from: store, authority: router)
         let prompt = try XCTUnwrap(registry.tool(named: "pack_com_example_pack_coach_me"))
         let promptResult = try await prompt.execute(args: ["thing": "dishes"])
         XCTAssertTrue(promptResult.contains("dishes"))
@@ -185,8 +186,13 @@ final class ComposedToolContainmentTests: XCTestCase {
     // MARK: - Wrapper execution refusal
 
     func testWrapperRefusesRestrictedTargetWithoutExecuting() async throws {
+        // The wrapper holds no tool instance any more: it resolves the child call and hands it to
+        // the authority, which refuses a restricted target under the shipping default. A pack that
+        // slipped past admission and quarantine still cannot actuate.
         let spy = ExecutionSpy()
-        var breaches: [String] = []
+        let registry = NativeToolRegistry(locationService: LocationService())
+        registry.register(ActuatorStub(name: "smart_home", spy: spy))
+        let router = NativeToolRouter(registry: registry)
         let wrapper = SkillPackToolWrapper(
             packId: "com.example.pack",
             action: SkillPackAction(
@@ -194,15 +200,17 @@ final class ComposedToolContainmentTests: XCTestCase {
                 description: "Unlocks the door.",
                 parametersSchema: ["type": "object"],
                 binding: .tool(name: "smart_home", boundArgs: ["action": "unlock"])),
-            resolveNativeTool: { _ in ActuatorStub(name: "smart_home", spy: spy) },
-            onContainmentBreach: { breaches.append($0) })
+            dispatchChild: { [weak router] call in
+                await router?.execute(call) ?? .failure("no authority")
+            })
 
         let result = try await wrapper.execute(args: [:])
         XCTAssertFalse(spy.invoked, "a refusal that still executes is the bug")
         XCTAssertTrue(result.contains("smart_home"))
         XCTAssertTrue(result.contains("confirmation"))
-        XCTAssertEqual(breaches.count, 1, "the diagnostic fires exactly once")
-        XCTAssertTrue(breaches[0].contains("unlock_door"))
+        let event = try XCTUnwrap(router.authorizationEvents.events.first,
+                                  "the refusal is recorded as a security event")
+        XCTAssertEqual(event.verdict, ToolRefusalReason.restrictedTarget.rawValue)
     }
 
     // MARK: - Siri Actions

--- a/OpenGlassesTests/SkillPackCatalogTests.swift
+++ b/OpenGlassesTests/SkillPackCatalogTests.swift
@@ -220,7 +220,9 @@ final class SkillPackCatalogTests: XCTestCase {
         }
         nonisolated(unsafe) var captured: [String: Any] = [:]
         registry.register(CapturingTimer(onArgs: { captured = $0 }))
-        registry.registerSkillPackTools(from: store)
+        // A composed binding runs only through the execution authority, so the merge needs one.
+        let router = NativeToolRouter(registry: registry)
+        registry.registerSkillPackTools(from: store, authority: router)
         let breakTool = try XCTUnwrap(registry.tool(named: "pack_com_openglasses_focus_start_break"))
         _ = try await breakTool.execute(args: [:])
         XCTAssertEqual(captured["seconds"] as? Int, 300,

--- a/OpenGlassesTests/SkillPackTests.swift
+++ b/OpenGlassesTests/SkillPackTests.swift
@@ -297,7 +297,9 @@ final class SkillPackTests: XCTestCase {
         let store = makeStore(nativeNames: ["echo"])
         _ = store.install(manifestData: manifestJSON(actions: [composed]),
                           signatureBase64: nil, developerMode: true)
-        registry.registerSkillPackTools(from: store)
+        // A composed binding runs only through the execution authority, so the merge needs one.
+        let router = NativeToolRouter(registry: registry)
+        registry.registerSkillPackTools(from: store, authority: router)
 
         let tool = try XCTUnwrap(registry.tool(named: "pack_com_example_barista_shout"))
         let result = try await tool.execute(args: ["word": "espresso"])

--- a/OpenGlassesTests/ToolExecutionAuthorityTests.swift
+++ b/OpenGlassesTests/ToolExecutionAuthorityTests.swift
@@ -1,0 +1,397 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DJ P1 — every acting call, composed or direct, reaches one authorization authority exactly
+/// once, and it decides on the *resolved* target with its final merged arguments. These cover the
+/// pure policy (no registry, no confirmation UI, no `Config`), the routed child path a skill pack's
+/// `.tool` binding now takes, and the invariant that the classifier's LLM-free fast path can't
+/// smuggle an acting tool past the gate.
+@MainActor
+final class ToolExecutionAuthorityTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Counts executions: "confirmed once" and "declined, never ran" are both counting claims.
+    private final class ExecutionSpy {
+        var invocations: [[String: Any]] = []
+        var count: Int { invocations.count }
+    }
+
+    private struct SpyTool: NativeTool {
+        let name: String
+        let description = "spy"
+        let spy: ExecutionSpy
+        var parametersSchema: [String: Any] { ["type": "object"] }
+        func execute(args: [String: Any]) async throws -> String {
+            spy.invocations.append(args)
+            return "ran:\(name)"
+        }
+    }
+
+    /// Records the resolved call it was handed, then answers — a stand-in for the router when the
+    /// test is about what the wrapper *asks for*, not what the router decides.
+    @MainActor
+    private final class RecordingAuthority: ToolExecutionAuthority {
+        private(set) var calls: [ResolvedToolCall] = []
+        var result: ToolResult = .success("dispatched")
+        func execute(_ call: ResolvedToolCall) async -> ToolResult {
+            calls.append(call)
+            return result
+        }
+    }
+
+    private func wrapper(packId: String = "com.example.pack",
+                         action name: String = "do_it",
+                         target: String,
+                         boundArgs: [String: String] = [:],
+                         dispatch: @escaping @MainActor (ResolvedToolCall) async -> ToolResult)
+        -> SkillPackToolWrapper {
+        SkillPackToolWrapper(
+            packId: packId,
+            action: SkillPackAction(name: name, description: "Fixture.",
+                                    parametersSchema: ["type": "object"],
+                                    binding: .tool(name: target, boundArgs: boundArgs)),
+            dispatchChild: dispatch)
+    }
+
+    private func agentContext(rules: Set<SafetyRuleKind> = [],
+                              autonomy: Autonomy = .autoAct) -> SafetyContext {
+        SafetyContext(now: Date(), location: nil, homeRegion: nil, enabledRules: rules,
+                      quietHoursStart: 22, quietHoursEnd: 7, autonomy: autonomy)
+    }
+
+    /// Spin until the coordinator publishes a pending confirmation, then resolve it.
+    private func resolveWhenPending(_ coordinator: ToolConfirmationCoordinator,
+                                    _ approved: Bool) async -> PendingToolConfirmation? {
+        for _ in 0..<50 {
+            if let pending = coordinator.pending {
+                coordinator.resolve(approved)
+                return pending
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("confirmation never became pending")
+        return nil
+    }
+
+    // MARK: - Invocation model
+
+    func testArgumentsSurviveTheSendableRoundTrip() {
+        let raw: [String: Any] = [
+            "text": "hello", "count": 3, "ratio": 1.5, "flag": true,
+            "nested": ["items": [1, 2], "on": false],
+        ]
+        let round = ToolArguments(raw).rawValues
+
+        XCTAssertEqual(round["text"] as? String, "hello")
+        XCTAssertEqual(round["count"] as? Int, 3)
+        XCTAssertEqual(round["ratio"] as? Double, 1.5)
+        // A bridged Bool is an NSNumber too — the round trip must not turn `true` into 1.
+        XCTAssertEqual(round["flag"] as? Bool, true)
+        XCTAssertEqual(ToolArguments(raw)["flag"], .bool(true))
+        XCTAssertEqual(ToolArguments(raw)["count"], .int(3))
+        let nested = round["nested"] as? [String: Any]
+        XCTAssertEqual(nested?["items"] as? [Int], [1, 2])
+        XCTAssertEqual(nested?["on"] as? Bool, false)
+    }
+
+    func testProvenanceIsAdditiveAcrossNestedDispatch() {
+        let root = ResolvedToolCall.root(name: "pack_com_example_pack_do_it", origin: .model)
+        let child = root.child(name: "set_timer", arguments: ["seconds": 300],
+                               composerID: "com.example.pack")
+        let grandchild = child.child(name: "save_note", arguments: [:], composerID: "com.other.pack")
+
+        XCTAssertEqual(child.context.rootInvocationID, root.context.invocationID)
+        XCTAssertEqual(grandchild.context.rootInvocationID, root.context.invocationID,
+                       "the root invocation survives every hop")
+        XCTAssertEqual(child.context.parent?.toolName, "pack_com_example_pack_do_it")
+        XCTAssertEqual(child.context.parent?.composerID, "com.example.pack")
+        XCTAssertEqual(grandchild.context.parent?.invocationID, child.context.invocationID)
+        XCTAssertEqual(grandchild.context.depth, 2)
+        XCTAssertEqual(grandchild.context.ancestry,
+                       ["pack_com_example_pack_do_it", "set_timer"])
+        XCTAssertTrue(grandchild.context.wouldCycle("set_timer"))
+        XCTAssertFalse(grandchild.context.wouldCycle("save_note"))
+    }
+
+    // MARK: - Pure policy
+
+    func testCompositionFloorRefusesChainingCyclesAndDepth() {
+        let root = ResolvedToolCall.root(name: "pack_a_run", origin: .model)
+
+        let chained = root.child(name: "pack_b_run", arguments: [:], composerID: "a")
+        guard case .refuse(let chainReason, _) = ToolAuthorizationPolicy.evaluate(
+            .init(call: chained, agentModeEnabled: false)) else {
+            return XCTFail("one pack calling another must be refused")
+        }
+        XCTAssertEqual(chainReason, .packChaining)
+
+        var cycling = root.child(name: "get_weather", arguments: [:], composerID: "a")
+        cycling = cycling.child(name: "pack_a_run", arguments: [:], composerID: "a")
+        cycling = cycling.child(name: "get_weather", arguments: [:], composerID: "a")
+        guard case .refuse(let cycleReason, _) = ToolAuthorizationPolicy.evaluate(
+            .init(call: cycling, agentModeEnabled: false)) else {
+            return XCTFail("re-entering a call already on the stack must be refused")
+        }
+        XCTAssertEqual(cycleReason, .parentCycle)
+
+        var deep = root
+        for step in 0...ToolInvocationContext.maxDepth {
+            deep = deep.child(name: "step_\(step)", arguments: [:], composerID: "a")
+        }
+        XCTAssertGreaterThan(deep.context.depth, ToolInvocationContext.maxDepth)
+        guard case .refuse(let depthReason, _) = ToolAuthorizationPolicy.evaluate(
+            .init(call: deep, agentModeEnabled: false)) else {
+            return XCTFail("composition past the depth ceiling must be refused")
+        }
+        XCTAssertEqual(depthReason, .depthLimit)
+    }
+
+    func testRestrictedTargetsAreRefusedForCompositionByDefaultOnly() {
+        let root = ResolvedToolCall.root(name: "pack_a_unlock", origin: .model)
+        let child = root.child(name: "smart_home", arguments: ["action": "unlock"], composerID: "a")
+
+        guard case .refuse(let reason, let message) = ToolAuthorizationPolicy.evaluate(
+            .init(call: child, agentModeEnabled: false)) else {
+            return XCTFail("the shipping default keeps the composition floor closed")
+        }
+        XCTAssertEqual(reason, .restrictedTarget)
+        XCTAssertTrue(message.contains("smart_home"))
+
+        // Routed instead: the same call becomes a confirmation on the real action, not a refusal.
+        guard case .confirm(let summary) = ToolAuthorizationPolicy.evaluate(
+            .init(call: child, agentModeEnabled: false, composedTargets: .confirmResolved)) else {
+            return XCTFail("routed composition must reach the confirmation gate")
+        }
+        XCTAssertTrue(summary.lowercased().contains("unlock"), "copy names the real action: \(summary)")
+        XCTAssertTrue(summary.contains("‘a’"), "copy names the originating pack: \(summary)")
+
+        // A direct model call to a *non*-restricted tool is untouched by the floor.
+        if case .allow = ToolAuthorizationPolicy.evaluate(
+            .init(call: .root(name: "get_weather", origin: .model), agentModeEnabled: false)) {} else {
+            XCTFail("read-only direct calls must not be gated")
+        }
+    }
+
+    func testSiriOriginIsGovernedByTheCompositionFloorAtDepthZero() {
+        let siri = ResolvedToolCall.root(name: "smart_home", arguments: ["action": "unlock"],
+                                         origin: .siriAction)
+        guard case .refuse(let reason, _) = ToolAuthorizationPolicy.evaluate(
+            .init(call: siri, agentModeEnabled: false)) else {
+            return XCTFail("a saved Siri Action is composition even at the root")
+        }
+        XCTAssertEqual(reason, .restrictedTarget)
+
+        if case .allow = ToolAuthorizationPolicy.evaluate(
+            .init(call: .root(name: "teleprompter", origin: .siriAction), agentModeEnabled: false)) {} else {
+            XCTFail("a read-only Siri Action still runs")
+        }
+    }
+
+    func testAgentModeRulesApplyToChildCalls() {
+        let root = ResolvedToolCall.root(name: "pack_a_send", origin: .model)
+        let child = root.child(name: "send_message", arguments: ["to": "mum"], composerID: "a")
+
+        guard case .confirm(let summary) = ToolAuthorizationPolicy.evaluate(.init(
+            call: child, agentModeEnabled: true,
+            safetyContext: agentContext(rules: [.needsVoiceApproval]),
+            composedTargets: .confirmResolved)) else {
+            return XCTFail("supervisor rules must reach the child call")
+        }
+        XCTAssertTrue(summary.contains("‘a’"))
+
+        guard case .hold = ToolAuthorizationPolicy.evaluate(.init(
+            call: child, agentModeEnabled: true,
+            safetyContext: agentContext(rules: [.needsVoiceApproval], autonomy: .paused),
+            composedTargets: .confirmResolved)) else {
+            return XCTFail("the presence ceiling must hold an acting child call")
+        }
+    }
+
+    // MARK: - Routed child execution
+
+    /// The confirmation a wrapped high-impact call raises must be indistinguishable from the one a
+    /// direct call raises, and it must carry the arguments the pack actually bound.
+    func testWrappedHighImpactCallConfirmsLikeADirectCall() async throws {
+        let saved = Config.agentModeEnabled
+        Config.setAgentModeEnabled(false)
+        defer { Config.setAgentModeEnabled(saved) }
+
+        let spy = ExecutionSpy()
+        let registry = NativeToolRegistry(locationService: LocationService())
+        registry.register(SpyTool(name: "smart_home", spy: spy))
+        let coordinator = ToolConfirmationCoordinator()
+        let router = NativeToolRouter(registry: registry)
+        router.confirmationCoordinator = coordinator
+        router.composedTargetPolicy = .confirmResolved
+
+        let composed = wrapper(target: "smart_home",
+                               boundArgs: ["action": "unlock", "device": "{{door}}"],
+                               dispatch: { [weak router] call in
+                                   await router?.execute(call) ?? .failure("no authority")
+                               })
+
+        // Direct: what the user is asked when the model calls the tool itself.
+        async let direct = router.handleToolCall(name: "smart_home",
+                                                 args: ["action": "unlock", "device": "Front Door"])
+        let directPrompt = await resolveWhenPending(coordinator, true)
+        _ = await direct
+        XCTAssertEqual(spy.count, 1)
+
+        // Wrapped: the same ask, reached through the pack.
+        async let approvedComposed = composed.execute(args: ["door": "Front Door"])
+        let composedPrompt = await resolveWhenPending(coordinator, true)
+        _ = try await approvedComposed
+
+        let directSummary = try XCTUnwrap(directPrompt?.summary)
+        let composedSummary = try XCTUnwrap(composedPrompt?.summary)
+        XCTAssertEqual(composedPrompt?.toolName, "smart_home",
+                       "the card names the resolved target, not the wrapper")
+        XCTAssertTrue(composedSummary.hasPrefix(directSummary),
+                      "same ask as the direct call: \(composedSummary) vs \(directSummary)")
+        XCTAssertTrue(composedSummary.contains("Front Door"), "with the final bound arguments")
+        XCTAssertTrue(composedSummary.contains("com.example.pack"), "attributed to the pack")
+
+        // Approve → executed exactly once, with the merged arguments.
+        XCTAssertEqual(spy.count, 2)
+        XCTAssertEqual(spy.invocations.last?["action"] as? String, "unlock")
+        XCTAssertEqual(spy.invocations.last?["device"] as? String, "Front Door")
+
+        // Decline → the fake executor is never reached again.
+        async let declined = composed.execute(args: ["door": "Front Door"])
+        _ = await resolveWhenPending(coordinator, false)
+        let declinedResult = try await declined
+        XCTAssertEqual(spy.count, 2, "a declined composed call must not execute")
+        XCTAssertTrue(declinedResult.contains("did NOT approve"))
+    }
+
+    func testComposedCallFailsClosedWithoutConfirmationUI() async throws {
+        let saved = Config.agentModeEnabled
+        Config.setAgentModeEnabled(false)
+        defer { Config.setAgentModeEnabled(saved) }
+
+        let spy = ExecutionSpy()
+        let registry = NativeToolRegistry(locationService: LocationService())
+        registry.register(SpyTool(name: "smart_home", spy: spy))
+        let router = NativeToolRouter(registry: registry)
+        router.composedTargetPolicy = .confirmResolved   // no confirmationCoordinator wired
+
+        let composed = wrapper(target: "smart_home", boundArgs: ["action": "unlock"],
+                               dispatch: { [weak router] call in
+                                   await router?.execute(call) ?? .failure("no authority")
+                               })
+        let result = try await composed.execute(args: [:])
+        XCTAssertEqual(spy.count, 0, "no confirmation surface means no actuation")
+        XCTAssertTrue(result.contains("requires user confirmation"))
+    }
+
+    func testWrapperWithNoAuthorityRefusesInsteadOfExecuting() async throws {
+        let composed = SkillPackToolWrapper(
+            packId: "com.example.pack",
+            action: SkillPackAction(name: "do_it", description: "Fixture.",
+                                    parametersSchema: ["type": "object"],
+                                    binding: .tool(name: "get_weather", boundArgs: [:])))
+        let result = try await composed.execute(args: [:])
+        XCTAssertTrue(result.contains("couldn't be checked for safety"),
+                      "composition with no authorization boundary is not a supported mode")
+    }
+
+    func testWrapperResolvesTheChildCallBeforeHandingItOver() async throws {
+        let authority = RecordingAuthority()
+        let composed = wrapper(target: "set_timer", boundArgs: ["seconds": "{{minutes}}0"],
+                               dispatch: { await authority.execute($0) })
+
+        _ = try await composed.execute(args: ["minutes": 3, "label": "tea"])
+
+        let call = try XCTUnwrap(authority.calls.first)
+        XCTAssertEqual(call.name, "set_timer", "the authority sees the real target")
+        XCTAssertEqual(call.arguments["seconds"], .int(30), "coerced, substituted, merged")
+        XCTAssertEqual(call.arguments["label"], .string("tea"), "caller args pass through underneath")
+        XCTAssertEqual(call.context.origin, .skillPack)
+        XCTAssertEqual(call.context.parent?.composerID, "com.example.pack")
+        XCTAssertEqual(call.context.depth, 1)
+    }
+
+    func testReadOnlyWrappedToolIsUnchangedByRouting() async throws {
+        let spy = ExecutionSpy()
+        let registry = NativeToolRegistry(locationService: LocationService())
+        registry.register(SpyTool(name: "get_weather", spy: spy))
+        let router = NativeToolRouter(registry: registry)
+
+        let composed = wrapper(target: "get_weather",
+                               dispatch: { [weak router] call in
+                                   await router?.execute(call) ?? .failure("no authority")
+                               })
+        let result = try await composed.execute(args: [:])
+        XCTAssertEqual(result, "ran:get_weather")
+        XCTAssertEqual(spy.count, 1)
+        XCTAssertEqual(router.takeTurnToolNames(), ["get_weather"],
+                       "the resolved target is recorded for the turn")
+    }
+
+    func testRouterRefusesPackChainingAndRecordsAContentFreeEvent() async throws {
+        let spy = ExecutionSpy()
+        let registry = NativeToolRegistry(locationService: LocationService())
+        let inner = wrapper(packId: "com.example.inner", action: "inner", target: "get_weather",
+                            dispatch: { _ in .success("unreachable") })
+        registry.register(inner)
+        registry.register(SpyTool(name: "get_weather", spy: spy))
+        let router = NativeToolRouter(registry: registry)
+
+        let outer = wrapper(packId: "com.example.outer", action: "outer", target: inner.name,
+                            dispatch: { [weak router] call in
+                                await router?.execute(call) ?? .failure("no authority")
+                            })
+        let result = try await outer.execute(args: [:])
+        XCTAssertTrue(result.contains("one skill can't call another"))
+        XCTAssertEqual(spy.count, 0)
+
+        let event = try XCTUnwrap(router.authorizationEvents.events.first)
+        XCTAssertEqual(event.verdict, ToolRefusalReason.packChaining.rawValue)
+        XCTAssertEqual(event.toolName, inner.name)
+        XCTAssertEqual(event.depth, 1)
+        XCTAssertNotNil(event.composerFingerprint)
+        XCTAssertNotEqual(event.composerFingerprint, "com.example.outer",
+                          "pack ids are fingerprinted, never logged in the clear")
+        XCTAssertEqual(event.composerFingerprint,
+                       ToolAuthorizationEventLog.fingerprint("com.example.outer"))
+    }
+
+    func testComposedCallCannotReachTheGatewayFallback() async throws {
+        let registry = NativeToolRegistry(locationService: LocationService())
+        let router = NativeToolRouter(registry: registry)
+        let composed = wrapper(target: "definitely_not_registered",
+                               dispatch: { [weak router] call in
+                                   await router?.execute(call) ?? .failure("no authority")
+                               })
+        let result = try await composed.execute(args: [:])
+        XCTAssertTrue(result.contains("isn't available on this device"),
+                      "a binding composes over native tools only")
+    }
+
+    // MARK: - The LLM-free fast path
+
+    /// Tier-0 dispatch now goes through the authority, so the classifier's allowlist is a routing
+    /// shortcut rather than the only thing standing between a pattern match and an action. This
+    /// pins the second half of that: nothing reachable from the allowlist is an acting tool the
+    /// router would have gated.
+    func testEveryClassifierFastPathToolIsUngated() {
+        let classifier = ConversationClassifier()
+        let utterances = [
+            "what time is it", "play music", "pause", "next track", "flashlight on",
+            "turn off the flashlight", "how many steps have i taken", "what's my battery",
+            "what's the weather", "what's on my calendar", "what's on my calendar tomorrow",
+            "new topic",
+        ]
+        var matched: Set<String> = []
+        for utterance in utterances {
+            guard let direct = classifier.classify(utterance).directToolCall else { continue }
+            matched.insert(direct.toolName)
+            XCTAssertFalse(ComposedToolPolicy.isRestrictedTarget(direct.toolName),
+                           "\(direct.toolName) is gated by the router and must not be pattern-dispatched")
+        }
+        XCTAssertTrue(matched.contains("get_datetime"), "the fixtures must actually exercise tier-0")
+        XCTAssertTrue(matched.contains("flashlight"))
+        XCTAssertTrue(matched.contains("get_weather"))
+    }
+}


### PR DESCRIPTION
Implements P1 of `docs/plans/DJ-composed-tool-safety-and-execution-outcomes.md` — "Route child calls through one execution authority". Stacked on #358 (P0); retargets to `main` when that merges.

## The problem P0 didn't fix

P0 made composition fail closed. It didn't change the architecture: `SkillPackToolWrapper.execute` still resolved its `.tool` target from the registry and called `tool.execute(args:)` itself, so the router — which owns the actuation floor, the `SafetySupervisor`, the confirmation gate, the MCP egress screen, progress reporting, and the timeout — never saw the resolved child call. And `NativeToolRegistry.executeTool` still had three other direct callers.

## What lands

**An invocation model** (`OpenGlasses/Sources/Models/ToolInvocation.swift`) — `ToolArgumentValue`/`ToolArguments` (genuinely `Sendable`, lossless to and from `[String: Any]`, with the `NSNumber`/`Bool` bridging preserved so tools' `as? Int`/`as? Bool` checks behave exactly as they do for provider-parsed JSON), `ToolInvocationOrigin`, `ToolCallParent`, `ToolInvocationContext` (invocation id, root id, parent, depth, ancestry), and `ResolvedToolCall` with a `child(...)` factory. A `ToolInvocationScope` task-local carries the executing call so a composing tool can name its own invocation as the parent.

**A pure policy** (`ToolAuthorizationPolicy`) — the whole ladder as one function over `(call, agentModeEnabled, safetyContext, composedTargets)`, returning `allow` / `refuse` / `block` / `hold` / `confirm`. No registry, no confirmation UI, no global `Config`, so a verdict can be asserted without executing anything.

**One authority** — `NativeToolRouter.execute(_ call: ResolvedToolCall)`, with `handleToolCall(name:args:)` kept as a thin root-call adapter so the provider integrations are untouched. Every acting path now goes through it.

**The wrapper holds no tool.** `resolveNativeTool` is replaced by an injected `dispatchChild`; the wrapper substitutes, coerces, builds the resolved child call (real target + final merged args + pack id + parent invocation) and hands it over. Without an authority it refuses instead of finding another route. Confirmation copy names the real action and the pack that asked for it.

**Composition floor in the authority** — a child target beginning `pack_`, a parent cycle, or depth above 4 is refused, and each refusal records a content-free security event (`ToolAuthorizationEventLog`: SHA-256 fingerprints of invocation/root/pack ids, the verdict, the tool name, depth — never arguments, templates, or results).

**Progress and turn names** — a composed child records its resolved target in `turnToolNames` alongside the pack action its parent recorded, but only a model's own root call speaks the "still working" updates, so the user-visible turn isn't narrated twice.

## The four direct callers

| Caller | Handling |
|---|---|
| `IntentSupport.runTool` (Siri Actions) | Routed with a `.siriAction` origin. The composition floor applies at depth 0 for that origin, so P0's refusal is now the authority's decision rather than a second check. |
| Tier-0 fast path in `OpenGlassesApp` | Routed with a `.user` origin; a failure still falls through to the LLM path, which re-reaches the same gate. Backed by a test that fails if anything reachable from the classifier allowlist is a tool the router would gate. |
| Weather-context pre-fetch | Routed with an `.appInternal` origin. |
| Remote-invoke `addNote` (`save_note`) | Routed with an `.appInternal` origin. Not in the plan text; found in review, same invariant. |

`NativeToolRegistry.executeTool(name:arguments:)` is **deleted** — the guard is structural rather than a lint: there is no lookup-and-execute helper left to call.

## P0 containment: what stands, what moved

Kept, all of it by default: `SkillPackValidator` still rejects a restricted `.tool` binding at admission, `registerSkillPackTools` still quarantines legacy installed actions, and `SiriActionCatalog`/`SiriActionDispatcher` still refuse restricted bindings.

One P0 mechanism changed shape: the wrapper's own execution-time refusal (with its debug `assertionFailure`) is gone, because a restricted composed target reaching the router is no longer a routing bug — it is the contained path. The refusal itself is unchanged in effect and is now the authority's, recorded as a security event; `ComposedToolContainmentTests.testWrapperRefusesRestrictedTargetWithoutExecuting` asserts the same outcome through the new seam.

Nothing is lifted by default. `ComposedToolPolicy.Mode` defaults to `.refuse`; `.confirmResolved` — where a restricted composed target reaches the same confirmation a direct call gets, with the resolved arguments and the pack named — is proven by `testWrappedHighImpactCallConfirmsLikeADirectCall` (decline → the fake executor is never invoked; approve → invoked exactly once with the merged args) but is not the shipping default. Turning it on is a follow-up, and it needs one more thing considered first: under `.confirmResolved` a Siri-origin call could suspend awaiting a confirmation UI that a background intent can't present.

## Tests

`OpenGlassesTests/ToolExecutionAuthorityTests.swift` (14): argument round-trip fidelity; provenance across nested dispatch; chaining/cycle/depth refusals; restricted-target refusal by default and confirmation under `.confirmResolved`; Siri origin governed at depth 0; Agent Mode confirm + presence hold through the child path; the wrapped-vs-direct confirmation equivalence with decline/approve counting; fail-closed with no confirmation UI; fail-closed with no authority; the resolved child call the wrapper hands over; read-only wrappers unchanged; composed calls can't reach MCP or the gateway; pack chaining refused with a content-free event; the classifier fast-path confinement.

Full unit suite green apart from the usual unsigned-build keychain failures. Release build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
