### PR TITLE
Harden My Day release and privacy-safe learning

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -1826,6 +1826,12 @@ class AppState: ObservableObject, AppStateProtocol {
             guard let self else { return true }
             return self.isProcessing || self.isListening || self.speechService.isSpeaking
         }
+        myDayService.protectedDataAvailable = {
+            UIApplication.shared.isProtectedDataAvailable
+        }
+        myDayDelivery.protectedDataAvailable = {
+            UIApplication.shared.isProtectedDataAvailable
+        }
         myDayDelivery.sourceAccessReady = { [weak self] in
             guard let self else { return false }
             let included = MyDaySourceSelection.current

--- a/OpenGlasses/Sources/App/Views/MyDayView.swift
+++ b/OpenGlasses/Sources/App/Views/MyDayView.swift
@@ -139,6 +139,7 @@ struct MyDayView: View {
         } else if item.actions.contains(.directions),
                   let url = service.directionsURL(for: item.id) {
             Button {
+                service.recordAction(.startDirections)
                 openURL(url)
             } label: {
                 Image(systemName: "arrow.triangle.turn.up.right.diamond")
@@ -159,6 +160,7 @@ struct MyDayView: View {
             .accessibilityLabel("Dismiss \(item.title)")
         } else if item.actions.contains(.open), let dueAt = item.dueAt {
             Button {
+                service.recordAction(.openEvent)
                 let seconds = dueAt.timeIntervalSinceReferenceDate
                 if let url = URL(string: "calshow:\(seconds)") { openURL(url) }
             } label: {
@@ -273,6 +275,7 @@ struct MyDayHomeView: View {
                     .fixedSize(horizontal: false, vertical: true)
 
                 Button("Set Up My Day") {
+                    MyDayMetricsStore.shared.record(.optedIn, at: Date())
                     isEnabled = true
                 }
                 .buttonStyle(.borderedProminent)

--- a/OpenGlasses/Sources/Services/MyDay/EventKitDayStore.swift
+++ b/OpenGlasses/Sources/Services/MyDay/EventKitDayStore.swift
@@ -45,16 +45,32 @@ final class EventKitDayStore {
 
     func requestCalendarAccess() async throws -> Bool {
         if #available(iOS 17.0, *) {
-            return try await eventStore.requestFullAccessToEvents()
+            switch EKEventStore.authorizationStatus(for: .event) {
+            case .fullAccess: return true
+            case .notDetermined: return try await eventStore.requestFullAccessToEvents()
+            default: return false
+            }
         }
-        return try await eventStore.requestAccess(to: .event)
+        switch EKEventStore.authorizationStatus(for: .event) {
+        case .authorized: return true
+        case .notDetermined: return try await eventStore.requestAccess(to: .event)
+        default: return false
+        }
     }
 
     func requestRemindersAccess() async throws -> Bool {
         if #available(iOS 17.0, *) {
-            return try await eventStore.requestFullAccessToReminders()
+            switch EKEventStore.authorizationStatus(for: .reminder) {
+            case .fullAccess: return true
+            case .notDetermined: return try await eventStore.requestFullAccessToReminders()
+            default: return false
+            }
         }
-        return try await eventStore.requestAccess(to: .reminder)
+        switch EKEventStore.authorizationStatus(for: .reminder) {
+        case .authorized: return true
+        case .notDetermined: return try await eventStore.requestAccess(to: .reminder)
+        default: return false
+        }
     }
 
     func calendarEvents(from start: Date, to end: Date) -> [EventKitCalendarRecord] {
@@ -113,9 +129,9 @@ final class EventKitDayStore {
         reminder.title = title
         reminder.calendar = eventStore.defaultCalendarForNewReminders()
         if let dueDate {
-            var components = Calendar.current.dateComponents([.year, .month, .day], from: dueDate)
+            var components = Calendar.autoupdatingCurrent.dateComponents([.year, .month, .day], from: dueDate)
             if hasTime {
-                let time = Calendar.current.dateComponents([.hour, .minute], from: dueDate)
+                let time = Calendar.autoupdatingCurrent.dateComponents([.hour, .minute], from: dueDate)
                 components.hour = time.hour
                 components.minute = time.minute
                 reminder.addAlarm(EKAlarm(absoluteDate: dueDate))
@@ -149,7 +165,7 @@ final class EventKitDayStore {
 
     private static func record(from reminder: EKReminder) -> EventKitReminderRecord {
         let components = reminder.dueDateComponents
-        let date = components.flatMap { Calendar.current.date(from: $0) }
+        let date = components.flatMap { Calendar.autoupdatingCurrent.date(from: $0) }
         return EventKitReminderRecord(
             id: reminder.calendarItemIdentifier,
             title: reminder.title?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? "Untitled",

--- a/OpenGlasses/Sources/Services/MyDay/MyDayComposer.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayComposer.swift
@@ -5,7 +5,7 @@ struct MyDayComposer: Sendable {
     let locale: Locale
     let maxItems: Int
 
-    init(calendar: Calendar = .current, locale: Locale = .current, maxItems: Int = 6) {
+    init(calendar: Calendar = .autoupdatingCurrent, locale: Locale = .autoupdatingCurrent, maxItems: Int = 6) {
         self.calendar = calendar
         self.locale = locale
         self.maxItems = max(1, maxItems)
@@ -342,21 +342,69 @@ struct MyDayComposer: Sendable {
     }
 }
 
+enum MyDaySpeechPolicy {
+    /// A conservative deterministic ceiling for the normal iOS speech rate. Actual device timing
+    /// remains a physical-device release check because installed voices and accessibility speech
+    /// settings vary.
+    static let maximumDuration: TimeInterval = 35
+    static let wordsPerSecond = 2.4
+    static let charactersPerSecond = 15.0
+    static let maximumWords = Int(maximumDuration * wordsPerSecond)
+    static let maximumCharacters = Int(maximumDuration * charactersPerSecond)
+
+    static func estimatedDuration(for text: String) -> TimeInterval {
+        let words = text.split(whereSeparator: { $0.isWhitespace }).count
+        return max(
+            Double(words) / wordsPerSecond,
+            Double(text.count) / charactersPerSecond
+        )
+    }
+
+    static func bounded(_ text: String) -> String {
+        let words = text.split(whereSeparator: { $0.isWhitespace })
+        var result = words.prefix(maximumWords).joined(separator: " ")
+        if result.count > maximumCharacters - 1 {
+            result = String(result.prefix(maximumCharacters - 1))
+            if let lastSpace = result.lastIndex(of: " ") {
+                result = String(result[..<lastSpace])
+            }
+        }
+        result = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard result.count < text.trimmingCharacters(in: .whitespacesAndNewlines).count else {
+            return result
+        }
+        return result.trimmingCharacters(in: .punctuationCharacters) + "…"
+    }
+}
+
 struct MyDaySpokenFormatter: Sendable {
     func format(_ snapshot: MyDaySnapshot) -> String {
-        var sentences = [snapshot.headline]
-        sentences.append(contentsOf: snapshot.items.map { item in
+        var candidates = [snapshot.headline]
+
+        let unavailable = snapshot.sourceStates.filter { $0.availability != .available }
+        if !unavailable.isEmpty {
+            let names = unavailable.map { $0.source.displayName }.joined(separator: " and ")
+            candidates.append("\(names) \(unavailable.count == 1 ? "is" : "are") unavailable.")
+        }
+
+        candidates.append(contentsOf: snapshot.items.map { item in
             if let detail = item.detail, !detail.isEmpty {
                 return "\(item.title): \(detail)."
             }
             return "\(item.title)."
         })
 
-        let unavailable = snapshot.sourceStates.filter { $0.availability != .available }
-        if !unavailable.isEmpty {
-            let names = unavailable.map { $0.source.displayName }.joined(separator: " and ")
-            sentences.append("\(names) \(unavailable.count == 1 ? "is" : "are") unavailable.")
+        var result = ""
+        for candidate in candidates {
+            let proposed = result.isEmpty ? candidate : result + " " + candidate
+            if MyDaySpeechPolicy.estimatedDuration(for: proposed) <= MyDaySpeechPolicy.maximumDuration {
+                result = proposed
+            } else if result.isEmpty {
+                result = MyDaySpeechPolicy.bounded(candidate)
+            } else {
+                break
+            }
         }
-        return sentences.joined(separator: " ")
+        return MyDaySpeechPolicy.bounded(result)
     }
 }

--- a/OpenGlasses/Sources/Services/MyDay/MyDayDelivery.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayDelivery.swift
@@ -44,9 +44,11 @@ struct MyDayDeliveryContext: Equatable {
     let isOnline: Bool
     let isBusy: Bool
     let sourceAccessReady: Bool
+    let isProtectedDataAvailable: Bool
 }
 
 enum MyDayDeliveryDeferral: Equatable {
+    case protectedData
     case quietHours
     case sourceAccess
 }
@@ -88,6 +90,7 @@ enum MyDayDeliveryPolicy {
             return .notDue
         }
 
+        guard context.isProtectedDataAvailable else { return .deferred(.protectedData) }
         if settings.quietHoursEnabled,
            isQuiet(
                minute: minute,
@@ -141,16 +144,20 @@ final class MyDayScheduledDeliveryService: ObservableObject {
     var isOnline: () -> Bool = { false }
     var isBusy: () -> Bool = { true }
     var sourceAccessReady: () -> Bool = { false }
+    var protectedDataAvailable: () -> Bool = { false }
     var onDelivery: ((MyDayDeliverySlot, String, Bool, String) -> Void)?
 
     private let myDayService: MyDayService
-    private let calendar: Calendar
+    private let calendarProvider: () -> Calendar
     private var timer: Timer?
     private var checkInFlight = false
 
-    init(myDayService: MyDayService, calendar: Calendar = .current) {
+    init(
+        myDayService: MyDayService,
+        calendarProvider: @escaping () -> Calendar = { .autoupdatingCurrent }
+    ) {
         self.myDayService = myDayService
-        self.calendar = calendar
+        self.calendarProvider = calendarProvider
     }
 
     func start() {
@@ -173,21 +180,22 @@ final class MyDayScheduledDeliveryService: ObservableObject {
 
         let decision = MyDayDeliveryPolicy.decide(
             now: now,
-            calendar: calendar,
+            calendar: calendarProvider(),
             settings: settings(),
             context: .init(
                 presence: presence(),
                 power: power(),
                 isOnline: isOnline(),
                 isBusy: isBusy(),
-                sourceAccessReady: sourceAccessReady()
+                sourceAccessReady: sourceAccessReady(),
+                isProtectedDataAvailable: protectedDataAvailable()
             ),
             lastMorningDayKey: Config.myDayLastMorningDeliveryDay,
             lastEveningDayKey: Config.myDayLastEveningDeliveryDay
         )
         guard case .deliver(let slot, let dayKey, let speak) = decision else { return }
 
-        let text = await myDayService.spokenBriefing(now: now)
+        let text = await myDayService.spokenBriefing(now: now, channel: .scheduled)
         switch slot {
         case .morning: Config.myDayLastMorningDeliveryDay = dayKey
         case .evening: Config.myDayLastEveningDeliveryDay = dayKey

--- a/OpenGlasses/Sources/Services/MyDay/MyDayMetrics.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayMetrics.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+enum MyDayBriefingChannel: String, CaseIterable, Sendable {
+    case phone
+    case scheduled
+    case voice
+}
+
+enum MyDayActionMetric: String, CaseIterable, Sendable {
+    case completeReminder
+    case openEvent
+    case startDirections
+}
+
+enum MyDaySnapshotLatencyBucket: String, CaseIterable, Sendable {
+    case under250Milliseconds
+    case under500Milliseconds
+    case underOneSecond
+    case underTwoSeconds
+    case twoSecondsOrMore
+
+    init(seconds: TimeInterval) {
+        switch max(0, seconds) {
+        case ..<0.25: self = .under250Milliseconds
+        case ..<0.5: self = .under500Milliseconds
+        case ..<1: self = .underOneSecond
+        case ..<2: self = .underTwoSeconds
+        default: self = .twoSecondsOrMore
+        }
+    }
+}
+
+enum MyDaySpokenDurationBucket: String, CaseIterable, Sendable {
+    case under20Seconds
+    case target20Through35Seconds
+    case over35Seconds
+
+    init(seconds: TimeInterval) {
+        switch max(0, seconds) {
+        case ..<20: self = .under20Seconds
+        case ...MyDaySpeechPolicy.maximumDuration: self = .target20Through35Seconds
+        default: self = .over35Seconds
+        }
+    }
+}
+
+/// A closed metric vocabulary. There is deliberately no String, metadata dictionary, or generic
+/// payload case: titles, locations, reminder text, notification bodies, and generated speech
+/// cannot be represented by this API.
+enum MyDayMetricEvent: Equatable, Sendable {
+    case optedIn
+    case briefingRequested(MyDayBriefingChannel)
+    case action(MyDayActionMetric)
+    case dismissal
+    case sevenDayReturn
+    case snapshotLatency(MyDaySnapshotLatencyBucket)
+    case spokenDuration(MyDaySpokenDurationBucket)
+}
+
+protocol MyDayMetricsRecording: AnyObject {
+    func record(_ event: MyDayMetricEvent, at date: Date)
+}
+
+struct MyDayMetricsSnapshot: Equatable, Sendable {
+    let optIns: Int
+    let briefingRequests: [MyDayBriefingChannel: Int]
+    let actions: [MyDayActionMetric: Int]
+    let dismissals: Int
+    let sevenDayReturns: Int
+    let snapshotLatencies: [MyDaySnapshotLatencyBucket: Int]
+    let spokenDurations: [MyDaySpokenDurationBucket: Int]
+}
+
+/// Local-only aggregate learning for My Day. It stores counters and one content-free timestamp
+/// used to recognize a seven-day return. It keeps no event log and has no network/export path.
+final class MyDayMetricsStore: MyDayMetricsRecording, @unchecked Sendable {
+    static let shared = MyDayMetricsStore()
+
+    private enum Key {
+        static let prefix = "myDayMetrics.v1."
+        static let optIns = prefix + "optIns"
+        static let dismissals = prefix + "dismissals"
+        static let sevenDayReturns = prefix + "sevenDayReturns"
+        static let firstBriefingAt = prefix + "firstBriefingAt"
+        static let sevenDayReturnRecorded = prefix + "sevenDayReturnRecorded"
+
+        static func briefing(_ channel: MyDayBriefingChannel) -> String {
+            prefix + "briefing." + channel.rawValue
+        }
+
+        static func action(_ action: MyDayActionMetric) -> String {
+            prefix + "action." + action.rawValue
+        }
+
+        static func latency(_ bucket: MyDaySnapshotLatencyBucket) -> String {
+            prefix + "latency." + bucket.rawValue
+        }
+
+        static func spoken(_ bucket: MyDaySpokenDurationBucket) -> String {
+            prefix + "spoken." + bucket.rawValue
+        }
+    }
+
+    private let defaults: UserDefaults
+    private let calendar: Calendar
+    private let lock = NSLock()
+
+    init(defaults: UserDefaults = .standard, calendar: Calendar = .autoupdatingCurrent) {
+        self.defaults = defaults
+        self.calendar = calendar
+    }
+
+    func record(_ event: MyDayMetricEvent, at date: Date = Date()) {
+        lock.withLock {
+            switch event {
+            case .optedIn:
+                increment(Key.optIns)
+            case .briefingRequested(let channel):
+                increment(Key.briefing(channel))
+                recordSevenDayReturnIfNeeded(at: date)
+            case .action(let action):
+                increment(Key.action(action))
+            case .dismissal:
+                increment(Key.dismissals)
+            case .sevenDayReturn:
+                guard !defaults.bool(forKey: Key.sevenDayReturnRecorded) else { return }
+                defaults.set(true, forKey: Key.sevenDayReturnRecorded)
+                increment(Key.sevenDayReturns)
+            case .snapshotLatency(let bucket):
+                increment(Key.latency(bucket))
+            case .spokenDuration(let bucket):
+                increment(Key.spoken(bucket))
+            }
+        }
+    }
+
+    func snapshot() -> MyDayMetricsSnapshot {
+        lock.withLock {
+            MyDayMetricsSnapshot(
+                optIns: defaults.integer(forKey: Key.optIns),
+                briefingRequests: Dictionary(uniqueKeysWithValues: MyDayBriefingChannel.allCases.map {
+                    ($0, defaults.integer(forKey: Key.briefing($0)))
+                }),
+                actions: Dictionary(uniqueKeysWithValues: MyDayActionMetric.allCases.map {
+                    ($0, defaults.integer(forKey: Key.action($0)))
+                }),
+                dismissals: defaults.integer(forKey: Key.dismissals),
+                sevenDayReturns: defaults.integer(forKey: Key.sevenDayReturns),
+                snapshotLatencies: Dictionary(uniqueKeysWithValues: MyDaySnapshotLatencyBucket.allCases.map {
+                    ($0, defaults.integer(forKey: Key.latency($0)))
+                }),
+                spokenDurations: Dictionary(uniqueKeysWithValues: MyDaySpokenDurationBucket.allCases.map {
+                    ($0, defaults.integer(forKey: Key.spoken($0)))
+                })
+            )
+        }
+    }
+
+    private func recordSevenDayReturnIfNeeded(at date: Date) {
+        guard !defaults.bool(forKey: Key.sevenDayReturnRecorded) else { return }
+        guard let first = defaults.object(forKey: Key.firstBriefingAt) as? Date else {
+            defaults.set(date, forKey: Key.firstBriefingAt)
+            return
+        }
+        guard let threshold = calendar.date(byAdding: .day, value: 7, to: first), date >= threshold else {
+            return
+        }
+        defaults.set(true, forKey: Key.sevenDayReturnRecorded)
+        increment(Key.sevenDayReturns)
+    }
+
+    private func increment(_ key: String) {
+        defaults.set(defaults.integer(forKey: key) + 1, forKey: key)
+    }
+}
+
+private extension NSLock {
+    func withLock<T>(_ body: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return body()
+    }
+}

--- a/OpenGlasses/Sources/Services/MyDay/MyDayService.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayService.swift
@@ -18,7 +18,13 @@ final class MyDayService: ObservableObject {
     private let sourceSelection: () -> MyDaySourceSelection
     private let composer: MyDayComposer
     private let spokenFormatter: MyDaySpokenFormatter
-    private let calendar: Calendar
+    private let calendarProvider: () -> Calendar
+    private let metrics: any MyDayMetricsRecording
+    private let monotonicNow: () -> TimeInterval
+
+    /// EventKit and the content-bearing snapshot are not touched while iOS protected data is
+    /// unavailable. AppState replaces this default with UIApplication's live lock-state signal.
+    var protectedDataAvailable: () -> Bool = { true }
 
     init(
         calendarSource: any CalendarDaySource,
@@ -29,7 +35,9 @@ final class MyDayService: ObservableObject {
         sourceSelection: @escaping () -> MyDaySourceSelection = { .current },
         composer: MyDayComposer = MyDayComposer(),
         spokenFormatter: MyDaySpokenFormatter = MyDaySpokenFormatter(),
-        calendar: Calendar = .current
+        calendarProvider: @escaping () -> Calendar = { .autoupdatingCurrent },
+        metrics: any MyDayMetricsRecording = MyDayMetricsStore.shared,
+        monotonicNow: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
     ) {
         self.calendarSource = calendarSource
         self.remindersSource = remindersSource
@@ -39,21 +47,50 @@ final class MyDayService: ObservableObject {
         self.sourceSelection = sourceSelection
         self.composer = composer
         self.spokenFormatter = spokenFormatter
-        self.calendar = calendar
+        self.calendarProvider = calendarProvider
+        self.metrics = metrics
+        self.monotonicNow = monotonicNow
     }
 
     @discardableResult
-    func refresh(now: Date = Date()) async -> MyDaySnapshot {
+    func refresh(
+        now: Date = Date(),
+        channel: MyDayBriefingChannel? = .phone
+    ) async -> MyDaySnapshot {
+        let refreshStartedAt = monotonicNow()
+        if let channel {
+            metrics.record(.briefingRequested(channel), at: now)
+        }
         let previous: MyDaySnapshot?
         if case .loaded(let snapshot) = state { previous = snapshot } else { previous = nil }
         state = .loading(previous: previous)
 
+        let calendar = calendarProvider()
+        let refreshComposer = MyDayComposer(
+            calendar: calendar,
+            locale: composer.locale,
+            maxItems: composer.maxItems
+        )
         let start = calendar.startOfDay(for: now)
         let end = calendar.date(byAdding: .day, value: 2, to: start) ?? now
         // Calendar and Reminders can each show a first-use system permission sheet. Keep those in
         // sequence; weather and the first-party digest have no permission prompt and can run beside
         // them. Travel starts after Calendar because it consumes that authoritative event set.
         let selection = sourceSelection()
+        guard protectedDataAvailable() else {
+            let snapshot = refreshComposer.compose(
+                inputs: .init(
+                    events: [],
+                    reminders: [],
+                    weather: nil,
+                    sourceStates: lockedSourceStates(for: selection)
+                ),
+                now: now
+            )
+            state = .loaded(snapshot)
+            recordLatency(since: refreshStartedAt, at: now)
+            return snapshot
+        }
         async let weatherLoad = loadWeather(enabled: selection.weather)
         async let digestLoad = loadDigest(enabled: selection.digest, now: now)
         let events = await loadEvents(enabled: selection.calendar, from: start, to: end)
@@ -68,7 +105,7 @@ final class MyDayService: ObservableObject {
         let digest = await digestLoad
         let sourceStates = [events?.state, reminders?.state, weather?.state, travel?.state, digest?.state]
             .compactMap { $0 }
-        let snapshot = composer.compose(
+        let snapshot = refreshComposer.compose(
             inputs: MyDayInputs(
                 events: events?.value ?? [],
                 reminders: reminders?.value ?? [],
@@ -80,11 +117,20 @@ final class MyDayService: ObservableObject {
             now: now
         )
         state = .loaded(snapshot)
+        recordLatency(since: refreshStartedAt, at: now)
         return snapshot
     }
 
-    func spokenBriefing(now: Date = Date()) async -> String {
-        spokenFormatter.format(await refresh(now: now))
+    func spokenBriefing(
+        now: Date = Date(),
+        channel: MyDayBriefingChannel = .voice
+    ) async -> String {
+        let text = spokenFormatter.format(await refresh(now: now, channel: channel))
+        metrics.record(
+            .spokenDuration(.init(seconds: MyDaySpeechPolicy.estimatedDuration(for: text))),
+            at: now
+        )
+        return text
     }
 
     func directionsURL(for itemID: MyDayItemID) -> URL? {
@@ -100,15 +146,21 @@ final class MyDayService: ObservableObject {
 
     @discardableResult
     func dismissDigestItem(id: String, now: Date = Date()) async -> MyDaySnapshot {
+        metrics.record(.dismissal, at: now)
         digestSource?.dismissDigestItem(id: id)
-        return await refresh(now: now)
+        return await refresh(now: now, channel: nil)
     }
 
     @discardableResult
     func completeReminder(id: String, now: Date = Date()) async throws -> String? {
+        metrics.record(.action(.completeReminder), at: now)
         let title = try await remindersSource.completeReminder(id: id)
-        _ = await refresh(now: now)
+        _ = await refresh(now: now, channel: nil)
         return title
+    }
+
+    func recordAction(_ action: MyDayActionMetric, at date: Date = Date()) {
+        metrics.record(.action(action), at: date)
     }
 
     private func loadEvents(
@@ -145,5 +197,23 @@ final class MyDayService: ObservableObject {
     ) async -> MyDaySourceLoad<[MyDayDigestUpdate]>? {
         guard enabled, let digestSource else { return nil }
         return await digestSource.loadDigest(now: now)
+    }
+
+    private func lockedSourceStates(for selection: MyDaySourceSelection) -> [MyDaySourceState] {
+        let message = "Unlock iPhone to refresh My Day."
+        return [
+            selection.calendar ? .unavailable(.calendar, message: message) : nil,
+            selection.reminders ? .unavailable(.reminders, message: message) : nil,
+            selection.weather ? .unavailable(.weather, message: message) : nil,
+            selection.travel ? .unavailable(.travel, message: message) : nil,
+            selection.digest ? .unavailable(.digest, message: message) : nil,
+        ].compactMap { $0 }
+    }
+
+    private func recordLatency(since start: TimeInterval, at date: Date) {
+        metrics.record(
+            .snapshotLatency(.init(seconds: max(0, monotonicNow() - start))),
+            at: date
+        )
     }
 }

--- a/OpenGlasses/Sources/Services/MyDay/MyDaySources.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDaySources.swift
@@ -129,7 +129,7 @@ final class NativeWeatherDaySource: WeatherDaySource {
         return decisionWords.contains { text.contains($0) }
     }
 
-    private static func looksUnavailable(_ summary: String) -> Bool {
+    static func looksUnavailable(_ summary: String) -> Bool {
         let text = summary.lowercased()
         return text.contains("can't get the weather")
             || text.contains("weather service is temporarily unavailable")

--- a/OpenGlasses/Sources/Utils/Config.swift
+++ b/OpenGlasses/Sources/Utils/Config.swift
@@ -2754,7 +2754,12 @@ struct Config {
     /// hides its surface and scheduled trigger without changing Calendar or Reminders data.
     @UserDefaultsBacked("myDayEnabled", default: false) static var myDayEnabled: Bool
 
-    static func setMyDayEnabled(_ enabled: Bool) { myDayEnabled = enabled }
+    static func setMyDayEnabled(_ enabled: Bool) {
+        myDayEnabled = enabled
+        if enabled {
+            MyDayMetricsStore.shared.record(.optedIn, at: Date())
+        }
+    }
 
     @UserDefaultsBacked("myDayTransportMode", default: MyDayTransportMode.walking.rawValue)
     private static var myDayTransportModeRaw: String

--- a/OpenGlassesTests/MyDayP3Tests.swift
+++ b/OpenGlassesTests/MyDayP3Tests.swift
@@ -131,7 +131,8 @@ final class MyDayDeliveryPolicyTests: XCTestCase {
             power: power,
             isOnline: online,
             isBusy: busy,
-            sourceAccessReady: access
+            sourceAccessReady: access,
+            isProtectedDataAvailable: true
         )
     }
 

--- a/OpenGlassesTests/MyDayP4Tests.swift
+++ b/OpenGlassesTests/MyDayP4Tests.swift
@@ -1,0 +1,436 @@
+import XCTest
+@testable import OpenGlasses
+
+final class MyDayP4CalendarHardeningTests: XCTestCase {
+    private func calendar(timeZone identifier: String) -> Calendar {
+        var value = Calendar(identifier: .gregorian)
+        value.locale = Locale(identifier: "en_US_POSIX")
+        value.timeZone = TimeZone(identifier: identifier)!
+        return value
+    }
+
+    private func date(_ value: String) -> Date {
+        ISO8601DateFormatter().date(from: value)!
+    }
+
+    func testOverlappingAndAllDayEventsRemainDistinctAndDeterministic() {
+        let calendar = calendar(timeZone: "Pacific/Auckland")
+        let now = date("2026-08-30T22:15:00Z")
+        let events = [
+            MyDayCalendarEvent(
+                id: "all-day", title: "Conference", startDate: date("2026-08-30T12:00:00Z"),
+                endDate: date("2026-08-31T12:00:00Z"), isAllDay: true, location: nil
+            ),
+            MyDayCalendarEvent(
+                id: "first", title: "First", startDate: date("2026-08-30T22:00:00Z"),
+                endDate: date("2026-08-30T23:00:00Z"), isAllDay: false, location: nil
+            ),
+            MyDayCalendarEvent(
+                id: "overlap", title: "Overlap", startDate: date("2026-08-30T22:30:00Z"),
+                endDate: date("2026-08-30T23:30:00Z"), isAllDay: false, location: nil
+            ),
+        ]
+
+        let snapshot = MyDayComposer(calendar: calendar, locale: Locale(identifier: "en_NZ"))
+            .compose(inputs: .init(events: events, reminders: [], weather: nil, sourceStates: []), now: now)
+
+        XCTAssertEqual(snapshot.items.map(\.id.rawValue), ["first", "overlap", "all-day"])
+        XCTAssertEqual(snapshot.items.last?.detail, "All day")
+        XCTAssertEqual(Set(snapshot.items.map(\.id.rawValue)).count, 3)
+    }
+
+    func testDeliveryUsesLocalCivilTimeAcrossDSTGapAndRepeatedHour() {
+        let calendar = calendar(timeZone: "America/Los_Angeles")
+        let settings = MyDayDeliverySettings(
+            myDayEnabled: true,
+            morningEnabled: true,
+            morningMinutes: 2 * 60 + 30,
+            eveningEnabled: false,
+            eveningMinutes: 19 * 60,
+            scheduledSpeechEnabled: true,
+            quietHoursEnabled: false,
+            quietStartMinutes: 22 * 60,
+            quietEndMinutes: 7 * 60
+        )
+        let context = MyDayDeliveryContext(
+            presence: .active,
+            power: .normal,
+            isOnline: true,
+            isBusy: false,
+            sourceAccessReady: true,
+            isProtectedDataAvailable: true
+        )
+
+        // 02:30 does not exist on the spring-forward day. The first civil time after it remains
+        // inside the bounded delivery window instead of losing the briefing.
+        XCTAssertEqual(
+            MyDayDeliveryPolicy.decide(
+                now: date("2026-03-08T10:05:00Z"),
+                calendar: calendar,
+                settings: settings,
+                context: context,
+                lastMorningDayKey: "",
+                lastEveningDayKey: ""
+            ),
+            .deliver(slot: .morning, dayKey: "2026-03-08", speak: true)
+        )
+
+        let firstRepeatedHour = date("2026-11-01T08:40:00Z")
+        let secondRepeatedHour = date("2026-11-01T09:40:00Z")
+        XCTAssertEqual(MyDayDeliveryPolicy.dayKey(for: firstRepeatedHour, calendar: calendar), "2026-11-01")
+        XCTAssertEqual(MyDayDeliveryPolicy.dayKey(for: secondRepeatedHour, calendar: calendar), "2026-11-01")
+        XCTAssertEqual(
+            MyDayDeliveryPolicy.decide(
+                now: secondRepeatedHour,
+                calendar: calendar,
+                settings: settings,
+                context: context,
+                lastMorningDayKey: "2026-11-01",
+                lastEveningDayKey: ""
+            ),
+            .notDue
+        )
+    }
+}
+
+@MainActor
+final class MyDayP4ServiceHardeningTests: XCTestCase {
+    func testRefreshAdoptsChangedTimezoneWithoutRecreatingService() async {
+        let now = iso("2026-08-30T00:00:00Z")
+        let event = MyDayCalendarEvent(
+            id: "timezone-event",
+            title: "Appointment",
+            startDate: iso("2026-08-30T10:00:00Z"),
+            endDate: iso("2026-08-30T11:00:00Z"),
+            isAllDay: false,
+            location: nil
+        )
+        let sources = P4FakeDaySources(events: [event])
+        let calendarBox = P4CalendarBox(calendar: fixedCalendar("UTC"))
+        let service = MyDayService(
+            calendarSource: sources,
+            remindersSource: sources,
+            weatherSource: sources,
+            sourceSelection: { .init(calendar: true, reminders: false, weather: false, travel: false, digest: false) },
+            composer: MyDayComposer(calendar: fixedCalendar("UTC"), locale: Locale(identifier: "en_US")),
+            calendarProvider: { calendarBox.calendar }
+        )
+
+        let utc = await service.refresh(now: now)
+        calendarBox.calendar = fixedCalendar("Pacific/Auckland")
+        let auckland = await service.refresh(now: now)
+
+        XCTAssertNotEqual(utc.items.first?.detail, auckland.items.first?.detail)
+        XCTAssertNotEqual(sources.requestedRanges[0].start, sources.requestedRanges[1].start)
+    }
+
+    func testPermissionDenialThenRegrantRestoresOnlyAffectedSources() async {
+        let now = iso("2026-08-30T00:00:00Z")
+        let sources = P4FakeDaySources()
+        sources.calendarState = .denied(.calendar, message: "Calendar access is off.")
+        sources.remindersState = .denied(.reminders, message: "Reminders access is off.")
+        let service = MyDayService(
+            calendarSource: sources,
+            remindersSource: sources,
+            weatherSource: sources,
+            sourceSelection: { .init(calendar: true, reminders: true, weather: false, travel: false, digest: false) }
+        )
+
+        let denied = await service.refresh(now: now)
+        XCTAssertTrue(denied.sourceStates.allSatisfy { $0.availability == .denied })
+        XCTAssertTrue(denied.items.isEmpty)
+
+        sources.calendarState = .available(.calendar)
+        sources.remindersState = .available(.reminders)
+        sources.events = [
+            .init(id: "regranted-event", title: "Event", startDate: now.addingTimeInterval(3600),
+                  endDate: now.addingTimeInterval(7200), isAllDay: false, location: nil)
+        ]
+        sources.reminders = [
+            .init(id: "regranted-reminder", title: "Reminder", dueDate: now, hasTime: true, priority: 0)
+        ]
+
+        let regranted = await service.refresh(now: now)
+        XCTAssertTrue(regranted.sourceStates.allSatisfy { $0.availability == .available })
+        XCTAssertEqual(Set(regranted.items.map(\.id.rawValue)), ["regranted-event", "regranted-reminder"])
+    }
+
+    func testRouteFailureAndOfflineWeatherRemainHonestPartialSnapshot() async {
+        let now = iso("2026-08-30T00:00:00Z")
+        let sources = P4FakeDaySources(events: [
+            .init(id: "event", title: "Event", startDate: now.addingTimeInterval(3600),
+                  endDate: now.addingTimeInterval(7200), isAllDay: false, location: "22 Queen Street")
+        ])
+        sources.weatherState = .unavailable(.weather, message: "Weather is unavailable offline.")
+        sources.travelState = .unavailable(.travel, message: "Travel time could not be estimated.")
+        let service = MyDayService(
+            calendarSource: sources,
+            remindersSource: sources,
+            weatherSource: sources,
+            travelSource: sources,
+            sourceSelection: { .init(calendar: true, reminders: false, weather: true, travel: true, digest: false) }
+        )
+
+        let snapshot = await service.refresh(now: now)
+
+        XCTAssertTrue(snapshot.items.contains { $0.id.rawValue == "event" })
+        XCTAssertFalse(snapshot.items.contains { $0.kind == .leaveBy || $0.kind == .weather })
+        XCTAssertEqual(snapshot.sourceStates.first { $0.source == .travel }?.availability, .unavailable)
+        XCTAssertEqual(snapshot.sourceStates.first { $0.source == .weather }?.availability, .unavailable)
+        XCTAssertTrue(NativeWeatherDaySource.looksUnavailable("I can't get the weather right now."))
+    }
+
+    func testMissingLocationDoesNotAttemptRoutingOrMarkTravelUnavailable() async {
+        let now = iso("2026-08-30T00:00:00Z")
+        let events = [
+            MyDayCalendarEvent(id: "blank", title: "Blank", startDate: now.addingTimeInterval(600),
+                               endDate: now.addingTimeInterval(1200), isAllDay: false, location: "  "),
+            MyDayCalendarEvent(id: "virtual", title: "Virtual", startDate: now.addingTimeInterval(1200),
+                               endDate: now.addingTimeInterval(1800), isAllDay: false, location: "Zoom"),
+        ]
+
+        XCTAssertNil(MyDayTravelPlanner.nextLocatableEvent(in: events, now: now))
+        XCTAssertNil(MyDayTravelPlanner.usableDestination(nil))
+        XCTAssertNil(MyDayTravelPlanner.usableDestination("  "))
+    }
+
+    func testLockedPhoneDoesNotLoadContentAndUnlockCanRefresh() async {
+        let now = iso("2026-08-30T00:00:00Z")
+        let sources = P4FakeDaySources(events: [
+            .init(id: "private-event", title: "Private", startDate: now.addingTimeInterval(3600),
+                  endDate: now.addingTimeInterval(7200), isAllDay: false, location: "Private place")
+        ])
+        let service = MyDayService(
+            calendarSource: sources,
+            remindersSource: sources,
+            weatherSource: sources,
+            travelSource: sources,
+            digestSource: sources,
+            sourceSelection: { .all }
+        )
+        var unlocked = false
+        service.protectedDataAvailable = { unlocked }
+
+        let locked = await service.refresh(now: now)
+        XCTAssertTrue(locked.items.isEmpty)
+        XCTAssertTrue(locked.sourceStates.allSatisfy { $0.message == "Unlock iPhone to refresh My Day." })
+        XCTAssertEqual(sources.totalLoadCount, 0)
+
+        unlocked = true
+        let refreshed = await service.refresh(now: now)
+        XCTAssertTrue(refreshed.items.contains { $0.id.rawValue == "private-event" })
+        XCTAssertGreaterThan(sources.totalLoadCount, 0)
+    }
+
+    func testLockedScheduledDeliveryDefersWithoutConsumingOccurrence() {
+        let calendar = fixedCalendar("UTC")
+        let now = iso("2026-08-30T08:05:00Z")
+        let decision = MyDayDeliveryPolicy.decide(
+            now: now,
+            calendar: calendar,
+            settings: .init(
+                myDayEnabled: true, morningEnabled: true, morningMinutes: 8 * 60,
+                eveningEnabled: false, eveningMinutes: 19 * 60, scheduledSpeechEnabled: true,
+                quietHoursEnabled: false, quietStartMinutes: 22 * 60, quietEndMinutes: 7 * 60
+            ),
+            context: .init(
+                presence: .active, power: .normal, isOnline: true, isBusy: false,
+                sourceAccessReady: true, isProtectedDataAvailable: false
+            ),
+            lastMorningDayKey: "",
+            lastEveningDayKey: ""
+        )
+
+        XCTAssertEqual(decision, .deferred(.protectedData))
+    }
+
+    func testSnapshotLatencyRecordsOnlyABoundedBucket() async throws {
+        let suiteName = "MyDayP4Latency-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let metrics = MyDayMetricsStore(defaults: defaults, calendar: fixedCalendar("UTC"))
+        let clock = P4MonotonicClock(values: [100, 100.7])
+        let sources = P4FakeDaySources()
+        let service = MyDayService(
+            calendarSource: sources,
+            remindersSource: sources,
+            weatherSource: sources,
+            sourceSelection: { .init(calendar: true, reminders: false, weather: false, travel: false, digest: false) },
+            metrics: metrics,
+            monotonicNow: { clock.next() }
+        )
+
+        _ = await service.refresh(now: iso("2026-08-30T00:00:00Z"))
+
+        XCTAssertEqual(metrics.snapshot().snapshotLatencies[.underOneSecond], 1)
+        let persisted = String(describing: defaults.persistentDomain(forName: suiteName) ?? [:])
+        XCTAssertFalse(persisted.contains("title"))
+        XCTAssertFalse(persisted.contains("location"))
+    }
+
+    private func fixedCalendar(_ identifier: String) -> Calendar {
+        var value = Calendar(identifier: .gregorian)
+        value.locale = Locale(identifier: "en_US_POSIX")
+        value.timeZone = TimeZone(identifier: identifier)!
+        return value
+    }
+
+    private func iso(_ value: String) -> Date {
+        ISO8601DateFormatter().date(from: value)!
+    }
+}
+
+final class MyDayP4SpeechAndMetricsTests: XCTestCase {
+    func testSpokenBriefingHasHardDurationLimitAndPreservesAvailabilityWarning() {
+        let long = Array(repeating: "confidential", count: 120).joined(separator: " ")
+        let snapshot = MyDaySnapshot(
+            generatedAt: Date(),
+            period: .morning,
+            headline: "Here is what matters today.",
+            items: (0..<6).map { index in
+                .init(
+                    id: .init(source: .calendar, rawValue: "event-\(index)"),
+                    kind: .event,
+                    title: "Item \(index) \(long)",
+                    detail: long,
+                    dueAt: nil,
+                    urgency: .upcoming,
+                    actions: [.open]
+                )
+            },
+            sourceStates: [.denied(.calendar)],
+            nextRefreshAt: nil
+        )
+
+        let spoken = MyDaySpokenFormatter().format(snapshot)
+
+        XCTAssertLessThanOrEqual(
+            MyDaySpeechPolicy.estimatedDuration(for: spoken),
+            MyDaySpeechPolicy.maximumDuration
+        )
+        XCTAssertLessThanOrEqual(spoken.count, MyDaySpeechPolicy.maximumCharacters)
+        XCTAssertTrue(spoken.contains("Calendar is unavailable."))
+    }
+
+    func testLocalMetricsAggregateFixedVocabularyAndSevenDayReturn() throws {
+        let suiteName = "MyDayP4Metrics-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let store = MyDayMetricsStore(defaults: defaults, calendar: calendar)
+        let first = Date(timeIntervalSince1970: 1_788_065_600)
+
+        store.record(.optedIn, at: first)
+        store.record(.briefingRequested(.phone), at: first)
+        store.record(.briefingRequested(.voice), at: first.addingTimeInterval(6 * 86_400))
+        store.record(.briefingRequested(.scheduled), at: first.addingTimeInterval(7 * 86_400))
+        store.record(.briefingRequested(.phone), at: first.addingTimeInterval(8 * 86_400))
+        store.record(.action(.openEvent), at: first)
+        store.record(.action(.completeReminder), at: first)
+        store.record(.action(.startDirections), at: first)
+        store.record(.dismissal, at: first)
+        store.record(.snapshotLatency(.under500Milliseconds), at: first)
+        store.record(.spokenDuration(.target20Through35Seconds), at: first)
+
+        let snapshot = store.snapshot()
+        XCTAssertEqual(snapshot.optIns, 1)
+        XCTAssertEqual(snapshot.briefingRequests[.phone], 2)
+        XCTAssertEqual(snapshot.briefingRequests[.voice], 1)
+        XCTAssertEqual(snapshot.briefingRequests[.scheduled], 1)
+        XCTAssertEqual(snapshot.actions.values.reduce(0, +), 3)
+        XCTAssertEqual(snapshot.dismissals, 1)
+        XCTAssertEqual(snapshot.sevenDayReturns, 1)
+        XCTAssertEqual(snapshot.snapshotLatencies[.under500Milliseconds], 1)
+        XCTAssertEqual(snapshot.spokenDurations[.target20Through35Seconds], 1)
+
+        let persisted = String(describing: defaults.persistentDomain(forName: suiteName) ?? [:])
+        for forbidden in ["Dental appointment", "22 Queen Street", "Buy medicine", "Private body", "Generated speech"] {
+            XCTAssertFalse(persisted.contains(forbidden))
+        }
+    }
+}
+
+@MainActor
+private final class P4FakeDaySources: CalendarDaySource, RemindersDaySource, WeatherDaySource,
+                                      TravelTimeDaySource, DigestDaySource {
+    var events: [MyDayCalendarEvent]
+    var reminders: [MyDayReminder] = []
+    var weather: MyDayWeather?
+    var travel: MyDayTravelEstimate?
+    var digestUpdates: [MyDayDigestUpdate] = []
+    var calendarState = MyDaySourceState.available(.calendar)
+    var remindersState = MyDaySourceState.available(.reminders)
+    var weatherState = MyDaySourceState.available(.weather)
+    var travelState = MyDaySourceState.available(.travel)
+    var digestState = MyDaySourceState.available(.digest)
+    var requestedRanges: [(start: Date, end: Date)] = []
+    private(set) var totalLoadCount = 0
+
+    init(events: [MyDayCalendarEvent] = [], weather: MyDayWeather? = nil) {
+        self.events = events
+        self.weather = weather
+    }
+
+    func loadEvents(from start: Date, to end: Date) async -> MyDaySourceLoad<[MyDayCalendarEvent]> {
+        totalLoadCount += 1
+        requestedRanges.append((start, end))
+        return .init(value: events, state: calendarState)
+    }
+
+    func loadReminders() async -> MyDaySourceLoad<[MyDayReminder]> {
+        totalLoadCount += 1
+        return .init(value: reminders, state: remindersState)
+    }
+
+    func completeReminder(id: String) async throws -> String? {
+        guard let index = reminders.firstIndex(where: { $0.id == id }) else { return nil }
+        return reminders.remove(at: index).title
+    }
+
+    func loadWeather() async -> MyDaySourceLoad<MyDayWeather?> {
+        totalLoadCount += 1
+        return .init(value: weather, state: weatherState)
+    }
+
+    func loadTravel(
+        for events: [MyDayCalendarEvent],
+        now: Date
+    ) async -> MyDaySourceLoad<MyDayTravelEstimate?> {
+        totalLoadCount += 1
+        return .init(value: travel, state: travelState)
+    }
+
+    func directionsURL(for eventID: String) -> URL? { nil }
+
+    func loadDigest(now: Date) async -> MyDaySourceLoad<[MyDayDigestUpdate]> {
+        totalLoadCount += 1
+        return .init(value: digestUpdates, state: digestState)
+    }
+
+    func dismissDigestItem(id: String) {
+        digestUpdates.removeAll { $0.id == id }
+    }
+}
+
+private final class P4CalendarBox: @unchecked Sendable {
+    var calendar: Calendar
+
+    init(calendar: Calendar) {
+        self.calendar = calendar
+    }
+}
+
+private final class P4MonotonicClock: @unchecked Sendable {
+    private var values: [TimeInterval]
+
+    init(values: [TimeInterval]) {
+        self.values = values
+    }
+
+    func next() -> TimeInterval {
+        values.removeFirst()
+    }
+}

--- a/docs/plans/DY-my-day-everyday-briefing.md
+++ b/docs/plans/DY-my-day-everyday-briefing.md
@@ -1,7 +1,7 @@
 # Plan DY — My Day: Everyday Briefing and Preparation
 
-**Status:** 🟠 P0/P1/P2/P3 implemented and automated verification complete (2026-08-30);
-physical-device routing, permission/audio, and accessibility walkthroughs pending
+**Status:** 🟠 P0–P4 implementation and automated verification complete (2026-08-31);
+physical-device routing, permission/lock/audio, oldest-phone latency, and accessibility walkthroughs pending
 **Origin:** The opportunity assessment names Everyday Briefing as the P1 daily-retention loop and
 places it before differentiated intelligence such as the private-memory timeline.
 **Priority:** P1 everyday product, immediately after the DK privacy close-out.
@@ -99,17 +99,57 @@ more tools.
 - Quiet hours defer delivery. Away, busy, offline, and power-reserve states still refresh and expose
   the deterministic phone briefing, while suppressing private speech.
 
-### Automated evidence (2026-08-30)
+### Implemented P4 slice (2026-08-31)
+
+- My Day now asks for an autoupdating calendar on every refresh and scheduled-delivery evaluation,
+  so timezone and daylight-saving changes do not require recreating the service. EventKit access
+  checks return immediately for an existing grant or denial and request only while status is
+  undetermined, allowing a later Settings regrant to appear on the next refresh.
+- The deterministic composer and route-candidate policy keep overlapping and all-day events
+  distinct, never route all-day/virtual/blank-location events, and retain the authoritative event
+  when routing or weather is unavailable.
+- Scheduled delivery explicitly defers while iOS protected data is unavailable and does not consume
+  the occurrence marker. On-demand refresh also refuses to touch source adapters while locked and
+  returns content-free unlock guidance; a later unlocked refresh loads the sources normally.
+- Spoken output has a deterministic 35-second estimated ceiling using both word and character
+  budgets. Partial-source warnings are admitted before item detail. Actual timing still depends on
+  the installed voice and accessibility speech settings and remains a physical-device check.
+- `MyDayMetricsStore` is local-only aggregate learning behind a closed enum API. It counts opt-ins,
+  phone/voice/scheduled briefing requests, reminder/event/directions actions, dismissals, one
+  seven-day return, latency buckets, and spoken-duration buckets. It has no free-form payload,
+  event log, network/export path, or field capable of recording titles, locations, reminder text,
+  notification bodies, or generated speech.
+
+### Automated evidence (2026-08-31)
 
 - Focused My Day contract/service suite: 14 passed, 0 failures.
 - Focused P2 My Day/travel/digest suite: 41 passed, 0 failures.
 - Focused P3 My Day/digest/delivery suite: 51 passed, 0 failures.
-- Full unit suite on iPhone 17 Pro / iOS 27 simulator: 3,774 passed, 4
-  environment-gated skips, 0 failures (3,778 total).
-- Release iOS Simulator build: passed.
+- P4-only hardening/privacy suite on iPhone 17 Pro / iOS 27 simulator: 11 passed, 0 skips,
+  0 failures. It covers dynamic timezone refresh, DST skipped/repeated civil times, overlapping and
+  all-day events, missing/virtual locations, route failure, offline weather, locked protected data,
+  denial-to-regrant source transitions, fixed-vocabulary metrics, seven-day return, latency
+  bucketing, and the estimated spoken-duration ceiling. EventKit/MapKit/lock tests use injected
+  seams; they do not represent physical-device validation.
+- Current focused My Day composer/service/travel/delivery/P4 matrix on iPhone 17 / iOS 27 simulator:
+  41 passed, 0 skips, 0 failures.
+- Full unit suite on iPhone 17 / iOS 27 simulator: 3,785 passed, 4 environment-gated skips,
+  0 failures (3,789 total).
+- Release iOS Simulator build with Xcode 27: passed.
 
-Still required before enabling by default: physical-device Calendar/Reminders denial and regrant,
-spoken-duration/privacy review, VoiceOver walkthrough, and largest Dynamic Type walkthrough.
+### Physical-device-only verification still required
+
+No physical-device checks were performed for P4. Before enabling My Day by default, run and record:
+
+- Calendar and Reminders system-sheet denial, Settings regrant, and the next-refresh recovery path;
+- a live timezone change and both DST-boundary scenarios against EventKit data;
+- all-day, overlapping, and missing-location events from real calendar accounts;
+- successful and failed MapKit routes plus offline Weather behavior on the supported network stack;
+- locked-phone scheduled delivery, unlock retry, generic notification content, and absence of private
+  speech while locked/away;
+- snapshot latency and actual spoken duration on the oldest supported iPhone, including installed
+  voices and accessibility speech-rate variants; and
+- VoiceOver and largest Dynamic Type walkthroughs on the phone surfaces.
 
 ## Decisions and invariants
 
@@ -253,14 +293,16 @@ preserve item count, source facts, times, and action labels or be rejected whole
 3. Add the complete phone settings surface and opt-in scheduled delivery with presence, quiet-hour,
    offline, and power gates.
 
-### P4 — Release and learning 🟡
+### P4 — Release and learning 🟠 implementation/automation complete; device matrix pending
 
-1. Device tests for permission denial/regrant, timezone and daylight-saving changes, all-day and
-   overlapping events, no-location events, route failure, offline weather, and locked phone.
-2. Measure snapshot latency and speech duration on the oldest supported phone; no source content in
-   telemetry.
-3. Track opt-in, briefings requested, actions taken, dismissals, and seven-day return without
-   recording titles, locations, reminder text, or generated speech.
+1. Automated seams cover permission denial/regrant, timezone and daylight-saving changes, all-day
+   and overlapping events, no-location events, route failure, offline weather, and locked-phone
+   policy. The corresponding physical-device matrix above remains required.
+2. Snapshot latency and estimated speech duration are recorded in content-free buckets; the oldest
+   supported phone measurement and actual voice timing remain required.
+3. Local-only aggregate metrics track opt-in, briefings requested, actions taken, dismissals, and
+   seven-day return without recording titles, locations, reminder text, notification bodies, or
+   generated speech. ✅
 
 ## Rollout and exit criteria
 

--- a/docs/plans/DZ-local-gguf-and-durable-agent-runtime.md
+++ b/docs/plans/DZ-local-gguf-and-durable-agent-runtime.md
@@ -1,0 +1,884 @@
+# Plan DZ — Local GGUF Runtime and Durable Agent Loops
+
+**Status:** 📝 Drafted (2026-08-30)
+**Priority:** P1 for the text-only GGUF runtime and model acquisition path; P1 reliability work for
+scheduled tasks; P2 for memory curation; vision and skill-pack storage remain gated follow-ups.
+
+---
+
+## Product promise
+
+OpenGlasses can run a broader range of user-selected local models without weakening the existing
+MLX path, can acquire those models safely, and can keep scheduled work and long-term memory honest
+when the app is suspended, a model is unavailable, or a write fails.
+
+The implementation is deliberately split into independently reversible tracks:
+
+1. a common local-inference seam and a text-only GGUF backend;
+2. a revision-pinned model catalog, importer, and resumable installer;
+3. durable scheduled-task outcomes and retry state;
+4. transactional, reviewable memory curation;
+5. a later multimodal GGUF adapter after text inference is proven on devices; and
+6. an optional host-managed storage binding for signed, data-only skill packs.
+
+No phase depends on copying another application's UI, lifecycle, or agent architecture. This plan is
+the complete implementation contract.
+
+## Existing system to preserve
+
+- `LocalLLMService` is the current local-inference façade. It owns MLX download, load, generation,
+  cancellation, and published UI state. Existing callers should continue to use it during migration.
+- `LLMService` owns provider routing, conversation assembly, the tool loop, and local-output parsing.
+  A local backend returns streamed assistant text; it does not execute tools itself.
+- `LocalModelBudget` and `MemoryHeadroom` already make context and turn-time admission decisions.
+  GGUF models must use these policies instead of creating a second, optimistic memory heuristic.
+- `LocalModelManagerView` is the single user-facing place to discover, download, load, unload, and
+  remove local models.
+- `AgentScheduler` currently stores task definitions in `UserDefaults`, runs opportunistically, and
+  treats most execution errors as completed runs. That completion behavior must be replaced.
+- `AgentNotificationQueue` is the durable delivery path for results that should be spoken after the
+  device reconnects.
+- `SemanticMemoryStore`, `ConversationIndex`, `BrainStore`, and `AgentDocumentStore` remain the
+  authoritative memory stores. Curation adds coordination and provenance; it does not create a new
+  universal memory database.
+- `MemoryLoopService` handles immediate per-turn detection. Batch curation complements it and must
+  not duplicate facts or autonomously rewrite safety/personality documents.
+- `SkillPackManifest` describes signed data-only capability packs. Packs remain non-executable.
+- The Xcode project is generated from the YAML specifications. Package changes go through
+  `project.base.yml` and the package manifests, never direct project-file edits.
+
+## Decisions and invariants
+
+1. **GGUF is a second runtime, not an MLX replacement.** Existing downloaded MLX models, first-run
+   offers, model IDs, and saved configurations continue to work without redownload or user action.
+2. **One coordinator owns local model residency.** Only one large local model backend may be loaded
+   at a time. Switching runtime always awaits generation cancellation, backend unload, accelerator
+   synchronization, and memory release before loading the next model.
+3. **Text-only first.** The first shipping GGUF slice accepts text conversation history and streams
+   text tokens. Image projection and multimodal prompt construction are a later phase.
+4. **Full-history generation is the safe initial cache policy.** Each GGUF generation clears the KV
+   cache and renders the complete supplied conversation. Prefix-cache reuse is out until a tested
+   prefix-diff can prove there is no duplicated or stale history.
+5. **The model's embedded chat template is authoritative.** The runtime applies a usable template
+   found in the GGUF metadata. Arbitrary imports without a supported template are installable only
+   as inactive files and cannot be selected for chat. Curated entries must pass a template smoke
+   test before inclusion.
+6. **Context admission happens before decode.** Prompt tokens plus a reserved output allowance must
+   fit the selected context window. The user receives a typed, actionable error; input is never
+   silently truncated in the backend.
+7. **Prompt decode is batched.** Token input is partitioned into chunks no larger than the runtime's
+   configured batch size. Long prompts must not be submitted as one oversized batch.
+8. **Runtime pointers are actor-owned.** Model, context, vocabulary, sampler, multimodal projector,
+   and batch allocations never cross the owning actor unsafely. Cancellation is checked between
+   prompt batches and generated tokens.
+9. **Downloads are immutable and integrity-checked.** A model is selected at an exact repository
+   revision. Every file has an expected size and digest. Installation becomes visible only after all
+   files validate and the staged directory is moved atomically into place.
+10. **No remote executable catalog.** The first catalog ships in the app bundle. A future remotely
+    updated catalog requires signed metadata, expiry, rollback protection, and the same validation
+    as signed content packs.
+11. **Public model acquisition first.** The first importer supports anonymous public repositories.
+    Gated/private repository credentials are a separate opt-in design and must use Keychain storage.
+12. **Local inference is foreground-best-effort.** Metal-backed model execution is not presented as
+    reliable background work. A scheduled task using an unloaded or unavailable local model defers;
+    it never auto-loads a multi-gigabyte model at launch or in the background.
+13. **Attempts and successes are separate facts.** A failed, cancelled, or uncheckable scheduled run
+    does not advance `lastSuccessAt` or consume the recurrence.
+14. **Curation commits atomically.** Its cursor advances only after all planned writes have either
+    committed or been recorded as explicit no-ops. Retries use stable idempotency keys.
+15. **Curation cannot change authority.** It may create/update memory records and propose learned
+    skills. It may not rewrite `SOUL`, grant tools, change safety policy, enable automation, or turn a
+    skill proposal into an active skill without the existing review path.
+16. **Prompt content stays out of diagnostics.** Performance records contain model/runtime IDs,
+    token counts, durations, memory readings, and thermal state; never prompt, response, filename,
+    or user-memory text.
+17. **Every track is feature-flagged and fail-closed.** Disabling GGUF leaves MLX available;
+    disabling the new scheduler pauses scheduled execution instead of restoring the known
+    success-on-error path; disabling curation stops new batches. None of these actions deletes data.
+
+## Target architecture
+
+```text
+LLMService / tool loop
+        │
+        ▼
+LocalLLMService compatibility façade
+        │
+        ▼
+LocalInferenceCoordinator (actor; one resident model)
+        │
+        ├── MLXLocalInferenceBackend
+        └── LlamaCppLocalInferenceBackend
+                 │
+                 └── optional GGUFMultimodalAdapter (later)
+
+LocalModelCatalog ── LocalModelRepository ── LocalModelDownloadManager
+        │                     │                         │
+ bundled descriptors      installed manifest      staged/validated files
+
+AgentScheduleStore ── SchedulePolicy ── AgentScheduler ── AgentNotificationQueue
+
+MemoryCurationStore ── MemoryCurationPlanner ── MemoryCurationCommitter
+        │                                            ├── SemanticMemoryStore
+ completed batches/cursor                            ├── AgentDocumentStore snapshots
+                                                     └── EvolvedSkillStore proposals
+```
+
+## Core data contracts
+
+### Runtime and model identity
+
+Add a stable descriptor that separates a model's identity from its runtime-specific files:
+
+```swift
+enum LocalModelRuntime: String, Codable, Sendable {
+    case mlx
+    case llamaCpp
+}
+
+struct LocalModelID: RawRepresentable, Hashable, Codable, Sendable {
+    let rawValue: String
+}
+
+struct LocalModelDescriptor: Codable, Hashable, Sendable {
+    let id: LocalModelID
+    let displayName: String
+    let runtime: LocalModelRuntime
+    let repositoryID: String
+    let revision: String
+    let files: [LocalModelFile]
+    let quantization: String?
+    let capabilities: Set<LocalModelCapability>
+    let contextLength: Int
+    let estimatedWeightsBytes: Int64
+    let estimatedWorkingBytes: Int64
+    let minimumHeadroomBytes: Int64
+    let license: LocalModelLicenseSummary
+}
+
+struct LocalModelFile: Codable, Hashable, Sendable {
+    let relativePath: String
+    let byteCount: Int64
+    let sha256: String
+    let role: Role       // weights, projector, tokenizer, config, auxiliary
+}
+```
+
+Rules:
+
+- `id` is app-owned and stable across display-name or URL changes.
+- `repositoryID + revision + relativePath` identifies a remote artifact; floating branches are not
+  valid installed-model metadata.
+- Relative paths must be normalized, non-empty, and contained beneath the model's staging root.
+- Capabilities are factual: `.text`, `.vision`, `.toolFriendly`. A model is never inferred to be
+  vision-capable from its name.
+- Model license metadata includes the displayed name, a bundled summary, whether explicit acceptance
+  is required, and the accepted license revision. Installation records that acceptance locally.
+- Existing MLX model strings map to bundled descriptors. Unknown legacy MLX strings receive a
+  generated compatibility descriptor with `runtime = .mlx`; no saved configuration becomes invalid.
+
+### Backend protocol
+
+```swift
+protocol LocalInferenceBackend: Sendable {
+    var runtime: LocalModelRuntime { get }
+    func load(_ installation: InstalledLocalModel,
+              configuration: LocalLoadConfiguration) async throws -> LocalLoadedModel
+    func generate(_ request: LocalGenerationRequest) -> AsyncThrowingStream<String, Error>
+    func cancelGeneration() async
+    func unload() async
+}
+
+struct LocalGenerationRequest: Sendable {
+    let messages: [LocalChatMessage]
+    let images: [LocalImageInput]
+    let maxOutputTokens: Int
+    let sampling: LocalSamplingConfiguration
+    let stopSequences: [String]
+}
+```
+
+The protocol is intentionally narrow. Downloading, catalog metadata, conversation storage, tool
+execution, and UI state do not belong in a backend. The coordinator translates backend state into
+the existing `LocalLLMService` published properties while the migration is in progress.
+
+### Installed-model manifest
+
+Each installed model directory contains `installation.json` and a `.complete` marker. The manifest
+records descriptor version, exact revision, validated files, installation date, license acceptance,
+and the framework build identifier used for the latest successful load. Directory layout:
+
+```text
+Application Support/LocalModels/
+├── installed/<percent-encoded stable model ID>/
+│   ├── installation.json
+│   ├── *.gguf or MLX model files
+│   └── .complete
+├── staging/<download UUID>/
+│   ├── download-plan.json
+│   └── partial files
+└── quarantine/<download UUID>/
+    └── validation-failure.json
+```
+
+All directories are excluded from backup and use the app's protected-file policy. A directory
+without both a valid manifest and `.complete` is never presented as installed. Quarantine is bounded
+by age and total size and contains no credentials.
+
+### Scheduled-run state
+
+Keep task definition separate from mutable execution state:
+
+```swift
+enum ScheduledTaskRunStatus: Codable, Equatable {
+    case succeeded(reported: Bool)
+    case deferred(reason: ScheduleDeferralReason)
+    case couldNotCheck(reason: ScheduleCheckFailure)
+    case failed(SanitizedTaskFailure)
+    case cancelled
+}
+
+struct ScheduledTaskState: Codable, Equatable {
+    let taskID: String
+    var lastAttemptAt: Date?
+    var lastSuccessAt: Date?
+    var nextEligibleAt: Date?
+    var consecutiveFailures: Int
+    var firstFailureAt: Date?
+    var lastFailure: SanitizedTaskFailure?
+    var lastWarningAt: Date?
+    var recentRuns: [ScheduledTaskRunRecord]
+}
+```
+
+`[NOTHING]` remains an output adapter and maps to `succeeded(reported: false)`. It is not a failure.
+The store retains a bounded run history per task (default 20 records) and no response text.
+
+### Memory curation records
+
+```swift
+struct MemoryCurationBatch: Codable, Sendable {
+    let id: UUID
+    let cursorBefore: MemoryCurationCursor
+    let inputReferences: [MemoryInputReference]
+    let createdAt: Date
+    var state: MemoryCurationBatchState
+    var proposedMutations: [MemoryMutationProposal]
+    var appliedMutationIDs: Set<String>
+}
+
+enum MemoryMutationProposal: Codable, Sendable {
+    case upsertMemory(idempotencyKey: String, record: CuratedMemoryRecord)
+    case supersedeMemory(idempotencyKey: String, oldID: String, replacementID: String)
+    case proposeSkill(idempotencyKey: String, proposal: CuratedSkillProposal)
+    case noOp(idempotencyKey: String, reason: MemoryNoOpReason)
+}
+```
+
+Every proposal names the input records that justify it and a confidence. The committer validates
+scope, size, and allowed mutation type again; it does not trust model-produced operation names.
+
+## Work packages and pull-request sequence
+
+### P0 / PR1 — Runtime seam, model records, and migration
+
+Build the deterministic core before linking another inference engine.
+
+1. Add `LocalModelRuntime`, `LocalModelDescriptor`, `InstalledLocalModel`, `LocalModelRepository`,
+   `LocalInferenceBackend`, and `LocalInferenceCoordinator`.
+2. Wrap the existing MLX implementation in `MLXLocalInferenceBackend`. This should initially be a
+   thin adapter around the current load/generate/unload code, not a behavior rewrite.
+3. Keep `LocalLLMService` as the UI-compatible façade. Route one feature-flagged MLX generation
+   through the coordinator and assert byte-for-byte-equivalent prompt assembly and equivalent
+   streamed-output semantics.
+4. Move the recommended model list into a versioned bundled catalog while preserving the current
+   static accessors as compatibility projections.
+5. Add a legacy migration:
+   - known saved MLX IDs resolve to their bundled descriptor;
+   - unknown IDs resolve to a compatibility MLX descriptor;
+   - already downloaded MLX directories are discovered without moving files in this PR;
+   - migration is idempotent and writes a version only after successful validation.
+6. Implement backend-aware admission in `LocalModelBudget`. Inputs include runtime, declared weights,
+   configured context, live app footprint, available process memory, image working set, and a safety
+   reserve. The output is `allow`, `allowConstrained`, or a typed refusal.
+7. Add feature flags `localRuntimeCoordinatorEnabled`, `ggufModelsEnabled`,
+   `durableSchedulerStateEnabled`, and `memoryCurationEnabled`, all default off.
+
+PR1 exit criteria:
+
+- every current local-model test remains green;
+- existing MLX models load and generate through the compatibility façade;
+- no model redownload occurs;
+- the coordinator refuses a second resident model and unloads cleanly; and
+- decoding any pre-DZ saved model/task configuration succeeds.
+
+### P1 / PR2 — Reproducible llama runtime package
+
+Add the native runtime as a local package named `LlamaCpp`.
+
+Expected package layout:
+
+```text
+Vendor/LlamaCpp/
+├── Package.swift
+├── Sources/LlamaCppWrapper/
+│   ├── include/LlamaCppWrapper.h
+│   └── LlamaCppWrapper.mm
+├── Frameworks/llama.xcframework        # fetched/generated, not hand-edited
+├── REVISION
+├── SHA256SUMS
+└── NOTICES.md
+Scripts/build-llamacpp-framework.sh
+Scripts/fetch-llamacpp-framework.sh     # if CI consumes a prebuilt artifact
+```
+
+Requirements:
+
+- Pin an exact engine revision in `REVISION`; never build a moving branch.
+- Produce device and simulator slices for the current iOS deployment target and merge them into one
+  XCFramework. Enable Metal and Accelerate; omit command-line tools, examples, tests, and server code.
+- The build script validates the expected revision, build options, architectures, and final digest.
+- Prefer a small Objective-C++/C wrapper with an intentionally minimal C ABI over exposing unstable
+  C++ types to Swift. The wrapper exposes model/context lifecycle, metadata lookup, tokenization,
+  chat-template application, batched decode, sampling, detokenization, cancellation checks, and
+  accelerator synchronization.
+- Add the local package to `project.base.yml` and the root Swift package if both build surfaces need
+  the application services. Do not edit a generated Xcode project.
+- Update post-clone CI to fetch or build the framework and validate its checksum before resolving the
+  app. Keep large generated binaries out of ordinary source commits unless repository policy is
+  explicitly changed.
+- Record third-party notices and compile settings in the vendored package.
+- Add a compile-only smoke test that imports the wrapper in Debug, Release, device, and simulator
+  configurations. A successful simulator build is not evidence that Metal device execution works.
+
+PR2 exit criteria:
+
+- a clean clone can deterministically obtain the exact binary;
+- checksum or revision drift fails with a clear error;
+- Debug and Release compile for simulator and device; and
+- removing `ggufModelsEnabled` from the active build leaves all MLX behavior unchanged.
+
+### P1 / PR3 — Text-only GGUF load and generation
+
+Implement `LlamaCppLocalInferenceBackend` as an actor.
+
+Load flow:
+
+1. Resolve a completed installation by stable ID and validate the manifest again.
+2. Ask the coordinator for exclusive residency and run the memory-admission policy.
+3. Load model metadata without guessing architecture or chat format from the filename.
+4. Read and validate the embedded chat template. If it cannot render a minimal system/user/assistant
+   exchange, return `unsupportedChatTemplate` and unload.
+5. Clamp context length to the smaller of model capability, descriptor policy, and memory budget.
+6. Create the context and sampler; publish loaded state only after all resources succeed.
+7. On any failure, destroy partially created resources in reverse order and report a typed error.
+
+Generation flow:
+
+1. Reject images in the text-only phase with `visionNotAvailable`.
+2. Convert `LocalChatMessage` values into the runtime's chat-message representation.
+3. Apply the embedded template, tokenize with special-token handling appropriate to the template,
+   and calculate the output reserve.
+4. If `promptTokens + outputReserve > nContext`, fail before decode with counts in the diagnostic
+   metadata but not the prompt text.
+5. Clear the KV cache for every request.
+6. Decode prompt tokens in chunks `<= nBatch`, checking cancellation between chunks.
+7. Sample one token at a time, stop on EOS, configured stop sequences, cancellation, or output cap,
+   and emit only valid Swift strings.
+8. Use a byte accumulator for token pieces so split UTF-8 sequences are not emitted as replacement
+   characters or dropped.
+9. Record load time, prompt-decode time, first-token latency, generated-token count, tokens/second,
+   context usage, memory-headroom deltas, and thermal state.
+10. Synchronize outstanding accelerator work during cancellation and before resource destruction.
+
+Sampling starts with conservative app-owned defaults: temperature, top-p, top-k, repeat penalty,
+and deterministic seed injection for tests. Per-model overrides live in the bundled descriptor, not
+in filename heuristics.
+
+Tool behavior remains in `LLMService`. The backend streams assistant text in the same shape as MLX,
+including any textual tool-call envelope expected by the current parser. Curated models marked
+`toolFriendly` must pass a tool-call conformance fixture before receiving that capability.
+
+PR3 exit criteria:
+
+- a curated small GGUF loads, answers a one-turn prompt, and unloads on a physical device;
+- a second turn contains exactly one copy of each prior message;
+- a prompt longer than `nBatch` succeeds through multiple decode calls;
+- an over-context prompt fails before native decode;
+- cancellation stops token delivery and releases the coordinator lease; and
+- switching GGUF → MLX → GGUF does not leave two model allocations resident.
+
+### P2 / PR4 — Safe catalog, repository importer, and downloader
+
+Add one acquisition pipeline used by curated entries and custom public-repository imports.
+
+#### Import parsing
+
+- Accept `owner/repository` or a full repository URL.
+- Reject schemes other than HTTPS, embedded credentials, query-based token material, malformed
+  repository names, non-allowlisted hosts, and paths outside the repository form.
+- Resolve repository metadata to an exact immutable revision before creating a download plan.
+- Enumerate eligible `.gguf` files and optional projector files. Never execute repository scripts or
+  consume arbitrary HTML.
+- Parse quantization labels as display metadata, not as trust evidence. Prefer a curated default only
+  when the exact file is present; otherwise require user selection.
+
+#### Fit and consent
+
+Before download, show:
+
+- model name, runtime, quantization, capabilities, exact download size, and available storage;
+- a conservative load verdict based on declared weights plus working reserve;
+- the license summary and acceptance control when required; and
+- a warning that an import may install successfully but remain unloadable if its architecture or
+  chat template is unsupported.
+
+Unknown size, missing digest, or unresolved revision prevents installation. An unreadable free-space
+reading is a visible inability to check, not permission to proceed optimistically.
+
+#### Download state machine
+
+```text
+planned → awaitingConsent → queued → downloading → validating → installing → installed
+                          ↘ cancelled
+downloading/validating/installing → failed(retryable | terminal)
+```
+
+- Use a background `URLSession` with a stable task identifier and persisted `download-plan.json`.
+- Limit acquisition to one model plan at a time and download a plan's files sequentially to bound
+  disk and memory pressure.
+- Restore task-to-plan mapping after relaunch; progress comes from persisted expected/completed bytes,
+  not only in-memory callbacks.
+- Stream to staging files. Do not buffer model files into memory.
+- Revalidate the final redirect host and HTTPS policy for every response.
+- Verify normalized destination containment, HTTP status, expected bytes, and SHA-256 before install.
+- Move the completed staging directory atomically, write `.complete` last, and then publish installed
+  state. Power loss at every prior step must leave either the previous installation or a recoverable
+  staging plan, never a half-installed model.
+- Cancellation removes the session tasks and moves incomplete state to bounded quarantine or deletes
+  only the exact validated staging directory.
+- Deleting a model first cancels its downloads, then unloads it if resident, then removes the exact
+  installed directory after checking it is beneath the model root.
+
+#### Catalog policy
+
+Ship a small bundled GGUF catalog, initially text-only and tool-capable where verified. Each entry has
+an exact revision, exact files, digests, context policy, memory estimate, and license metadata. Do not
+add a model based only on a successful load; it must complete the conversation, long-prompt,
+cancellation, tool-call, and device-memory fixtures relevant to its capability badges.
+
+PR4 exit criteria:
+
+- curated and custom imports use the same state machine;
+- pause/relaunch/resume preserves progress;
+- size, digest, redirect, traversal, and revision mismatches cannot produce `.complete`;
+- cancellation and deletion affect only the selected model plan; and
+- the app recovers cleanly from termination during each transition.
+
+### P2 / PR5 — Local model manager and diagnostics
+
+Extend `LocalModelManagerView` instead of creating a second model screen.
+
+Required UI:
+
+- filter or group by MLX/GGUF and text/vision capability;
+- runtime and quantization badges;
+- installed, staged, incompatible, loaded, and update-available states;
+- download size, on-disk size, estimated working memory, and current fit verdict;
+- per-file/background progress with cancel and retry;
+- load, unload, remove, and “show incompatibility reason” actions;
+- a custom import sheet with repository parser, file/quant selection, license acceptance, and final
+  download confirmation; and
+- a diagnostic card showing framework revision, model revision, context, first-token latency,
+  tokens/second, memory delta, and thermal state.
+
+Accessibility requirements:
+
+- progress changes are announced at bounded intervals, plus completion/failure immediately;
+- badges have full VoiceOver labels rather than relying on color;
+- destructive removal requires confirmation and names whether staged and installed files are removed;
+- unsupported models explain what metadata or runtime capability is missing; and
+- leaving the screen during a background download explicitly says the download continues.
+
+The selected local model stored in app configuration becomes a stable `LocalModelID`; the runtime is
+resolved from the descriptor. For one compatibility release, retain the legacy string field and keep
+it synchronized. Downgrading to a build without DZ must still leave an MLX selection usable.
+
+### P1 / PR6 — Durable scheduler semantics
+
+This work can begin after P0 contracts and does not wait for the GGUF UI.
+
+1. Extract pure `SchedulePolicy` functions for due calculation, recurrence, retry delay, catch-up,
+   warning thresholds, and next wake suggestion.
+2. Add an actor-backed `AgentScheduleStore` using an atomically replaced JSON file in Application
+   Support. Store task definitions and execution state separately. Migrate the existing
+   `agentScheduledTasks` blob once; retain it as a rollback copy for one release.
+3. Replace `TaskRunOutcome.completed` with the typed statuses above. Every error path must classify
+   itself; an absent `appState` is `couldNotCheck`, never success.
+4. Update state as follows:
+   - every dispatched run records `lastAttemptAt`;
+   - only `succeeded` records `lastSuccessAt` and advances normal recurrence;
+   - `deferred` sets a short eligibility delay without incrementing failure count;
+   - `couldNotCheck` and `failed` increment consecutive failures and apply bounded exponential
+     backoff with deterministic jitter injection for tests;
+   - `cancelled` records the attempt but neither success nor failure streak; and
+   - the first subsequent success resets failure state and warning suppression.
+5. Prevent catch-up storms. On activation, a periodic task may run at most once even if several
+   periods were missed, then schedules from the successful current run. A once-daily task may catch
+   up once within its configured day window. Only one task runs per scheduler cycle.
+6. Preserve the current foreground timer as an opportunistic trigger. Add a background-refresh
+   adapter only as another chance to call the same policy; never claim exact timing.
+7. Apply backend-aware execution policy:
+   - loaded local model + foreground: eligible;
+   - unloaded local model: deferred without auto-load;
+   - background local model: deferred;
+   - cloud model: eligible only if its existing credentials, privacy mode, network policy, and task
+     configuration permit cloud use; and
+   - no silent runtime fallback for a task pinned to a specific model.
+8. Warn through `AgentNotificationQueue` after three consecutive failed/could-not-check attempts or
+   six hours without a successful check, whichever is later. Suppress repeats for 24 hours unless
+   the failure reason materially changes. Recovery clears the warning episode.
+9. Add a bounded task history and status details to `ScheduledTasksView`: last success, last attempt,
+   next eligibility, failure streak, sanitized reason, and “Run now”. Manual runs use the same
+   outcome and persistence path.
+
+Suggested initial retry delays are 5, 15, 30, 60, and 120 minutes, capped at two hours. The policy
+owns these values so tests do not sleep and product tuning does not alter execution code.
+
+PR6 exit criteria:
+
+- thrown errors never update `lastSuccessAt`;
+- deferred local work retries only when eligible and does not increase the failure streak;
+- relaunch preserves attempts, backoff, and warning suppression;
+- a week of missed intervals produces one catch-up run, not a replay storm;
+- recovery resets the episode and produces no stale warning; and
+- existing task creation/edit/delete flows operate through the new store.
+
+### P2 / PR7 — Two-stage memory curation
+
+Replace the current scheduled “memory reflection” prompt with a dedicated, opt-in pipeline. The old
+task remains disabled during migration and is removed only after this phase is proven.
+
+#### Stage A — Freeze an immutable input batch
+
+1. Read completed conversation-turn references after the durable cursor, bounded by turn count,
+   character count, age, and active memory/privacy policy.
+2. Record stable input references and the cursor-before value in `MemoryCurationStore` before invoking
+   a model. Do not copy attachments, images, or full chat history into the curation database.
+3. Ask an injected analyzer for a strictly structured set of candidate facts, preferences,
+   procedures, corrections, and explicit no-ops. Local-only is the default. In a privacy mode that
+   forbids cloud processing, the analyzer must be an already loaded local model or the batch defers.
+4. Validate the analyzer output against app-owned enums, size limits, scopes, and provenance. Unknown
+   operations, autonomous instructions, tool grants, and personality/safety edits are rejected.
+5. Persist the validated proposals with deterministic idempotency keys derived from input IDs,
+   mutation kind, scope, and normalized content.
+
+#### Stage B — Curate and commit
+
+1. Resolve candidate duplicates against `SemanticMemoryStore` and pending/applied curation batches.
+2. Classify each proposal as insert, update, supersede, skill proposal, or no-op. Conflicting facts do
+   not overwrite silently: keep the previous record, add a correction linked to it, and expose the
+   conflict for later user review.
+3. Before any bounded rewrite of `AgentDocumentStore.memory`, create a versioned snapshot containing
+   the prior bytes, digest, date, and batch ID. Keep the most recent 10 snapshots and any snapshot
+   newer than 30 days; never prune the only known-good snapshot.
+4. Apply memory mutations through authoritative store APIs. Supersession uses tombstones/links rather
+   than hard deletion. Skill-shaped knowledge goes only to `EvolvedSkillStore` as a pending proposal.
+5. Record each committed idempotency key immediately. A retry skips already committed mutations and
+   resumes the remaining plan.
+6. Advance the global cursor only after every proposal is committed or recorded as an explicit no-op.
+   A failed write leaves the batch retryable with the prior cursor.
+7. Enforce a `MemoryCurationBudget` for injected memory, individual records, proposal counts, and
+   document size. Prefer relevance and recency while preserving explicit user memories. Exact defaults
+   live in one tested policy type.
+
+#### Trigger and controls
+
+- Trigger after a configurable number of completed turns or from a two-hour scheduler opportunity,
+  whichever comes first. Only one curation batch may run at a time.
+- Default off for existing users. The control explains what content is analyzed, whether cloud is
+  allowed, and that learned skills still require review.
+- Add a phone status surface under Memory: enabled state, analyzer policy, pending batch, last success,
+  last error, proposed-skill count, snapshot list, and restore action.
+- Restoring a snapshot requires confirmation, creates a snapshot of the current bytes first, performs
+  an atomic replacement, and records an audit event. It does not rewind unrelated semantic memories.
+- Disabling curation stops future batches without deleting existing memory. “Erase curation history”
+  removes batch metadata only after no batch is running and does not imply erasing authoritative
+  memories.
+
+PR7 exit criteria:
+
+- a failed mutation cannot advance the cursor;
+- process termination between mutations resumes without duplicate records;
+- identical input is idempotent across retries and relaunch;
+- `SOUL`, active `SKILLS`, tool grants, schedules, and safety settings cannot be mutation targets;
+- cloud analysis is impossible when the active privacy policy forbids it;
+- every destructive document rewrite has a verified, restorable snapshot; and
+- the current immediate memory loop still works without double-saving curated facts.
+
+### P3 / PR8 — GGUF multimodal adapter, gated on text evidence
+
+Do not start this phase until PR3–PR5 have passed the device matrix and switching between runtimes no
+longer shows unexplained memory growth.
+
+Add an optional multimodal adapter around the runtime's supported projector path:
+
+- model descriptors name the exact projector file and compatible model revision;
+- load validates model/projector compatibility before publishing vision capability;
+- `LocalGenerationRequest.images` accepts bounded, normalized images and text messages;
+- image preprocessing runs off the main actor, preserves aspect ratio, and uses
+  `LocalModelBudget.multimodalTurnPlan` plus live `MemoryHeadroom` at turn time;
+- below the safe headroom floor, the request fails before allocating image tensors;
+- image tokens and text tokens share one context-budget calculation;
+- projector/context allocations stay within the GGUF backend actor and unload with it; and
+- vision routes advertise capability only after a real image fixture succeeds on that installation.
+
+The initial consumer is an explicit photo question. Continuous scene narration remains gated until
+its latency, thermal duty cycle, and Metal contention with local TTS are measured. No camera-frame
+retention is added.
+
+PR8 exit criteria:
+
+- a curated model answers a fixed image fixture on supported physical devices;
+- incompatible or missing projector files fail before generation;
+- the measured low-headroom scenario returns an error rather than process termination;
+- repeated image turns have bounded footprint growth; and
+- text-only models never appear vision-capable.
+
+### P4 / PR9 — Optional skill-pack storage binding
+
+This phase is independent and must not delay the inference, scheduler, or memory tracks. Implement it
+only when a real data-only pack needs durable structured state.
+
+Extend `SkillPackBinding` with a declarative storage operation:
+
+```swift
+case storage(StorageBinding)
+
+struct StorageBinding: Codable, Equatable {
+    let collection: String
+    let operation: Operation       // append, set, update, delete, query
+    let schema: Data               // bounded JSON Schema subset
+    let argumentMap: [String: String]
+    let query: StorageQuery?
+}
+```
+
+Host requirements:
+
+- one SQLite namespace per installed pack ID; pack IDs and collection names never become unchecked
+  filesystem paths;
+- JSON values only, validated against a bounded schema subset with maximum nesting, field count,
+  string length, row count, query limit, and per-pack byte quota;
+- no SQL, JavaScript, HTML, expressions, network calls, dynamic imports, or file access supplied by
+  the pack;
+- all actions flow through the same composed-tool authority and audit path as other bindings;
+- delete and bulk update require the existing destructive-action confirmation policy;
+- pack uninstall asks whether to retain or erase namespaced data and reports the exact choice; and
+- schema upgrades are explicit versioned migrations that can be validated without executing pack
+  code.
+
+PR9 exit criteria:
+
+- two packs cannot read or mutate each other's namespace;
+- malformed schemas and quota overruns fail without partial writes;
+- CRUD and bounded query behavior are deterministic and headless-testable;
+- destructive confirmation cannot be bypassed through a composed action; and
+- unknown storage operations are surfaced in the existing lossy-decode report.
+
+## Expected file changes
+
+New runtime/model files:
+
+```text
+OpenGlasses/Sources/Services/LocalInference/
+├── LocalInferenceBackend.swift
+├── LocalInferenceCoordinator.swift
+├── LocalInferenceTypes.swift
+├── LocalModelCatalog.swift
+├── LocalModelRepository.swift
+├── LocalModelDownloadManager.swift
+├── LocalModelDownloadPlan.swift
+├── MLXLocalInferenceBackend.swift
+└── LlamaCpp/
+    ├── LlamaCppLocalInferenceBackend.swift
+    ├── LlamaCppChatTemplate.swift
+    ├── LlamaCppTokenDecoder.swift
+    └── GGUFMetadataValidator.swift
+Vendor/LlamaCpp/**
+Scripts/build-llamacpp-framework.sh
+Scripts/fetch-llamacpp-framework.sh
+OpenGlasses/Sources/Resources/LocalModelCatalog.json
+```
+
+New durability files:
+
+```text
+OpenGlasses/Sources/Services/Scheduling/
+├── AgentScheduleStore.swift
+├── SchedulePolicy.swift
+└── ScheduledTaskRunState.swift
+OpenGlasses/Sources/Services/Memory/Curation/
+├── MemoryCurationStore.swift
+├── MemoryCurationPlanner.swift
+├── MemoryCurationCommitter.swift
+├── MemoryCurationBudget.swift
+└── MemoryDocumentSnapshotStore.swift
+OpenGlasses/Sources/Services/SkillPacks/
+└── SkillPackStorage.swift                     # optional P4 only
+```
+
+Existing files expected to change:
+
+- `OpenGlasses/Sources/Services/LocalLLMService.swift` — compatibility façade and state projection.
+- `OpenGlasses/Sources/Services/LLMService.swift` — backend-neutral local routing only; tool loop stays.
+- `OpenGlasses/Sources/Services/LocalModelBudget.swift` and `MemoryHeadroom.swift` — backend-aware
+  admission and metrics inputs.
+- `OpenGlasses/Sources/App/Views/LocalModelManagerView.swift` — unified manager and import sheet.
+- `OpenGlasses/Sources/App/Views/ModelFormView.swift` and configuration migration — stable model IDs.
+- `OpenGlasses/Sources/Services/AgentScheduler.swift` and
+  `OpenGlasses/Sources/App/Views/ScheduledTasksView.swift` — typed outcomes/store/status.
+- `OpenGlasses/Sources/Services/Memory/MemoryLoopService.swift` — deduplication handoff and trigger.
+- `OpenGlasses/Sources/Services/AgentDocumentStore.swift` — snapshot-safe atomic memory replacement.
+- `OpenGlasses/Sources/Models/SkillPackManifest.swift` and binding executor — optional storage case.
+- `project.base.yml`, root `Package.swift`, post-clone CI, privacy metadata, and localized strings.
+
+File placement may be adjusted to match the codebase at implementation time, but ownership boundaries
+and actor isolation should remain as specified.
+
+## Test plan
+
+### Pure unit tests
+
+- legacy model-ID migration defaults to MLX and is idempotent;
+- descriptor/revision/file validation and stable-ID encoding;
+- repository URL parser and host/scheme rejection;
+- relative-path normalization rejects absolute paths, `..`, encoded traversal, and symlink escape;
+- GGUF filename/quantization display parsing without capability inference;
+- model fit verdicts across runtime, context, footprint, headroom, and thermal inputs;
+- context/output-reserve calculation and over-context refusal;
+- prompt partitioning produces only batches `<= nBatch`;
+- full-history rendering plus KV reset on every generation using a fake backend;
+- split UTF-8 token pieces produce the intended string exactly once;
+- stop-sequence matching across token-piece boundaries;
+- download-plan transitions, relaunch restoration, cancellation, digest mismatch, size mismatch,
+  redirect rejection, atomic install, and power-loss recovery;
+- schedule due calculation, daily windows, single catch-up, retry ladder, warning suppression, recovery,
+  and deterministic jitter;
+- every scheduler error classification leaves `lastSuccessAt` unchanged;
+- curation cursor persistence, validation, idempotency, partial-commit retry, conflict handling, size
+  budget, snapshot pruning, and restore;
+- curation mutation validator refuses authority/safety/personality targets;
+- privacy policy refuses cloud analysis when prohibited; and
+- optional skill storage schema, namespace isolation, quota, CRUD, bounded query, confirmation, and
+  lossy-decode reporting.
+
+### Integration tests with fakes
+
+- coordinator load/cancel/unload ordering across MLX and GGUF fake backends;
+- only one resident backend lease at a time;
+- `LLMService` receives equivalent streamed text from both local runtimes and keeps tool execution in
+  the existing authority path;
+- task execution persists an attempt before dispatch and a status after completion;
+- queued notifications survive reconnection without duplicating a successful run;
+- curation termination after each mutation boundary resumes exactly once; and
+- snapshot write failure prevents destructive document replacement.
+
+### Physical-device evidence
+
+For each supported phone tier, record Debug and Release separately:
+
+- cold load duration and peak footprint;
+- first-token latency and decode tokens/second for short and long prompts;
+- 20-turn conversation correctness and footprint trend;
+- prompt larger than one batch;
+- cancellation during prompt decode and during token generation;
+- GGUF ↔ MLX switching and post-unload memory recovery;
+- 15-minute generation session thermal state and battery delta;
+- background/foreground transition during download;
+- low-storage download refusal and relaunch recovery;
+- scheduler activation with loaded local, unloaded local, and permitted cloud models; and
+- multimodal long-edge tiers, headroom refusal, repeated photo turns, and local-TTS contention when P3
+  begins.
+
+Record device model, OS build, app build, runtime/framework revision, model revision/quantization,
+context size, and whether increased-memory entitlement is active. Never record prompts or responses.
+
+## Rollout and rollback
+
+1. Land P0 with all flags off and exercise MLX through internal tests only.
+2. Enable GGUF framework/runtime for developer builds, then an internal cohort with one curated small
+   text model.
+3. Enable public-repository import only after the curated path survives relaunch and corruption tests.
+4. Enable durable scheduler state independently. Keep the legacy task blob for one release and offer
+   a one-way repair command that can rebuild state from task definitions without inventing success.
+   Before cutover the flag selects the legacy implementation; after the migrated scheduler ships,
+   turning its kill switch off pauses scheduling and must never reactivate the legacy executor.
+5. Enable memory curation for internal users, local-analyzer-only, with snapshot UI visible before any
+   document compaction. Expand analyzer policy only after privacy review.
+6. Add multimodal capability per exact model/device tier, never globally by runtime.
+7. Keep skill storage off until a signed pack and product flow justify it.
+
+Rollback behavior:
+
+- disabling GGUF prevents load/import but leaves validated installations for re-enable or explicit
+  removal; MLX remains available;
+- a native-runtime crash kill switch refuses new GGUF loads without touching model files;
+- disabling durable scheduler state pauses scheduler execution rather than falling back to the old
+  success-on-error path;
+- disabling curation stops new batches and retains snapshots/pending work for review; and
+- disabling skill storage makes those actions unavailable without deleting pack data.
+
+## Risk register and mitigations
+
+| Risk | Required mitigation |
+|---|---|
+| Native ABI or build drift | Exact revision, reproducible script, checksums, compile matrix, narrow wrapper |
+| Jetsam while switching models | Single coordinator lease, awaited unload/sync, live headroom gate, device matrix |
+| Incorrect multi-turn answers | Clear KV per call, full-history template fixture, 20-turn device test |
+| Oversized prompt crashes decode | Preflight context budget and `nBatch` partitioning |
+| Invalid UTF-8 streaming | Byte accumulator with boundary tests |
+| Malicious or corrupt model path | HTTPS allowlist, exact revision, size/digest validation, containment checks, atomic install |
+| Background task claims exceed iOS behavior | Opportunistic semantics, typed deferral, no local auto-load, visible last-success state |
+| Retry or catch-up notification storm | One task per cycle, bounded backoff, one catch-up, episode warning suppression |
+| Memory corruption or silent loss | Immutable batch, snapshot-before-rewrite, idempotent commits, cursor-last transaction |
+| Curation changes assistant authority | App-owned mutation enum, denylist by construction, skill proposal review only |
+| Diagnostics leak private content | Typed metadata fields, no free-form prompt/response/path logging |
+| Skill pack becomes executable app platform | Declarative JSON-only operations, host schema/quota/authority enforcement |
+
+## Exit criteria
+
+The core plan is complete when P0–P2 and PR6–PR7 satisfy all of the following:
+
+- existing MLX models and configurations work without migration loss or redownload;
+- at least one curated text GGUF can be installed, loaded, used across 20 turns, cancelled, unloaded,
+  and switched with MLX on every supported device tier that advertises it;
+- install state is revision-pinned, resumable, integrity-checked, and crash-consistent;
+- custom public imports cannot bypass host, path, size, digest, template, or architecture validation;
+- local tool-capable output enters the existing tool authority path and cannot execute directly;
+- scheduled failures are never recorded as successes, retry state survives relaunch, and missed work
+  cannot create a catch-up storm;
+- curation retries cannot duplicate memories or advance past a failed write;
+- users can see curation status and restore every document rewrite from a verified snapshot;
+- privacy modes prevent prohibited cloud analysis and diagnostics contain no user content; and
+- feature flags can independently disable GGUF, scheduler execution, curation, and optional pack
+  storage without deleting user data or breaking MLX.
+
+Multimodal GGUF and skill-pack storage have their own PR exit criteria and do not block declaring the
+core text/runtime/durability plan shipped.
+
+## Explicit non-goals
+
+- Replacing MLX, Apple Intelligence, or cloud providers.
+- Running local Metal inference as a reliable background service.
+- Shipping arbitrary binaries, scripts, JavaScript, HTML/WebView agents, or repository-provided code.
+- Letting a native runtime own conversation history, tool execution, memory policy, or UI.
+- Guessing chat templates, architecture, capability, context, or projector compatibility from names.
+- Automatically downloading a large model during onboarding, launch, or a scheduled task.
+- Supporting gated/private repositories in the first importer.
+- Remotely mutating the bundled catalog without signed, rollback-safe metadata.
+- Autonomously editing `SOUL`, activating learned skills, changing safety policy, or granting tools.
+- Replacing authoritative memory stores with a copied universal memory database.
+- Promising exact-time scheduling or replaying every interval missed while iOS suspended the app.
+- Enabling continuous GGUF vision before explicit photo turns pass memory, thermal, and contention
+  evidence on physical devices.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -141,6 +141,7 @@ core first, with the live/device/backend edge deferred; one PR per plan.
 | [DW](DW-offline-perception-tier.md) | Offline Perception Tier: Local STT and Vision Fallback | 📝 Drafted 2026-08-27 — mic-tap fan-out audit, a locale-independent on-device transducer ASR tier behind the transcription seam (with silence-trim and split-timeout hygiene), and a backgroundable Vision classify+OCR caption floor terminating the model fallback chain |
 | [DX](DX-private-memory-timeline.md) | Private Memory Timeline and Control Surface | 📝 Drafted 2026-08-29 — phone-first provenance, correction, deletion, and federated search over existing authoritative memory stores; no copied timeline database or HUD dependency; conversation entries require DK P0–P2 |
 | [DY](DY-my-day-everyday-briefing.md) | My Day: Everyday Briefing and Preparation | 🟠 P0/P1 MVP implemented + automated suite green 2026-08-30 — feature-flagged phone/audio snapshot over shared Calendar, Reminders, and Weather sources with deterministic ranking/actions; physical UX validation, MapKit leave-by, and digest remain; no waveguide dependency |
+| [DZ](DZ-local-gguf-and-durable-agent-runtime.md) | Local GGUF Runtime and Durable Agent Loops | 📝 Drafted 2026-08-30 — adds a second, text-first local runtime beside MLX, revision-pinned resumable model acquisition, truthful scheduled-task outcomes, transactional memory curation, and separately gated multimodal/skill-storage follow-ups |
 
 **Three selectable expert-stream transports** (Plans L/M + the meeting-link connector): **MJPEG** (same-LAN browser viewer), **Meeting link** (zero-infra — your meeting tool hosts the call; recommended for remote, nothing to self-host), and **WebRTC** (self-hosted peer-to-peer, needs your own signaling + TURN).
 
@@ -229,6 +230,11 @@ the suggested sequences.
   composer; P1 is an on-demand phone/spoken briefing; P2 adds route-backed leave-by; P3 adds evening
   preparation and opt-in scheduling. DX contracts may proceed independently, but its visible product
   surface follows the daily loop. No waveguide/HUD dependency.
+- **Round 20 — local model breadth and durable agent loops (DZ).** Land the backend-neutral runtime
+  and legacy-safe model migration first, then the reproducible text GGUF backend before its unified
+  downloader and manager UI. Durable scheduler outcomes can proceed after the shared contracts and
+  should land before memory curation uses scheduling opportunities. Multimodal GGUF waits for the
+  text-runtime device matrix; declarative skill-pack storage is an optional independent follow-up.
 - **Standalone tools.** First-Aid (AA), HECA (AC), Structured Vision (AD), Study Mode (AE), Memory/Recall (AY), Vehicle (AZ), and the planned/drafted items (AB, AF, AG, AH, AI, BP) sit outside a single round but are indexed and lettered above.
 
 ## Dependency graph


### PR DESCRIPTION
## Summary
- harden My Day for timezone and DST changes, overlapping and all-day events, missing locations, route and weather failure, protected-data lock state, and permission regrant
- add a deterministic 35-second estimated speech ceiling and local-only fixed-schema aggregate metrics with no source-content fields or network path
- add P4 automated coverage and separate it from the still-pending physical-device matrix in Plan DY
- include the requested Plan DZ draft and plans index entry

## Verification
- P4-only suite: 11 passed, 0 skipped, 0 failed on iPhone 17 Pro / iOS 27 simulator
- focused My Day suite: 41 passed, 0 skipped, 0 failed on iPhone 17 / iOS 27 simulator
- full unit suite: 3,785 passed, 4 environment-gated skips, 0 failed (3,789 total)
- Release iOS Simulator build with Xcode 27: passed

## Physical-device status
No physical-device checks were performed. Plan DY keeps permission-sheet and regrant, live timezone and DST, real EventKit and MapKit, offline Weather, locked-phone delivery, oldest-phone latency and speech timing, VoiceOver, and largest Dynamic Type verification explicitly pending.