### PR TITLE
Sentence-case My Day headlines and drop 'all day' from all-day events

### DIFF
--- a/OpenGlasses/Sources/Services/MyDay/MyDayComposer.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayComposer.swift
@@ -296,7 +296,9 @@ struct MyDayComposer: Sendable {
         var parts: [String] = []
         if period == .evening, let firstTomorrow {
             if firstTomorrow.isAllDay {
-                parts.append("tomorrow includes \(firstTomorrow.title) all day")
+                // No "all day" here: an event named "X's birthday" already is, and the absence
+                // of a time says the rest. The card's detail row still carries the qualifier.
+                parts.append("tomorrow includes \(firstTomorrow.title)")
             } else {
                 parts.append("tomorrow starts with \(firstTomorrow.title) at \(formatTime(firstTomorrow.startDate))")
             }
@@ -315,7 +317,14 @@ struct MyDayComposer: Sendable {
             }
             return items.isEmpty ? "Your day is clear." : "Here is what matters today."
         }
-        return parts.joined(separator: "; ") + "."
+        return Self.sentenceCased(parts.joined(separator: "; ")) + "."
+    }
+
+    /// Capitalize only the leading character — the parts are written mid-sentence ("tomorrow
+    /// includes…") and event titles keep their own casing.
+    static func sentenceCased(_ text: String) -> String {
+        guard let first = text.first else { return text }
+        return first.uppercased() + text.dropFirst()
     }
 
     private func formatTime(_ date: Date) -> String {

--- a/OpenGlassesTests/MyDayComposerTests.swift
+++ b/OpenGlassesTests/MyDayComposerTests.swift
@@ -143,7 +143,26 @@ final class MyDayComposerTests: XCTestCase {
         XCTAssertEqual(snapshot.items.map(\.id.rawValue), ["first", "prepare:first"])
         XCTAssertTrue(snapshot.items[0].detail?.contains("Tomorrow") == true)
         XCTAssertEqual(snapshot.items[1].kind, .preparation)
-        XCTAssertTrue(snapshot.headline.contains("tomorrow starts with Event first"))
+        XCTAssertTrue(snapshot.headline.contains("Tomorrow starts with Event first"))
+        XCTAssertTrue(snapshot.headline.first?.isUppercase == true,
+                      "headline is a sentence and must start capitalized")
+    }
+
+    /// "X's birthday, all day" reads as parody — an all-day event's headline names the event and
+    /// lets the missing time say the rest. The card detail row keeps the qualifier.
+    func testEveningHeadlineForAllDayEventOmitsAllDay() {
+        let birthday = MyDayCalendarEvent(
+            id: "bday", title: "Mike's birthday",
+            startDate: date(0, day: 31), endDate: date(23, day: 31, minute: 59),
+            isAllDay: true, location: nil)
+        let snapshot = MyDayComposer(calendar: calendar).compose(
+            inputs: inputs(events: [birthday]),
+            now: date(20)
+        )
+        XCTAssertTrue(snapshot.headline.contains("Tomorrow includes Mike's birthday"))
+        XCTAssertFalse(snapshot.headline.contains("all day"))
+        XCTAssertTrue(snapshot.items[0].detail?.contains("all day") == true,
+                      "the detail row keeps the schedule qualifier")
     }
 
     func testDigestUpdatesAreCappedAtTwoAndOnlyFillRemainingCapacity() {


### PR DESCRIPTION
On-device feedback: the My Day headline rendered as "tomorrow includes Mike Kilpatrick's 52nd birthday all day" — lowercase sentence start, and an 'all day' qualifier that is self-parody on a birthday. Headlines now sentence-case their leading character at the join (titles keep their own casing) and all-day events drop the qualifier from the headline; the card's detail row keeps "Tomorrow, all day" where it is genuine schedule information. New composer test pins both; full suite green (3859 ran; the single failing pair was the documented erased-sim cold-start flake, green in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)