### PR TITLE
Run an irreversible action at most once, and record what became of it

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -883,6 +883,19 @@ class AppState: ObservableObject, AppStateProtocol {
         nativeToolRouter.onActionHeld = { [weak self] summary in
             self?.heldRecommendations.record(summary: summary, at: Date())
         }
+        // An operation that resolves after the turn has moved on updates the record and the log,
+        // and stops there: the conversation already said what was known at the time, and a second
+        // announcement arriving minutes later would be worse than the uncertainty it replaces.
+        nativeToolRouter.onOperationStatusChange = { record in
+            guard record.resolvedLate else { return }
+            NSLog("[AppState] Operation for %@ settled as %@ after the turn ended",
+                  record.toolName, record.state.rawValue)
+        }
+        // Anything a previous process left in flight is unknown until a tool that can check says
+        // otherwise. Off the launch path; nothing waits on it.
+        Task { @MainActor [weak self] in
+            await self?.nativeToolRouter.reconcileRecoveredOperations()
+        }
         toolConfirmationCoordinator.onSpeakPrompt = { [weak self] prompt in
             guard let self else { return }
             // Shared consent surface (BN P1): spoken prompt + in-lens HUD card together.

--- a/OpenGlasses/Sources/Models/OperationRecord.swift
+++ b/OpenGlasses/Sources/Models/OperationRecord.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Where one journaled operation stands.
+///
+/// `unknown` is the state this whole mechanism exists to keep: an operation that began and whose
+/// result nobody can vouch for. It is never quietly rewritten to `failed` — not by a timeout, and
+/// not by the app being killed mid-flight.
+enum OperationState: String, Codable, Sendable, Equatable {
+    /// Dispatched, still in flight in this process.
+    case started
+    /// Authoritative success.
+    case completed
+    /// Authoritative failure with no side effect.
+    case failed
+    /// Began and may still land. Only an authoritative completion or a reconciliation answer
+    /// moves it out of this state.
+    case unknown
+
+    init(_ outcome: ToolExecutionOutcome) {
+        switch outcome {
+        case .completed: self = .completed
+        // A rejection never reaches the journal (nothing is admitted until policy has allowed the
+        // call), so it can only arrive here as a late relay from a composed child.
+        case .rejected, .failedBeforeExecution: self = .failed
+        case .outcomeUnknown: self = .unknown
+        }
+    }
+
+    var isTerminal: Bool { self == .completed || self == .failed }
+    /// Whether repeating the operation could duplicate an effect that already landed.
+    var isUnresolved: Bool { self == .started || self == .unknown }
+}
+
+/// One row of the operation journal.
+///
+/// Deliberately content-free. The operation and idempotency ids are opaque, the provenance is
+/// fingerprinted the way `ToolAuthorizationEvent` fingerprints it, and the tool name — from a fixed,
+/// app-defined vocabulary — is the only human-readable field. No argument, result, template, or
+/// message is stored, in memory-encoded form or on disk.
+struct OperationRecord: Codable, Sendable, Equatable {
+    let operationID: String
+    let idempotencyKey: String
+    let toolName: String
+    let effect: ToolEffect
+    let origin: ToolInvocationOrigin
+    let depth: Int
+    let rootFingerprint: String
+    let parentFingerprint: String?
+    let composerFingerprint: String?
+    let startedAt: Date
+    var updatedAt: Date
+    var state: OperationState
+    /// True when this row was carried over from a previous process that died mid-operation.
+    var recoveredFromRestart: Bool = false
+    /// True when the authoritative answer arrived after the caller had already been told the
+    /// outcome was unknown — the turn has moved on, so this resolution belongs to operation status
+    /// and diagnostics rather than to the conversation.
+    var resolvedLate: Bool = false
+
+    var isUnresolved: Bool { state.isUnresolved }
+}
+
+// `ToolEffect` and `ToolInvocationOrigin` are plain string enums; the journal is the only thing
+// that needs them on disk, so their `Codable` conformance is declared here rather than widening
+// the model types themselves.
+extension ToolEffect: Codable {}
+extension ToolInvocationOrigin: Codable {}

--- a/OpenGlasses/Sources/Services/Agent/PlanExecutor.swift
+++ b/OpenGlasses/Sources/Services/Agent/PlanExecutor.swift
@@ -4,8 +4,8 @@ import Foundation
 /// a fake in tests. Matches `NativeToolRouter.executeRoot` so the router conforms for free.
 @MainActor
 protocol ToolExecuting: AnyObject {
-    func executeRoot(name: String, args: [String: Any],
-                     origin: ToolInvocationOrigin) async -> ToolExecutionOutcome
+    func executeRoot(name: String, args: [String: Any], origin: ToolInvocationOrigin,
+                     invocationID: String) async -> ToolExecutionOutcome
 }
 
 extension NativeToolRouter: ToolExecuting {}
@@ -48,12 +48,18 @@ final class PlanExecutor {
     func execute(_ plan: AgentPlan) async -> PlanRunResult {
         var transcript: [String] = []
         var completed = 0
+        let runID = UUID().uuidString
 
         for (index, step) in plan.steps.enumerated() {
             onStep?(index + 1, plan.steps.count, step)
             if !step.rationale.isEmpty { onNarrate?(step.rationale) }
 
-            switch await router.executeRoot(name: step.tool, args: step.args, origin: .model) {
+            // One identity per step of this run, so a step is the same operation wherever it is
+            // observed. A fresh run of the same plan gets a fresh run id and executes normally —
+            // re-running a plan is a decision, not a redelivery.
+            let stepInvocationID = "\(runID)#\(index)"
+            switch await router.executeRoot(name: step.tool, args: step.args, origin: .model,
+                                            invocationID: stepInvocationID) {
             case .completed(let text):
                 completed += 1
                 transcript.append("✓ \(step.tool): \(String(text.prefix(120)))")

--- a/OpenGlasses/Sources/Services/LLM/ToolLoopDriver.swift
+++ b/OpenGlasses/Sources/Services/LLM/ToolLoopDriver.swift
@@ -68,8 +68,11 @@ struct ToolDispatchOutcome {
 /// a mock executor.
 struct ToolDispatcher {
     /// Executes a well-formed native/gateway tool call. `rawArguments` is the original arg string
-    /// (OpenAI) for the bridge `task` fallback.
-    let execute: (_ name: String, _ args: [String: Any], _ rawArguments: String?) async -> ToolExecutionOutcome
+    /// (OpenAI) for the bridge `task` fallback. `callID` is the provider's own id for this call —
+    /// the identity a redelivery repeats, and what the operation journal keys at-most-once
+    /// execution off; nil where the provider is name-keyed (Gemini) and no such identity exists.
+    let execute: (_ name: String, _ args: [String: Any], _ rawArguments: String?,
+                  _ callID: String?) async -> ToolExecutionOutcome
     /// Reports status transitions (executing → completed/failed/unknown) to the UI.
     let onStatus: (ToolCallStatus) -> Void
 
@@ -77,7 +80,7 @@ struct ToolDispatcher {
         onStatus(.executing(invocation.name))
         let outcome: ToolExecutionOutcome
         if let args = invocation.arguments {
-            outcome = await execute(invocation.name, args, invocation.rawArguments)
+            outcome = await execute(invocation.name, args, invocation.rawArguments, invocation.id)
         } else {
             // Malformed arguments never reached a tool, so this is authoritative.
             outcome = .failedBeforeExecution(reason: "Could not parse the arguments for '\(invocation.name)' as JSON. Re-issue the call with valid JSON arguments.")

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -472,12 +472,15 @@ class LLMService: ObservableObject {
     /// `ToolDispatcher` value type so the whole step is unit-testable with a mock executor.
     private func makeToolDispatcher() -> ToolDispatcher {
         ToolDispatcher(
-            execute: { [weak self] name, args, rawArgs in
+            execute: { [weak self] name, args, rawArgs, callID in
                 guard let self else {
                     return .failedBeforeExecution(reason: "Service unavailable")
                 }
                 if let router = self.nativeToolRouter {
-                    return await router.executeRoot(name: name, args: args)
+                    // The provider's own call id, where it gave one: a redelivery of this exact
+                    // call then resolves to the operation that already ran instead of running again.
+                    return await router.executeRoot(name: name, args: args, origin: .model,
+                                                    invocationID: callID ?? UUID().uuidString)
                 } else if let bridge = self.openClawBridge, Config.isOpenClawAgentActive {
                     let taskDesc = args["task"] as? String ?? (rawArgs ?? String(describing: args))
                     return ToolExecutionOutcome(

--- a/OpenGlasses/Sources/Services/MCPClient.swift
+++ b/OpenGlasses/Sources/Services/MCPClient.swift
@@ -122,16 +122,15 @@ final class MCPClient: ObservableObject {
     /// Perform the actual `tools/call` network request. Egress screening is applied by the
     /// caller (`NativeToolRouter`) before this runs; `arguments` here are already screened.
     /// The JSON-RPC `name` is the server's *bare* tool name, never the qualified one.
-    func performCall(tool: MCPTool, server: MCPServerConfig, arguments: [String: Any]) async -> String {
-        let payload: [String: Any] = [
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "tools/call",
-            "params": [
-                "name": tool.name,
-                "arguments": arguments,
-            ] as [String: Any],
-        ]
+    ///
+    /// `idempotencyKey` identifies the operation across redeliveries. `tools/call` has no key field
+    /// of its own, so it rides in the request's `_meta` — the one place the protocol reserves for
+    /// exactly this, and which a server that doesn't understand it ignores. It is a digest, so it
+    /// carries no argument content off the device.
+    func performCall(tool: MCPTool, server: MCPServerConfig, arguments: [String: Any],
+                     idempotencyKey: String? = nil) async -> String {
+        let payload = Self.callPayload(toolName: tool.name, arguments: arguments,
+                                       idempotencyKey: idempotencyKey)
 
         guard let data = try? await mcpRequest(server: server, payload: payload),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -151,6 +150,25 @@ final class MCPClient: ObservableObject {
         }
         return "Tool executed successfully."
     }
+
+    /// The `tools/call` request body. Pure and static so the wire shape — including whether an
+    /// idempotency key actually reaches the server — is assertable without a network.
+    nonisolated static func callPayload(toolName: String, arguments: [String: Any],
+                                        idempotencyKey: String?) -> [String: Any] {
+        var params: [String: Any] = ["name": toolName, "arguments": arguments]
+        if let idempotencyKey {
+            params["_meta"] = [Self.idempotencyMetaKey: idempotencyKey]
+        }
+        return [
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": params,
+        ]
+    }
+
+    /// Namespaced so it can never collide with a protocol-reserved `_meta` key.
+    nonisolated static let idempotencyMetaKey = "nz.co.skunkworks.openglasses/idempotency-key"
 
     // MARK: - Server Management
 

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRouter.swift
@@ -49,6 +49,21 @@ final class NativeToolRouter: ToolExecutionAuthority {
     /// Content-free record of refusals, for diagnostics and for tests to assert against.
     let authorizationEvents = ToolAuthorizationEventLog()
 
+    /// Durable at-most-once record for operations that cannot safely be repeated. Injected so a
+    /// test writes to its own directory; the app-wide protected store is the default because
+    /// durability here is the safety property, not a wiring detail somebody might forget.
+    var operationJournal: any OperationJournal = ProtectedOperationJournal.shared
+
+    /// One operation at a time per logical resource, for the adapters that can't de-duplicate for
+    /// themselves.
+    private let resourceSerializer = OperationResourceSerializer()
+
+    /// An operation's journal state changed. The one case that matters is a record arriving with
+    /// `resolvedLate` set: the caller was already told the outcome was unknown and the turn has
+    /// moved on, so the answer belongs to operation status and diagnostics — never to a second
+    /// spoken success after the fact.
+    var onOperationStatusChange: ((OperationRecord) -> Void)?
+
     /// Names of tools routed since the last `takeTurnToolNames()` — lets the memory loop
     /// (Memory & Recall Phase 3) see which tools a turn used, to spot repeated multi-step
     /// requests worth saving as a skill.
@@ -76,9 +91,16 @@ final class NativeToolRouter: ToolExecutionAuthority {
     /// The same root adapter, keeping the typed outcome. Callers that can act on the retry
     /// disposition (the tool-loop driver, the live-session router) use this one; the `ToolResult`
     /// adapter above stays for the provider wires, which only ever needed the text.
+    ///
+    /// `invocationID` is the caller's own identifier for the delivery — a provider's `tool_use` /
+    /// `tool_call` id, or a live-session function-call id. Supplying it is what lets a redelivery of
+    /// the same call be recognised as the same operation instead of executed a second time; where a
+    /// caller has no stable id, the default fresh UUID keeps every delivery distinct.
     func executeRoot(name: String, args: [String: Any],
-                     origin: ToolInvocationOrigin = .model) async -> ToolExecutionOutcome {
-        await execute(.root(name: name, arguments: ToolArguments(args), origin: origin))
+                     origin: ToolInvocationOrigin = .model,
+                     invocationID: String = UUID().uuidString) async -> ToolExecutionOutcome {
+        await execute(.root(name: name, arguments: ToolArguments(args), origin: origin,
+                            invocationID: invocationID))
     }
 
     /// Authorize and dispatch one resolved call. Routing order: native → MCP → OpenClaw → error.
@@ -127,7 +149,8 @@ final class NativeToolRouter: ToolExecutionAuthority {
                 NSLog("[NativeToolRouter] No confirmation coordinator; refusing %@", name)
                 return .rejected(reason: ToolAuthorizationPolicy.unavailableConfirmationMessage(name))
             }
-            NSLog("[NativeToolRouter] Confirmation required for %@: %@", name, summary)
+            NSLog("[NativeToolRouter] Confirmation required for %@: %@", name,
+                  ToolLogContent.redacted(summary))
             let approved = await coordinator.requestConfirmation(toolName: name, summary: summary)
             guard approved else {
                 NSLog("[NativeToolRouter] User declined %@", name)
@@ -140,16 +163,25 @@ final class NativeToolRouter: ToolExecutionAuthority {
         // narrate.
         let reportProgress = call.context.origin == .model && call.context.depth == 0
 
+        // Cancelled while it was being authorized — the turn was abandoned, the session torn down.
+        // Nothing has been dispatched and nothing is journaled: this is the one place where "it did
+        // not happen" is something we actually know.
+        if Task.isCancelled {
+            return .failedBeforeExecution(reason: Self.cancelledBeforeDispatch(name))
+        }
+
         // 1. Check native tools first.
         if let tool = registry.tool(named: name) {
             NSLog("[NativeToolRouter] Executing native tool: %@", name)
-            return await executeWithTimeout(name: name, semantics: tool.executionSemantics,
-                                            operationID: call.context.invocationID,
-                                            reportProgress: reportProgress) {
+            return await dispatch(call, semantics: tool.executionSemantics,
+                                  reportProgress: reportProgress) { key in
                 // The executing call is task-local so a tool that composes another one names its
-                // own invocation as the parent instead of inventing a fresh root.
+                // own invocation as the parent instead of inventing a fresh root; the operation's
+                // idempotency key rides alongside for any adapter that can put one on the wire.
                 try await ToolInvocationScope.$current.withValue(call) {
-                    try await tool.execute(args: args)
+                    try await OperationScope.$idempotencyKey.withValue(key) {
+                        try await tool.execute(args: args)
+                    }
                 }
             }
         }
@@ -183,10 +215,10 @@ final class NativeToolRouter: ToolExecutionAuthority {
             // A third-party server's tool declares nothing about itself, so it gets the same
             // assumption an unclassified native tool gets: it reached outside, we can't stop it,
             // and we don't know what a timeout left behind.
-            return await executeWithTimeout(name: name, semantics: .conservativeDefault,
-                                            operationID: call.context.invocationID,
-                                            reportProgress: reportProgress) {
-                await mcp.performCall(tool: tool, server: server, arguments: outboundArgs)
+            return await dispatch(call, semantics: .conservativeDefault,
+                                  reportProgress: reportProgress) { key in
+                await mcp.performCall(tool: tool, server: server, arguments: outboundArgs,
+                                      idempotencyKey: key)
             }
         }
 
@@ -194,12 +226,100 @@ final class NativeToolRouter: ToolExecutionAuthority {
         // an autonomous action, so it needs Agent Mode on, not just a configured gateway).
         if let bridge = openClawBridge, Config.isOpenClawAgentActive {
             let taskDesc = args["task"] as? String ?? String(describing: args)
-            NSLog("[NativeToolRouter] Delegating to OpenClaw: %@(%@)", name, String(taskDesc.prefix(100)))
+            NSLog("[NativeToolRouter] Delegating to OpenClaw: %@(%@)", name,
+                  ToolLogContent.redacted(String(taskDesc.prefix(100))))
             // The bridge answers authoritatively or not at all — it has no timeout race of its own.
             return ToolExecutionOutcome(await bridge.delegateTask(task: taskDesc, toolName: name))
         }
 
         return .failedBeforeExecution(reason: "Unknown tool: \(name)")
+    }
+
+    // MARK: - At-most-once dispatch
+
+    /// Take one authorized call to the tool, at most once.
+    ///
+    /// Operations whose repetition is harmless — every read, and everything that converges on the
+    /// same world state — go straight through: journaling them would buy nothing and would fill a
+    /// security store with noise. Everything else is admitted against the journal first, so a second
+    /// delivery of a call already recorded is answered from the record instead of being run again,
+    /// across a process restart as well as within a session.
+    private func dispatch(_ call: ResolvedToolCall, semantics: ToolExecutionSemantics,
+                          reportProgress: Bool,
+                          work: @escaping (String) async throws -> String) async -> ToolExecutionOutcome {
+        let key = OperationIdempotencyKey.derive(call)
+        let name = call.name
+
+        guard !semantics.isSafeToRepeat else {
+            return await executeWithTimeout(name: name, semantics: semantics,
+                                            operationID: call.context.invocationID,
+                                            reportProgress: reportProgress) { try await work(key) }
+        }
+
+        let journal = operationJournal
+        switch journal.admit(call: call, semantics: semantics, key: key, at: Date()) {
+        case .duplicate(let existing):
+            let advice = OperationRetryPolicy.advice(for: existing, semantics: semantics)
+            NSLog("[NativeToolRouter] %@ already journaled as %@ — not run again (%@)",
+                  name, existing.state.rawValue,
+                  advice.allowsAutomaticRetry ? "repeatable" : "needs reconciliation before retry")
+            return journal.replayOutcome(for: existing)
+
+        case .proceed(let record):
+            let sink = journalSink(operationID: record.operationID)
+            return await resourceSerializer.withResource(name) {
+                await executeWithTimeout(name: name, semantics: semantics,
+                                         operationID: record.operationID,
+                                         reportProgress: reportProgress,
+                                         journalSink: sink) { try await work(key) }
+            }
+        }
+    }
+
+    /// Writes an operation's fate to the journal at the moment it is decided — including when it is
+    /// decided *after* the router stopped waiting, which is the whole reason the sink exists rather
+    /// than a return-value update: by then nobody is awaiting anything to update.
+    private func journalSink(operationID: String) -> (ToolExecutionOutcome) -> Void {
+        { [weak self] outcome in
+            guard let self else { return }
+            let resolution = self.operationJournal.resolve(operationID: operationID,
+                                                           outcome: outcome, at: Date())
+            switch resolution {
+            case .recorded(let record):
+                self.onOperationStatusChange?(record)
+            case .late(let record):
+                NSLog("[NativeToolRouter] Operation for %@ resolved late as %@", record.toolName,
+                      record.state.rawValue)
+                self.onOperationStatusChange?(record)
+            case .unknownOperation:
+                break
+            }
+        }
+    }
+
+    /// Ask tools that can answer what became of operations a previous process left in flight.
+    ///
+    /// Records nothing can answer for stay `unknown` — that is the honest state, and converting them
+    /// to failures is exactly the lie this phase exists to stop.
+    @discardableResult
+    func reconcileRecoveredOperations(at now: Date = Date()) async -> Int {
+        var settled = 0
+        for record in operationJournal.recoveredOperations {
+            guard let reconciler = registry.tool(named: record.toolName) as? OperationReconciling,
+                  let outcome = await reconciler.reconcile(operationID: record.operationID,
+                                                           idempotencyKey: record.idempotencyKey)
+            else { continue }
+            operationJournal.resolve(operationID: record.operationID, outcome: outcome, at: now)
+            settled += 1
+        }
+        if settled > 0 {
+            NSLog("[NativeToolRouter] Reconciled %d interrupted operation(s)", settled)
+        }
+        return settled
+    }
+
+    static func cancelledBeforeDispatch(_ tool: String) -> String {
+        "'\(tool)' was cancelled before it ran, so it had no effect."
     }
 
     // MARK: - Timeout + "Still Working" Updates
@@ -212,6 +332,7 @@ final class NativeToolRouter: ToolExecutionAuthority {
     /// instead, because its effect may land in the moment after we stopped listening.
     private func executeWithTimeout(name: String, semantics: ToolExecutionSemantics,
                                     operationID: String, reportProgress: Bool = true,
+                                    journalSink: ((ToolExecutionOutcome) -> Void)? = nil,
                                     work: @escaping () async throws -> String) async -> ToolExecutionOutcome {
         let startTime = Date()
         let timeoutSeconds = semantics.timeout.resolved(default: toolTimeoutSeconds)
@@ -262,11 +383,17 @@ final class NativeToolRouter: ToolExecutionAuthority {
                     finished = .failedBeforeExecution(
                         reason: "Tool error: \(error.localizedDescription)")
                 }
+                // Both branches journal, and both journal *here*, at the instant the fate is
+                // decided. The late branch is the one that could not be done by returning a value:
+                // nobody is awaiting this call any more, so the record is the only place the truth
+                // can still land.
                 if claim() {
+                    journalSink?(finished)
                     continuation.resume(returning: finished)
                 } else {
                     NSLog("[NativeToolRouter] Tool %@ finished after it timed out — its effect landed late",
                           name)
+                    journalSink?(finished)
                 }
             }
 
@@ -277,12 +404,14 @@ final class NativeToolRouter: ToolExecutionAuthority {
                 // and hides that the work is still in flight; only ask when it can answer.
                 if semantics.cancellation.respondsToCancellation { workTask.cancel() }
                 let seconds = Int(timeoutSeconds)
-                continuation.resume(returning: semantics.timeoutIsAuthoritative
+                let timedOut: ToolExecutionOutcome = semantics.timeoutIsAuthoritative
                     ? .failedBeforeExecution(
                         reason: ToolExecutionOutcome.timedOutRead(tool: name, seconds: seconds))
                     : .outcomeUnknown(
                         operationID: operationID,
-                        message: ToolExecutionOutcome.timedOutUnknown(tool: name, seconds: seconds)))
+                        message: ToolExecutionOutcome.timedOutUnknown(tool: name, seconds: seconds))
+                journalSink?(timedOut)
+                continuation.resume(returning: timedOut)
             }
         }
 
@@ -291,14 +420,16 @@ final class NativeToolRouter: ToolExecutionAuthority {
         let duration = Date().timeIntervalSince(startTime)
         switch outcome {
         case .completed(let text):
-            NSLog("[NativeToolRouter] Tool %@ succeeded in %.1fs: %@", name, duration, String(text.prefix(200)))
+            NSLog("[NativeToolRouter] Tool %@ succeeded in %.1fs: %@", name, duration,
+                  ToolLogContent.redacted(String(text.prefix(200))))
         case .outcomeUnknown:
             // Not a failure and not a success: the effect may still be in flight. Nothing is fed to
             // the skill-gap signal, and nothing may retry it automatically.
             NSLog("[NativeToolRouter] Tool %@ outcome unknown after %.1fs (%@ / %@)", name, duration,
                   semantics.effect.rawValue, semantics.cancellation.rawValue)
         case .rejected(let reason), .failedBeforeExecution(let reason):
-            NSLog("[NativeToolRouter] Tool %@ failed in %.1fs: %@", name, duration, reason)
+            NSLog("[NativeToolRouter] Tool %@ failed in %.1fs: %@", name, duration,
+                  ToolLogContent.redacted(reason))
             // Skill Self-Evolution (Plan AW): a genuine tool-execution error is a skill-gap signal.
             // Record it off the critical path; the service is Agent-Mode-gated and re-checks. Timeouts
             // and intentional outcomes are filtered out so the proposal bank stays clean.

--- a/OpenGlasses/Sources/Services/NativeTools/OperationJournal.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/OperationJournal.swift
@@ -1,0 +1,422 @@
+import Foundation
+import CryptoKit
+
+// MARK: - Idempotency key
+
+/// The stable identity of one operation, derived rather than invented.
+///
+/// Two deliveries of the same tool call must land on the same key or at-most-once execution is
+/// impossible, so the key is built from what a redelivery repeats: the root invocation id the
+/// provider gave the call, the path from that root down to the resolved target, and a digest of the
+/// final arguments. A *different* call — different target, different arguments, or a fresh root —
+/// gets a different key and runs normally.
+///
+/// The caller supplying a stable root id is what makes this work. `ToolDispatcher` passes the
+/// provider's `tool_use`/`tool_call` id and the live-session router passes the function-call id;
+/// where no such id exists the root is a fresh UUID, the key is unique, and nothing is de-duplicated
+/// — the guarantee holds exactly where the delivery is identifiable, and never pretends otherwise.
+enum OperationIdempotencyKey {
+    static func derive(_ call: ResolvedToolCall) -> String {
+        let path = (call.context.ancestry + [call.name]).joined(separator: "/")
+        let material = [
+            call.context.rootInvocationID,
+            path,
+            ToolCallBreaker.argsKey(call.arguments.rawValues),
+        ].joined(separator: "|")
+        return SHA256.hash(data: Data(material.utf8)).prefix(16)
+            .map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// The idempotency key of the operation currently executing, for adapters that can carry one on the
+/// wire. A task-local rather than a parameter on `NativeTool.execute(args:)`, which is the
+/// registry-wide signature that all 36+ tools share and only a handful of them could use.
+enum OperationScope {
+    @TaskLocal static var idempotencyKey: String?
+}
+
+// MARK: - Journal
+
+/// What admitting a call to the journal decided.
+enum OperationAdmission: Equatable {
+    /// No live record for this key: the operation is journaled as `started` and may dispatch.
+    case proceed(OperationRecord)
+    /// This exact call already ran, or is running. The existing record governs; do not dispatch.
+    case duplicate(OperationRecord)
+}
+
+/// What recording a terminal outcome amounted to.
+enum OperationResolution: Equatable {
+    case recorded(OperationRecord)
+    /// The authoritative answer arrived after the caller had been told the outcome was unknown.
+    /// The conversation has moved on, so this is an operation-status update and never a second
+    /// spoken success.
+    case late(OperationRecord)
+    /// No such operation — the call was never journaled (a read, or an intrinsically repeatable
+    /// tool), so there is nothing to update.
+    case unknownOperation
+}
+
+/// A durable record of operations that cannot safely be repeated.
+///
+/// Deliberately narrow: it is asked whether a call may run, and told how it ended. Everything else
+/// — retention, recovery, protection at rest — belongs to the implementation.
+@MainActor
+protocol OperationJournal: AnyObject {
+    /// Whether this call may dispatch, journaling it as `started` when it may.
+    func admit(call: ResolvedToolCall, semantics: ToolExecutionSemantics, key: String,
+               at now: Date) -> OperationAdmission
+    /// Record how an operation ended.
+    @discardableResult
+    func resolve(operationID: String, outcome: ToolExecutionOutcome, at now: Date) -> OperationResolution
+    /// The outcome a repeat delivery is answered with, from what the record knows.
+    func replayOutcome(for record: OperationRecord) -> ToolExecutionOutcome
+    /// Newest first.
+    var records: [OperationRecord] { get }
+    func record(forKey key: String) -> OperationRecord?
+}
+
+extension OperationJournal {
+    /// Operations left unresolved by a process that died mid-flight.
+    var recoveredOperations: [OperationRecord] {
+        records.filter { $0.recoveredFromRestart && $0.isUnresolved }
+    }
+}
+
+// MARK: - Retention
+
+/// How much content-free history the journal keeps.
+///
+/// Small on purpose. The journal exists to stop an action happening twice and to be able to say
+/// afterwards that something's fate is unknown; neither needs a long tail, and a security store
+/// that grows without bound is its own liability.
+struct OperationJournalRetention: Sendable, Equatable {
+    /// Hard ceiling on rows, whatever their age.
+    let maxRecords: Int
+    /// How long a settled operation is kept.
+    let settledMaxAge: TimeInterval
+    /// How long an unresolved one is kept — longer, because it is the row someone may need to
+    /// explain a duplicate charge or a message nobody can account for.
+    let unresolvedMaxAge: TimeInterval
+
+    static let `default` = OperationJournalRetention(
+        maxRecords: 200, settledMaxAge: 7 * 24 * 3600, unresolvedMaxAge: 30 * 24 * 3600)
+}
+
+// MARK: - Reconciliation
+
+/// A tool that can be asked, after the fact, whether an operation it started actually landed.
+///
+/// Nothing conforms today — none of the current adapters (MCP `tools/call`, the gateway bridge, a
+/// user-authored URL scheme) exposes a status endpoint to ask. The seam is here so that a tool which
+/// gains one can settle its own unresolved rows instead of leaving them unknown forever.
+@MainActor
+protocol OperationReconciling {
+    /// The authoritative outcome, or nil when the tool cannot tell either.
+    func reconcile(operationID: String, idempotencyKey: String) async -> ToolExecutionOutcome?
+}
+
+// MARK: - Retry advice
+
+/// Whether an interrupted operation may be tried again, and on whose say-so.
+enum OperationRetryAdvice: Equatable {
+    /// Nothing landed, or landing twice converges — a retry is safe without asking anyone.
+    case safeToRetry
+    /// The effect may already exist. A person may retry only after checking what actually happened.
+    case reconcileFirst(String)
+    /// It already succeeded; repeating it would duplicate the effect for no reason.
+    case doNotRetry(String)
+
+    /// The only question the tool loop asks. Automatic retry is the exception, not the default.
+    var allowsAutomaticRetry: Bool { self == .safeToRetry }
+}
+
+enum OperationRetryPolicy {
+    static func advice(for record: OperationRecord,
+                       semantics: ToolExecutionSemantics) -> OperationRetryAdvice {
+        switch record.state {
+        case .failed:
+            return .safeToRetry
+        case .completed:
+            return .doNotRetry(
+                "'\(record.toolName)' already completed for this request; use that result.")
+        case .started, .unknown:
+            guard !semantics.isSafeToRepeat else { return .safeToRetry }
+            return .reconcileFirst(
+                "Whether '\(record.toolName)' took effect is unknown. Check what actually happened "
+                    + "before running it again.")
+        }
+    }
+}
+
+// MARK: - Serialization by logical resource
+
+/// A fair, first-come queue per logical resource.
+///
+/// The idempotency key stops the *same* operation running twice, but nothing stops two different
+/// operations reaching the same place at once — and the adapters that would otherwise sort that out
+/// (a server-side key, a transaction) don't exist here. Holding one operation per resource at a time
+/// is the part that can be done on this side of the wire.
+///
+/// The resource defaults to the tool name, which is as fine-grained as anything here can honestly
+/// claim to know. Re-entering the same resource from inside a held operation cannot happen: the
+/// authorization policy already refuses a call that re-enters a tool on its own ancestry.
+@MainActor
+final class OperationResourceSerializer {
+    private var busy: Set<String> = []
+    private var waiting: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+    /// Run `body` with exclusive hold on `resource`. Released when `body` returns — including when
+    /// it returns because the router stopped waiting, which is what bounds the hold.
+    func withResource<T>(_ resource: String, _ body: () async -> T) async -> T {
+        await acquire(resource)
+        defer { release(resource) }
+        return await body()
+    }
+
+    private func acquire(_ resource: String) async {
+        guard busy.contains(resource) else {
+            busy.insert(resource)
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiting[resource, default: []].append(continuation)
+        }
+        // Resumed by `release`, which hands the hold over rather than clearing it.
+    }
+
+    private func release(_ resource: String) {
+        guard var queue = waiting[resource], !queue.isEmpty else {
+            waiting[resource] = nil
+            busy.remove(resource)
+            return
+        }
+        let next = queue.removeFirst()
+        waiting[resource] = queue.isEmpty ? nil : queue
+        next.resume()
+    }
+}
+
+// MARK: - Protected on-device journal
+
+/// The operation journal, kept as one small protected JSON file.
+///
+/// Protected at rest with `NSFileProtectionCompleteUntilFirstUserAuthentication` rather than
+/// `...Complete`: the journal has to be readable at launch — that is when a process that died
+/// mid-operation is discovered — and a locked device would otherwise hide exactly the rows that
+/// matter. Nothing in it is sensitive on its own; the protection is there because a record of what
+/// this device did, and when, is worth keeping off a lifted disk regardless.
+@MainActor
+final class ProtectedOperationJournal: OperationJournal {
+    static let shared = ProtectedOperationJournal()
+
+    static let fileProtection = FileProtectionType.completeUntilFirstUserAuthentication
+
+    private let directory: URL
+    private let fileURL: URL
+    private let retention: OperationJournalRetention
+    private var rows: [OperationRecord] = []
+    /// Successful tool output, kept only for the life of this process so a redelivery inside the
+    /// same session can be answered with the real result. Never encoded, never written to disk.
+    private var completedValues: [String: String] = [:]
+    private static let memoLimit = 32
+    /// Whether the last write applied the protection attribute without error. The simulator's
+    /// filesystem accepts the attribute and then reports none back, so this — not a read-back — is
+    /// what a headless test can check.
+    private(set) var protectionApplied = false
+
+    var records: [OperationRecord] { rows }
+
+    init(directory: URL? = nil, retention: OperationJournalRetention = .default,
+         now: Date = Date()) {
+        self.directory = directory ?? Self.defaultDirectory()
+        self.fileURL = self.directory.appendingPathComponent("operations.json")
+        self.retention = retention
+        load()
+        recoverInterruptedOperations(at: now)
+        prune(at: now)
+        persist()
+    }
+
+    private static func defaultDirectory() -> URL {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory,
+                                            in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        return base.appendingPathComponent("OperationJournal", isDirectory: true)
+    }
+
+    // MARK: Journal
+
+    func admit(call: ResolvedToolCall, semantics: ToolExecutionSemantics, key: String,
+               at now: Date) -> OperationAdmission {
+        if let existing = record(forKey: key) {
+            // A settled failure means nothing happened, so the same call may legitimately be made
+            // again; the old row is replaced rather than blocking the retry it authorises.
+            if existing.state.isUnresolved || existing.state == .completed {
+                return .duplicate(existing)
+            }
+            rows.removeAll { $0.idempotencyKey == key }
+        }
+
+        let context = call.context
+        let record = OperationRecord(
+            operationID: context.invocationID,
+            idempotencyKey: key,
+            toolName: call.name,
+            effect: semantics.effect,
+            origin: context.origin,
+            depth: context.depth,
+            rootFingerprint: ToolAuthorizationEventLog.fingerprint(context.rootInvocationID),
+            parentFingerprint: context.parent.map {
+                ToolAuthorizationEventLog.fingerprint($0.invocationID)
+            },
+            composerFingerprint: context.parent?.composerID.map(
+                ToolAuthorizationEventLog.fingerprint),
+            startedAt: now,
+            updatedAt: now,
+            state: .started)
+        rows.insert(record, at: 0)
+        prune(at: now)
+        persist()
+        return .proceed(record)
+    }
+
+    @discardableResult
+    func resolve(operationID: String, outcome: ToolExecutionOutcome,
+                 at now: Date) -> OperationResolution {
+        guard let index = rows.firstIndex(where: { $0.operationID == operationID }) else {
+            return .unknownOperation
+        }
+        // The late-completion case: the caller was already told the outcome was unknown, and this
+        // is the answer arriving afterwards. Updating the row is the whole point — the conversation
+        // is over, but the record of what happened should still be true.
+        let wasUnknown = rows[index].state == .unknown
+        rows[index].state = OperationState(outcome)
+        rows[index].updatedAt = now
+        rows[index].resolvedLate = wasUnknown && rows[index].state.isTerminal
+        if case .completed(let value) = outcome { memoize(value, for: operationID) }
+        let updated = rows[index]
+        prune(at: now)
+        persist()
+        return updated.resolvedLate ? .late(updated) : .recorded(updated)
+    }
+
+    func record(forKey key: String) -> OperationRecord? {
+        rows.first { $0.idempotencyKey == key }
+    }
+
+    func replayOutcome(for record: OperationRecord) -> ToolExecutionOutcome {
+        switch record.state {
+        case .completed:
+            return .completed(completedValues[record.operationID]
+                ?? Self.alreadyCompleted(record.toolName))
+        case .started:
+            return .outcomeUnknown(operationID: record.operationID,
+                                   message: Self.alreadyInFlight(record.toolName))
+        case .unknown:
+            return .outcomeUnknown(operationID: record.operationID,
+                                   message: Self.stillUnresolved(record.toolName))
+        case .failed:
+            // Not reachable through `admit`, which lets a settled failure be retried.
+            return .failedBeforeExecution(reason: Self.alreadyFailed(record.toolName))
+        }
+    }
+
+    // MARK: Copy (model-facing: it must not invite the retry the journal just prevented)
+
+    static func alreadyCompleted(_ tool: String) -> String {
+        "'\(tool)' was already run for this request and completed, so it was not run a second time. "
+            + "Use the earlier result and do not call it again."
+    }
+
+    static func alreadyInFlight(_ tool: String) -> String {
+        "'\(tool)' is already running for this request and was not started a second time. Do NOT "
+            + "call it again; tell the user you're waiting on the first attempt."
+    }
+
+    static func stillUnresolved(_ tool: String) -> String {
+        "'\(tool)' was already attempted for this request and whether it took effect is still "
+            + "unknown, so it was not run again. Do NOT retry it; tell the user you're checking "
+            + "whether the first attempt went through."
+    }
+
+    static func alreadyFailed(_ tool: String) -> String {
+        "'\(tool)' already failed for this request without taking effect."
+    }
+
+    // MARK: Recovery
+
+    /// Rows left `started` by a process that died mid-operation become `unknown`, never `failed`.
+    /// The app cannot know whether the message went out before it was killed, and guessing "no" is
+    /// how the message gets sent twice.
+    private func recoverInterruptedOperations(at now: Date) {
+        for index in rows.indices where rows[index].state == .started {
+            rows[index].state = .unknown
+            rows[index].updatedAt = now
+            rows[index].recoveredFromRestart = true
+            NSLog("[OperationJournal] Recovered interrupted operation for %@ as unknown",
+                  rows[index].toolName)
+        }
+    }
+
+    // MARK: Retention
+
+    private func prune(at now: Date) {
+        rows.removeAll { row in
+            let age = now.timeIntervalSince(row.updatedAt)
+            guard row.state != .started else { return false }  // in flight in this process
+            return age > (row.isUnresolved ? retention.unresolvedMaxAge : retention.settledMaxAge)
+        }
+        if rows.count > retention.maxRecords {
+            // Settled rows go first: an unresolved one is the row someone may actually need.
+            let overflow = rows.count - retention.maxRecords
+            let droppable = rows.indices.filter { rows[$0].state.isTerminal }.suffix(overflow)
+            for index in droppable.sorted(by: >) { rows.remove(at: index) }
+        }
+        if rows.count > retention.maxRecords {
+            rows.removeLast(rows.count - retention.maxRecords)
+        }
+        let live = Set(rows.map(\.operationID))
+        completedValues = completedValues.filter { live.contains($0.key) }
+    }
+
+    private func memoize(_ value: String, for operationID: String) {
+        completedValues[operationID] = value
+        guard completedValues.count > Self.memoLimit else { return }
+        let keep = Set(rows.prefix(Self.memoLimit).map(\.operationID))
+        completedValues = completedValues.filter { keep.contains($0.key) }
+    }
+
+    // MARK: Storage
+
+    private func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        rows = (try? decoder.decode([OperationRecord].self, from: data)) ?? []
+    }
+
+    private func persist() {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true,
+                                                    attributes: [.protectionKey: Self.fileProtection])
+            try encoder.encode(rows).write(to: fileURL, options: .atomic)
+            // An atomic write replaces the inode, so the attribute is re-applied every time rather
+            // than set once at creation.
+            try FileManager.default.setAttributes([.protectionKey: Self.fileProtection],
+                                                  ofItemAtPath: fileURL.path)
+            protectionApplied = true
+            var url = fileURL
+            var values = URLResourceValues()
+            values.isExcludedFromBackup = true
+            try? url.setResourceValues(values)
+        } catch {
+            NSLog("[OperationJournal] persist failed: %@", error.localizedDescription)
+        }
+    }
+
+    /// The store's location, for the protection assertion in tests and for diagnostics.
+    var storeURL: URL { fileURL }
+}

--- a/OpenGlasses/Sources/Services/NativeTools/ToolAuthorizationEventLog.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/ToolAuthorizationEventLog.swift
@@ -1,6 +1,22 @@
 import Foundation
 import CryptoKit
 
+/// Keeps tool arguments, results, and confirmation copy out of release logs.
+///
+/// A device log is readable by anything with the device in hand, and these strings are the actual
+/// message being sent, the actual note being saved, the actual address being navigated to. In a
+/// debug build they are exactly what you need while working on a tool; in a shipped build the shape
+/// of the log — which tool, when, how long, what verdict — is kept and the content is not.
+enum ToolLogContent {
+    static func redacted(_ text: String) -> String {
+        #if DEBUG
+        return text
+        #else
+        return "<\(text.count) chars>"
+        #endif
+    }
+}
+
 /// A content-free record of one authorization verdict.
 ///
 /// Ids are fingerprints, never the values: an invocation id correlates a refusal with the turn that

--- a/OpenGlasses/Sources/Services/ToolCallRouter.swift
+++ b/OpenGlasses/Sources/Services/ToolCallRouter.swift
@@ -44,7 +44,7 @@ class ToolCallRouter {
         let callName = call.name
 
         NSLog("[ToolCall] Received: %@ (id: %@) args: %@",
-              callName, callId, String(describing: call.args))
+              callName, callId, ToolLogContent.redacted(String(describing: call.args)))
 
         // Plan BR P1: refuse suspended/runaway calls without executing — the message rides
         // back as the tool error so the model learns in-band and informs the user.
@@ -75,7 +75,10 @@ class ToolCallRouter {
             // Route through NativeToolRouter first (handles native → MCP → OpenClaw cascade)
             var outcome: ToolExecutionOutcome
             if let router = nativeToolRouter {
-                outcome = await router.executeRoot(name: callName, args: call.args)
+                // The live session's own id for this function call: a reconnect that redelivers it
+                // resolves to the operation that already ran rather than running it twice.
+                outcome = await router.executeRoot(name: callName, args: call.args,
+                                                   origin: .model, invocationID: callId)
             } else if Config.isOpenClawAgentActive {
                 // Fallback: direct OpenClaw delegation (legacy path). BK P0: only as an active
                 // agentic capability — delegateTask itself now fails closed otherwise, but don't
@@ -112,7 +115,7 @@ class ToolCallRouter {
             }
 
             NSLog("[ToolCall] Result for %@ (id: %@): %@",
-                  callName, callId, String(describing: outcome))
+                  callName, callId, ToolLogContent.redacted(String(describing: outcome)))
 
             let response = self.buildToolResponse(callId: callId, name: callName,
                                                   result: outcome.toolResult)

--- a/OpenGlassesTests/AgentPlanLoopTests.swift
+++ b/OpenGlassesTests/AgentPlanLoopTests.swift
@@ -134,8 +134,8 @@ private final class FakePlanRouter: ToolExecuting {
     var calls: [String] = []
     var failTools: Set<String> = []
 
-    func executeRoot(name: String, args: [String: Any],
-                     origin: ToolInvocationOrigin) async -> ToolExecutionOutcome {
+    func executeRoot(name: String, args: [String: Any], origin: ToolInvocationOrigin,
+                     invocationID: String) async -> ToolExecutionOutcome {
         calls.append(name)
         return failTools.contains(name)
             ? .rejected(reason: "blocked")

--- a/OpenGlassesTests/AgentSafetyTests.swift
+++ b/OpenGlassesTests/AgentSafetyTests.swift
@@ -280,8 +280,8 @@ private final class FakeRouter: ToolExecuting {
     var responses: [String: ToolExecutionOutcome] = [:]
     var defaultResult: ToolExecutionOutcome = .completed("ok")
 
-    func executeRoot(name: String, args: [String: Any],
-                     origin: ToolInvocationOrigin) async -> ToolExecutionOutcome {
+    func executeRoot(name: String, args: [String: Any], origin: ToolInvocationOrigin,
+                     invocationID: String) async -> ToolExecutionOutcome {
         calls.append((name, args))
         return responses[name] ?? defaultResult
     }

--- a/OpenGlassesTests/OperationJournalTests.swift
+++ b/OpenGlassesTests/OperationJournalTests.swift
@@ -1,0 +1,552 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DJ P3 — an action that cannot safely be repeated happens at most once, and what became of
+/// it is written down.
+///
+/// Two properties are pinned here. The first is at-most-once: a second delivery of the same call is
+/// answered from the journal instead of being run again, and that holds across a process restart,
+/// which is the case an in-memory guard cannot cover. The second is that the record ends up true —
+/// including when the truth arrives after the router stopped waiting, and including when the app was
+/// killed mid-operation, where the record says "unknown" rather than guessing "no".
+@MainActor
+final class OperationJournalTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// A one-shot signal with no polling and no sleeping.
+    private final class AsyncSignal: @unchecked Sendable {
+        private let lock = NSLock()
+        private var fired = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func fire() {
+            lock.lock()
+            let pending = waiters
+            waiters = []
+            fired = true
+            lock.unlock()
+            for waiter in pending { waiter.resume() }
+        }
+
+        func wait() async {
+            await withCheckedContinuation { continuation in
+                lock.lock()
+                if fired {
+                    lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                waiters.append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+
+    /// Parks until released, then either returns or throws.
+    private struct ParkedTool: NativeTool {
+        let name: String
+        let description = "parked test fixture"
+        let executionSemantics: ToolExecutionSemantics
+        let release: AsyncSignal
+        var failsAfterRelease = false
+        var parametersSchema: [String: Any] { ["type": "object"] }
+
+        struct Failure: Error, LocalizedError {
+            var errorDescription: String? { "the late failure" }
+        }
+
+        func execute(args: [String: Any]) async throws -> String {
+            await release.wait()
+            if failsAfterRelease { throw Failure() }
+            return "finished"
+        }
+    }
+
+    /// Counts executions and reports the idempotency key it ran under.
+    private final class CountingTool: NativeTool, @unchecked Sendable {
+        let name: String
+        let description = "counting test fixture"
+        let executionSemantics: ToolExecutionSemantics
+        private(set) var runs = 0
+        private(set) var keysSeen: [String?] = []
+        var parametersSchema: [String: Any] { ["type": "object"] }
+
+        init(name: String, semantics: ToolExecutionSemantics) {
+            self.name = name
+            self.executionSemantics = semantics
+        }
+
+        func execute(args: [String: Any]) async throws -> String {
+            runs += 1
+            keysSeen.append(OperationScope.idempotencyKey)
+            return "ran \(runs)"
+        }
+    }
+
+    /// Parks like `ParkedTool`, and counts how many executions are inside it at once.
+    private final class ConcurrencyProbeTool: NativeTool, @unchecked Sendable {
+        let name: String
+        let description = "concurrency probe fixture"
+        let executionSemantics: ToolExecutionSemantics
+        let release: AsyncSignal
+        private(set) var entries = 0
+        private(set) var maxActive = 0
+        private var active = 0
+        var parametersSchema: [String: Any] { ["type": "object"] }
+
+        init(name: String, semantics: ToolExecutionSemantics, release: AsyncSignal) {
+            self.name = name
+            self.executionSemantics = semantics
+            self.release = release
+        }
+
+        func execute(args: [String: Any]) async throws -> String {
+            entries += 1
+            active += 1
+            maxActive = max(maxActive, active)
+            await release.wait()
+            active -= 1
+            return "finished"
+        }
+    }
+
+    /// A tool that can be asked afterwards what actually happened.
+    private struct ReconcilingTool: NativeTool, OperationReconciling {
+        let name: String
+        let description = "reconcilable test fixture"
+        var executionSemantics: ToolExecutionSemantics { .external(.bestEffort) }
+        var parametersSchema: [String: Any] { ["type": "object"] }
+        let answer: ToolExecutionOutcome?
+
+        func execute(args: [String: Any]) async throws -> String { "ran" }
+
+        func reconcile(operationID: String, idempotencyKey: String) async -> ToolExecutionOutcome? {
+            answer
+        }
+    }
+
+    private var directories: [URL] = []
+
+    override func tearDown() {
+        for url in directories { try? FileManager.default.removeItem(at: url) }
+        directories = []
+        super.tearDown()
+    }
+
+    private func temporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("operation-journal-\(UUID().uuidString)", isDirectory: true)
+        directories.append(url)
+        return url
+    }
+
+    private func router(with tool: any NativeTool, journalDirectory: URL,
+                        timeout: TimeInterval = 0.05) -> NativeToolRouter {
+        let registry = NativeToolRegistry(locationService: LocationService())
+        registry.register(tool)
+        let router = NativeToolRouter(registry: registry)
+        router.toolTimeoutSeconds = timeout
+        router.operationJournal = ProtectedOperationJournal(directory: journalDirectory)
+        return router
+    }
+
+    private func call(_ name: String, invocationID: String,
+                      args: [String: Any] = [:]) -> ResolvedToolCall {
+        .root(name: name, arguments: ToolArguments(args), origin: .model, invocationID: invocationID)
+    }
+
+    // MARK: - Timer wins, the answer arrives later
+
+    /// The caller is told the outcome is unknown and the turn moves on. When the work finally
+    /// succeeds, the record — not the conversation — is what gets updated.
+    func testLateSuccessSettlesTheRecordWithoutASecondSuccess() async {
+        let release = AsyncSignal()
+        let tool = ParkedTool(name: "send_it", executionSemantics: .external(.notCancellable),
+                              release: release)
+        let router = router(with: tool, journalDirectory: temporaryDirectory())
+
+        var lateRecords: [OperationRecord] = []
+        let settled = AsyncSignal()
+        router.onOperationStatusChange = { record in
+            guard record.resolvedLate else { return }
+            lateRecords.append(record)
+            settled.fire()
+        }
+
+        let outcome = await router.executeRoot(name: "send_it", args: [:])
+        guard case .outcomeUnknown(let operationID, _) = outcome else {
+            return XCTFail("the timer winning on a send must leave the outcome unknown: \(outcome)")
+        }
+        XCTAssertEqual(router.operationJournal.records.first?.state, .unknown)
+
+        release.fire()
+        await settled.wait()
+
+        XCTAssertEqual(lateRecords.count, 1, "the late answer is one status update, not a retelling")
+        let record = try? XCTUnwrap(router.operationJournal.records.first)
+        XCTAssertEqual(record?.operationID, operationID)
+        XCTAssertEqual(record?.state, .completed)
+        XCTAssertTrue(record?.resolvedLate == true)
+        // What the caller was told is unchanged: nothing rewrites an answer already given.
+        XCTAssertEqual(outcome.retryDisposition, .unsafeToRetry)
+    }
+
+    /// The same shape when the late answer is a failure: authoritative, and recorded as such.
+    func testLateFailureSettlesTheRecordAsFailed() async {
+        let release = AsyncSignal()
+        let tool = ParkedTool(name: "send_it", executionSemantics: .external(.notCancellable),
+                              release: release, failsAfterRelease: true)
+        let router = router(with: tool, journalDirectory: temporaryDirectory())
+
+        let settled = AsyncSignal()
+        router.onOperationStatusChange = { record in
+            if record.resolvedLate { settled.fire() }
+        }
+
+        let outcome = await router.executeRoot(name: "send_it", args: [:])
+        guard case .outcomeUnknown = outcome else { return XCTFail("expected unknown: \(outcome)") }
+
+        release.fire()
+        await settled.wait()
+
+        XCTAssertEqual(router.operationJournal.records.first?.state, .failed)
+        XCTAssertTrue(router.operationJournal.records.first?.resolvedLate == true)
+    }
+
+    // MARK: - At most once
+
+    func testASecondDeliveryOfTheSameCallIsAnsweredFromTheRecord() async {
+        let tool = CountingTool(name: "send_it", semantics: .external(.cooperative))
+        let router = router(with: tool, journalDirectory: temporaryDirectory(), timeout: 30)
+
+        let first = await router.executeRoot(name: "send_it", args: ["to": "mum"],
+                                             invocationID: "call-1")
+        let second = await router.executeRoot(name: "send_it", args: ["to": "mum"],
+                                             invocationID: "call-1")
+
+        XCTAssertEqual(tool.runs, 1, "a redelivery must not send the message a second time")
+        XCTAssertEqual(first, .completed("ran 1"))
+        XCTAssertEqual(second, .completed("ran 1"), "the recorded result answers the redelivery")
+        XCTAssertEqual(router.operationJournal.records.count, 1)
+    }
+
+    /// The property the in-turn guard cannot provide: the record outlives the process.
+    func testADuplicateInvocationIdExecutesAtMostOnceAcrossARestart() async {
+        let directory = temporaryDirectory()
+        let firstTool = CountingTool(name: "send_it", semantics: .external(.cooperative))
+        let firstRouter = router(with: firstTool, journalDirectory: directory, timeout: 30)
+        _ = await firstRouter.executeRoot(name: "send_it", args: ["to": "mum"],
+                                          invocationID: "call-1")
+        XCTAssertEqual(firstTool.runs, 1)
+
+        // A new process: new router, new journal, same store.
+        let secondTool = CountingTool(name: "send_it", semantics: .external(.cooperative))
+        let secondRouter = router(with: secondTool, journalDirectory: directory, timeout: 30)
+        let replay = await secondRouter.executeRoot(name: "send_it", args: ["to": "mum"],
+                                                    invocationID: "call-1")
+
+        XCTAssertEqual(secondTool.runs, 0, "the same call must not run again after a restart")
+        guard case .completed(let text) = replay else {
+            return XCTFail("a completed operation replays as completed: \(replay)")
+        }
+        // The result itself was never persisted, so the replay says so rather than inventing one.
+        XCTAssertTrue(text.contains("already"), text)
+        XCTAssertFalse(text.contains("ran 1"))
+    }
+
+    func testADifferentCallToTheSameToolStillRuns() async {
+        let tool = CountingTool(name: "send_it", semantics: .external(.cooperative))
+        let router = router(with: tool, journalDirectory: temporaryDirectory(), timeout: 30)
+
+        _ = await router.executeRoot(name: "send_it", args: ["to": "mum"], invocationID: "call-1")
+        _ = await router.executeRoot(name: "send_it", args: ["to": "dad"], invocationID: "call-2")
+        // Same arguments, different delivery: a person asking twice is not a redelivery.
+        _ = await router.executeRoot(name: "send_it", args: ["to": "mum"], invocationID: "call-3")
+
+        XCTAssertEqual(tool.runs, 3)
+    }
+
+    /// Repeating a converging action costs nothing, so it is not journaled and never blocked.
+    func testAnIntrinsicallyRepeatableToolIsNeitherJournaledNorDeDuplicated() async {
+        let tool = CountingTool(name: "torch", semantics: .actuation(idempotency: .intrinsic))
+        let router = router(with: tool, journalDirectory: temporaryDirectory(), timeout: 30)
+
+        _ = await router.executeRoot(name: "torch", args: ["on": true], invocationID: "call-1")
+        _ = await router.executeRoot(name: "torch", args: ["on": true], invocationID: "call-1")
+
+        XCTAssertEqual(tool.runs, 2)
+        XCTAssertTrue(router.operationJournal.records.isEmpty,
+                      "the journal is for operations that must not repeat, and nothing else")
+    }
+
+    // MARK: - Keys reach the adapters
+
+    func testTheSameDeliveryResolvesToTheSameIdempotencyKey() async {
+        let tool = CountingTool(name: "torch", semantics: .actuation(idempotency: .intrinsic))
+        let router = router(with: tool, journalDirectory: temporaryDirectory(), timeout: 30)
+
+        _ = await router.executeRoot(name: "torch", args: ["on": true], invocationID: "call-1")
+        _ = await router.executeRoot(name: "torch", args: ["on": true], invocationID: "call-1")
+        _ = await router.executeRoot(name: "torch", args: ["on": true], invocationID: "call-2")
+
+        XCTAssertEqual(tool.keysSeen.count, 3)
+        XCTAssertNotNil(tool.keysSeen[0])
+        XCTAssertEqual(tool.keysSeen[0], tool.keysSeen[1], "a redelivery carries the same key")
+        XCTAssertNotEqual(tool.keysSeen[0], tool.keysSeen[2], "a different delivery does not")
+    }
+
+    func testKeyDerivationIsStableAndPathSensitive() {
+        let root = call("send_it", invocationID: "call-1", args: ["to": "mum"])
+        XCTAssertEqual(OperationIdempotencyKey.derive(root), OperationIdempotencyKey.derive(root))
+
+        let sameRootDifferentArgs = call("send_it", invocationID: "call-1", args: ["to": "dad"])
+        XCTAssertNotEqual(OperationIdempotencyKey.derive(root),
+                          OperationIdempotencyKey.derive(sameRootDifferentArgs))
+
+        // A child of the same root is a different operation from the root itself.
+        let child = root.child(name: "smart_home", arguments: ToolArguments(["action": "unlock"]),
+                               composerID: "pack-1")
+        XCTAssertNotEqual(OperationIdempotencyKey.derive(root),
+                          OperationIdempotencyKey.derive(child))
+        // …and the same child of the same root is the same operation.
+        let sameChild = root.child(name: "smart_home",
+                                   arguments: ToolArguments(["action": "unlock"]),
+                                   composerID: "pack-1")
+        XCTAssertEqual(OperationIdempotencyKey.derive(child),
+                       OperationIdempotencyKey.derive(sameChild))
+    }
+
+    /// The one adapter with somewhere to put a key puts it there; the digest carries no argument
+    /// content off the device.
+    func testMCPCallPayloadCarriesTheIdempotencyKey() throws {
+        let payload = MCPClient.callPayload(toolName: "create_issue",
+                                            arguments: ["title": "secret title"],
+                                            idempotencyKey: "abc123")
+        let params = try XCTUnwrap(payload["params"] as? [String: Any])
+        let meta = try XCTUnwrap(params["_meta"] as? [String: String])
+        XCTAssertEqual(meta[MCPClient.idempotencyMetaKey], "abc123")
+
+        let unkeyed = MCPClient.callPayload(toolName: "create_issue", arguments: [:],
+                                            idempotencyKey: nil)
+        let unkeyedParams = try XCTUnwrap(unkeyed["params"] as? [String: Any])
+        XCTAssertNil(unkeyedParams["_meta"], "no key, no field — the request shape is unchanged")
+    }
+
+    // MARK: - Recovery after the process dies
+
+    func testAnInterruptedOperationComesBackAsUnknownNotFailed() {
+        let directory = temporaryDirectory()
+        let journal = ProtectedOperationJournal(directory: directory)
+        let started = journal.admit(call: call("send_it", invocationID: "call-1"),
+                                    semantics: .external(.bestEffort),
+                                    key: "key-1", at: Date())
+        guard case .proceed(let record) = started else { return XCTFail("expected admission") }
+        XCTAssertEqual(record.state, .started)
+
+        // The process dies here. A new one opens the same store.
+        let recoveredJournal = ProtectedOperationJournal(directory: directory)
+        let recovered = recoveredJournal.records.first
+        XCTAssertEqual(recovered?.state, .unknown,
+                       "a killed process cannot know the send didn't go out")
+        XCTAssertTrue(recovered?.recoveredFromRestart == true)
+        XCTAssertEqual(recoveredJournal.recoveredOperations.count, 1)
+    }
+
+    func testRecoveredOperationsAreReconciledWhereAToolCanAnswer() async {
+        let directory = temporaryDirectory()
+        let journal = ProtectedOperationJournal(directory: directory)
+        _ = journal.admit(call: call("send_it", invocationID: "call-1"),
+                          semantics: .external(.bestEffort), key: "key-1", at: Date())
+
+        let router = router(with: ReconcilingTool(name: "send_it", answer: .completed("it landed")),
+                            journalDirectory: directory)
+        XCTAssertEqual(router.operationJournal.recoveredOperations.count, 1)
+
+        let settled = await router.reconcileRecoveredOperations()
+        XCTAssertEqual(settled, 1)
+        XCTAssertEqual(router.operationJournal.records.first?.state, .completed)
+    }
+
+    func testAnOperationNothingCanAnswerForStaysUnknown() async {
+        let directory = temporaryDirectory()
+        let journal = ProtectedOperationJournal(directory: directory)
+        _ = journal.admit(call: call("send_it", invocationID: "call-1"),
+                          semantics: .external(.bestEffort), key: "key-1", at: Date())
+
+        // The tool exists but cannot tell — and a tool with no status API at all is the same case.
+        let router = router(with: ReconcilingTool(name: "send_it", answer: nil),
+                            journalDirectory: directory)
+        let settled = await router.reconcileRecoveredOperations()
+
+        XCTAssertEqual(settled, 0)
+        XCTAssertEqual(router.operationJournal.records.first?.state, .unknown,
+                       "unknown is the honest state; failed would be a guess")
+    }
+
+    // MARK: - Retry advice
+
+    func testANonIdempotentUnresolvedOperationIsNeverRetriedAutomatically() {
+        func record(_ tool: String, _ state: OperationState) -> OperationRecord {
+            OperationRecord(
+                operationID: "op-1", idempotencyKey: "key-1", toolName: tool,
+                effect: .externalMutation, origin: .model, depth: 0, rootFingerprint: "root",
+                parentFingerprint: nil, composerFingerprint: nil, startedAt: Date(),
+                updatedAt: Date(), state: state)
+        }
+
+        let advice = OperationRetryPolicy.advice(for: record("send_message", .unknown),
+                                                 semantics: .external(.bestEffort))
+        guard case .reconcileFirst(let message) = advice else {
+            return XCTFail("a message that may already have been sent is not retryable: \(advice)")
+        }
+        XCTAssertFalse(advice.allowsAutomaticRetry)
+        XCTAssertTrue(message.lowercased().contains("check"), message)
+
+        // A converging action is a different matter.
+        XCTAssertEqual(
+            OperationRetryPolicy.advice(for: record("flashlight", .unknown),
+                                        semantics: .actuation(idempotency: .intrinsic)),
+            .safeToRetry)
+
+        // An authoritative failure left nothing behind.
+        XCTAssertEqual(
+            OperationRetryPolicy.advice(for: record("send_message", .failed),
+                                        semantics: .external(.bestEffort)),
+            .safeToRetry)
+
+        // A success needs no retry at all.
+        XCTAssertFalse(
+            OperationRetryPolicy.advice(for: record("send_message", .completed),
+                                        semantics: .external(.bestEffort)).allowsAutomaticRetry)
+    }
+
+    // MARK: - Cancellation before dispatch
+
+    func testACallCancelledBeforeDispatchNeverReachesTheToolOrTheJournal() async {
+        let tool = CountingTool(name: "send_it", semantics: .external(.cooperative))
+        let router = router(with: tool, journalDirectory: temporaryDirectory(), timeout: 30)
+
+        let task = Task { @MainActor in
+            await router.executeRoot(name: "send_it", args: [:], invocationID: "call-1")
+        }
+        task.cancel()
+        let outcome = await task.value
+
+        guard case .failedBeforeExecution(let reason) = outcome else {
+            return XCTFail("a call stopped before dispatch did not happen: \(outcome)")
+        }
+        XCTAssertTrue(reason.contains("no effect"), reason)
+        XCTAssertEqual(outcome.retryDisposition, .safeToRetry)
+        XCTAssertEqual(tool.runs, 0)
+        XCTAssertTrue(router.operationJournal.records.isEmpty,
+                      "nothing that never ran belongs in the operation journal")
+    }
+
+    // MARK: - Retention
+
+    func testRetentionKeepsAShortWindowAndDropsSettledRowsFirst() {
+        let start = Date(timeIntervalSince1970: 1_000_000)
+        let journal = ProtectedOperationJournal(
+            directory: temporaryDirectory(),
+            retention: OperationJournalRetention(maxRecords: 3, settledMaxAge: 60,
+                                                 unresolvedMaxAge: 600))
+
+        func operation(_ index: Int, at when: Date, settle: Bool) {
+            let identifier = "op-\(index)"
+            _ = journal.admit(call: call("send_it", invocationID: identifier),
+                              semantics: .external(.bestEffort), key: "key-\(index)", at: when)
+            if settle {
+                journal.resolve(operationID: identifier, outcome: .completed("ok"), at: when)
+            } else {
+                journal.resolve(operationID: identifier,
+                                outcome: .outcomeUnknown(operationID: identifier, message: "?"),
+                                at: when)
+            }
+        }
+
+        operation(1, at: start, settle: false)              // unresolved, oldest
+        operation(2, at: start.addingTimeInterval(1), settle: true)
+        operation(3, at: start.addingTimeInterval(2), settle: true)
+        operation(4, at: start.addingTimeInterval(3), settle: true)
+        XCTAssertEqual(journal.records.count, 3)
+        XCTAssertTrue(journal.records.contains { $0.operationID == "op-1" },
+                      "the unresolved row is the one worth keeping")
+        XCTAssertFalse(journal.records.contains { $0.operationID == "op-2" })
+
+        // Age: a settled row falls out of the window, the unresolved one does not.
+        operation(5, at: start.addingTimeInterval(120), settle: true)
+        XCTAssertEqual(journal.records.map(\.operationID).sorted(), ["op-1", "op-5"])
+
+        // …until it too is past its own, longer window.
+        operation(6, at: start.addingTimeInterval(1_000), settle: true)
+        XCTAssertEqual(journal.records.map(\.operationID), ["op-6"])
+    }
+
+    // MARK: - Protection and content-freedom
+
+    func testTheStoreIsProtectedAtRest() throws {
+        let directory = temporaryDirectory()
+        let journal = ProtectedOperationJournal(directory: directory)
+        _ = journal.admit(call: call("send_it", invocationID: "call-1"),
+                          semantics: .external(.bestEffort), key: "key-1", at: Date())
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: journal.storeURL.path))
+        XCTAssertEqual(ProtectedOperationJournal.fileProtection,
+                       .completeUntilFirstUserAuthentication)
+        XCTAssertTrue(journal.protectionApplied,
+                      "the write must have set the protection attribute, not merely intended to")
+
+        // The simulator's filesystem accepts the attribute and then reports none back, so the
+        // read-back is asserted only where the platform implements data protection.
+        let attributes = try FileManager.default.attributesOfItem(atPath: journal.storeURL.path)
+        if let applied = attributes[.protectionKey] as? FileProtectionType {
+            XCTAssertEqual(applied, ProtectedOperationJournal.fileProtection)
+        }
+    }
+
+    func testTheJournalNeverWritesArgumentsOrResults() throws {
+        let directory = temporaryDirectory()
+        let journal = ProtectedOperationJournal(directory: directory)
+        let sensitive = call("send_message", invocationID: "call-1",
+                             args: ["to": "+64211234567", "body": "meet me at the safehouse"])
+        _ = journal.admit(call: sensitive, semantics: .external(.bestEffort),
+                          key: OperationIdempotencyKey.derive(sensitive), at: Date())
+        journal.resolve(operationID: "call-1", outcome: .completed("Sent to +64211234567"),
+                        at: Date())
+
+        let contents = try String(contentsOf: journal.storeURL, encoding: .utf8)
+        for secret in ["+64211234567", "safehouse", "Sent to"] {
+            XCTAssertFalse(contents.contains(secret), "the journal wrote \(secret) to disk")
+        }
+        XCTAssertTrue(contents.contains("send_message"),
+                      "the tool name is the one readable field, and it is app-defined")
+    }
+
+    // MARK: - Serialization by resource
+
+    /// Two different operations on the same resource do not interleave. Without the queue both
+    /// would be parked inside the tool at once, which is what the probe counts.
+    func testOperationsOnOneResourceRunOneAtATime() async {
+        let release = AsyncSignal()
+        let tool = ConcurrencyProbeTool(name: "send_it",
+                                        semantics: .external(.notCancellable), release: release)
+        let router = router(with: tool, journalDirectory: temporaryDirectory(), timeout: 30)
+
+        async let first = router.executeRoot(name: "send_it", args: ["to": "mum"],
+                                             invocationID: "call-1")
+        await Task.yield()
+        async let second = router.executeRoot(name: "send_it", args: ["to": "dad"],
+                                              invocationID: "call-2")
+        await Task.yield()
+        release.fire()
+
+        let outcomes = await (first, second)
+        XCTAssertEqual(outcomes.0, .completed("finished"))
+        XCTAssertEqual(outcomes.1, .completed("finished"))
+        XCTAssertEqual(tool.entries, 2, "both operations must actually have run")
+        XCTAssertEqual(tool.maxActive, 1, "one operation at a time on one resource")
+        XCTAssertEqual(router.operationJournal.records.count, 2)
+        XCTAssertTrue(router.operationJournal.records.allSatisfy { $0.state == .completed })
+    }
+}

--- a/OpenGlassesTests/ToolEffectClassificationTests.swift
+++ b/OpenGlassesTests/ToolEffectClassificationTests.swift
@@ -291,7 +291,7 @@ final class ToolEffectClassificationTests: XCTestCase {
     func testLoopRefusesToRepeatACallWhoseOutcomeIsUnresolved() async throws {
         var dispatched: [String] = []
         let dispatcher = ToolDispatcher(
-            execute: { name, _, _ in
+            execute: { name, _, _, _ in
                 dispatched.append(name)
                 return .outcomeUnknown(operationID: "op-1", message: "may still land")
             },
@@ -323,7 +323,7 @@ final class ToolEffectClassificationTests: XCTestCase {
     func testLoopStillAllowsADifferentCallToTheSameTool() async throws {
         var dispatched: [[String: Any]] = []
         let dispatcher = ToolDispatcher(
-            execute: { _, args, _ in
+            execute: { _, args, _, _ in
                 dispatched.append(args)
                 return .outcomeUnknown(operationID: "op", message: "may still land")
             },
@@ -358,7 +358,7 @@ final class ToolEffectClassificationTests: XCTestCase {
     func testDispatcherReportsAnUnresolvedOutcomeAsItsOwnStatus() async {
         var statuses: [ToolCallStatus] = []
         let dispatcher = ToolDispatcher(
-            execute: { _, _, _ in .outcomeUnknown(operationID: "op", message: "may still land") },
+            execute: { _, _, _, _ in .outcomeUnknown(operationID: "op", message: "may still land") },
             onStatus: { statuses.append($0) })
 
         let outcome = await dispatcher.dispatch(

--- a/OpenGlassesTests/ToolLoopDriverTests.swift
+++ b/OpenGlassesTests/ToolLoopDriverTests.swift
@@ -11,7 +11,7 @@ final class ToolLoopDriverTests: XCTestCase {
     func testDispatcherExecutesWellFormedCallAndTracksStatus() async {
         var statuses: [ToolCallStatus] = []
         let dispatcher = ToolDispatcher(
-            execute: { name, args, _ in .completed("ran \(name) with \(args["x"] ?? "?")") },
+            execute: { name, args, _, _ in .completed("ran \(name) with \(args["x"] ?? "?")") },
             onStatus: { statuses.append($0) }
         )
         let outcome = await dispatcher.dispatch(
@@ -25,7 +25,7 @@ final class ToolLoopDriverTests: XCTestCase {
     func testDispatcherReturnsParseErrorForNilArgumentsWithoutExecuting() async {
         var executed = false
         let dispatcher = ToolDispatcher(
-            execute: { _, _, _ in executed = true; return .completed("should not run") },
+            execute: { _, _, _, _ in executed = true; return .completed("should not run") },
             onStatus: { _ in }
         )
         let outcome = await dispatcher.dispatch(
@@ -39,7 +39,7 @@ final class ToolLoopDriverTests: XCTestCase {
     func testDispatcherReportsFailureStatus() async {
         var statuses: [ToolCallStatus] = []
         let dispatcher = ToolDispatcher(
-            execute: { _, _, _ in .failedBeforeExecution(reason: "boom") },
+            execute: { _, _, _, _ in .failedBeforeExecution(reason: "boom") },
             onStatus: { statuses.append($0) }
         )
         _ = await dispatcher.dispatch(ToolInvocation(id: "1", name: "t", arguments: [:]))
@@ -67,7 +67,8 @@ final class ToolLoopDriverTests: XCTestCase {
     private func makeScriptedAdapter(
         label: String = "Test",
         turns: [AssistantTurn],
-        execute: @escaping (String, [String: Any], String?) async -> ToolExecutionOutcome = { name, _, _ in .completed("ok:\(name)") },
+        execute: @escaping (String, [String: Any], String?, String?) async -> ToolExecutionOutcome
+            = { name, _, _, _ in .completed("ok:\(name)") },
         history: Box<[String]>,
         statuses: Box<[ToolCallStatus]>
     ) -> ProviderLoopAdapter {
@@ -125,7 +126,7 @@ final class ToolLoopDriverTests: XCTestCase {
                 ToolInvocation(id: "1", name: "yield_to_human", arguments: [:]),
                 ToolInvocation(id: "2", name: "never", arguments: [:])
             ])],
-            execute: { name, _, _ in
+            execute: { name, _, _, _ in
                 name == "yield_to_human" ? .completed("YIELD_TO_HUMAN: your turn") : .completed("ran")
             },
             history: history, statuses: statuses


### PR DESCRIPTION
Final phase of `docs/plans/DJ-composed-tool-safety-and-execution-outcomes.md` (P3 — operation journal
and idempotency). Stacked on #362 (P2), which is stacked on #361 (P1) and #358 (P0). **Review the
last commit only.**

## Why

A provider redelivering a tool call, and a process dying mid-send, can each put the same message,
unlock, or export through twice. The turn-scoped guard added with the typed outcomes covers neither:
it forgets at the end of the turn and it dies with the process.

## What ships

**`OperationJournal` + `ProtectedOperationJournal`.** One small JSON file under Application Support,
`NSFileProtectionCompleteUntilFirstUserAuthentication` (not `...Complete`: a launch on a locked
device is exactly when an interrupted operation has to be discovered), excluded from backup. Each row
holds the operation id, idempotency key, tool name, effect class, origin/depth, fingerprinted
root/parent/composer ids, timestamps, and state. No arguments, results, templates, or messages —
asserted by a test that greps the written file for the values it fed in.

**At-most-once dispatch.** The key is `SHA256(rootInvocationID | ancestry/target | argsDigest)`. The
providers now pass their own delivery ids down — Anthropic/OpenAI `tool_use`/`tool_call` id via
`ToolDispatcher`, the live session's function-call id via `ToolCallRouter`, a per-run step id from
`PlanExecutor` — so a redelivery derives the same key and is answered from the record instead of
executed. Where a caller has no stable id the default fresh UUID keeps every delivery distinct and
nothing is de-duplicated; the guarantee holds exactly where the delivery is identifiable.

Only operations that are **not safe to repeat** are journaled. A read, or anything intrinsically
idempotent (the torch, a scene, a capture), goes straight through — journaling it would buy nothing
and fill a security store with noise.

**Late completion.** When the timer wins, the row is marked `unknown` at that instant; when the
abandoned work finishes it updates the row atomically and fires `onOperationStatusChange`. It never
becomes a second spoken success after the turn has moved on — the app-side handler logs and stops.

**Recovery.** Rows left `started` by a killed process come back as `unknown`, never `failed`, and are
reconciled at launch through the new `OperationReconciling` seam. Nothing conforms today (no current
adapter exposes a status endpoint), so those rows stay honestly unknown.

**Adapters.** MCP `tools/call` carries the key in the request's reserved `_meta` (a pure
`callPayload` builder makes the wire shape assertable). The gateway bridge and user-authored URL
schemes have no key field, so they get the `OperationScope.idempotencyKey` task-local seam, and
in the meantime two operations on one logical resource are serialized rather than interleaved.
`OperationRetryPolicy` is the decision point for a manual retry: an unresolved non-idempotent
operation returns `.reconcileFirst`, never an automatic retry.

**Retention.** 200 rows, 7 days settled / 30 days unresolved, pruned deterministically with settled
rows dropped before unresolved ones.

**In passing:** release logs at the execution boundary no longer carry argument, result, or
confirmation text (`ToolLogContent.redacted`), which was the one remaining exit criterion the code
did not meet.

## Tests

18 new tests in `OperationJournalTests`: timer-wins/late-success and late-failure, duplicate delivery
in-process and across a simulated restart, different-call-still-runs, intrinsic tools not journaled,
key stability and path sensitivity, MCP payload key, interrupted-operation recovery, reconciliation
with and without an answering tool, non-idempotent no-auto-retry, cancellation before dispatch,
retention/pruning, protection at rest, content-freedom, and one-at-a-time per resource. Controllable
signals and continuations throughout — no wall-clock sleeps.

Full suite: 3728 passed, 0 failures (signed run, iPhone 17e sim). Release build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)