### PR TITLE
Speed up the noisy-JPEG test fixture (25+ min → seconds)

### DIFF
--- a/OpenGlassesTests/LLMImagePreparerTests.swift
+++ b/OpenGlassesTests/LLMImagePreparerTests.swift
@@ -135,20 +135,28 @@ final class LLMImagePreparerTests: XCTestCase {
     }
 
     /// Noise defeats JPEG's entropy coding, so this actually lands over the byte caps a flat
-    /// colour would sail under.
+    /// colour would sail under. Filled as a raw pixel buffer (deterministic xorshift) rather
+    /// than per-pixel CoreGraphics fills, which took minutes at 12 MP.
     private func noisyJPEG(width: Int, height: Int) -> Data {
-        let format = UIGraphicsImageRendererFormat.default()
-        format.scale = 1
-        let image = UIGraphicsImageRenderer(size: CGSize(width: width, height: height), format: format).image { ctx in
-            for y in stride(from: 0, to: height, by: 2) {
-                for x in stride(from: 0, to: width, by: 2) {
-                    UIColor(hue: CGFloat((x &* 7 &+ y &* 13) % 360) / 360,
-                            saturation: 1, brightness: 1, alpha: 1).setFill()
-                    ctx.fill(CGRect(x: x, y: y, width: 2, height: 2))
-                }
+        let bytesPerRow = width * 4
+        var pixels = Data(count: bytesPerRow * height)
+        pixels.withUnsafeMutableBytes { buffer in
+            let words = buffer.bindMemory(to: UInt64.self)
+            var state: UInt64 = 0x9E37_79B9_7F4A_7C15
+            for i in words.indices {
+                state ^= state << 13
+                state ^= state >> 7
+                state ^= state << 17
+                words[i] = state
             }
         }
-        return image.jpegData(compressionQuality: 1.0)!
+        let cg = CGImage(width: width, height: height,
+                         bitsPerComponent: 8, bitsPerPixel: 32, bytesPerRow: bytesPerRow,
+                         space: CGColorSpaceCreateDeviceRGB(),
+                         bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipLast.rawValue),
+                         provider: CGDataProvider(data: pixels as CFData)!,
+                         decode: nil, shouldInterpolate: false, intent: .defaultIntent)!
+        return UIImage(cgImage: cg).jpegData(compressionQuality: 1.0)!
     }
 
     func testRealFramesAreNotDegenerate() {


### PR DESCRIPTION
## Summary
- `LLMImagePreparerTests.noisyJPEG(width:height:)` built its high-entropy fixture with one `UIColor` + `ctx.fill` call per 2×2 block — ~3.05M CoreGraphics calls at 12 MP — which made `testOriginalIsStillHeldToTheProviderCeiling` and `testACompactPresetCapsBothBytesAndLongEdge` each run 25+ minutes at ~99% CPU and stall the whole `xcodebuild test` run.
- The fixture is now a raw RGBA buffer filled by a deterministic xorshift64 sequence and wrapped in a `CGImage` (`.noneSkipLast`, so the alpha byte is ignored), then JPEG-encoded at quality 1.0. Per-pixel white noise is strictly higher-entropy than the old 2×2 hue blocks, so it compresses even worse.
- The load-bearing assertion is unchanged: `testACompactPresetCapsBothBytesAndLongEdge` still verifies the fixture genuinely exceeds `limits.maxBytes` before exercising the preparer.

## Test plan
- Focused run (`-only-testing:OpenGlassesTests/LLMImagePreparerTests`, iOS simulator via Xcode-beta, `SWIFT_EMIT_LOC_STRINGS=NO`): 13/13 passed in 2.3s; the two rewritten tests at 1.66s / 0.13s.
- Full suite: passed (`** TEST SUCCEEDED **`, zero failing test cases), with the two tests at 1.653s and 0.499s. (A first full-suite attempt hit the known intermittent runner flake with no individual test failure; the immediate re-run was clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)