### PR TITLE
Fix captions overlay accessibility regression

### DIFF
--- a/OpenGlasses/Sources/App/Views/VoiceTab.swift
+++ b/OpenGlasses/Sources/App/Views/VoiceTab.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 /// Voice tab — the primary interaction screen, kept to three zones:
 ///
@@ -12,6 +13,7 @@ struct VoiceTab: View {
     @State private var showModelPicker = false
     @State private var showPersonaPicker = false
     @State private var showChatInput = false
+    @State private var captionsActive = false
     @AppStorage("myDayEnabled") private var myDayEnabled = false
     @ScaledMetric(relativeTo: .caption) private var recordingDot: CGFloat = 8
     @Environment(\.dynamicTypeSize) private var typeSize
@@ -60,6 +62,7 @@ struct VoiceTab: View {
             }
         }
         }
+        .onReceive(appState.ambientCaptions.$isActive) { captionsActive = $0 }
         .fullScreenCover(isPresented: $showPreview) {
             LivePreviewView()
                 .environmentObject(appState)
@@ -79,7 +82,8 @@ struct VoiceTab: View {
 
     /// The shipped three-zone composition: status card at the top, useful day context in the
     /// middle, then captions and transcript above the dock. My Day contracts while listening and
-    /// yields the centre entirely while the assistant thinks or speaks.
+    /// yields the centre entirely while the assistant thinks or speaks, or while live captions
+    /// need the space to keep every line readable.
     @ViewBuilder
     private func conversationZone(_ voiceState: VoiceVisualState) -> some View {
         // Status card — one status surface: state, mode, persona, and the connection
@@ -90,7 +94,7 @@ struct VoiceTab: View {
 
         Spacer()
 
-        if voiceState != .thinking && voiceState != .speaking {
+        if shouldShowMyDay(for: voiceState) {
             MyDayHomeView(
                 service: appState.myDayService,
                 isEnabled: $myDayEnabled,
@@ -102,7 +106,7 @@ struct VoiceTab: View {
         Spacer()
 
         // Ambient captions
-        if appState.ambientCaptions.isActive {
+        if captionsActive {
             AmbientCaptionOverlay(captionService: appState.ambientCaptions)
                 .padding(.bottom, 8)
         }
@@ -124,7 +128,8 @@ struct VoiceTab: View {
     /// So above the accessibility threshold the conversation zone scrolls and the dock stays
     /// pinned, which is the same trade onboarding's hero pages make. Unlike the old decorative
     /// waveline, My Day is content, so it remains reachable here and uses its compact form while
-    /// listening. It still yields while the assistant thinks or speaks.
+    /// listening. It still yields while the assistant thinks or speaks, and while live captions
+    /// are active so the same content priority applies at every text size.
     @ViewBuilder
     private func accessibleConversationZone(_ voiceState: VoiceVisualState) -> some View {
         ScrollView {
@@ -132,7 +137,7 @@ struct VoiceTab: View {
                 StatusIndicator(session: session, openAISession: openAISession,
                                 openClawBridge: appState.openClawBridge)
 
-                if voiceState != .thinking && voiceState != .speaking {
+                if shouldShowMyDay(for: voiceState) {
                     MyDayHomeView(
                         service: appState.myDayService,
                         isEnabled: $myDayEnabled,
@@ -140,7 +145,7 @@ struct VoiceTab: View {
                     )
                 }
 
-                if appState.ambientCaptions.isActive {
+                if captionsActive {
                     AmbientCaptionOverlay(captionService: appState.ambientCaptions)
                 }
 
@@ -149,6 +154,14 @@ struct VoiceTab: View {
             .padding(.top, 12)
             .padding(.bottom, 8)
         }
+    }
+
+    /// Captions are current speech and cannot be recovered if their rows are compressed. My Day
+    /// remains one tap away after the caption session ends, so it gives the conversation zone to
+    /// captions just as it already does to an assistant response.
+    private func shouldShowMyDay(for voiceState: VoiceVisualState) -> Bool {
+        guard !captionsActive else { return false }
+        return voiceState != .thinking && voiceState != .speaking
     }
 
     // MARK: - Recording Badge

--- a/OpenGlassesUITests/SessionSurfaceAccessibilityTests.swift
+++ b/OpenGlassesUITests/SessionSurfaceAccessibilityTests.swift
@@ -70,6 +70,11 @@ final class SessionSurfaceAccessibilityTests: AccessibilityAuditCase {
         XCTAssertTrue(liveLine.waitForExistence(timeout: 60),
                       "The live caption line does not name itself as the current line")
 
+        XCTAssertFalse(
+            app.staticTexts["Put what matters next here instead of an animation."].exists,
+            "My Day is still occupying the conversation zone while live captions need its height"
+        )
+
         audit(app, screen: "Session surface — captions overlay",
               deferring: [.contrastThroughGlass, .focusableCaptionHistory])
     }


### PR DESCRIPTION
## Summary
- observe live-caption activation so the Voice surface reliably updates when captions start or stop
- let live captions take the conversation zone instead of compressing beneath the My Day setup card
- assert the My Day setup card yields before the captions accessibility audit runs

## Validation
- full OpenGlasses unit suite passed
- Release simulator build succeeded
- reproduced the original focused audit failure locally: three textClipped findings
- verified the corrected seeded layout in the simulator; the local Xcode 27 beta UI runner omitted XCUIApplication launch arguments on post-fix attempts and opened onboarding, so the accessibility-labeled CI run is the authoritative post-fix audit