### PR TITLE
Complete My Day P3 delivery and preparation

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -7,6 +7,7 @@ import UIKit
 import CarPlay
 import MLXLLM
 import MediaPlayer
+import UserNotifications
 
 extension Notification.Name {
     static let onboardingCompleted = Notification.Name("onboardingCompleted")
@@ -607,6 +608,8 @@ class AppState: ObservableObject, AppStateProtocol {
     let presenceMonitor = PresenceMonitor()
     /// Notification digest (Plan BZ): first-party event streams composed into one glance.
     let notificationDigest = NotificationDigestService()
+    /// My Day owns its own opt-in schedule; it does not depend on Agent Mode or an LLM.
+    lazy var myDayDelivery = MyDayScheduledDeliveryService(myDayService: myDayService)
     /// Turn-by-turn walking navigation (Plan CA).
     let walkingRoute = WalkingRouteService()
     /// Web HUD mirror server (Plan BP) — entitlement-free Ray-Ban Display web-view path.
@@ -1307,6 +1310,7 @@ class AppState: ObservableObject, AppStateProtocol {
 
         // Wire the battery/thermal power posture (Plan BV) to the device signals.
         configurePower()
+        myDayDelivery.start()
 
         // Tell VoiceOver what the session is doing (Plan DF P2).
         configureAccessibilityAnnouncements()
@@ -1808,10 +1812,40 @@ class AppState: ObservableObject, AppStateProtocol {
             self?.agentNotificationQueue.markDelivered(ids: ids)
         }
         notificationDigest.isOffline = { [weak self] in !(self?.reachability.isOnline ?? true) }
+        myDayService.setDigestSource(NotificationDigestDaySource(service: notificationDigest))
         agentNotificationQueue.onQueued = { [weak self] notification in
             self?.notificationDigest.ingest(
                 source: .agent, title: notification.message, priority: notification.priority,
                 threadKey: notification.id, awaitingReply: notification.priority == .high)
+        }
+
+        myDayDelivery.presence = { [weak self] in self?.presenceMonitor.mode ?? .away }
+        myDayDelivery.power = { PowerPolicyService.shared.posture }
+        myDayDelivery.isOnline = { [weak self] in self?.reachability.isOnline ?? false }
+        myDayDelivery.isBusy = { [weak self] in
+            guard let self else { return true }
+            return self.isProcessing || self.isListening || self.speechService.isSpeaking
+        }
+        myDayDelivery.sourceAccessReady = { [weak self] in
+            guard let self else { return false }
+            let included = MyDaySourceSelection.current
+            return (!included.calendar || self.eventKitStore.calendarAuthorizationIsResolved)
+                && (!included.reminders || self.eventKitStore.remindersAuthorizationIsResolved)
+        }
+        myDayDelivery.onDelivery = { [weak self] slot, text, shouldSpeak, identifier in
+            guard let self else { return }
+            self.lastResponse = text
+
+            let content = UNMutableNotificationContent()
+            content.title = "My Day"
+            content.body = "Your \(slot.rawValue) briefing is ready."
+            content.sound = shouldSpeak ? nil : .default
+            let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
+            UNUserNotificationCenter.current().add(request)
+
+            if shouldSpeak {
+                Task { await self.speechService.speak(text, mirrorToHUD: false) }
+            }
         }
         hudLauncher.digestHasContent = { [weak self] in self?.notificationDigest.hasContent ?? false }
         hudLauncher.openDigest = { [weak self] in

--- a/OpenGlasses/Sources/App/Views/MyDayView.swift
+++ b/OpenGlasses/Sources/App/Views/MyDayView.swift
@@ -147,6 +147,16 @@ struct MyDayView: View {
             .buttonStyle(.plain)
             .foregroundStyle(accent)
             .accessibilityLabel("Start directions for \(item.title)")
+        } else if item.actions.contains(.dismiss) {
+            Button {
+                Task { await service.dismissDigestItem(id: item.id.rawValue) }
+            } label: {
+                Image(systemName: "xmark.circle")
+                    .frame(width: OGMetrics.minTouchTarget, height: OGMetrics.minTouchTarget)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(accent)
+            .accessibilityLabel("Dismiss \(item.title)")
         } else if item.actions.contains(.open), let dueAt = item.dueAt {
             Button {
                 let seconds = dueAt.timeIntervalSinceReferenceDate
@@ -197,7 +207,9 @@ struct MyDayView: View {
         switch kind {
         case .event: "calendar"
         case .leaveBy: "location.fill"
+        case .preparation: "checkmark.seal"
         case .reminder: "checklist"
+        case .update: "bell.badge"
         case .weather: "cloud.sun"
         }
     }
@@ -416,7 +428,9 @@ struct MyDayHomeView: View {
         switch kind {
         case .event: "calendar"
         case .leaveBy: "location.fill"
+        case .preparation: "checkmark.seal"
         case .reminder: "checklist"
+        case .update: "bell.badge"
         case .weather: "cloud.sun"
         }
     }

--- a/OpenGlasses/Sources/App/Views/ScheduledTasksView.swift
+++ b/OpenGlasses/Sources/App/Views/ScheduledTasksView.swift
@@ -175,16 +175,6 @@ struct ScheduledTasksView: View {
 
     private func runTaskNow(_ task: AgentScheduler.ScheduledTask) async {
         guard !appState.isProcessing else { return }
-        if task.id == "morning-briefing" {
-            guard Config.myDayEnabled else {
-                appState.lastResponse = "My Day is off. Turn it on in Settings under Works with your iPhone."
-                return
-            }
-            let result = await appState.myDayService.spokenBriefing()
-            appState.lastResponse = result
-            if task.speakResult { await appState.speechService.speak(result) }
-            return
-        }
         await appState.sendTextMessage(task.prompt)
     }
 }

--- a/OpenGlasses/Sources/App/Views/SettingsJourneyScreens.swift
+++ b/OpenGlasses/Sources/App/Views/SettingsJourneyScreens.swift
@@ -45,12 +45,26 @@ struct AppleIntegrationsSettingsScreen: View {
 
     @State private var disabledTools: Set<String> = Config.disabledTools
     @State private var permissionDeniedTool: String?
+    @State private var didResetMyDayHistory = false
     @AppStorage("myDayEnabled") private var myDayEnabled = false
+    @AppStorage("myDayCalendarIncluded") private var myDayCalendarIncluded = true
+    @AppStorage("myDayRemindersIncluded") private var myDayRemindersIncluded = true
+    @AppStorage("myDayWeatherIncluded") private var myDayWeatherIncluded = true
+    @AppStorage("myDayTravelIncluded") private var myDayTravelIncluded = true
+    @AppStorage("myDayDigestIncluded") private var myDayDigestIncluded = true
     @AppStorage("myDayTransportMode") private var myDayTransportMode = MyDayTransportMode.walking.rawValue
     @AppStorage("myDayTravelBufferMinutes") private var myDayTravelBufferMinutes = 10
     @AppStorage("myDayTravelOrigin") private var myDayTravelOrigin = MyDayTravelOrigin.currentLocation.rawValue
     @AppStorage("myDayHomeAddress") private var myDayHomeAddress = ""
     @AppStorage("myDayWorkAddress") private var myDayWorkAddress = ""
+    @AppStorage("myDayMorningDeliveryEnabled") private var myDayMorningDeliveryEnabled = false
+    @AppStorage("myDayMorningDeliveryMinutes") private var myDayMorningDeliveryMinutes = 8 * 60
+    @AppStorage("myDayEveningDeliveryEnabled") private var myDayEveningDeliveryEnabled = false
+    @AppStorage("myDayEveningDeliveryMinutes") private var myDayEveningDeliveryMinutes = 19 * 60
+    @AppStorage("myDayScheduledSpeechEnabled") private var myDayScheduledSpeechEnabled = false
+    @AppStorage("myDayQuietHoursEnabled") private var myDayQuietHoursEnabled = true
+    @AppStorage("myDayQuietStartMinutes") private var myDayQuietStartMinutes = 22 * 60
+    @AppStorage("myDayQuietEndMinutes") private var myDayQuietEndMinutes = 7 * 60
 
     var body: some View {
         Form {
@@ -60,40 +74,113 @@ struct AppleIntegrationsSettingsScreen: View {
                         Config.setMyDayEnabled(enabled)
                     }
 
-                if myDayEnabled {
-                    Picker("Travel mode", selection: $myDayTransportMode) {
-                        ForEach(MyDayTransportMode.allCases, id: \.rawValue) { mode in
-                            Text(mode.displayName).tag(mode.rawValue)
-                        }
-                    }
-
-                    Stepper(
-                        "Leave-by buffer: \(myDayTravelBufferMinutes) min",
-                        value: $myDayTravelBufferMinutes,
-                        in: 0...60,
-                        step: 5
-                    )
-
-                    Picker("Start from", selection: $myDayTravelOrigin) {
-                        ForEach(MyDayTravelOrigin.allCases, id: \.rawValue) { origin in
-                            Text(origin.displayName).tag(origin.rawValue)
-                        }
-                    }
-
-                    if myDayTravelOrigin == MyDayTravelOrigin.home.rawValue {
-                        TextField("Home address", text: $myDayHomeAddress)
-                            .textContentType(.fullStreetAddress)
-                            .autocorrectionDisabled()
-                    } else if myDayTravelOrigin == MyDayTravelOrigin.work.rawValue {
-                        TextField("Work address", text: $myDayWorkAddress)
-                            .textContentType(.fullStreetAddress)
-                            .autocorrectionDisabled()
-                    }
-                }
             } header: {
                 Text("Everyday Briefing")
             } footer: {
-                Text("Adds a phone and spoken briefing from Calendar, Reminders, Weather, and a short-lived Maps travel estimate for the next event with a physical location. Event locations and routes are not saved by OpenGlasses.")
+                Text("Adds a phone and spoken briefing of what matters next. My Day keeps an ephemeral read model and does not save a separate copy of your day.")
+            }
+
+            if myDayEnabled {
+                Section {
+                    Toggle("Calendar", isOn: $myDayCalendarIncluded)
+                    Toggle("Reminders", isOn: $myDayRemindersIncluded)
+                    Toggle("Weather", isOn: $myDayWeatherIncluded)
+                    Toggle("Travel time", isOn: $myDayTravelIncluded)
+                        .disabled(!myDayCalendarIncluded)
+                    Toggle("Actionable updates", isOn: $myDayDigestIncluded)
+                } header: {
+                    Text("Included in My Day")
+                } footer: {
+                    Text("Calendar includes Apple, Outlook, Microsoft 365, and other accounts that are available in the iPhone Calendar app. My Day does not connect directly to the Outlook app.")
+                }
+
+                if myDayCalendarIncluded && myDayTravelIncluded {
+                    Section {
+                        Picker("Travel mode", selection: $myDayTransportMode) {
+                            ForEach(MyDayTransportMode.allCases, id: \.rawValue) { mode in
+                                Text(mode.displayName).tag(mode.rawValue)
+                            }
+                        }
+
+                        Stepper(
+                            "Leave-by buffer: \(myDayTravelBufferMinutes) min",
+                            value: $myDayTravelBufferMinutes,
+                            in: 0...60,
+                            step: 5
+                        )
+
+                        Picker("Start from", selection: $myDayTravelOrigin) {
+                            ForEach(MyDayTravelOrigin.allCases, id: \.rawValue) { origin in
+                                Text(origin.displayName).tag(origin.rawValue)
+                            }
+                        }
+
+                        if myDayTravelOrigin == MyDayTravelOrigin.home.rawValue {
+                            TextField("Home address", text: $myDayHomeAddress)
+                                .textContentType(.fullStreetAddress)
+                                .autocorrectionDisabled()
+                        } else if myDayTravelOrigin == MyDayTravelOrigin.work.rawValue {
+                            TextField("Work address", text: $myDayWorkAddress)
+                                .textContentType(.fullStreetAddress)
+                                .autocorrectionDisabled()
+                        }
+                    } header: {
+                        Text("Leave By")
+                    } footer: {
+                        Text("Maps estimates only the next event with a physical location. Event locations and routes are not saved by OpenGlasses.")
+                    }
+                }
+
+                Section {
+                    Toggle("Morning briefing", isOn: $myDayMorningDeliveryEnabled)
+                    if myDayMorningDeliveryEnabled {
+                        DatePicker(
+                            "Morning time",
+                            selection: timeBinding($myDayMorningDeliveryMinutes),
+                            displayedComponents: .hourAndMinute
+                        )
+                    }
+
+                    Toggle("Evening preparation", isOn: $myDayEveningDeliveryEnabled)
+                    if myDayEveningDeliveryEnabled {
+                        DatePicker(
+                            "Evening time",
+                            selection: timeBinding($myDayEveningDeliveryMinutes),
+                            displayedComponents: .hourAndMinute
+                        )
+                    }
+
+                    Toggle("Speak scheduled briefings", isOn: $myDayScheduledSpeechEnabled)
+                        .disabled(!myDayMorningDeliveryEnabled && !myDayEveningDeliveryEnabled)
+
+                    Toggle("Quiet hours", isOn: $myDayQuietHoursEnabled)
+                    if myDayQuietHoursEnabled {
+                        DatePicker(
+                            "Quiet from",
+                            selection: timeBinding($myDayQuietStartMinutes),
+                            displayedComponents: .hourAndMinute
+                        )
+                        DatePicker(
+                            "Quiet until",
+                            selection: timeBinding($myDayQuietEndMinutes),
+                            displayedComponents: .hourAndMinute
+                        )
+                    }
+                } header: {
+                    Text("Scheduled Delivery")
+                } footer: {
+                    Text("Delivered while OpenGlasses is active. Open My Day once to resolve Calendar and Reminders access before scheduled delivery. Speech is private-by-default: it only plays while you are present, outside quiet hours, online, and out of power reserve.")
+                }
+
+                Section {
+                    Button(didResetMyDayHistory ? "Delivery history reset" : "Reset delivery history") {
+                        Config.resetMyDayDeliveryHistory()
+                        didResetMyDayHistory = true
+                    }
+                    .disabled(didResetMyDayHistory)
+                } footer: {
+                    Text("Resets content-free occurrence markers only. It does not delete Calendar, Reminders, routes, or digest items.")
+                }
             }
 
             Section {
@@ -143,6 +230,24 @@ struct AppleIntegrationsSettingsScreen: View {
                     .accessibilityHidden(true)
             }
         }
+    }
+
+    private func timeBinding(_ minutes: Binding<Int>) -> Binding<Date> {
+        Binding(
+            get: {
+                let value = min(23 * 60 + 59, max(0, minutes.wrappedValue))
+                return Calendar.current.date(
+                    bySettingHour: value / 60,
+                    minute: value % 60,
+                    second: 0,
+                    of: Date()
+                ) ?? Date()
+            },
+            set: { date in
+                let parts = Calendar.current.dateComponents([.hour, .minute], from: date)
+                minutes.wrappedValue = (parts.hour ?? 0) * 60 + (parts.minute ?? 0)
+            }
+        )
     }
 
     /// The same write the full tool list performs, including the permission

--- a/OpenGlasses/Sources/Services/AgentScheduler.swift
+++ b/OpenGlasses/Sources/Services/AgentScheduler.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 /// Scheduled background tasks for the agent personality mode.
-/// Runs periodic prompts (morning briefing, email check, self-reflection)
+/// Runs periodic agent prompts (calendar checks, awareness, self-reflection)
 /// only when Agentic Features is enabled.
 @MainActor
 class AgentScheduler: ObservableObject {
@@ -10,8 +10,6 @@ class AgentScheduler: ObservableObject {
     @Published var lastRunTime: Date?
 
     private var timer: Timer?
-    private var morningBriefingDone = false
-
     weak var appState: AppState?
 
     /// Built-in scheduled tasks. Users can add more via quick actions.
@@ -28,14 +26,6 @@ class AgentScheduler: ObservableObject {
         var createdBy: String?     // Which agent created this task (for audit trail)
 
         static let defaults: [ScheduledTask] = [
-            ScheduledTask(
-                id: "morning-briefing",
-                name: "Morning Briefing",
-                prompt: "Build My Day from the authoritative Calendar, Reminders, and Weather sources.",
-                intervalMinutes: 0,  // 0 = once per day, on first activation
-                enabled: true,
-                speakResult: true
-            ),
             ScheduledTask(
                 id: "calendar-check",
                 name: "Upcoming Events",
@@ -78,7 +68,6 @@ class AgentScheduler: ObservableObject {
         guard timer == nil else { return }
 
         NSLog("[AgentScheduler] Starting")
-        morningBriefingDone = false
         scheduleNextCheck()
 
         // Run onboarding check immediately if needed
@@ -90,11 +79,6 @@ class AgentScheduler: ObservableObject {
             }
         }
 
-        // Morning briefing on first start of the day
-        Task {
-            try? await Task.sleep(nanoseconds: 5_000_000_000)
-            await checkMorningBriefing()
-        }
     }
 
     /// Schedule the next check based on glasses connection state.
@@ -150,37 +134,6 @@ class AgentScheduler: ObservableObject {
 
         await executeAgentPrompt(onboardingPrompt, speakResult: true)
         Config.setAgentOnboardingComplete(true)
-    }
-
-    // MARK: - Morning Briefing
-
-    private func checkMorningBriefing() async {
-        guard !morningBriefingDone else { return }
-        guard let appState, Config.agentModeEnabled else { return }
-        guard Config.myDayEnabled else { return }
-        guard !appState.isProcessing, !appState.isListening else { return }
-
-        let tasks = loadTasks()
-        guard let briefing = tasks.first(where: { $0.id == "morning-briefing" && $0.enabled }) else { return }
-
-        // Check if already run today
-        if let lastRun = briefing.lastRun, Calendar.current.isDateInToday(lastRun) {
-            morningBriefingDone = true
-            return
-        }
-
-        NSLog("[AgentScheduler] Running morning briefing")
-        let result = await appState.myDayService.spokenBriefing()
-        appState.lastResponse = result
-        if briefing.speakResult {
-            appState.agentNotificationQueue.enqueue(
-                message: result,
-                source: "My Day",
-                priority: .medium
-            )
-        }
-        morningBriefingDone = true
-        markTaskRun("morning-briefing")
     }
 
     // MARK: - Periodic Tasks
@@ -336,7 +289,7 @@ class AgentScheduler: ObservableObject {
     private func loadTasks() -> [ScheduledTask] {
         if let data = UserDefaults.standard.data(forKey: "agentScheduledTasks"),
            let tasks = try? JSONDecoder().decode([ScheduledTask].self, from: data) {
-            return tasks
+            return Self.withoutLegacyMyDayTask(tasks)
         }
         return ScheduledTask.defaults
     }
@@ -354,14 +307,18 @@ class AgentScheduler: ObservableObject {
     static func savedTasks() -> [ScheduledTask] {
         if let data = UserDefaults.standard.data(forKey: "agentScheduledTasks"),
            let tasks = try? JSONDecoder().decode([ScheduledTask].self, from: data) {
-            return tasks
+            return withoutLegacyMyDayTask(tasks)
         }
         return ScheduledTask.defaults
     }
 
     static func saveTasks(_ tasks: [ScheduledTask]) {
-        if let data = try? JSONEncoder().encode(tasks) {
+        if let data = try? JSONEncoder().encode(withoutLegacyMyDayTask(tasks)) {
             UserDefaults.standard.set(data, forKey: "agentScheduledTasks")
         }
+    }
+
+    private static func withoutLegacyMyDayTask(_ tasks: [ScheduledTask]) -> [ScheduledTask] {
+        tasks.filter { $0.id != "morning-briefing" }
     }
 }

--- a/OpenGlasses/Sources/Services/Digest/NotificationDigestService.swift
+++ b/OpenGlasses/Sources/Services/Digest/NotificationDigestService.swift
@@ -113,6 +113,19 @@ final class NotificationDigestService: ObservableObject {
         lastPresented = nil
     }
 
+    /// Retire one source-owned item from My Day and acknowledge its upstream agent row when
+    /// applicable. This mutates the digest owner rather than hiding a copied My Day row.
+    func dismissItem(id: String) {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        let item = items[index]
+        items[index].seenCount = max(items[index].seenCount, 99)
+        if item.source == .agent, let threadKey = item.threadKey {
+            acknowledgeAgentItems?([threadKey])
+        }
+        prune()
+        save()
+    }
+
     /// Auto-surface on glasses (re)connect: only with an urgent item pending, only when the
     /// user is actually there (Plan W), and never under power reserve (Plan BV).
     func autoSurfaceOnConnect() async {

--- a/OpenGlasses/Sources/Services/MyDay/EventKitDayStore.swift
+++ b/OpenGlasses/Sources/Services/MyDay/EventKitDayStore.swift
@@ -33,6 +33,16 @@ final class EventKitDayStore {
         return status == .authorized
     }
 
+    /// Scheduled My Day must never trigger a first-use permission sheet. A denied/restricted
+    /// source is still resolved: its adapter can report an honest partial-availability state.
+    var calendarAuthorizationIsResolved: Bool {
+        EKEventStore.authorizationStatus(for: .event) != .notDetermined
+    }
+
+    var remindersAuthorizationIsResolved: Bool {
+        EKEventStore.authorizationStatus(for: .reminder) != .notDetermined
+    }
+
     func requestCalendarAccess() async throws -> Bool {
         if #available(iOS 17.0, *) {
             return try await eventStore.requestFullAccessToEvents()

--- a/OpenGlasses/Sources/Services/MyDay/MyDayComposer.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayComposer.swift
@@ -33,8 +33,10 @@ struct MyDayComposer: Sendable {
            travel.eventStart < endOfTomorrow {
             ranked.append(leaveByItem(travel, now: now))
         }
-        if period == .evening, let firstTomorrow = tomorrowEvents.first {
+        let firstTomorrow = tomorrowEvents.first
+        if period == .evening, let firstTomorrow {
             ranked.append(tomorrowItem(firstTomorrow))
+            ranked.append(preparationItem(firstTomorrow))
         }
 
         for reminder in inputs.reminders {
@@ -53,6 +55,10 @@ struct MyDayComposer: Sendable {
             }
         }
 
+        for update in inputs.digestUpdates.prefix(MyDayDigestPolicy.limit) {
+            ranked.append(digestItem(update))
+        }
+
         let items = ranked
             .sorted(by: rankedOrder)
             .prefix(maxItems)
@@ -69,6 +75,8 @@ struct MyDayComposer: Sendable {
                     guard let due = $0.dueDate else { return false }
                     return $0.hasTime ? due < now : due < startOfToday
                 }.count,
+                period: period,
+                firstTomorrow: firstTomorrow,
                 travel: inputs.travel,
                 items: items
             ),
@@ -140,6 +148,25 @@ struct MyDayComposer: Sendable {
                 kind: .event,
                 title: event.title,
                 detail: "Tomorrow, \(event.isAllDay ? "all day" : formatTime(event.startDate))" + locationSuffix(event.location),
+                dueAt: event.startDate,
+                urgency: .upcoming,
+                actions: [.open]
+            )
+        )
+    }
+
+    private func preparationItem(_ event: MyDayCalendarEvent) -> RankedItem {
+        let timing = event.isAllDay
+            ? "Tomorrow, all day"
+            : "Tomorrow at \(formatTime(event.startDate))"
+        return RankedItem(
+            rank: 5,
+            secondaryRank: 1,
+            item: MyDayItem(
+                id: .init(source: .calendar, rawValue: "prepare:\(event.id)"),
+                kind: .preparation,
+                title: "Prepare for \(event.title)",
+                detail: timing + locationSuffix(event.location) + ". Check what you need before then.",
                 dueAt: event.startDate,
                 urgency: .upcoming,
                 actions: [.open]
@@ -234,6 +261,21 @@ struct MyDayComposer: Sendable {
         )
     }
 
+    private func digestItem(_ update: MyDayDigestUpdate) -> RankedItem {
+        RankedItem(
+            rank: 8,
+            item: MyDayItem(
+                id: .init(source: .digest, rawValue: update.id),
+                kind: .update,
+                title: update.title,
+                detail: update.detail,
+                dueAt: update.createdAt,
+                urgency: update.urgency,
+                actions: [.dismiss]
+            )
+        )
+    }
+
     private func rankedOrder(_ lhs: RankedItem, _ rhs: RankedItem) -> Bool {
         if lhs.rank != rhs.rank { return lhs.rank < rhs.rank }
         if lhs.item.dueAt != rhs.item.dueAt {
@@ -246,11 +288,19 @@ struct MyDayComposer: Sendable {
     private func headline(
         todayCommitments: Int,
         overdueReminders: Int,
+        period: MyDayPeriod,
+        firstTomorrow: MyDayCalendarEvent?,
         travel: MyDayTravelEstimate?,
         items: [MyDayItem]
     ) -> String {
         var parts: [String] = []
-        if todayCommitments > 0 {
+        if period == .evening, let firstTomorrow {
+            if firstTomorrow.isAllDay {
+                parts.append("tomorrow includes \(firstTomorrow.title) all day")
+            } else {
+                parts.append("tomorrow starts with \(firstTomorrow.title) at \(formatTime(firstTomorrow.startDate))")
+            }
+        } else if todayCommitments > 0 {
             parts.append("\(todayCommitments) commitment\(todayCommitments == 1 ? "" : "s") today")
         }
         if overdueReminders > 0 {
@@ -260,6 +310,9 @@ struct MyDayComposer: Sendable {
             parts.append("leave by \(formatTime(travel.leaveAt)) for \(travel.eventTitle)")
         }
         if parts.isEmpty {
+            if period == .evening {
+                return items.isEmpty ? "Your evening is clear." : "Here is what matters before tomorrow."
+            }
             return items.isEmpty ? "Your day is clear." : "Here is what matters today."
         }
         return parts.joined(separator: "; ") + "."

--- a/OpenGlasses/Sources/Services/MyDay/MyDayConfig.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayConfig.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+extension Config {
+    static var myDayCalendarIncluded: Bool {
+        get { storedBool("myDayCalendarIncluded", default: true) }
+        set { UserDefaults.standard.set(newValue, forKey: "myDayCalendarIncluded") }
+    }
+
+    static var myDayRemindersIncluded: Bool {
+        get { storedBool("myDayRemindersIncluded", default: true) }
+        set { UserDefaults.standard.set(newValue, forKey: "myDayRemindersIncluded") }
+    }
+
+    static var myDayWeatherIncluded: Bool {
+        get { storedBool("myDayWeatherIncluded", default: true) }
+        set { UserDefaults.standard.set(newValue, forKey: "myDayWeatherIncluded") }
+    }
+
+    static var myDayTravelIncluded: Bool {
+        get { storedBool("myDayTravelIncluded", default: true) }
+        set { UserDefaults.standard.set(newValue, forKey: "myDayTravelIncluded") }
+    }
+
+    static var myDayDigestIncluded: Bool {
+        get { storedBool("myDayDigestIncluded", default: true) }
+        set { UserDefaults.standard.set(newValue, forKey: "myDayDigestIncluded") }
+    }
+
+    static var myDayMorningDeliveryEnabled: Bool {
+        get { storedBool("myDayMorningDeliveryEnabled", default: false) }
+        set { UserDefaults.standard.set(newValue, forKey: "myDayMorningDeliveryEnabled") }
+    }
+
+    static var myDayMorningDeliveryMinutes: Int {
+        get { boundedDayMinutes(storedInt("myDayMorningDeliveryMinutes", default: 8 * 60)) }
+        set { UserDefaults.standard.set(boundedDayMinutes(newValue), forKey: "myDayMorningDeliveryMinutes") }
+    }
+
+    static var myDayEveningDeliveryEnabled: Bool {
+        get { storedBool("myDayEveningDeliveryEnabled", default: false) }
+        set { UserDefaults.standard.set(newValue, forKey: "myDayEveningDeliveryEnabled") }
+    }
+
+    static var myDayEveningDeliveryMinutes: Int {
+        get { boundedDayMinutes(storedInt("myDayEveningDeliveryMinutes", default: 19 * 60)) }
+        set { UserDefaults.standard.set(boundedDayMinutes(newValue), forKey: "myDayEveningDeliveryMinutes") }
+    }
+
+    static var myDayScheduledSpeechEnabled: Bool {
+        get { storedBool("myDayScheduledSpeechEnabled", default: false) }
+        set { UserDefaults.standard.set(newValue, forKey: "myDayScheduledSpeechEnabled") }
+    }
+
+    static var myDayQuietHoursEnabled: Bool {
+        get { storedBool("myDayQuietHoursEnabled", default: true) }
+        set { UserDefaults.standard.set(newValue, forKey: "myDayQuietHoursEnabled") }
+    }
+
+    static var myDayQuietStartMinutes: Int {
+        get { boundedDayMinutes(storedInt("myDayQuietStartMinutes", default: 22 * 60)) }
+        set { UserDefaults.standard.set(boundedDayMinutes(newValue), forKey: "myDayQuietStartMinutes") }
+    }
+
+    static var myDayQuietEndMinutes: Int {
+        get { boundedDayMinutes(storedInt("myDayQuietEndMinutes", default: 7 * 60)) }
+        set { UserDefaults.standard.set(boundedDayMinutes(newValue), forKey: "myDayQuietEndMinutes") }
+    }
+
+    static var myDayLastMorningDeliveryDay: String {
+        get { UserDefaults.standard.string(forKey: "myDayLastMorningDeliveryDay") ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: "myDayLastMorningDeliveryDay") }
+    }
+
+    static var myDayLastEveningDeliveryDay: String {
+        get { UserDefaults.standard.string(forKey: "myDayLastEveningDeliveryDay") ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: "myDayLastEveningDeliveryDay") }
+    }
+
+    static func resetMyDayDeliveryHistory() {
+        myDayLastMorningDeliveryDay = ""
+        myDayLastEveningDeliveryDay = ""
+        myDayLastDeliveredLeaveByID = ""
+    }
+
+    private static func storedBool(_ key: String, default defaultValue: Bool) -> Bool {
+        UserDefaults.standard.object(forKey: key) as? Bool ?? defaultValue
+    }
+
+    private static func storedInt(_ key: String, default defaultValue: Int) -> Int {
+        UserDefaults.standard.object(forKey: key) as? Int ?? defaultValue
+    }
+
+    private static func boundedDayMinutes(_ value: Int) -> Int {
+        min(23 * 60 + 59, max(0, value))
+    }
+}

--- a/OpenGlasses/Sources/Services/MyDay/MyDayDelivery.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayDelivery.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+enum MyDayDeliverySlot: String, Equatable, Sendable {
+    case morning
+    case evening
+
+    var displayName: String {
+        switch self {
+        case .morning: "Morning"
+        case .evening: "Evening"
+        }
+    }
+}
+
+struct MyDayDeliverySettings: Equatable, Sendable {
+    let myDayEnabled: Bool
+    let morningEnabled: Bool
+    let morningMinutes: Int
+    let eveningEnabled: Bool
+    let eveningMinutes: Int
+    let scheduledSpeechEnabled: Bool
+    let quietHoursEnabled: Bool
+    let quietStartMinutes: Int
+    let quietEndMinutes: Int
+
+    static var current: Self {
+        .init(
+            myDayEnabled: Config.myDayEnabled,
+            morningEnabled: Config.myDayMorningDeliveryEnabled,
+            morningMinutes: Config.myDayMorningDeliveryMinutes,
+            eveningEnabled: Config.myDayEveningDeliveryEnabled,
+            eveningMinutes: Config.myDayEveningDeliveryMinutes,
+            scheduledSpeechEnabled: Config.myDayScheduledSpeechEnabled,
+            quietHoursEnabled: Config.myDayQuietHoursEnabled,
+            quietStartMinutes: Config.myDayQuietStartMinutes,
+            quietEndMinutes: Config.myDayQuietEndMinutes
+        )
+    }
+}
+
+struct MyDayDeliveryContext: Equatable {
+    let presence: EngagementMode
+    let power: PowerPosture
+    let isOnline: Bool
+    let isBusy: Bool
+    let sourceAccessReady: Bool
+}
+
+enum MyDayDeliveryDeferral: Equatable {
+    case quietHours
+    case sourceAccess
+}
+
+enum MyDayDeliveryDecision: Equatable {
+    case notDue
+    case deferred(MyDayDeliveryDeferral)
+    case deliver(slot: MyDayDeliverySlot, dayKey: String, speak: Bool)
+}
+
+enum MyDayDeliveryPolicy {
+    /// A wearer who was briefly away or whose app resumed late should still get today's delivery,
+    /// but a stale briefing hours later is worse than no automatic briefing.
+    static let deliveryWindowMinutes = 120
+
+    static func decide(
+        now: Date,
+        calendar: Calendar,
+        settings: MyDayDeliverySettings,
+        context: MyDayDeliveryContext,
+        lastMorningDayKey: String,
+        lastEveningDayKey: String
+    ) -> MyDayDeliveryDecision {
+        guard settings.myDayEnabled else { return .notDue }
+        let dayKey = self.dayKey(for: now, calendar: calendar)
+        let minute = minuteOfDay(for: now, calendar: calendar)
+
+        let candidates: [(MyDayDeliverySlot, Bool, Int, String)] = [
+            (.morning, settings.morningEnabled, bounded(settings.morningMinutes), lastMorningDayKey),
+            (.evening, settings.eveningEnabled, bounded(settings.eveningMinutes), lastEveningDayKey),
+        ]
+
+        guard let slot = candidates.first(where: { _, enabled, scheduled, deliveredDay in
+            enabled
+                && deliveredDay != dayKey
+                && minute >= scheduled
+                && minute - scheduled <= deliveryWindowMinutes
+        })?.0 else {
+            return .notDue
+        }
+
+        if settings.quietHoursEnabled,
+           isQuiet(
+               minute: minute,
+               start: bounded(settings.quietStartMinutes),
+               end: bounded(settings.quietEndMinutes)
+           ) {
+            return .deferred(.quietHours)
+        }
+        guard context.sourceAccessReady else { return .deferred(.sourceAccess) }
+
+        let wearerPresent = context.presence == .active || context.presence == .present
+        let speak = settings.scheduledSpeechEnabled
+            && wearerPresent
+            && context.power != .reserve
+            && context.isOnline
+            && !context.isBusy
+        return .deliver(slot: slot, dayKey: dayKey, speak: speak)
+    }
+
+    static func dayKey(for date: Date, calendar: Calendar) -> String {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        return String(
+            format: "%04d-%02d-%02d",
+            components.year ?? 0,
+            components.month ?? 0,
+            components.day ?? 0
+        )
+    }
+
+    private static func minuteOfDay(for date: Date, calendar: Calendar) -> Int {
+        let components = calendar.dateComponents([.hour, .minute], from: date)
+        return (components.hour ?? 0) * 60 + (components.minute ?? 0)
+    }
+
+    private static func isQuiet(minute: Int, start: Int, end: Int) -> Bool {
+        guard start != end else { return false }
+        if start < end { return minute >= start && minute < end }
+        return minute >= start || minute < end
+    }
+
+    private static func bounded(_ minutes: Int) -> Int {
+        min(23 * 60 + 59, max(0, minutes))
+    }
+}
+
+@MainActor
+final class MyDayScheduledDeliveryService: ObservableObject {
+    var settings: () -> MyDayDeliverySettings = { .current }
+    var presence: () -> EngagementMode = { .away }
+    var power: () -> PowerPosture = { .reserve }
+    var isOnline: () -> Bool = { false }
+    var isBusy: () -> Bool = { true }
+    var sourceAccessReady: () -> Bool = { false }
+    var onDelivery: ((MyDayDeliverySlot, String, Bool, String) -> Void)?
+
+    private let myDayService: MyDayService
+    private let calendar: Calendar
+    private var timer: Timer?
+    private var checkInFlight = false
+
+    init(myDayService: MyDayService, calendar: Calendar = .current) {
+        self.myDayService = myDayService
+        self.calendar = calendar
+    }
+
+    func start() {
+        guard timer == nil else { return }
+        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+            Task { @MainActor in await self?.evaluate() }
+        }
+        Task { @MainActor [weak self] in await self?.evaluate() }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    func evaluate(now: Date = Date()) async {
+        guard !checkInFlight else { return }
+        checkInFlight = true
+        defer { checkInFlight = false }
+
+        let decision = MyDayDeliveryPolicy.decide(
+            now: now,
+            calendar: calendar,
+            settings: settings(),
+            context: .init(
+                presence: presence(),
+                power: power(),
+                isOnline: isOnline(),
+                isBusy: isBusy(),
+                sourceAccessReady: sourceAccessReady()
+            ),
+            lastMorningDayKey: Config.myDayLastMorningDeliveryDay,
+            lastEveningDayKey: Config.myDayLastEveningDeliveryDay
+        )
+        guard case .deliver(let slot, let dayKey, let speak) = decision else { return }
+
+        let text = await myDayService.spokenBriefing(now: now)
+        switch slot {
+        case .morning: Config.myDayLastMorningDeliveryDay = dayKey
+        case .evening: Config.myDayLastEveningDeliveryDay = dayKey
+        }
+        onDelivery?(slot, text, speak, "my-day-\(slot.rawValue)-\(dayKey)")
+    }
+
+    deinit {
+        timer?.invalidate()
+    }
+}

--- a/OpenGlasses/Sources/Services/MyDay/MyDayDigestSource.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayDigestSource.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+enum MyDayDigestPolicy {
+    static let limit = 2
+
+    static func select(
+        _ items: [DigestItem],
+        now: Date,
+        limit: Int = MyDayDigestPolicy.limit
+    ) -> [MyDayDigestUpdate] {
+        let live = DigestComposer.compose(
+            items,
+            now: now,
+            topN: items.count
+        ).items
+
+        return live
+            .filter(isEligible)
+            .prefix(max(0, limit))
+            .map { item in
+                MyDayDigestUpdate(
+                    id: item.id,
+                    title: bounded(item.title, limit: 80),
+                    detail: bounded(
+                        item.rawBody.isEmpty ? item.source.displayTag : item.rawBody,
+                        limit: 160
+                    ),
+                    createdAt: item.createdAt,
+                    urgency: urgency(for: item, now: now)
+                )
+            }
+    }
+
+    /// Calendar, reminder, and proactive items already have authoritative My Day rows. Mirroring
+    /// them through the digest would duplicate the same commitment or leave-by warning. P3 only
+    /// admits first-party updates that still call for attention.
+    private static func isEligible(_ item: DigestItem) -> Bool {
+        switch item.source {
+        case .geofence:
+            true
+        case .agent:
+            item.awaitingReply || item.priority == .high
+        case .sync:
+            item.priority == .high
+        case .calendar, .proactive, .reminder:
+            false
+        }
+    }
+
+    private static func urgency(for item: DigestItem, now: Date) -> MyDayUrgency {
+        switch DigestRanker.tier(of: item, now: now) {
+        case .urgent: .immediate
+        case .timeSensitive, .actionable: .important
+        case .informational: .upcoming
+        case .routine: .routine
+        }
+    }
+
+    private static func bounded(_ text: String, limit: Int) -> String {
+        let collapsed = text
+            .split(whereSeparator: \Character.isWhitespace)
+            .joined(separator: " ")
+        guard collapsed.count > limit else { return collapsed }
+        return String(collapsed.prefix(limit - 1)) + "…"
+    }
+}
+
+@MainActor
+final class NotificationDigestDaySource: DigestDaySource {
+    private let service: NotificationDigestService
+
+    init(service: NotificationDigestService) {
+        self.service = service
+    }
+
+    func loadDigest(now: Date) async -> MyDaySourceLoad<[MyDayDigestUpdate]> {
+        guard Config.digestEnabled else {
+            return .init(
+                value: [],
+                state: .unavailable(.digest, message: "Actionable updates are off.")
+            )
+        }
+        return .init(
+            value: MyDayDigestPolicy.select(service.items, now: now),
+            state: .available(.digest)
+        )
+    }
+
+    func dismissDigestItem(id: String) {
+        service.dismissItem(id: id)
+    }
+}

--- a/OpenGlasses/Sources/Services/MyDay/MyDayModels.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayModels.swift
@@ -9,7 +9,9 @@ enum MyDayPeriod: String, Equatable, Sendable {
 enum MyDayKind: String, Equatable, Sendable {
     case event
     case leaveBy
+    case preparation
     case reminder
+    case update
     case weather
 }
 
@@ -26,6 +28,7 @@ enum MyDayUrgency: Int, Comparable, Equatable, Sendable {
 
 enum MyDaySource: String, CaseIterable, Equatable, Sendable {
     case calendar
+    case digest
     case reminders
     case travel
     case weather
@@ -33,6 +36,7 @@ enum MyDaySource: String, CaseIterable, Equatable, Sendable {
     var displayName: String {
         switch self {
         case .calendar: "Calendar"
+        case .digest: "Actionable Updates"
         case .reminders: "Reminders"
         case .travel: "Travel Time"
         case .weather: "Weather"
@@ -70,6 +74,7 @@ enum MyDayAction: Hashable, Sendable {
     case open
     case complete
     case directions
+    case dismiss
 }
 
 struct MyDayItem: Identifiable, Equatable, Sendable {
@@ -152,11 +157,47 @@ struct MyDayTravelEstimate: Equatable, Sendable {
     let mode: MyDayTransportMode
 }
 
+struct MyDayDigestUpdate: Equatable, Sendable {
+    let id: String
+    let title: String
+    let detail: String?
+    let createdAt: Date
+    let urgency: MyDayUrgency
+}
+
+struct MyDaySourceSelection: Equatable, Sendable {
+    let calendar: Bool
+    let reminders: Bool
+    let weather: Bool
+    let travel: Bool
+    let digest: Bool
+
+    static var current: Self {
+        let calendar = Config.myDayCalendarIncluded
+        return .init(
+            calendar: calendar,
+            reminders: Config.myDayRemindersIncluded,
+            weather: Config.myDayWeatherIncluded,
+            travel: calendar && Config.myDayTravelIncluded,
+            digest: Config.myDayDigestIncluded
+        )
+    }
+
+    static let all = Self(
+        calendar: true,
+        reminders: true,
+        weather: true,
+        travel: true,
+        digest: true
+    )
+}
+
 struct MyDayInputs: Equatable, Sendable {
     let events: [MyDayCalendarEvent]
     let reminders: [MyDayReminder]
     let weather: MyDayWeather?
     let travel: MyDayTravelEstimate?
+    let digestUpdates: [MyDayDigestUpdate]
     let sourceStates: [MyDaySourceState]
 
     init(
@@ -164,12 +205,14 @@ struct MyDayInputs: Equatable, Sendable {
         reminders: [MyDayReminder],
         weather: MyDayWeather?,
         travel: MyDayTravelEstimate? = nil,
+        digestUpdates: [MyDayDigestUpdate] = [],
         sourceStates: [MyDaySourceState]
     ) {
         self.events = events
         self.reminders = reminders
         self.weather = weather
         self.travel = travel
+        self.digestUpdates = digestUpdates
         self.sourceStates = sourceStates
     }
 }

--- a/OpenGlasses/Sources/Services/MyDay/MyDayService.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayService.swift
@@ -14,6 +14,8 @@ final class MyDayService: ObservableObject {
     private let remindersSource: any RemindersDaySource
     private let weatherSource: any WeatherDaySource
     private let travelSource: (any TravelTimeDaySource)?
+    private var digestSource: (any DigestDaySource)?
+    private let sourceSelection: () -> MyDaySourceSelection
     private let composer: MyDayComposer
     private let spokenFormatter: MyDaySpokenFormatter
     private let calendar: Calendar
@@ -23,6 +25,8 @@ final class MyDayService: ObservableObject {
         remindersSource: any RemindersDaySource,
         weatherSource: any WeatherDaySource,
         travelSource: (any TravelTimeDaySource)? = nil,
+        digestSource: (any DigestDaySource)? = nil,
+        sourceSelection: @escaping () -> MyDaySourceSelection = { .current },
         composer: MyDayComposer = MyDayComposer(),
         spokenFormatter: MyDaySpokenFormatter = MyDaySpokenFormatter(),
         calendar: Calendar = .current
@@ -31,6 +35,8 @@ final class MyDayService: ObservableObject {
         self.remindersSource = remindersSource
         self.weatherSource = weatherSource
         self.travelSource = travelSource
+        self.digestSource = digestSource
+        self.sourceSelection = sourceSelection
         self.composer = composer
         self.spokenFormatter = spokenFormatter
         self.calendar = calendar
@@ -44,23 +50,31 @@ final class MyDayService: ObservableObject {
 
         let start = calendar.startOfDay(for: now)
         let end = calendar.date(byAdding: .day, value: 2, to: start) ?? now
-        // Calendar and Reminders can each show a first-use system permission sheet. Load them in
-        // sequence so iOS never has to arbitrate two permission prompts at once; weather can run
-        // alongside both because it has no prompt of its own.
-        async let weatherLoad = weatherSource.loadWeather()
-        let events = await calendarSource.loadEvents(from: start, to: end)
-        async let travelLoad = loadTravel(for: events.value, now: now)
-        let reminders = await remindersSource.loadReminders()
+        // Calendar and Reminders can each show a first-use system permission sheet. Keep those in
+        // sequence; weather and the first-party digest have no permission prompt and can run beside
+        // them. Travel starts after Calendar because it consumes that authoritative event set.
+        let selection = sourceSelection()
+        async let weatherLoad = loadWeather(enabled: selection.weather)
+        async let digestLoad = loadDigest(enabled: selection.digest, now: now)
+        let events = await loadEvents(enabled: selection.calendar, from: start, to: end)
+        async let travelLoad = loadTravel(
+            enabled: selection.travel,
+            for: events?.value ?? [],
+            now: now
+        )
+        let reminders = await loadReminders(enabled: selection.reminders)
         let weather = await weatherLoad
         let travel = await travelLoad
-        var sourceStates = [events.state, reminders.state, weather.state]
-        if let travel { sourceStates.append(travel.state) }
+        let digest = await digestLoad
+        let sourceStates = [events?.state, reminders?.state, weather?.state, travel?.state, digest?.state]
+            .compactMap { $0 }
         let snapshot = composer.compose(
             inputs: MyDayInputs(
-                events: events.value,
-                reminders: reminders.value,
-                weather: weather.value,
+                events: events?.value ?? [],
+                reminders: reminders?.value ?? [],
+                weather: weather?.value,
                 travel: travel?.value,
+                digestUpdates: digest?.value ?? [],
                 sourceStates: sourceStates
             ),
             now: now
@@ -80,6 +94,16 @@ final class MyDayService: ObservableObject {
         return travelSource?.directionsURL(for: eventID)
     }
 
+    func setDigestSource(_ source: any DigestDaySource) {
+        digestSource = source
+    }
+
+    @discardableResult
+    func dismissDigestItem(id: String, now: Date = Date()) async -> MyDaySnapshot {
+        digestSource?.dismissDigestItem(id: id)
+        return await refresh(now: now)
+    }
+
     @discardableResult
     func completeReminder(id: String, now: Date = Date()) async throws -> String? {
         let title = try await remindersSource.completeReminder(id: id)
@@ -87,11 +111,39 @@ final class MyDayService: ObservableObject {
         return title
     }
 
+    private func loadEvents(
+        enabled: Bool,
+        from start: Date,
+        to end: Date
+    ) async -> MyDaySourceLoad<[MyDayCalendarEvent]>? {
+        guard enabled else { return nil }
+        return await calendarSource.loadEvents(from: start, to: end)
+    }
+
+    private func loadReminders(enabled: Bool) async -> MyDaySourceLoad<[MyDayReminder]>? {
+        guard enabled else { return nil }
+        return await remindersSource.loadReminders()
+    }
+
+    private func loadWeather(enabled: Bool) async -> MyDaySourceLoad<MyDayWeather?>? {
+        guard enabled else { return nil }
+        return await weatherSource.loadWeather()
+    }
+
     private func loadTravel(
+        enabled: Bool,
         for events: [MyDayCalendarEvent],
         now: Date
     ) async -> MyDaySourceLoad<MyDayTravelEstimate?>? {
-        guard let travelSource else { return nil }
+        guard enabled, let travelSource else { return nil }
         return await travelSource.loadTravel(for: events, now: now)
+    }
+
+    private func loadDigest(
+        enabled: Bool,
+        now: Date
+    ) async -> MyDaySourceLoad<[MyDayDigestUpdate]>? {
+        guard enabled, let digestSource else { return nil }
+        return await digestSource.loadDigest(now: now)
     }
 }

--- a/OpenGlasses/Sources/Services/MyDay/MyDaySources.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDaySources.swift
@@ -25,6 +25,12 @@ protocol TravelTimeDaySource: AnyObject {
     func directionsURL(for eventID: String) -> URL?
 }
 
+@MainActor
+protocol DigestDaySource: AnyObject {
+    func loadDigest(now: Date) async -> MyDaySourceLoad<[MyDayDigestUpdate]>
+    func dismissDigestItem(id: String)
+}
+
 extension EventKitDayStore: CalendarDaySource {
     func loadEvents(from start: Date, to end: Date) async -> MyDaySourceLoad<[MyDayCalendarEvent]> {
         do {

--- a/OpenGlasses/Sources/Services/NativeTools/DailyBriefingTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/DailyBriefingTool.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Selection and time math happen in `MyDayComposer`; no model discovers or ranks commitments.
 struct DailyBriefingTool: NativeTool {
     let name = "daily_briefing"
-    let description = "Get My Day: a concise, authoritative briefing of today's calendar, due reminders, and weather."
+    let description = "Get My Day: a concise, authoritative briefing of calendar, due reminders, weather, leave-by guidance, preparation, and actionable first-party updates."
     let parametersSchema: [String: Any] = [
         "type": "object",
         "properties": [:] as [String: Any],

--- a/OpenGlassesTests/MyDayComposerTests.swift
+++ b/OpenGlassesTests/MyDayComposerTests.swift
@@ -28,9 +28,11 @@ final class MyDayComposerTests: XCTestCase {
         reminders: [MyDayReminder] = [],
         weather: MyDayWeather? = nil,
         travel: MyDayTravelEstimate? = nil,
+        digestUpdates: [MyDayDigestUpdate] = [],
         states: [MyDaySourceState] = MyDaySource.allCases.map(MyDaySourceState.available)
     ) -> MyDayInputs {
         .init(events: events, reminders: reminders, weather: weather, travel: travel,
+              digestUpdates: digestUpdates,
               sourceStates: states)
     }
 
@@ -132,14 +134,39 @@ final class MyDayComposerTests: XCTestCase {
         XCTAssertEqual(snapshot.sourceStates.first?.availability, .denied)
     }
 
-    func testEveningIncludesFirstTomorrowCommitment() {
+    func testEveningIncludesFirstTomorrowCommitmentAndOnePreparationCue() {
         let snapshot = MyDayComposer(calendar: calendar).compose(
             inputs: inputs(events: [event("second", at: 11, day: 31), event("first", at: 8, day: 31)]),
             now: date(20)
         )
         XCTAssertEqual(snapshot.period, .evening)
-        XCTAssertEqual(snapshot.items.map(\.id.rawValue), ["first"])
+        XCTAssertEqual(snapshot.items.map(\.id.rawValue), ["first", "prepare:first"])
         XCTAssertTrue(snapshot.items[0].detail?.contains("Tomorrow") == true)
+        XCTAssertEqual(snapshot.items[1].kind, .preparation)
+        XCTAssertTrue(snapshot.headline.contains("tomorrow starts with Event first"))
+    }
+
+    func testDigestUpdatesAreCappedAtTwoAndOnlyFillRemainingCapacity() {
+        let updates = (1...3).map {
+            MyDayDigestUpdate(
+                id: "update-\($0)",
+                title: "Update \($0)",
+                detail: "Agent",
+                createdAt: date(8, minute: $0),
+                urgency: .important
+            )
+        }
+        let snapshot = MyDayComposer(calendar: calendar, maxItems: 3).compose(
+            inputs: inputs(
+                reminders: [reminder("due", due: date(10))],
+                digestUpdates: updates
+            ),
+            now: date(9)
+        )
+
+        XCTAssertEqual(snapshot.items.map(\.id.rawValue), ["due", "update-1", "update-2"])
+        XCTAssertEqual(snapshot.items.filter { $0.kind == .update }.count, 2)
+        XCTAssertEqual(snapshot.items.last?.actions, [.dismiss])
     }
 
     func testAllDayEventIsUpcomingRatherThanImmediate() {

--- a/OpenGlassesTests/MyDayP3Tests.swift
+++ b/OpenGlassesTests/MyDayP3Tests.swift
@@ -1,0 +1,228 @@
+import XCTest
+@testable import OpenGlasses
+
+final class MyDayDigestPolicyTests: XCTestCase {
+    private let now = Date(timeIntervalSinceReferenceDate: 2_000_000)
+
+    private func item(
+        id: String,
+        source: DigestSource,
+        age: TimeInterval,
+        priority: NotificationPriority = .medium,
+        awaitingReply: Bool = false
+    ) -> DigestItem {
+        .init(
+            id: id,
+            source: source,
+            title: "Update \(id)",
+            createdAt: now.addingTimeInterval(-age),
+            priority: priority,
+            awaitingReply: awaitingReply
+        )
+    }
+
+    func testSelectionKeepsOnlyTwoActionableFirstPartyUpdates() {
+        let selected = MyDayDigestPolicy.select([
+            item(id: "calendar", source: .calendar, age: 1, priority: .high),
+            item(id: "leave-by", source: .proactive, age: 2, priority: .high),
+            item(id: "agent-info", source: .agent, age: 3),
+            item(id: "geofence", source: .geofence, age: 4),
+            item(id: "agent-reply", source: .agent, age: 5, priority: .high, awaitingReply: true),
+            item(id: "sync-failure", source: .sync, age: 6, priority: .high),
+        ], now: now)
+
+        XCTAssertEqual(selected.map(\.id), ["agent-reply", "sync-failure"])
+        XCTAssertEqual(selected.count, MyDayDigestPolicy.limit)
+        XCTAssertTrue(selected.allSatisfy { $0.urgency == .immediate })
+    }
+
+    func testSelectionBoundsAndCollapsesDigestText() {
+        let selected = MyDayDigestPolicy.select([
+            DigestItem(
+                id: "long",
+                source: .agent,
+                title: String(repeating: "T", count: 100),
+                rawBody: String(repeating: "detail  \n", count: 30),
+                createdAt: now,
+                priority: .high,
+                awaitingReply: true
+            ),
+        ], now: now)
+
+        XCTAssertEqual(selected.first?.title.count, 80)
+        XCTAssertEqual(selected.first?.detail?.count, 160)
+        XCTAssertFalse(selected.first?.detail?.contains("\n") == true)
+    }
+
+    @MainActor
+    func testDismissRetiresDigestOwnerAndAcknowledgesAgentSource() {
+        let oldEnabled = Config.digestEnabled
+        Config.digestEnabled = true
+        defer { Config.digestEnabled = oldEnabled }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("my-day-digest-\(UUID().uuidString).json")
+        let service = NotificationDigestService(storageURL: url)
+        var acknowledged = Set<String>()
+        service.acknowledgeAgentItems = { acknowledged.formUnion($0) }
+        service.ingest(
+            id: "agent-item",
+            source: .agent,
+            title: "Need your answer",
+            priority: .high,
+            threadKey: "queue-item",
+            awaitingReply: true
+        )
+
+        service.dismissItem(id: "agent-item")
+
+        XCTAssertTrue(service.items.isEmpty)
+        XCTAssertEqual(acknowledged, ["queue-item"])
+        try? FileManager.default.removeItem(at: url)
+    }
+}
+
+final class MyDayDeliveryPolicyTests: XCTestCase {
+    private var calendar: Calendar {
+        var value = Calendar(identifier: .gregorian)
+        value.timeZone = TimeZone(secondsFromGMT: 0)!
+        return value
+    }
+
+    private func date(_ hour: Int, minute: Int = 0) -> Date {
+        DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: 2026,
+            month: 8,
+            day: 30,
+            hour: hour,
+            minute: minute
+        ).date!
+    }
+
+    private func settings(
+        morning: Bool = true,
+        evening: Bool = false,
+        speech: Bool = true,
+        quiet: Bool = false
+    ) -> MyDayDeliverySettings {
+        .init(
+            myDayEnabled: true,
+            morningEnabled: morning,
+            morningMinutes: 8 * 60,
+            eveningEnabled: evening,
+            eveningMinutes: 19 * 60,
+            scheduledSpeechEnabled: speech,
+            quietHoursEnabled: quiet,
+            quietStartMinutes: 22 * 60,
+            quietEndMinutes: 7 * 60
+        )
+    }
+
+    private func context(
+        presence: EngagementMode = .active,
+        power: PowerPosture = .normal,
+        online: Bool = true,
+        busy: Bool = false,
+        access: Bool = true
+    ) -> MyDayDeliveryContext {
+        .init(
+            presence: presence,
+            power: power,
+            isOnline: online,
+            isBusy: busy,
+            sourceAccessReady: access
+        )
+    }
+
+    func testMorningFiresOnceInsideBoundedWindow() {
+        let due = MyDayDeliveryPolicy.decide(
+            now: date(8, minute: 5),
+            calendar: calendar,
+            settings: settings(),
+            context: context(),
+            lastMorningDayKey: "",
+            lastEveningDayKey: ""
+        )
+        XCTAssertEqual(due, .deliver(slot: .morning, dayKey: "2026-08-30", speak: true))
+
+        let duplicate = MyDayDeliveryPolicy.decide(
+            now: date(8, minute: 6),
+            calendar: calendar,
+            settings: settings(),
+            context: context(),
+            lastMorningDayKey: "2026-08-30",
+            lastEveningDayKey: ""
+        )
+        XCTAssertEqual(duplicate, .notDue)
+
+        let stale = MyDayDeliveryPolicy.decide(
+            now: date(10, minute: 1),
+            calendar: calendar,
+            settings: settings(),
+            context: context(),
+            lastMorningDayKey: "",
+            lastEveningDayKey: ""
+        )
+        XCTAssertEqual(stale, .notDue)
+    }
+
+    func testQuietHoursAndMissingSourceAccessDeferWithoutConsumingDelivery() {
+        var quietSettings = settings(quiet: true)
+        quietSettings = .init(
+            myDayEnabled: quietSettings.myDayEnabled,
+            morningEnabled: true,
+            morningMinutes: 6 * 60,
+            eveningEnabled: false,
+            eveningMinutes: quietSettings.eveningMinutes,
+            scheduledSpeechEnabled: true,
+            quietHoursEnabled: true,
+            quietStartMinutes: 22 * 60,
+            quietEndMinutes: 7 * 60
+        )
+        XCTAssertEqual(
+            MyDayDeliveryPolicy.decide(
+                now: date(6, minute: 30), calendar: calendar, settings: quietSettings,
+                context: context(), lastMorningDayKey: "", lastEveningDayKey: ""
+            ),
+            .deferred(.quietHours)
+        )
+        XCTAssertEqual(
+            MyDayDeliveryPolicy.decide(
+                now: date(8), calendar: calendar, settings: settings(),
+                context: context(access: false), lastMorningDayKey: "", lastEveningDayKey: ""
+            ),
+            .deferred(.sourceAccess)
+        )
+    }
+
+    func testAwayOfflineBusyOrReserveStillDeliversPrivatelyWithoutSpeech() {
+        let restrictedContexts = [
+            context(presence: .away),
+            context(online: false),
+            context(busy: true),
+            context(power: .reserve),
+        ]
+
+        for value in restrictedContexts {
+            XCTAssertEqual(
+                MyDayDeliveryPolicy.decide(
+                    now: date(8), calendar: calendar, settings: settings(), context: value,
+                    lastMorningDayKey: "", lastEveningDayKey: ""
+                ),
+                .deliver(slot: .morning, dayKey: "2026-08-30", speak: false)
+            )
+        }
+    }
+
+    func testEveningUsesItsOwnOccurrenceMarker() {
+        XCTAssertEqual(
+            MyDayDeliveryPolicy.decide(
+                now: date(19, minute: 15), calendar: calendar,
+                settings: settings(morning: false, evening: true), context: context(),
+                lastMorningDayKey: "2026-08-30", lastEveningDayKey: ""
+            ),
+            .deliver(slot: .evening, dayKey: "2026-08-30", speak: true)
+        )
+    }
+}

--- a/OpenGlassesTests/MyDayServiceTests.swift
+++ b/OpenGlassesTests/MyDayServiceTests.swift
@@ -11,7 +11,8 @@ final class MyDayServiceTests: XCTestCase {
                                      hasTime: true, priority: 0)
         let sources = FakeDaySources(events: [event], reminders: [reminder],
                                      weather: .init(summary: "Rain.", isDecisionRelevant: true))
-        let service = MyDayService(calendarSource: sources, remindersSource: sources, weatherSource: sources)
+        let service = MyDayService(calendarSource: sources, remindersSource: sources,
+                                   weatherSource: sources, sourceSelection: { .all })
 
         let snapshot = await service.refresh(now: now)
 
@@ -22,7 +23,8 @@ final class MyDayServiceTests: XCTestCase {
     func testRefreshIsHonestWhenCalendarDenied() async {
         let sources = FakeDaySources()
         sources.calendarState = .denied(.calendar, message: "Calendar access is off.")
-        let service = MyDayService(calendarSource: sources, remindersSource: sources, weatherSource: sources)
+        let service = MyDayService(calendarSource: sources, remindersSource: sources,
+                                   weatherSource: sources, sourceSelection: { .all })
 
         let snapshot = await service.refresh()
 
@@ -56,7 +58,8 @@ final class MyDayServiceTests: XCTestCase {
             calendarSource: sources,
             remindersSource: sources,
             weatherSource: sources,
-            travelSource: sources
+            travelSource: sources,
+            sourceSelection: { .all }
         )
 
         let snapshot = await service.refresh(now: now)
@@ -73,7 +76,8 @@ final class MyDayServiceTests: XCTestCase {
         let sources = FakeDaySources(reminders: [
             .init(id: "exact-id", title: "Call Ana", dueDate: now, hasTime: true, priority: 0)
         ])
-        let service = MyDayService(calendarSource: sources, remindersSource: sources, weatherSource: sources)
+        let service = MyDayService(calendarSource: sources, remindersSource: sources,
+                                   weatherSource: sources, sourceSelection: { .all })
         _ = await service.refresh(now: now)
 
         let title = try await service.completeReminder(id: "exact-id", now: now)
@@ -110,20 +114,73 @@ final class MyDayServiceTests: XCTestCase {
         }
         XCTAssertNotNil(date)
     }
+
+    func testRefreshLoadsAndDismissesActionableDigestThroughItsOwner() async {
+        let now = Date(timeIntervalSince1970: 1_788_065_600)
+        let sources = FakeDaySources()
+        sources.digestUpdates = [
+            .init(id: "agent-reply", title: "Agent needs your answer", detail: "Agent",
+                  createdAt: now, urgency: .important)
+        ]
+        let service = MyDayService(
+            calendarSource: sources,
+            remindersSource: sources,
+            weatherSource: sources,
+            digestSource: sources,
+            sourceSelection: { .all }
+        )
+
+        var snapshot = await service.refresh(now: now)
+        XCTAssertEqual(snapshot.items.first { $0.kind == .update }?.id.rawValue, "agent-reply")
+
+        snapshot = await service.dismissDigestItem(id: "agent-reply", now: now)
+        XCTAssertEqual(sources.dismissedDigestIDs, ["agent-reply"])
+        XCTAssertFalse(snapshot.items.contains { $0.kind == .update })
+    }
+
+    func testDisabledSourcesAreNotLoadedOrReportedUnavailable() async {
+        let sources = FakeDaySources()
+        let service = MyDayService(
+            calendarSource: sources,
+            remindersSource: sources,
+            weatherSource: sources,
+            travelSource: sources,
+            digestSource: sources,
+            sourceSelection: {
+                .init(calendar: false, reminders: true, weather: false, travel: false, digest: false)
+            }
+        )
+
+        let snapshot = await service.refresh()
+
+        XCTAssertEqual(sources.calendarLoadCount, 0)
+        XCTAssertEqual(sources.remindersLoadCount, 1)
+        XCTAssertEqual(sources.weatherLoadCount, 0)
+        XCTAssertEqual(sources.travelLoadCount, 0)
+        XCTAssertEqual(sources.digestLoadCount, 0)
+        XCTAssertEqual(snapshot.sourceStates.map(\.source), [.reminders])
+    }
 }
 
 @MainActor
 private final class FakeDaySources: CalendarDaySource, RemindersDaySource, WeatherDaySource,
-                                    TravelTimeDaySource {
+                                    TravelTimeDaySource, DigestDaySource {
     var events: [MyDayCalendarEvent]
     var reminders: [MyDayReminder]
     var weather: MyDayWeather?
     var travel: MyDayTravelEstimate?
+    var digestUpdates: [MyDayDigestUpdate] = []
     var calendarState = MyDaySourceState.available(.calendar)
     var remindersState = MyDaySourceState.available(.reminders)
     var weatherState = MyDaySourceState.available(.weather)
     var completedIDs: [String] = []
     var travelEventIDs: [String] = []
+    var dismissedDigestIDs: [String] = []
+    var calendarLoadCount = 0
+    var remindersLoadCount = 0
+    var weatherLoadCount = 0
+    var travelLoadCount = 0
+    var digestLoadCount = 0
 
     init(events: [MyDayCalendarEvent] = [], reminders: [MyDayReminder] = [], weather: MyDayWeather? = nil) {
         self.events = events
@@ -132,11 +189,13 @@ private final class FakeDaySources: CalendarDaySource, RemindersDaySource, Weath
     }
 
     func loadEvents(from start: Date, to end: Date) async -> MyDaySourceLoad<[MyDayCalendarEvent]> {
-        .init(value: events, state: calendarState)
+        calendarLoadCount += 1
+        return .init(value: events, state: calendarState)
     }
 
     func loadReminders() async -> MyDaySourceLoad<[MyDayReminder]> {
-        .init(value: reminders, state: remindersState)
+        remindersLoadCount += 1
+        return .init(value: reminders, state: remindersState)
     }
 
     func completeReminder(id: String) async throws -> String? {
@@ -146,13 +205,15 @@ private final class FakeDaySources: CalendarDaySource, RemindersDaySource, Weath
     }
 
     func loadWeather() async -> MyDaySourceLoad<MyDayWeather?> {
-        .init(value: weather, state: weatherState)
+        weatherLoadCount += 1
+        return .init(value: weather, state: weatherState)
     }
 
     func loadTravel(
         for events: [MyDayCalendarEvent],
         now: Date
     ) async -> MyDaySourceLoad<MyDayTravelEstimate?> {
+        travelLoadCount += 1
         travelEventIDs = events.map(\.id)
         return .init(value: travel, state: .available(.travel))
     }
@@ -162,5 +223,15 @@ private final class FakeDaySources: CalendarDaySource, RemindersDaySource, Weath
         var components = URLComponents(string: "https://maps.apple.com/")
         components?.queryItems = [URLQueryItem(name: "daddr", value: travel?.destination)]
         return components?.url
+    }
+
+    func loadDigest(now: Date) async -> MyDaySourceLoad<[MyDayDigestUpdate]> {
+        digestLoadCount += 1
+        return .init(value: digestUpdates, state: .available(.digest))
+    }
+
+    func dismissDigestItem(id: String) {
+        dismissedDigestIDs.append(id)
+        digestUpdates.removeAll { $0.id == id }
     }
 }

--- a/docs/plans/DY-my-day-everyday-briefing.md
+++ b/docs/plans/DY-my-day-everyday-briefing.md
@@ -1,6 +1,6 @@
 # Plan DY — My Day: Everyday Briefing and Preparation
 
-**Status:** 🟠 P0/P1/P2 implemented and automated verification complete (2026-08-30);
+**Status:** 🟠 P0/P1/P2/P3 implemented and automated verification complete (2026-08-30);
 physical-device routing, permission/audio, and accessibility walkthroughs pending
 **Origin:** The opportunity assessment names Everyday Briefing as the P1 daily-retention loop and
 places it before differentiated intelligence such as the private-memory timeline.
@@ -53,8 +53,8 @@ more tools.
   values through a pure policy, and completes by stable ID. Title fallback refuses ambiguous
   matches instead of completing the first substring.
 - The `daily_briefing` tool name and Siri intent remain compatible, but both now return the same My
-  Day spoken snapshot. The built-in morning scheduler task also calls that service directly rather
-  than asking an agent to discover and rank the day.
+  Day spoken snapshot. P3 moves scheduled delivery to the same service without an Agent Mode or LLM
+  dependency.
 - A feature-flagged **My Day** card replaces the decorative waveline in the centre of the Voice
   home screen. Its compact at-a-glance state shows what matters next, opens the full review surface,
   and yields room to active conversation; the full surface supports refresh, empty, stale, denied,
@@ -81,14 +81,31 @@ more tools.
   digest ingest is an upsert rather than an appended duplicate; one content-free occurrence ID
   prevents repeat speech/HUD delivery after relaunch.
 
-P3 digest composition/evening controls remain a separate follow-up.
+### Implemented P3 slice (2026-08-30)
+
+- Evening My Day now shows tomorrow's first commitment and one deterministic preparation cue. The
+  same bounded snapshot powers the phone card, full review, command/Siri response, and schedule.
+- My Day can include at most two live, actionable first-party digest updates. Calendar, Reminder,
+  proactive, routine, and arbitrary third-party notifications are excluded; displayed title/body
+  text is bounded, and dismissal returns to the digest owner and acknowledges agent-owned rows.
+- The existing iPhone integrations screen now owns included-source controls, morning/evening times,
+  opt-in scheduled speech, quiet hours, and content-free delivery-history reset alongside P2 travel
+  settings. Calendar reads every account exposed through iOS EventKit—including Outlook/Microsoft
+  365 accounts synced into iPhone Calendar—but does not directly access the Outlook app or Graph.
+- A dedicated My Day scheduler replaces the legacy AgentScheduler morning row, so delivery no
+  longer depends on Agent Mode or an LLM. It records one content-free occurrence key per slot/day,
+  avoids first-use permission sheets, preserves denied sources as honest partial availability, and
+  uses generic notification copy rather than private briefing content.
+- Quiet hours defer delivery. Away, busy, offline, and power-reserve states still refresh and expose
+  the deterministic phone briefing, while suppressing private speech.
 
 ### Automated evidence (2026-08-30)
 
 - Focused My Day contract/service suite: 14 passed, 0 failures.
 - Focused P2 My Day/travel/digest suite: 41 passed, 0 failures.
-- Full unit suite on iPhone 17 Pro Max / iOS 27 simulator: 3,764 passed, 4
-  environment-gated skips, 0 failures (3,768 total).
+- Focused P3 My Day/digest/delivery suite: 51 passed, 0 failures.
+- Full unit suite on iPhone 17 Pro / iOS 27 simulator: 3,774 passed, 4
+  environment-gated skips, 0 failures (3,778 total).
 - Release iOS Simulator build: passed.
 
 Still required before enabling by default: physical-device Calendar/Reminders denial and regrant,
@@ -229,7 +246,7 @@ preserve item count, source facts, times, and action labels or be rejected whole
 3. Feed leave-by into `ProactiveAlertService` and the digest as one stable item so the same warning is
    not spoken, notified, and displayed three times.
 
-### P3 — Evening preparation, digest, and controls 🟡
+### P3 — Evening preparation, digest, and controls ✅
 
 1. Add evening/tomorrow composition and one deterministic preparation cue.
 2. Add at most two still-actionable digest items; never mirror arbitrary notifications.


### PR DESCRIPTION
## Summary

- add deterministic evening preparation with tomorrow first commitment and one preparation cue
- include at most two bounded actionable first-party digest updates with owner-routed dismissal
- add included-source controls, Outlook-via-iPhone-Calendar guidance, morning/evening schedules, opt-in speech, quiet hours, and delivery-history reset
- replace the legacy AgentScheduler morning row with a dedicated My Day scheduler independent of Agent Mode and LLMs
- suppress scheduled speech while away, busy, offline, or in power reserve; defer quiet hours and unresolved first-use permissions while preserving denied sources as honest partial availability

## Verification

- Focused My Day/digest/delivery suite: 51 passed, 0 failures
- Full unit suite: 3,778 tests, 4 environment-gated skips, 0 failures
- Release iOS Simulator build: passed
- git diff --check: passed

## Notes

- Outlook and Microsoft 365 calendars are supported when exposed through the iPhone Calendar app via EventKit. This does not add direct Outlook app or Microsoft Graph access.
- Scheduled delivery runs while OpenGlasses is active and stores only content-free per-slot/day occurrence markers.