### PR TITLE
Add My Day travel time and leave-by alerts

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -588,6 +588,8 @@ class AppState: ObservableObject, AppStateProtocol {
     let locationService = LocationService()
     /// One EventKit owner shared by tools, proactive alerts, and My Day.
     let eventKitStore: EventKitDayStore
+    /// One short-lived MapKit estimator shared by My Day and proactive leave-by delivery.
+    let travelTimeSource: MapKitTravelTimeDaySource
     let proactiveAlerts: ProactiveAlertService
     let ambientCaptions = AmbientCaptionService()
     let glassesDisplay = GlassesDisplayService()
@@ -822,8 +824,13 @@ class AppState: ObservableObject, AppStateProtocol {
 
     init() {
         let sharedEventKitStore = EventKitDayStore()
+        let sharedTravelTimeSource = MapKitTravelTimeDaySource(locationService: locationService)
         eventKitStore = sharedEventKitStore
-        proactiveAlerts = ProactiveAlertService(eventStore: sharedEventKitStore)
+        travelTimeSource = sharedTravelTimeSource
+        proactiveAlerts = ProactiveAlertService(
+            eventStore: sharedEventKitStore,
+            travelSource: sharedTravelTimeSource
+        )
 
         // Initialize native tool system
         // Active project namespace for document scoping (Plan AN). Bind a local ref to
@@ -844,7 +851,8 @@ class AppState: ObservableObject, AppStateProtocol {
             semanticMemory: userMemory,
             documentStore: documentStore,
             activeNamespace: { memoryForNamespace.activePersonaId ?? "global" },
-            eventKitStore: sharedEventKitStore
+            eventKitStore: sharedEventKitStore,
+            travelTimeSource: sharedTravelTimeSource
         )
         nativeToolRouter = NativeToolRouter(registry: nativeToolRegistry, openClawBridge: openClawBridge)
 
@@ -1264,12 +1272,19 @@ class AppState: ObservableObject, AppStateProtocol {
         proactiveAlerts.onAlert = { [weak self] message, urgency in
             guard let self else { return }
             self.glassesDisplay.showNotification(title: "Reminder", body: message, icon: .calendar)
-            // Plan BZ: calendar/proactive alerts also feed the digest.
-            self.notificationDigest.ingest(source: .proactive, title: message,
-                                           priority: urgency == .high ? .high : .medium)
             Task {
                 await self.speechService.speak(message, urgency: urgency, mirrorToHUD: false)
             }
+        }
+        proactiveAlerts.onDigestItem = { [weak self] id, message, eventDate, urgency in
+            self?.notificationDigest.ingest(
+                id: id,
+                source: .proactive,
+                title: message,
+                priority: urgency == .high ? .high : .medium,
+                threadKey: id,
+                eventDate: eventDate
+            )
         }
         proactiveAlerts.onMeetingPlaybook = { [weak self] title, notes, steps in
             guard let self else { return }

--- a/OpenGlasses/Sources/App/Views/MyDayView.swift
+++ b/OpenGlasses/Sources/App/Views/MyDayView.swift
@@ -136,6 +136,17 @@ struct MyDayView: View {
             .buttonStyle(.plain)
             .foregroundStyle(accent)
             .accessibilityLabel("Complete \(item.title)")
+        } else if item.actions.contains(.directions),
+                  let url = service.directionsURL(for: item.id) {
+            Button {
+                openURL(url)
+            } label: {
+                Image(systemName: "arrow.triangle.turn.up.right.diamond")
+                    .frame(width: OGMetrics.minTouchTarget, height: OGMetrics.minTouchTarget)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(accent)
+            .accessibilityLabel("Start directions for \(item.title)")
         } else if item.actions.contains(.open), let dueAt = item.dueAt {
             Button {
                 let seconds = dueAt.timeIntervalSinceReferenceDate
@@ -185,6 +196,7 @@ struct MyDayView: View {
     private func icon(for kind: MyDayKind) -> String {
         switch kind {
         case .event: "calendar"
+        case .leaveBy: "location.fill"
         case .reminder: "checklist"
         case .weather: "cloud.sun"
         }
@@ -403,6 +415,7 @@ struct MyDayHomeView: View {
     private func icon(for kind: MyDayKind) -> String {
         switch kind {
         case .event: "calendar"
+        case .leaveBy: "location.fill"
         case .reminder: "checklist"
         case .weather: "cloud.sun"
         }

--- a/OpenGlasses/Sources/App/Views/SettingsJourneyScreens.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsJourneyScreens.swift
@@ -46,6 +46,11 @@ struct AppleIntegrationsSettingsScreen: View {
     @State private var disabledTools: Set<String> = Config.disabledTools
     @State private var permissionDeniedTool: String?
     @AppStorage("myDayEnabled") private var myDayEnabled = false
+    @AppStorage("myDayTransportMode") private var myDayTransportMode = MyDayTransportMode.walking.rawValue
+    @AppStorage("myDayTravelBufferMinutes") private var myDayTravelBufferMinutes = 10
+    @AppStorage("myDayTravelOrigin") private var myDayTravelOrigin = MyDayTravelOrigin.currentLocation.rawValue
+    @AppStorage("myDayHomeAddress") private var myDayHomeAddress = ""
+    @AppStorage("myDayWorkAddress") private var myDayWorkAddress = ""
 
     var body: some View {
         Form {
@@ -54,10 +59,41 @@ struct AppleIntegrationsSettingsScreen: View {
                     .onChange(of: myDayEnabled) { _, enabled in
                         Config.setMyDayEnabled(enabled)
                     }
+
+                if myDayEnabled {
+                    Picker("Travel mode", selection: $myDayTransportMode) {
+                        ForEach(MyDayTransportMode.allCases, id: \.rawValue) { mode in
+                            Text(mode.displayName).tag(mode.rawValue)
+                        }
+                    }
+
+                    Stepper(
+                        "Leave-by buffer: \(myDayTravelBufferMinutes) min",
+                        value: $myDayTravelBufferMinutes,
+                        in: 0...60,
+                        step: 5
+                    )
+
+                    Picker("Start from", selection: $myDayTravelOrigin) {
+                        ForEach(MyDayTravelOrigin.allCases, id: \.rawValue) { origin in
+                            Text(origin.displayName).tag(origin.rawValue)
+                        }
+                    }
+
+                    if myDayTravelOrigin == MyDayTravelOrigin.home.rawValue {
+                        TextField("Home address", text: $myDayHomeAddress)
+                            .textContentType(.fullStreetAddress)
+                            .autocorrectionDisabled()
+                    } else if myDayTravelOrigin == MyDayTravelOrigin.work.rawValue {
+                        TextField("Work address", text: $myDayWorkAddress)
+                            .textContentType(.fullStreetAddress)
+                            .autocorrectionDisabled()
+                    }
+                }
             } header: {
                 Text("Everyday Briefing")
             } footer: {
-                Text("Adds a phone and spoken briefing of what matters next from Calendar, Reminders, and Weather. It does not require a display or save a separate copy of your day.")
+                Text("Adds a phone and spoken briefing from Calendar, Reminders, Weather, and a short-lived Maps travel estimate for the next event with a physical location. Event locations and routes are not saved by OpenGlasses.")
             }
 
             Section {

--- a/OpenGlasses/Sources/Services/Digest/NotificationDigestService.swift
+++ b/OpenGlasses/Sources/Services/Digest/NotificationDigestService.swift
@@ -38,14 +38,21 @@ final class NotificationDigestService: ObservableObject {
 
     // MARK: - Ingest (called from AppState source wiring)
 
-    func ingest(source: DigestSource, title: String, body: String = "",
+    func ingest(id: String? = nil, source: DigestSource, title: String, body: String = "",
                 priority: NotificationPriority, threadKey: String? = nil,
                 eventDate: Date? = nil, awaitingReply: Bool = false) {
         guard Config.digestEnabled else { return }
-        let item = DigestItem(source: source, title: title, rawBody: body, createdAt: Date(),
-                              priority: priority, threadKey: threadKey, eventDate: eventDate,
-                              awaitingReply: awaitingReply)
-        items.append(item)
+        let stableID = id ?? UUID().uuidString
+        let existingSeenCount = items.first(where: { $0.id == stableID })?.seenCount ?? 0
+        let item = DigestItem(id: stableID, source: source, title: title, rawBody: body,
+                              createdAt: Date(), priority: priority, threadKey: threadKey,
+                              eventDate: eventDate, awaitingReply: awaitingReply,
+                              seenCount: existingSeenCount)
+        if let index = items.firstIndex(where: { $0.id == stableID }) {
+            items[index] = item
+        } else {
+            items.append(item)
+        }
         prune()
         save()
     }

--- a/OpenGlasses/Sources/Services/LocationService.swift
+++ b/OpenGlasses/Sources/Services/LocationService.swift
@@ -30,6 +30,8 @@ class LocationService: NSObject, ObservableObject {
 
     private let locationManager = CLLocationManager()
 
+    var authorizationStatus: CLAuthorizationStatus { locationManager.authorizationStatus }
+
     /// Region-monitoring event forwarders (BK P1). Set by `GeofenceTool.activate()`.
     var onRegionEvent: ((CLRegion, Bool) -> Void)?
     var onBecameAuthorizedAlways: (() -> Void)?

--- a/OpenGlasses/Sources/Services/MyDay/MyDayComposer.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayComposer.swift
@@ -28,6 +28,11 @@ struct MyDayComposer: Sendable {
         for event in todayEvents {
             ranked.append(eventItem(event, now: now))
         }
+        if let travel = inputs.travel,
+           travel.eventStart > now,
+           travel.eventStart < endOfTomorrow {
+            ranked.append(leaveByItem(travel, now: now))
+        }
         if period == .evening, let firstTomorrow = tomorrowEvents.first {
             ranked.append(tomorrowItem(firstTomorrow))
         }
@@ -64,6 +69,7 @@ struct MyDayComposer: Sendable {
                     guard let due = $0.dueDate else { return false }
                     return $0.hasTime ? due < now : due < startOfToday
                 }.count,
+                travel: inputs.travel,
                 items: items
             ),
             items: items,
@@ -151,7 +157,7 @@ struct MyDayComposer: Sendable {
             reminder.hasTime ? due < now : due < startOfToday
         } ?? false
         let isDueToday = reminder.dueDate.map { $0 >= startOfToday && $0 < startOfTomorrow } ?? false
-        let rank = isOverdue ? 1 : (isDueToday ? 3 : 6)
+        let rank = isOverdue ? 2 : (isDueToday ? 3 : 6)
         let urgency: MyDayUrgency = isOverdue ? .important : (isDueToday ? .upcoming : .routine)
 
         let detail: String?
@@ -174,6 +180,41 @@ struct MyDayComposer: Sendable {
                 dueAt: reminder.dueDate,
                 urgency: urgency,
                 actions: [.complete, .open]
+            )
+        )
+    }
+
+    private func leaveByItem(_ estimate: MyDayTravelEstimate, now: Date) -> RankedItem {
+        let secondsUntilLeave = estimate.leaveAt.timeIntervalSince(now)
+        let urgency: MyDayUrgency
+        if secondsUntilLeave <= 0 {
+            urgency = .immediate
+        } else if secondsUntilLeave <= 30 * 60 {
+            urgency = .important
+        } else {
+            urgency = .upcoming
+        }
+
+        let title = secondsUntilLeave <= 0
+            ? "Leave now for \(estimate.eventTitle)"
+            : "Leave by \(formatTime(estimate.leaveAt)) for \(estimate.eventTitle)"
+        let routeMinutes = max(1, Int((estimate.travelDuration / 60).rounded()))
+        let bufferMinutes = max(0, Int((estimate.bufferDuration / 60).rounded()))
+        var detail = "\(routeMinutes) min \(estimate.mode.displayName.lowercased()) to \(estimate.destination)"
+        if bufferMinutes > 0 {
+            detail += " + \(bufferMinutes) min buffer"
+        }
+
+        return RankedItem(
+            rank: 1,
+            item: MyDayItem(
+                id: .init(source: .travel, rawValue: "leave-by:\(estimate.eventID)"),
+                kind: .leaveBy,
+                title: title,
+                detail: detail,
+                dueAt: estimate.leaveAt,
+                urgency: urgency,
+                actions: [.directions]
             )
         )
     }
@@ -202,13 +243,21 @@ struct MyDayComposer: Sendable {
         return lhs.item.id < rhs.item.id
     }
 
-    private func headline(todayCommitments: Int, overdueReminders: Int, items: [MyDayItem]) -> String {
+    private func headline(
+        todayCommitments: Int,
+        overdueReminders: Int,
+        travel: MyDayTravelEstimate?,
+        items: [MyDayItem]
+    ) -> String {
         var parts: [String] = []
         if todayCommitments > 0 {
             parts.append("\(todayCommitments) commitment\(todayCommitments == 1 ? "" : "s") today")
         }
         if overdueReminders > 0 {
             parts.append("\(overdueReminders) overdue reminder\(overdueReminders == 1 ? "" : "s")")
+        }
+        if let travel, items.contains(where: { $0.kind == .leaveBy }) {
+            parts.append("leave by \(formatTime(travel.leaveAt)) for \(travel.eventTitle)")
         }
         if parts.isEmpty {
             return items.isEmpty ? "Your day is clear." : "Here is what matters today."

--- a/OpenGlasses/Sources/Services/MyDay/MyDayModels.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayModels.swift
@@ -8,6 +8,7 @@ enum MyDayPeriod: String, Equatable, Sendable {
 
 enum MyDayKind: String, Equatable, Sendable {
     case event
+    case leaveBy
     case reminder
     case weather
 }
@@ -26,12 +27,14 @@ enum MyDayUrgency: Int, Comparable, Equatable, Sendable {
 enum MyDaySource: String, CaseIterable, Equatable, Sendable {
     case calendar
     case reminders
+    case travel
     case weather
 
     var displayName: String {
         switch self {
         case .calendar: "Calendar"
         case .reminders: "Reminders"
+        case .travel: "Travel Time"
         case .weather: "Weather"
         }
     }
@@ -66,6 +69,7 @@ struct MyDayItemID: Hashable, Comparable, Sendable {
 enum MyDayAction: Hashable, Sendable {
     case open
     case complete
+    case directions
 }
 
 struct MyDayItem: Identifiable, Equatable, Sendable {
@@ -109,11 +113,65 @@ struct MyDayWeather: Equatable, Sendable {
     let isDecisionRelevant: Bool
 }
 
+enum MyDayTransportMode: String, CaseIterable, Codable, Equatable, Sendable {
+    case walking
+    case driving
+    case transit
+
+    var displayName: String {
+        switch self {
+        case .walking: "Walking"
+        case .driving: "Driving"
+        case .transit: "Transit"
+        }
+    }
+}
+
+enum MyDayTravelOrigin: String, CaseIterable, Codable, Equatable, Sendable {
+    case currentLocation
+    case home
+    case work
+
+    var displayName: String {
+        switch self {
+        case .currentLocation: "Current Location"
+        case .home: "Home"
+        case .work: "Work"
+        }
+    }
+}
+
+struct MyDayTravelEstimate: Equatable, Sendable {
+    let eventID: String
+    let eventTitle: String
+    let destination: String
+    let eventStart: Date
+    let travelDuration: TimeInterval
+    let bufferDuration: TimeInterval
+    let leaveAt: Date
+    let mode: MyDayTransportMode
+}
+
 struct MyDayInputs: Equatable, Sendable {
     let events: [MyDayCalendarEvent]
     let reminders: [MyDayReminder]
     let weather: MyDayWeather?
+    let travel: MyDayTravelEstimate?
     let sourceStates: [MyDaySourceState]
+
+    init(
+        events: [MyDayCalendarEvent],
+        reminders: [MyDayReminder],
+        weather: MyDayWeather?,
+        travel: MyDayTravelEstimate? = nil,
+        sourceStates: [MyDaySourceState]
+    ) {
+        self.events = events
+        self.reminders = reminders
+        self.weather = weather
+        self.travel = travel
+        self.sourceStates = sourceStates
+    }
 }
 
 struct MyDaySourceLoad<Value: Equatable & Sendable>: Equatable, Sendable {

--- a/OpenGlasses/Sources/Services/MyDay/MyDayService.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayService.swift
@@ -13,6 +13,7 @@ final class MyDayService: ObservableObject {
     private let calendarSource: any CalendarDaySource
     private let remindersSource: any RemindersDaySource
     private let weatherSource: any WeatherDaySource
+    private let travelSource: (any TravelTimeDaySource)?
     private let composer: MyDayComposer
     private let spokenFormatter: MyDaySpokenFormatter
     private let calendar: Calendar
@@ -21,6 +22,7 @@ final class MyDayService: ObservableObject {
         calendarSource: any CalendarDaySource,
         remindersSource: any RemindersDaySource,
         weatherSource: any WeatherDaySource,
+        travelSource: (any TravelTimeDaySource)? = nil,
         composer: MyDayComposer = MyDayComposer(),
         spokenFormatter: MyDaySpokenFormatter = MyDaySpokenFormatter(),
         calendar: Calendar = .current
@@ -28,6 +30,7 @@ final class MyDayService: ObservableObject {
         self.calendarSource = calendarSource
         self.remindersSource = remindersSource
         self.weatherSource = weatherSource
+        self.travelSource = travelSource
         self.composer = composer
         self.spokenFormatter = spokenFormatter
         self.calendar = calendar
@@ -46,14 +49,19 @@ final class MyDayService: ObservableObject {
         // alongside both because it has no prompt of its own.
         async let weatherLoad = weatherSource.loadWeather()
         let events = await calendarSource.loadEvents(from: start, to: end)
+        async let travelLoad = loadTravel(for: events.value, now: now)
         let reminders = await remindersSource.loadReminders()
         let weather = await weatherLoad
+        let travel = await travelLoad
+        var sourceStates = [events.state, reminders.state, weather.state]
+        if let travel { sourceStates.append(travel.state) }
         let snapshot = composer.compose(
             inputs: MyDayInputs(
                 events: events.value,
                 reminders: reminders.value,
                 weather: weather.value,
-                sourceStates: [events.state, reminders.state, weather.state]
+                travel: travel?.value,
+                sourceStates: sourceStates
             ),
             now: now
         )
@@ -65,10 +73,25 @@ final class MyDayService: ObservableObject {
         spokenFormatter.format(await refresh(now: now))
     }
 
+    func directionsURL(for itemID: MyDayItemID) -> URL? {
+        guard itemID.source == .travel,
+              itemID.rawValue.hasPrefix("leave-by:") else { return nil }
+        let eventID = String(itemID.rawValue.dropFirst("leave-by:".count))
+        return travelSource?.directionsURL(for: eventID)
+    }
+
     @discardableResult
     func completeReminder(id: String, now: Date = Date()) async throws -> String? {
         let title = try await remindersSource.completeReminder(id: id)
         _ = await refresh(now: now)
         return title
+    }
+
+    private func loadTravel(
+        for events: [MyDayCalendarEvent],
+        now: Date
+    ) async -> MyDaySourceLoad<MyDayTravelEstimate?>? {
+        guard let travelSource else { return nil }
+        return await travelSource.loadTravel(for: events, now: now)
     }
 }

--- a/OpenGlasses/Sources/Services/MyDay/MyDaySources.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDaySources.swift
@@ -16,6 +16,15 @@ protocol WeatherDaySource: AnyObject {
     func loadWeather() async -> MyDaySourceLoad<MyDayWeather?>
 }
 
+@MainActor
+protocol TravelTimeDaySource: AnyObject {
+    func loadTravel(
+        for events: [MyDayCalendarEvent],
+        now: Date
+    ) async -> MyDaySourceLoad<MyDayTravelEstimate?>
+    func directionsURL(for eventID: String) -> URL?
+}
+
 extension EventKitDayStore: CalendarDaySource {
     func loadEvents(from start: Date, to end: Date) async -> MyDaySourceLoad<[MyDayCalendarEvent]> {
         do {

--- a/OpenGlasses/Sources/Services/MyDay/TravelTimeDaySource.swift
+++ b/OpenGlasses/Sources/Services/MyDay/TravelTimeDaySource.swift
@@ -1,0 +1,392 @@
+import CoreLocation
+import Foundation
+import MapKit
+
+struct MyDayCoordinate: Equatable, Sendable {
+    let latitude: Double
+    let longitude: Double
+
+    init(latitude: Double, longitude: Double) {
+        self.latitude = latitude
+        self.longitude = longitude
+    }
+
+    init(_ coordinate: CLLocationCoordinate2D) {
+        self.init(latitude: coordinate.latitude, longitude: coordinate.longitude)
+    }
+
+    var coreLocation: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+}
+
+struct MyDayTravelSettings: Equatable, Sendable {
+    let mode: MyDayTransportMode
+    let bufferMinutes: Int
+    let origin: MyDayTravelOrigin
+    let homeAddress: String
+    let workAddress: String
+
+    static var current: Self {
+        .init(
+            mode: Config.myDayTransportMode,
+            bufferMinutes: Config.myDayTravelBufferMinutes,
+            origin: Config.myDayTravelOrigin,
+            homeAddress: Config.myDayHomeAddress,
+            workAddress: Config.myDayWorkAddress
+        )
+    }
+}
+
+enum MyDayTravelPlanner {
+    static func nextLocatableEvent(
+        in events: [MyDayCalendarEvent],
+        now: Date
+    ) -> MyDayCalendarEvent? {
+        events
+            .filter { !$0.isAllDay && $0.startDate > now && usableDestination($0.location) != nil }
+            .sorted {
+                if $0.startDate != $1.startDate { return $0.startDate < $1.startDate }
+                return $0.id < $1.id
+            }
+            .first
+    }
+
+    static func usableDestination(_ location: String?) -> String? {
+        guard let location else { return nil }
+        let trimmed = location.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 3 else { return nil }
+        let lower = trimmed.lowercased()
+        let virtualMarkers = [
+            "http://", "https://", "zoom", "microsoft teams", "google meet", "webex",
+            "facetime", "online", "virtual", "phone call", "tbd"
+        ]
+        guard !virtualMarkers.contains(where: lower.contains) else { return nil }
+        return trimmed
+    }
+
+    static func estimate(
+        event: MyDayCalendarEvent,
+        destination: String,
+        travelDuration: TimeInterval,
+        settings: MyDayTravelSettings
+    ) -> MyDayTravelEstimate? {
+        guard travelDuration.isFinite, travelDuration > 0 else { return nil }
+        let buffer = TimeInterval(min(60, max(0, settings.bufferMinutes)) * 60)
+        return .init(
+            eventID: event.id,
+            eventTitle: event.title,
+            destination: destination,
+            eventStart: event.startDate,
+            travelDuration: travelDuration,
+            bufferDuration: buffer,
+            leaveAt: event.startDate.addingTimeInterval(-(travelDuration + buffer)),
+            mode: settings.mode
+        )
+    }
+}
+
+struct MyDayTravelCacheMetadata: Equatable, Sendable {
+    let eventID: String
+    let eventStart: Date
+    let destinationKey: String
+    let origin: MyDayCoordinate
+    let originMode: MyDayTravelOrigin
+    let transportMode: MyDayTransportMode
+    let bufferMinutes: Int
+    let calculatedAt: Date
+}
+
+enum MyDayTravelCachePolicy {
+    static let lifetime: TimeInterval = 5 * 60
+    static let materialLocationChangeMeters = 250.0
+
+    static func canReuse(
+        _ cached: MyDayTravelCacheMetadata,
+        event: MyDayCalendarEvent,
+        destinationKey: String,
+        origin: MyDayCoordinate,
+        settings: MyDayTravelSettings,
+        now: Date
+    ) -> Bool {
+        guard now.timeIntervalSince(cached.calculatedAt) >= 0,
+              now.timeIntervalSince(cached.calculatedAt) <= lifetime,
+              cached.eventID == event.id,
+              cached.eventStart == event.startDate,
+              cached.destinationKey == destinationKey,
+              cached.originMode == settings.origin,
+              cached.transportMode == settings.mode,
+              cached.bufferMinutes == min(60, max(0, settings.bufferMinutes)) else {
+            return false
+        }
+        return distanceMeters(from: cached.origin, to: origin) <= materialLocationChangeMeters
+    }
+
+    static func distanceMeters(from: MyDayCoordinate, to: MyDayCoordinate) -> Double {
+        let earthRadius = 6_371_000.0
+        let lat1 = from.latitude * .pi / 180
+        let lat2 = to.latitude * .pi / 180
+        let deltaLat = (to.latitude - from.latitude) * .pi / 180
+        let deltaLon = (to.longitude - from.longitude) * .pi / 180
+        let a = sin(deltaLat / 2) * sin(deltaLat / 2)
+            + cos(lat1) * cos(lat2) * sin(deltaLon / 2) * sin(deltaLon / 2)
+        return earthRadius * 2 * atan2(sqrt(a), sqrt(1 - a))
+    }
+}
+
+struct MyDayLeaveByAlert: Equatable, Sendable {
+    let id: String
+    let eventID: String
+    let eventStart: Date
+    let message: String
+}
+
+enum MyDayLeaveByAlertPolicy {
+    /// Inside two minutes the existing "starting now" calendar alert is clearer than a late
+    /// route warning, so only one of the two delivery paths fires.
+    static let imminentEventWindow: TimeInterval = 2 * 60
+
+    static func alert(for estimate: MyDayTravelEstimate, now: Date) -> MyDayLeaveByAlert? {
+        guard now >= estimate.leaveAt,
+              now < estimate.eventStart,
+              estimate.eventStart.timeIntervalSince(now) > imminentEventWindow else {
+            return nil
+        }
+        let minutes = max(1, Int((estimate.travelDuration / 60).rounded()))
+        let occurrence = Int(estimate.eventStart.timeIntervalSince1970)
+        let mode = estimate.mode.displayName.lowercased()
+        return .init(
+            id: "leave-by:\(estimate.eventID):\(occurrence)",
+            eventID: estimate.eventID,
+            eventStart: estimate.eventStart,
+            message: "Leave now for \(estimate.eventTitle). Allow about \(minutes) minutes \(mode) to \(estimate.destination)."
+        )
+    }
+}
+
+@MainActor
+final class MapKitTravelTimeDaySource: TravelTimeDaySource {
+    private struct CacheEntry {
+        let metadata: MyDayTravelCacheMetadata
+        let estimate: MyDayTravelEstimate
+        let originQuery: String?
+        let destinationQuery: String
+    }
+
+    private weak var locationService: LocationService?
+    private let settings: () -> MyDayTravelSettings
+    private var cache: CacheEntry?
+
+    init(
+        locationService: LocationService,
+        settings: @escaping () -> MyDayTravelSettings = { .current }
+    ) {
+        self.locationService = locationService
+        self.settings = settings
+    }
+
+    func loadTravel(
+        for events: [MyDayCalendarEvent],
+        now: Date
+    ) async -> MyDaySourceLoad<MyDayTravelEstimate?> {
+        guard let event = MyDayTravelPlanner.nextLocatableEvent(in: events, now: now),
+              let destinationQuery = MyDayTravelPlanner.usableDestination(event.location) else {
+            cache = nil
+            return .init(value: nil, state: .available(.travel))
+        }
+
+        let currentSettings = settings()
+        let originResult = await resolveOrigin(settings: currentSettings)
+        guard case .success(let origin) = originResult else {
+            let message: String
+            let availability: MyDaySourceAvailability
+            switch originResult {
+            case .missingConfiguredOrigin(let name):
+                message = "Add a \(name) address in My Day settings."
+                availability = .unavailable
+            case .locationDenied:
+                message = "Location access is off."
+                availability = .denied
+            case .unavailable:
+                message = "Your travel origin is unavailable."
+                availability = .unavailable
+            case .success:
+                preconditionFailure("Handled above")
+            }
+            return .init(
+                value: nil,
+                state: .init(source: .travel, availability: availability, message: message)
+            )
+        }
+
+        let destinationKey = normalized(destinationQuery)
+        if let cache,
+           MyDayTravelCachePolicy.canReuse(
+               cache.metadata,
+               event: event,
+               destinationKey: destinationKey,
+               origin: origin,
+               settings: currentSettings,
+               now: now
+           ) {
+            return .init(value: cache.estimate, state: .available(.travel))
+        }
+
+        do {
+            let destination = try await resolvePlace(destinationQuery, near: origin)
+            let duration = try await routeDuration(
+                from: origin,
+                to: destination,
+                mode: currentSettings.mode
+            )
+            guard let estimate = MyDayTravelPlanner.estimate(
+                event: event,
+                destination: destination.name ?? destinationQuery,
+                travelDuration: duration,
+                settings: currentSettings
+            ) else {
+                throw TravelError.noRoute
+            }
+            cache = CacheEntry(
+                metadata: .init(
+                    eventID: event.id,
+                    eventStart: event.startDate,
+                    destinationKey: destinationKey,
+                    origin: origin,
+                    originMode: currentSettings.origin,
+                    transportMode: currentSettings.mode,
+                    bufferMinutes: min(60, max(0, currentSettings.bufferMinutes)),
+                    calculatedAt: now
+                ),
+                estimate: estimate,
+                originQuery: configuredOriginQuery(for: currentSettings),
+                destinationQuery: destinationQuery
+            )
+            return .init(value: estimate, state: .available(.travel))
+        } catch {
+            cache = nil
+            return .init(
+                value: nil,
+                state: .unavailable(.travel, message: "Travel time could not be estimated.")
+            )
+        }
+    }
+
+    func directionsURL(for eventID: String) -> URL? {
+        guard let cache, cache.estimate.eventID == eventID else { return nil }
+        var components = URLComponents(string: "https://maps.apple.com/")
+        var queryItems = [
+            URLQueryItem(name: "daddr", value: cache.destinationQuery),
+            URLQueryItem(name: "dirflg", value: cache.estimate.mode.mapsFlag)
+        ]
+        if let originQuery = cache.originQuery {
+            queryItems.insert(URLQueryItem(name: "saddr", value: originQuery), at: 0)
+        }
+        components?.queryItems = queryItems
+        return components?.url
+    }
+
+    private func configuredOriginQuery(for settings: MyDayTravelSettings) -> String? {
+        switch settings.origin {
+        case .currentLocation:
+            nil
+        case .home:
+            settings.homeAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+        case .work:
+            settings.workAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    private enum OriginResult {
+        case success(MyDayCoordinate)
+        case missingConfiguredOrigin(String)
+        case locationDenied
+        case unavailable
+    }
+
+    private func resolveOrigin(settings: MyDayTravelSettings) async -> OriginResult {
+        switch settings.origin {
+        case .currentLocation:
+            guard let locationService else { return .unavailable }
+            if let fix = await locationService.awaitFix(timeout: 2.5) {
+                return .success(MyDayCoordinate(fix.coordinate))
+            }
+            switch locationService.authorizationStatus {
+            case .denied, .restricted:
+                return .locationDenied
+            default:
+                return .unavailable
+            }
+        case .home, .work:
+            let name = settings.origin == .home ? "Home" : "Work"
+            let address = settings.origin == .home ? settings.homeAddress : settings.workAddress
+            let trimmed = address.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return .missingConfiguredOrigin(name) }
+            guard let item = try? await resolvePlace(trimmed, near: nil) else { return .unavailable }
+            return .success(MyDayCoordinate(item.location.coordinate))
+        }
+    }
+
+    private func resolvePlace(_ query: String, near origin: MyDayCoordinate?) async throws -> MKMapItem {
+        let request = MKLocalSearch.Request()
+        request.naturalLanguageQuery = query
+        if let origin {
+            request.region = MKCoordinateRegion(
+                center: origin.coreLocation,
+                latitudinalMeters: 50_000,
+                longitudinalMeters: 50_000
+            )
+        }
+        let response = try await MKLocalSearch(request: request).start()
+        guard let item = response.mapItems.first else { throw TravelError.noPlace }
+        return item
+    }
+
+    private func routeDuration(
+        from origin: MyDayCoordinate,
+        to destination: MKMapItem,
+        mode: MyDayTransportMode
+    ) async throws -> TimeInterval {
+        let request = MKDirections.Request()
+        request.source = MKMapItem(
+            location: CLLocation(latitude: origin.latitude, longitude: origin.longitude),
+            address: nil
+        )
+        request.destination = destination
+        request.transportType = mode.mapKitType
+        request.requestsAlternateRoutes = false
+        let response = try await MKDirections(request: request).calculate()
+        guard let route = response.routes.first else { throw TravelError.noRoute }
+        return route.expectedTravelTime
+    }
+
+    private func normalized(_ value: String) -> String {
+        value.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    private enum TravelError: Error {
+        case noPlace
+        case noRoute
+    }
+}
+
+private extension MyDayTransportMode {
+    var mapKitType: MKDirectionsTransportType {
+        switch self {
+        case .walking: .walking
+        case .driving: .automobile
+        case .transit: .transit
+        }
+    }
+
+    var mapsFlag: String {
+        switch self {
+        case .walking: "w"
+        case .driving: "d"
+        case .transit: "r"
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/NativeToolRegistry.swift
@@ -17,15 +17,19 @@ final class NativeToolRegistry {
          semanticMemory: SemanticMemoryStore? = nil,
          documentStore: DocumentStore? = nil,
          activeNamespace: (() -> String)? = nil,
-         eventKitStore: EventKitDayStore? = nil) {
+         eventKitStore: EventKitDayStore? = nil,
+         travelTimeSource: (any TravelTimeDaySource)? = nil) {
         let eventKitStore = eventKitStore ?? EventKitDayStore()
         let weatherTool = WeatherTool(locationService: locationService)
+        let travelTimeSource = travelTimeSource
+            ?? MapKitTravelTimeDaySource(locationService: locationService)
         let newsTool = NewsTool()
         let dateTimeTool = DateTimeTool()
         let myDayService = MyDayService(
             calendarSource: eventKitStore,
             remindersSource: eventKitStore,
-            weatherSource: NativeWeatherDaySource(weatherTool: weatherTool)
+            weatherSource: NativeWeatherDaySource(weatherTool: weatherTool),
+            travelSource: travelTimeSource
         )
         self.myDayService = myDayService
 

--- a/OpenGlasses/Sources/Services/ProactiveAlertService.swift
+++ b/OpenGlasses/Sources/Services/ProactiveAlertService.swift
@@ -17,9 +17,15 @@ final class ProactiveAlertService: ObservableObject {
     private var checkTimer: Timer?
     private var alertedEventIds: Set<String> = []
     private let eventStore: EventKitDayStore
+    private let travelSource: (any TravelTimeDaySource)?
+    private var checkInFlight = false
 
-    init(eventStore: EventKitDayStore? = nil) {
+    init(
+        eventStore: EventKitDayStore? = nil,
+        travelSource: (any TravelTimeDaySource)? = nil
+    ) {
         self.eventStore = eventStore ?? EventKitDayStore()
+        self.travelSource = travelSource
     }
 
     /// Presence-aware throttle (Plan W). Injected by AppState; nil ⇒ full cadence (unchanged).
@@ -28,6 +34,10 @@ final class ProactiveAlertService: ObservableObject {
 
     /// Callback to speak an alert through TTS, with an urgency for rate/prefix.
     var onAlert: ((String, TextToSpeechService.SpeechUrgency) -> Void)?
+
+    /// One structured ingest path for the first-party digest. Stable IDs make an alert an upsert
+    /// across foreground checks and process restarts instead of a second notification source.
+    var onDigestItem: ((String, String, Date?, TextToSpeechService.SpeechUrgency) -> Void)?
 
     /// Callback to auto-create a playbook from a calendar event's agenda/notes
     var onMeetingPlaybook: ((String, String, [String]) -> Void)?
@@ -49,12 +59,10 @@ final class ProactiveAlertService: ObservableObject {
 
         // Check immediately, then on interval
         throttle.reset()   // the immediate check below always runs
-        checkForAlerts()
+        scheduleAlertCheck()
 
         checkTimer = Timer.scheduledTimer(withTimeInterval: checkInterval, repeats: true) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.checkForAlerts()
-            }
+            Task { @MainActor [weak self] in self?.scheduleAlertCheck() }
         }
 
         NSLog("[ProactiveAlerts] Started — checking every %.0fs", checkInterval)
@@ -80,16 +88,26 @@ final class ProactiveAlertService: ObservableObject {
     func resumeAlerts() {
         guard isRunning, checkTimer == nil else { return }
         checkTimer = Timer.scheduledTimer(withTimeInterval: checkInterval, repeats: true) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.checkForAlerts()
-            }
+            Task { @MainActor [weak self] in self?.scheduleAlertCheck() }
         }
         NSLog("[ProactiveAlerts] Resumed after foreground")
     }
 
     // MARK: - Alert Checking
 
-    private func checkForAlerts() {
+    private func scheduleAlertCheck() {
+        guard !checkInFlight else { return }
+        checkInFlight = true
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.checkForAlerts()
+            self.checkInFlight = false
+        }
+    }
+
+    private func checkForAlerts() async {
+        guard isRunning else { return }
+
         // Presence throttle (Plan W): calendar alerts are time-sensitive, so they floor at `.present`
         // — never slower than 2× base and never paused merely because the user is idle (the existing
         // background path still pauses them when truly away). This trims redundant calendar queries
@@ -109,21 +127,52 @@ final class ProactiveAlertService: ObservableObject {
             .filter { !$0.isAllDay }
             .sorted { $0.startDate < $1.startDate }
 
+        var travelEstimate: MyDayTravelEstimate?
+        var leaveByAlert: MyDayLeaveByAlert?
+        if Config.myDayEnabled, let travelSource {
+            let travelEnd = Calendar.current.date(byAdding: .hour, value: 6, to: now) ?? lookAhead
+            let travelEvents = eventStore.calendarEvents(from: now, to: travelEnd).map {
+                MyDayCalendarEvent(
+                    id: $0.id,
+                    title: $0.title,
+                    startDate: $0.startDate,
+                    endDate: $0.endDate,
+                    isAllDay: $0.isAllDay,
+                    location: $0.location
+                )
+            }
+            let load = await travelSource.loadTravel(for: travelEvents, now: now)
+            guard isRunning else { return }
+            travelEstimate = load.value
+            if let estimate = load.value {
+                leaveByAlert = MyDayLeaveByAlertPolicy.alert(for: estimate, now: now)
+            }
+        }
+
+        var imminentEventIDs = Set<String>()
+
         for event in events {
             let minutesUntil = Int(event.startDate.timeIntervalSince(now) / 60)
-            let eventKey = event.id
+            let occurrence = Int(event.startDate.timeIntervalSince1970)
+            let eventKey = "calendar:\(event.id):\(occurrence)"
 
             // Imminent alert (0-1 minutes)
             let imminentKey = "\(eventKey)-imminent"
             if minutesUntil <= imminentAlertMinutes && minutesUntil >= 0 && !alertedEventIds.contains(imminentKey) {
                 alertedEventIds.insert(imminentKey)
+                imminentEventIDs.insert(event.id)
                 let title = event.title
                 var alert = "\(title) is starting now"
                 if let location = event.location, !location.isEmpty {
                     alert += " at \(location)"
                 }
                 alert += "."
-                deliverAlert(alert, urgency: .high)
+                deliverAlert(
+                    alert,
+                    urgency: .high,
+                    stableID: imminentKey,
+                    eventDate: event.startDate
+                )
 
                 // Auto-create playbook from calendar event notes/agenda
                 if let notes = event.notes, !notes.isEmpty {
@@ -137,7 +186,11 @@ final class ProactiveAlertService: ObservableObject {
             // Early alert (around 10 minutes)
             else {
                 let earlyKey = "\(eventKey)-early"
-                if minutesUntil <= earlyAlertMinutes && minutesUntil > imminentAlertMinutes && !alertedEventIds.contains(earlyKey) {
+                let hasLeaveBy = travelEstimate?.eventID == event.id
+                if !hasLeaveBy,
+                   minutesUntil <= earlyAlertMinutes,
+                   minutesUntil > imminentAlertMinutes,
+                   !alertedEventIds.contains(earlyKey) {
                     alertedEventIds.insert(earlyKey)
                     let title = event.title
                     var alert = "Heads up: \(title) starts in \(minutesUntil) minute\(minutesUntil == 1 ? "" : "s")"
@@ -145,9 +198,28 @@ final class ProactiveAlertService: ObservableObject {
                         alert += " at \(location)"
                     }
                     alert += "."
-                    deliverAlert(alert, urgency: .medium)
+                    deliverAlert(
+                        alert,
+                        urgency: .medium,
+                        stableID: earlyKey,
+                        eventDate: event.startDate
+                    )
                 }
             }
+        }
+
+        if let leaveByAlert,
+           !imminentEventIDs.contains(leaveByAlert.eventID),
+           Config.myDayLastDeliveredLeaveByID != leaveByAlert.id,
+           !alertedEventIds.contains(leaveByAlert.id) {
+            alertedEventIds.insert(leaveByAlert.id)
+            Config.myDayLastDeliveredLeaveByID = leaveByAlert.id
+            deliverAlert(
+                leaveByAlert.message,
+                urgency: .high,
+                stableID: leaveByAlert.id,
+                eventDate: leaveByAlert.eventStart
+            )
         }
 
         // Clean up old event IDs (keep last 100 max)
@@ -156,12 +228,18 @@ final class ProactiveAlertService: ObservableObject {
         }
     }
 
-    private func deliverAlert(_ message: String, urgency: TextToSpeechService.SpeechUrgency = .medium) {
+    private func deliverAlert(
+        _ message: String,
+        urgency: TextToSpeechService.SpeechUrgency = .medium,
+        stableID: String,
+        eventDate: Date?
+    ) {
         lastAlert = message
         NSLog("[ProactiveAlerts] %@", message)
 
         // Speak through TTS if callback is set
         onAlert?(message, urgency)
+        onDigestItem?(stableID, message, eventDate, urgency)
 
         // Also send a local notification in case the app is backgrounded
         let content = UNMutableNotificationContent()
@@ -171,7 +249,7 @@ final class ProactiveAlertService: ObservableObject {
         content.interruptionLevel = .timeSensitive
 
         let request = UNNotificationRequest(
-            identifier: "proactive-\(UUID().uuidString)",
+            identifier: "proactive-\(stableID)",
             content: content,
             trigger: nil // Deliver immediately
         )

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -2756,6 +2756,38 @@ struct Config {
 
     static func setMyDayEnabled(_ enabled: Bool) { myDayEnabled = enabled }
 
+    @UserDefaultsBacked("myDayTransportMode", default: MyDayTransportMode.walking.rawValue)
+    private static var myDayTransportModeRaw: String
+
+    static var myDayTransportMode: MyDayTransportMode {
+        get { MyDayTransportMode(rawValue: myDayTransportModeRaw) ?? .walking }
+        set { myDayTransportModeRaw = newValue.rawValue }
+    }
+
+    @UserDefaultsBacked("myDayTravelBufferMinutes", default: 10)
+    private static var storedMyDayTravelBufferMinutes: Int
+
+    static var myDayTravelBufferMinutes: Int {
+        get { min(60, max(0, storedMyDayTravelBufferMinutes)) }
+        set { storedMyDayTravelBufferMinutes = min(60, max(0, newValue)) }
+    }
+
+    @UserDefaultsBacked("myDayTravelOrigin", default: MyDayTravelOrigin.currentLocation.rawValue)
+    private static var myDayTravelOriginRaw: String
+
+    static var myDayTravelOrigin: MyDayTravelOrigin {
+        get { MyDayTravelOrigin(rawValue: myDayTravelOriginRaw) ?? .currentLocation }
+        set { myDayTravelOriginRaw = newValue.rawValue }
+    }
+
+    /// Explicit user-entered fallbacks. Event locations and resolved routes are never persisted.
+    @UserDefaultsBacked("myDayHomeAddress", default: "") static var myDayHomeAddress: String
+    @UserDefaultsBacked("myDayWorkAddress", default: "") static var myDayWorkAddress: String
+
+    /// Content-free delivery state prevents one leave-by occurrence being repeated after relaunch.
+    @UserDefaultsBacked("myDayLastDeliveredLeaveByID", default: "")
+    static var myDayLastDeliveredLeaveByID: String
+
     // MARK: - Glasses Display (in-lens HUD)
 
     /// When enabled, AI responses and ambient captions are mirrored to the

--- a/OpenGlassesTests/DigestCoreTests.swift
+++ b/OpenGlassesTests/DigestCoreTests.swift
@@ -198,4 +198,25 @@ final class DigestCoreTests: XCTestCase {
         screen.items[0].action()
         XCTAssertTrue(dismissed)
     }
+
+    @MainActor
+    func testStableIngestUpsertsInsteadOfDuplicatingAlert() {
+        let oldEnabled = Config.digestEnabled
+        Config.digestEnabled = true
+        defer { Config.digestEnabled = oldEnabled }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("digest-\(UUID().uuidString).json")
+        let service = NotificationDigestService(storageURL: url)
+
+        service.ingest(id: "leave-by:event:1", source: .proactive,
+                       title: "Leave soon", priority: .high,
+                       threadKey: "leave-by:event:1")
+        service.ingest(id: "leave-by:event:1", source: .proactive,
+                       title: "Leave now", priority: .high,
+                       threadKey: "leave-by:event:1")
+
+        XCTAssertEqual(service.items.count, 1)
+        XCTAssertEqual(service.items.first?.title, "Leave now")
+        try? FileManager.default.removeItem(at: url)
+    }
 }

--- a/OpenGlassesTests/MyDayComposerTests.swift
+++ b/OpenGlassesTests/MyDayComposerTests.swift
@@ -27,9 +27,11 @@ final class MyDayComposerTests: XCTestCase {
         events: [MyDayCalendarEvent] = [],
         reminders: [MyDayReminder] = [],
         weather: MyDayWeather? = nil,
+        travel: MyDayTravelEstimate? = nil,
         states: [MyDaySourceState] = MyDaySource.allCases.map(MyDaySourceState.available)
     ) -> MyDayInputs {
-        .init(events: events, reminders: reminders, weather: weather, sourceStates: states)
+        .init(events: events, reminders: reminders, weather: weather, travel: travel,
+              sourceStates: states)
     }
 
     func testPriorityPolicyPutsImmediateCommitmentThenOverdueAndDueItems() {
@@ -61,6 +63,35 @@ final class MyDayComposerTests: XCTestCase {
             now: date(9)
         )
         XCTAssertEqual(snapshot.items.map(\.id.rawValue), ["soon", "late"])
+    }
+
+    func testLeaveByRanksAfterImminentEventAndBeforeOverdueReminder() {
+        let now = date(9)
+        let later = event("dentist", at: 10)
+        let travel = MyDayTravelEstimate(
+            eventID: later.id,
+            eventTitle: "Dentist",
+            destination: "Queen Street Dental",
+            eventStart: later.startDate,
+            travelDuration: 20 * 60,
+            bufferDuration: 10 * 60,
+            leaveAt: date(9, minute: 30),
+            mode: .walking
+        )
+        let snapshot = MyDayComposer(calendar: calendar).compose(
+            inputs: inputs(
+                events: [event("standup", at: 9, minute: 15), later],
+                reminders: [reminder("overdue", due: date(8))],
+                travel: travel
+            ),
+            now: now
+        )
+
+        XCTAssertEqual(snapshot.items.prefix(3).map(\.id.rawValue),
+                       ["standup", "leave-by:dentist", "overdue"])
+        XCTAssertEqual(snapshot.items[1].kind, .leaveBy)
+        XCTAssertEqual(snapshot.items[1].actions, [.directions])
+        XCTAssertTrue(snapshot.headline.contains("leave by"))
     }
 
     func testStableIdentityKeepsSimilarlyNamedEventAndReminder() {

--- a/OpenGlassesTests/MyDayServiceTests.swift
+++ b/OpenGlassesTests/MyDayServiceTests.swift
@@ -30,6 +30,44 @@ final class MyDayServiceTests: XCTestCase {
         XCTAssertTrue(snapshot.items.isEmpty)
     }
 
+    func testRefreshLoadsTravelFromCalendarEventsAndExposesDirections() async {
+        let now = Date(timeIntervalSince1970: 1_788_065_600)
+        let start = now.addingTimeInterval(3600)
+        let event = MyDayCalendarEvent(
+            id: "event-with-location",
+            title: "Dentist",
+            startDate: start,
+            endDate: start.addingTimeInterval(1800),
+            isAllDay: false,
+            location: "Queen Street Dental"
+        )
+        let sources = FakeDaySources(events: [event])
+        sources.travel = .init(
+            eventID: event.id,
+            eventTitle: event.title,
+            destination: "Queen Street Dental",
+            eventStart: start,
+            travelDuration: 20 * 60,
+            bufferDuration: 10 * 60,
+            leaveAt: now.addingTimeInterval(1800),
+            mode: .walking
+        )
+        let service = MyDayService(
+            calendarSource: sources,
+            remindersSource: sources,
+            weatherSource: sources,
+            travelSource: sources
+        )
+
+        let snapshot = await service.refresh(now: now)
+
+        XCTAssertEqual(sources.travelEventIDs, [event.id])
+        let leaveBy = snapshot.items.first { $0.kind == .leaveBy }
+        XCTAssertEqual(leaveBy?.id.rawValue, "leave-by:event-with-location")
+        XCTAssertEqual(service.directionsURL(for: leaveBy!.id)?.absoluteString,
+                       "https://maps.apple.com/?daddr=Queen%20Street%20Dental")
+    }
+
     func testStableReminderCompletionRefreshesSnapshot() async throws {
         let now = Date()
         let sources = FakeDaySources(reminders: [
@@ -75,14 +113,17 @@ final class MyDayServiceTests: XCTestCase {
 }
 
 @MainActor
-private final class FakeDaySources: CalendarDaySource, RemindersDaySource, WeatherDaySource {
+private final class FakeDaySources: CalendarDaySource, RemindersDaySource, WeatherDaySource,
+                                    TravelTimeDaySource {
     var events: [MyDayCalendarEvent]
     var reminders: [MyDayReminder]
     var weather: MyDayWeather?
+    var travel: MyDayTravelEstimate?
     var calendarState = MyDaySourceState.available(.calendar)
     var remindersState = MyDaySourceState.available(.reminders)
     var weatherState = MyDaySourceState.available(.weather)
     var completedIDs: [String] = []
+    var travelEventIDs: [String] = []
 
     init(events: [MyDayCalendarEvent] = [], reminders: [MyDayReminder] = [], weather: MyDayWeather? = nil) {
         self.events = events
@@ -106,5 +147,20 @@ private final class FakeDaySources: CalendarDaySource, RemindersDaySource, Weath
 
     func loadWeather() async -> MyDaySourceLoad<MyDayWeather?> {
         .init(value: weather, state: weatherState)
+    }
+
+    func loadTravel(
+        for events: [MyDayCalendarEvent],
+        now: Date
+    ) async -> MyDaySourceLoad<MyDayTravelEstimate?> {
+        travelEventIDs = events.map(\.id)
+        return .init(value: travel, state: .available(.travel))
+    }
+
+    func directionsURL(for eventID: String) -> URL? {
+        guard travel?.eventID == eventID else { return nil }
+        var components = URLComponents(string: "https://maps.apple.com/")
+        components?.queryItems = [URLQueryItem(name: "daddr", value: travel?.destination)]
+        return components?.url
     }
 }

--- a/OpenGlassesTests/MyDayTravelTests.swift
+++ b/OpenGlassesTests/MyDayTravelTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import OpenGlasses
+
+final class MyDayTravelTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_788_066_000)
+
+    private func event(
+        _ id: String,
+        startsIn: TimeInterval,
+        location: String?,
+        allDay: Bool = false
+    ) -> MyDayCalendarEvent {
+        .init(
+            id: id,
+            title: "Event \(id)",
+            startDate: now.addingTimeInterval(startsIn),
+            endDate: now.addingTimeInterval(startsIn + 3600),
+            isAllDay: allDay,
+            location: location
+        )
+    }
+
+    private var settings: MyDayTravelSettings {
+        .init(mode: .driving, bufferMinutes: 10, origin: .currentLocation,
+              homeAddress: "", workAddress: "")
+    }
+
+    func testCandidateUsesFirstTimedPhysicalLocation() {
+        let selected = MyDayTravelPlanner.nextLocatableEvent(in: [
+            event("virtual", startsIn: 600, location: "Zoom"),
+            event("all-day", startsIn: 900, location: "Auckland", allDay: true),
+            event("later", startsIn: 3600, location: "22 Queen Street"),
+            event("first", startsIn: 1800, location: "Library")
+        ], now: now)
+
+        XCTAssertEqual(selected?.id, "first")
+        XCTAssertNil(MyDayTravelPlanner.usableDestination("https://meet.example.com/abc"))
+        XCTAssertNil(MyDayTravelPlanner.usableDestination("Phone call"))
+        XCTAssertEqual(MyDayTravelPlanner.usableDestination("  Civic Theatre  "), "Civic Theatre")
+    }
+
+    func testLeaveAtSubtractsRouteAndBoundedBuffer() {
+        let appointment = event("dentist", startsIn: 3600, location: "Dentist")
+        let estimate = MyDayTravelPlanner.estimate(
+            event: appointment,
+            destination: "Dentist",
+            travelDuration: 20 * 60,
+            settings: settings
+        )
+
+        XCTAssertEqual(estimate?.leaveAt, now.addingTimeInterval(30 * 60))
+        XCTAssertEqual(estimate?.bufferDuration, 10 * 60)
+        XCTAssertNil(MyDayTravelPlanner.estimate(
+            event: appointment,
+            destination: "Dentist",
+            travelDuration: 0,
+            settings: settings
+        ))
+    }
+
+    func testCacheInvalidatesForAgeLocationRouteOrSettingsChange() {
+        let appointment = event("dentist", startsIn: 3600, location: "Dentist")
+        let origin = MyDayCoordinate(latitude: -36.8485, longitude: 174.7633)
+        let metadata = MyDayTravelCacheMetadata(
+            eventID: appointment.id,
+            eventStart: appointment.startDate,
+            destinationKey: "dentist",
+            origin: origin,
+            originMode: .currentLocation,
+            transportMode: .driving,
+            bufferMinutes: 10,
+            calculatedAt: now
+        )
+
+        XCTAssertTrue(MyDayTravelCachePolicy.canReuse(
+            metadata, event: appointment, destinationKey: "dentist", origin: origin,
+            settings: settings, now: now.addingTimeInterval(299)
+        ))
+        XCTAssertFalse(MyDayTravelCachePolicy.canReuse(
+            metadata, event: appointment, destinationKey: "dentist", origin: origin,
+            settings: settings, now: now.addingTimeInterval(301)
+        ))
+        XCTAssertFalse(MyDayTravelCachePolicy.canReuse(
+            metadata, event: appointment, destinationKey: "dentist",
+            origin: .init(latitude: -36.8450, longitude: 174.7633),
+            settings: settings, now: now.addingTimeInterval(60)
+        ))
+        let walking = MyDayTravelSettings(mode: .walking, bufferMinutes: 10,
+                                          origin: .currentLocation,
+                                          homeAddress: "", workAddress: "")
+        XCTAssertFalse(MyDayTravelCachePolicy.canReuse(
+            metadata, event: appointment, destinationKey: "dentist", origin: origin,
+            settings: walking, now: now.addingTimeInterval(60)
+        ))
+    }
+
+    func testAlertFiresOnceLeaveTimeArrivesButYieldsToImminentEventAlert() {
+        let appointment = event("dentist", startsIn: 3600, location: "Dentist")
+        let estimate = MyDayTravelPlanner.estimate(
+            event: appointment,
+            destination: "Dentist",
+            travelDuration: 20 * 60,
+            settings: settings
+        )!
+
+        XCTAssertNil(MyDayLeaveByAlertPolicy.alert(
+            for: estimate,
+            now: estimate.leaveAt.addingTimeInterval(-1)
+        ))
+        let alert = MyDayLeaveByAlertPolicy.alert(for: estimate, now: estimate.leaveAt)
+        XCTAssertEqual(alert?.id, "leave-by:dentist:\(Int(appointment.startDate.timeIntervalSince1970))")
+        XCTAssertTrue(alert?.message.contains("Leave now") == true)
+        XCTAssertNil(MyDayLeaveByAlertPolicy.alert(
+            for: estimate,
+            now: appointment.startDate.addingTimeInterval(-60)
+        ))
+    }
+}

--- a/docs/plans/DY-my-day-everyday-briefing.md
+++ b/docs/plans/DY-my-day-everyday-briefing.md
@@ -1,7 +1,7 @@
 # Plan DY — My Day: Everyday Briefing and Preparation
 
-**Status:** 🟠 P0/P1 MVP implemented and automated verification complete (2026-08-30);
-physical-device permission/audio and accessibility walkthroughs pending
+**Status:** 🟠 P0/P1/P2 implemented and automated verification complete (2026-08-30);
+physical-device routing, permission/audio, and accessibility walkthroughs pending
 **Origin:** The opportunity assessment names Everyday Briefing as the P1 daily-retention loop and
 places it before differentiated intelligence such as the private-memory timeline.
 **Priority:** P1 everyday product, immediately after the DK privacy close-out.
@@ -61,15 +61,34 @@ more tools.
   offline/partial-source states, Calendar open, exact reminder completion, semantic text, and
   VoiceOver-labelled actions. The toggle lives under **Works with your iPhone** and defaults off;
   while off, the same home space offers an explicit setup action rather than requesting permissions.
-- No display, HUD, waveguide, private-memory, news, digest, or travel-time dependency was added.
+- No display, HUD, waveguide, private-memory, news, digest, or travel-time dependency was added to
+  the P0/P1 slice.
 
-P2 travel/leave-by and P3 digest/evening controls remain separate follow-ups.
+### Implemented P2 slice (2026-08-30)
+
+- My Day now estimates MapKit travel time for the next timed event with a usable physical location.
+  The origin can be current location or an explicit Home/Work address; walking, driving, and transit
+  modes and a 0–60 minute buffer are configured in the existing My Day settings section.
+- Leave-by is pure event-start minus route-duration minus buffer math. The route cache is in memory
+  for at most five minutes and invalidates when the event, destination, route settings, time, or
+  current origin changes materially. Event locations and resolved routes are not persisted.
+- The deterministic composer ranks leave-by after an imminent commitment and before overdue work,
+  shows the same result on the Voice-home My Day card/full review, and opens Apple Maps directions
+  from the origin used for the estimate.
+- `ProactiveAlertService` uses the shared travel source, suppresses its generic early warning when a
+  route-backed leave-by exists, yields to the existing imminent alert inside two minutes, and sends
+  one occurrence-stable item through speech/HUD, local notification, and digest delivery. Stable
+  digest ingest is an upsert rather than an appended duplicate; one content-free occurrence ID
+  prevents repeat speech/HUD delivery after relaunch.
+
+P3 digest composition/evening controls remain a separate follow-up.
 
 ### Automated evidence (2026-08-30)
 
 - Focused My Day contract/service suite: 14 passed, 0 failures.
-- Full unit suite on iPhone 17 Pro Max / iOS 27 simulator: 3,757 passed, 4
-  environment-gated skips, 0 failures (3,761 total).
+- Focused P2 My Day/travel/digest suite: 41 passed, 0 failures.
+- Full unit suite on iPhone 17 Pro Max / iOS 27 simulator: 3,764 passed, 4
+  environment-gated skips, 0 failures (3,768 total).
 - Release iOS Simulator build: passed.
 
 Still required before enabling by default: physical-device Calendar/Reminders denial and regrant,
@@ -201,7 +220,7 @@ preserve item count, source facts, times, and action labels or be rejected whole
 4. Ship deterministic empty, loading, denied, partial, offline, and stale states with VoiceOver and
    large Dynamic Type coverage.
 
-### P2 — Travel time and leave-by 🟠
+### P2 — Travel time and leave-by ✅
 
 1. Add MapKit travel-time estimation for the next event with a usable location, using current
    location or an explicit home/work origin and the configured transport mode.


### PR DESCRIPTION
## Summary
- add shared MapKit travel-time estimation for the next locatable calendar event
- rank leave-by guidance in My Day and open Apple Maps directions from the configured origin
- add walking, driving, transit, buffer, and current/Home/Work settings
- cache route metadata briefly without persisting event locations or resolved routes
- deliver one occurrence-stable proactive warning across speech, HUD, local notifications, and digest, including relaunch deduplication
- update Plan DY to mark P2 complete

## Verification
- focused My Day/travel/digest suite: 41 passed, 0 failures
- full iPhone 17 Pro Max / iOS 27 simulator suite: 3,764 passed, 4 environment-gated skips, 0 failures (3,768 total)
- Release iOS Simulator build: passed