### PR TITLE
Invite trial-license requests in the Field Assist access note

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ Hands-free, step-by-step guidance for technicians and other hands-busy work. Pro
 | "Next step" / "Go back" / "Repeat that" | Navigate the procedure hands-free |
 | "Call an expert" | Bridges to a remote human with live glasses video |
 
-**Access:** Field Assist unlocks with a signed license code (teams — issued with your purchase order) or a one-time in-app purchase. TestFlight builds unlock through the StoreKit sandbox at no charge, so beta testers don't need a code.
+**Access:** Field Assist unlocks with a signed license code (teams — issued with your purchase order) or a one-time in-app purchase. TestFlight builds unlock through the StoreKit sandbox at no charge, so beta testers don't need a code. Want to evaluate it? [Email us](mailto:g@skunkworks.kiwi?subject=Field%20Assist%20trial%20license) for a temporary trial license.
 
 ### Medical Compliance
 


### PR DESCRIPTION
Follow-up to #374: adds a one-line invite to the Field Assist access note — evaluators can email g@skunkworks.kiwi (the README's existing commercial contact) for a temporary trial license. No live code is published in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)