### PR TITLE
Render the picked conversation and curate My Day reminders to the day (EB round 2)

### DIFF
--- a/OpenGlasses/Sources/App/Views/BottomControlBar.swift
+++ b/OpenGlasses/Sources/App/Views/BottomControlBar.swift
@@ -222,17 +222,15 @@ struct BottomControlBar: View {
 
     // MARK: - Pages
 
-    /// The transcript, and above it the header that says *which* conversation it is. The header
+    /// The conversation, and above it the header that says *which* conversation it is. The header
     /// does not scroll with the transcript: "start a new one" and "go back to an earlier one" have
     /// to be reachable from the bottom of a long reply, not just the top.
     private var conversationPage: some View {
         VStack(spacing: 6) {
             ConversationPageHeader(store: appState.conversationStore)
-            ScrollView(.vertical) {
-                TranscriptOverlay(session: session, openAISession: openAISession)
-                    .padding(.horizontal, 2)
-            }
-            .scrollBounceBehavior(.basedOnSize)
+            ConversationPageBody(store: appState.conversationStore,
+                                 session: session,
+                                 openAISession: openAISession)
         }
     }
 

--- a/OpenGlasses/Sources/App/Views/Chat/ChatThreadView.swift
+++ b/OpenGlasses/Sources/App/Views/Chat/ChatThreadView.swift
@@ -313,7 +313,11 @@ struct ChatThreadView: View {
 
 /// Assistant bubble for an in-flight, streaming reply (on-device provider). Mirrors the
 /// assistant side of `MessageBubble` but renders live partial text with no timestamp.
-private struct StreamingBubble: View {
+///
+/// Shared with the dock's conversation page, like `MessageBubble` beside it: the two surfaces
+/// render the same conversation and a reply that looked different depending on which one you were
+/// looking at would be two designs for one thing.
+struct StreamingBubble: View {
     let text: String
 
     var body: some View {
@@ -328,8 +332,9 @@ private struct StreamingBubble: View {
     }
 }
 
-/// Three-dot "assistant is thinking" indicator shown while a reply is in flight.
-private struct TypingIndicator: View {
+/// Three-dot "assistant is thinking" indicator shown while a reply is in flight. Shared with the
+/// dock's conversation page.
+struct TypingIndicator: View {
     @State private var phase = 0
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let timer = Timer.publish(every: 0.35, on: .main, in: .common).autoconnect()

--- a/OpenGlasses/Sources/App/Views/ConversationPageBody.swift
+++ b/OpenGlasses/Sources/App/Views/ConversationPageBody.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+/// What sits under the conversation page's header: the conversation, or the live turn.
+///
+/// The page used to be able to draw only the live turn — two cards built from
+/// `AppState.currentTranscription` and `AppState.lastResponse`. Those are *turn* state, and
+/// resuming a thread touches neither, so picking a conversation out of the switcher produced an
+/// active thread with nothing on screen and, on a fresh launch, the empty state under it. The
+/// thread was genuinely active and the model genuinely had its history; the page simply never
+/// rendered a stored message. `ConversationContinuity.PageContent` is the decision, held apart
+/// from the view so both halves are provable without a screen.
+struct ConversationPageBody: View {
+    @EnvironmentObject var appState: AppState
+    /// Observed directly — a nested `ObservableObject`'s changes don't republish through
+    /// `appState`, and this view's whole job is to follow the store.
+    @ObservedObject var store: ConversationStore
+    @ObservedObject var session: GeminiLiveSessionManager
+    @ObservedObject var openAISession: OpenAIRealtimeSessionManager
+
+    private var isRealtime: Bool { appState.currentMode.isRealtime }
+
+    private var liveUserText: String {
+        switch appState.currentMode {
+        case .geminiLive: return session.userTranscript
+        case .openaiRealtime: return openAISession.userTranscript
+        case .direct: return appState.currentTranscription
+        }
+    }
+
+    private var liveAssistantText: String {
+        switch appState.currentMode {
+        case .geminiLive: return session.aiTranscript
+        case .openaiRealtime: return openAISession.aiTranscript
+        case .direct: return appState.lastResponse
+        }
+    }
+
+    private var content: ConversationContinuity.PageContent {
+        ConversationContinuity.pageContent(
+            store: store,
+            isRealtimeSession: isRealtime,
+            liveUserText: liveUserText,
+            liveAssistantText: liveAssistantText)
+    }
+
+    var body: some View {
+        switch content {
+        case .history(let threadId):
+            ConversationThreadTranscript(store: store, threadId: threadId)
+        case .liveTurn, .empty:
+            // `TranscriptOverlay` owns the live cards and the empty copy, and keeps owning them:
+            // in a realtime session it is the only honest view, and before the first turn is
+            // persisted it is the only thing there is to draw.
+            ScrollView(.vertical) {
+                TranscriptOverlay(session: session, openAISession: openAISession)
+                    .padding(.horizontal, 2)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+        }
+    }
+}
+
+/// One conversation, on the dock's glass: every message in it, scrolled to the newest, with the
+/// in-flight reply appending below.
+///
+/// The same `MessageBubble` the Chat tab draws — a reply that looked different depending on which
+/// surface you read it from would be two designs for one conversation. What differs is the frame:
+/// this one lives inside a fixed-height page of a horizontally-paging panel, so it scrolls
+/// vertically and adds no gesture of its own. That is the axis rule the panel's edit page follows
+/// too: a vertical scroll is not a competing gesture, and a *drag* would be.
+struct ConversationThreadTranscript: View {
+    @EnvironmentObject var appState: AppState
+    @ObservedObject var store: ConversationStore
+    let threadId: String
+
+    private let bottomAnchor = "dock-conversation-bottom"
+
+    private var thread: ConversationThread? { store.threads.first { $0.id == threadId } }
+    private var isThinking: Bool { appState.isProcessing && store.activeThreadId == threadId }
+
+    /// The reply currently streaming into *this* thread, if any.
+    private var streamingText: String? {
+        guard let turn = appState.streamingTurn, turn.threadId == threadId,
+              !turn.text.isEmpty else { return nil }
+        return turn.text
+    }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical) {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    ForEach(thread?.messages ?? []) { message in
+                        MessageBubble(message: message)
+                    }
+                    if let streamingText {
+                        StreamingBubble(text: streamingText)
+                    } else if isThinking {
+                        TypingIndicator()
+                    }
+                    // The scroll target. A one-point spacer rather than the last bubble, so a
+                    // reply that is still growing keeps its own bottom in view.
+                    Color.clear.frame(height: 1).id(bottomAnchor)
+                }
+                .padding(.horizontal, 2)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .onChange(of: thread?.messages.count) { _, _ in scrollToBottom(proxy) }
+            .onChange(of: isThinking) { _, _ in scrollToBottom(proxy) }
+            .onChange(of: streamingText) { _, _ in scrollToBottom(proxy) }
+            // The newest message is the one being read, and switching threads has to land on it
+            // rather than at the top of somebody's afternoon.
+            .onChange(of: threadId) { _, _ in scrollToBottom(proxy, animated: false) }
+            .onAppear { scrollToBottom(proxy, animated: false) }
+        }
+    }
+
+    private func scrollToBottom(_ proxy: ScrollViewProxy, animated: Bool = true) {
+        guard animated else {
+            proxy.scrollTo(bottomAnchor, anchor: .bottom)
+            return
+        }
+        withAnimation(.easeOut(duration: 0.2)) {
+            proxy.scrollTo(bottomAnchor, anchor: .bottom)
+        }
+    }
+}

--- a/OpenGlasses/Sources/App/Views/MyDayView.swift
+++ b/OpenGlasses/Sources/App/Views/MyDayView.swift
@@ -71,7 +71,11 @@ struct MyDayView: View {
         .padding(.horizontal, 4)
         .accessibilityElement(children: .combine)
 
-        if snapshot.items.isEmpty {
+        // The whole day, not the card's share of it. This screen is what "See all" opens, so
+        // anything the cap held back has to be here — otherwise clearing a row is the only way to
+        // discover it existed.
+        let allItems = snapshot.allItems
+        if allItems.isEmpty {
             OGSection {
                 VStack(alignment: .leading, spacing: 6) {
                     Label("Nothing urgent", systemImage: "checkmark.circle")
@@ -85,7 +89,7 @@ struct MyDayView: View {
             }
         } else {
             OGSection(header: "Next") {
-                ForEach(Array(snapshot.items.enumerated()), id: \.element.id) { index, item in
+                ForEach(Array(allItems.enumerated()), id: \.element.id) { index, item in
                     if index > 0 { OGDivider() }
                     MyDaySwipeToClear(label: item.title) {
                         Task { await service.dismiss(item) }
@@ -475,15 +479,29 @@ struct MyDayHomeView: View {
                             .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
+                        // The detail carries which Reminders list a task came from, and the
+                        // compact card does not draw it — so it is spoken explicitly rather than
+                        // left to whatever happened to be rendered.
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel([item.title, item.detail]
+                            .compactMap { $0 }
+                            .joined(separator: ", "))
+                        .accessibilityAddTraits(.isButton)
                         .accessibilityHint("Opens My Day")
                     }
                 }
 
-                if !compact, snapshot.items.count > visibleItems.count {
-                    Button("See all \(snapshot.items.count) items") {
+                // Counts the whole day, not the capped list. It used to count `items`, which is
+                // what the cap left — so a row that arrived when another was cleared looked like
+                // it had materialised, when it had been on the list the whole time and nothing on
+                // screen could say so.
+                let total = snapshot.allItems.count
+                if !compact, total > visibleItems.count {
+                    Button("See all \(total) items") {
                         showDetail = true
                     }
                     .font(.footnote.weight(.semibold))
+                    .accessibilityHint("Opens the full day. \(total - visibleItems.count) more than the card shows.")
                 }
             }
 

--- a/OpenGlasses/Sources/Models/ConversationContinuity.swift
+++ b/OpenGlasses/Sources/Models/ConversationContinuity.swift
@@ -147,6 +147,58 @@ enum ConversationContinuity {
         }
     }
 
+    // MARK: - What the page shows
+
+    /// Which of the two things the conversation page can draw belongs on screen.
+    ///
+    /// The page shipped able to draw exactly one: the live turn's two cards, built from
+    /// `AppState.currentTranscription` and `AppState.lastResponse`. Those are turn state, not
+    /// conversation state — resuming a thread changes neither — so a wearer who picked a
+    /// conversation out of the switcher got an active thread they could not see, under the empty
+    /// state. This type is the missing decision.
+    enum PageContent: Equatable {
+        /// The thread's own messages, oldest first, with the live turn appending below.
+        case history(threadId: String)
+        /// The live turn alone. A realtime session keeps its transcript in the session rather
+        /// than the store, and a wearer with conversation history switched off keeps it nowhere.
+        case liveTurn
+        /// Genuinely nothing said. The only state the empty copy belongs in.
+        case empty
+    }
+
+    /// - Parameters:
+    ///   - isRealtimeSession: Gemini Live / OpenAI Realtime. Their transcripts are the session's
+    ///     and are never persisted, so the live cards remain the only honest view there.
+    static func pageContent(
+        activeThreadId: String?,
+        activeThreadMessageCount: Int,
+        isRealtimeSession: Bool,
+        hasLiveUserText: Bool,
+        hasLiveAssistantText: Bool
+    ) -> PageContent {
+        let hasLiveText = hasLiveUserText || hasLiveAssistantText
+        if isRealtimeSession { return hasLiveText ? .liveTurn : .empty }
+        if let activeThreadId, activeThreadMessageCount > 0 {
+            return .history(threadId: activeThreadId)
+        }
+        // No thread yet, or an empty one, but something was just said: the turn that started this
+        // conversation is on screen before it has been persisted, and after a voice session has
+        // ended its thread the reply the wearer is still reading is only here.
+        return hasLiveText ? .liveTurn : .empty
+    }
+
+    /// The same decision from the live objects, so the page and its tests ask one question.
+    static func pageContent(store: ConversationStore, isRealtimeSession: Bool,
+                            liveUserText: String, liveAssistantText: String) -> PageContent {
+        pageContent(
+            activeThreadId: store.activeThreadId,
+            activeThreadMessageCount: activeThread(in: store)?.messages.count ?? 0,
+            isRealtimeSession: isRealtimeSession,
+            hasLiveUserText: !liveUserText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            hasLiveAssistantText: !liveAssistantText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        )
+    }
+
     // MARK: - VoiceOver
 
     /// A switcher row, spoken: the title, when it was last touched, and whether it is the one the

--- a/OpenGlasses/Sources/Services/MyDay/EventKitDayStore.swift
+++ b/OpenGlasses/Sources/Services/MyDay/EventKitDayStore.swift
@@ -17,6 +17,18 @@ struct EventKitReminderRecord: Equatable {
     let dueDate: Date?
     let hasTime: Bool
     let priority: Int
+    /// `EKReminder.calendar.title` — the Reminders list the item lives on.
+    let listName: String?
+
+    init(id: String, title: String, dueDate: Date?, hasTime: Bool, priority: Int,
+         listName: String? = nil) {
+        self.id = id
+        self.title = title
+        self.dueDate = dueDate
+        self.hasTime = hasTime
+        self.priority = priority
+        self.listName = listName
+    }
 }
 
 @MainActor
@@ -171,7 +183,8 @@ final class EventKitDayStore {
             title: reminder.title?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? "Untitled",
             dueDate: date,
             hasTime: components?.hour != nil,
-            priority: reminder.priority
+            priority: reminder.priority,
+            listName: reminder.calendar?.title.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
         )
     }
 }

--- a/OpenGlasses/Sources/Services/MyDay/MyDayComposer.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayComposer.swift
@@ -46,12 +46,13 @@ struct MyDayComposer: Sendable {
         }
 
         for reminder in inputs.reminders {
-            ranked.append(reminderItem(
+            guard let item = reminderItem(
                 reminder,
                 now: now,
                 startOfToday: startOfToday,
                 startOfTomorrow: startOfTomorrow
-            ))
+            ) else { continue }
+            ranked.append(item)
         }
 
         if let weather = inputs.weather {
@@ -71,11 +72,16 @@ struct MyDayComposer: Sendable {
         // headline describing rows that are gone. Here, a cleared row also frees its slot for the
         // next-ranked one, which is what a wearer clearing clutter is asking for.
         let dismissed = inputs.dismissals
-        let items = ranked
+        let surviving = ranked
             .sorted(by: rankedOrder)
             .filter { !MyDayDismissalPolicy.isDismissed($0.item, in: dismissed) }
-            .prefix(maxItems)
             .map(\.item)
+        // The cap still decides what the card and the spoken briefing carry — but what it left
+        // out travels with the snapshot now instead of vanishing. A row appearing the moment
+        // another was cleared is the same list all along; it only looked like conjuring because
+        // nothing on screen could say how long the list was.
+        let items = Array(surviving.prefix(maxItems))
+        let overflowItems = Array(surviving.dropFirst(maxItems))
 
         return MyDaySnapshot(
             generatedAt: now,
@@ -98,6 +104,7 @@ struct MyDayComposer: Sendable {
                 items: items
             ),
             items: items,
+            overflowItems: overflowItems,
             sourceStates: inputs.sourceStates.sorted { $0.source.rawValue < $1.source.rawValue },
             nextRefreshAt: calendar.date(byAdding: .minute, value: 15, to: now)
         )
@@ -191,27 +198,43 @@ struct MyDayComposer: Sendable {
         )
     }
 
+    /// A reminder's row, or nil if it is not part of *today*.
+    ///
+    /// My Day carried every incomplete reminder, ranking the undated ones last. On a real list
+    /// that is most of them: a "someday" pile with no date attached is not a day's work, and it
+    /// crowded out the things that were. So the card takes exactly two kinds — overdue, and due
+    /// today — and everything else stays in Reminders, which is the app for it. Future-dated items
+    /// were already ranked last for the same reason and are now excluded outright, so tomorrow's
+    /// task cannot displace today's.
+    ///
+    /// This is the same contract the morning-only all-day rule set: the card curates, the source
+    /// app keeps everything.
     private func reminderItem(
         _ reminder: MyDayReminder,
         now: Date,
         startOfToday: Date,
         startOfTomorrow: Date
-    ) -> RankedItem {
-        let isOverdue = reminder.dueDate.map { due in
-            reminder.hasTime ? due < now : due < startOfToday
-        } ?? false
-        let isDueToday = reminder.dueDate.map { $0 >= startOfToday && $0 < startOfTomorrow } ?? false
-        let rank = isOverdue ? 2 : (isDueToday ? 3 : 6)
-        let urgency: MyDayUrgency = isOverdue ? .important : (isDueToday ? .upcoming : .routine)
+    ) -> RankedItem? {
+        guard let dueDate = reminder.dueDate else { return nil }
+        let isOverdue = reminder.hasTime ? dueDate < now : dueDate < startOfToday
+        let isDueToday = dueDate >= startOfToday && dueDate < startOfTomorrow
+        guard isOverdue || isDueToday else { return nil }
 
-        let detail: String?
+        let rank = isOverdue ? 2 : 3
+        let urgency: MyDayUrgency = isOverdue ? .important : .upcoming
+
+        let timing: String
         if isOverdue {
-            detail = "Overdue"
-        } else if let due = reminder.dueDate, isDueToday {
-            detail = reminder.hasTime ? "Due \(formatTime(due))" : "Due today"
+            timing = "Overdue"
         } else {
-            detail = nil
+            timing = reminder.hasTime ? "Due \(formatTime(dueDate))" : "Due today"
         }
+        // The list is the answer to "which part of my life is this?", which a bare title cannot
+        // give when the day's reminders arrive from every list at once.
+        let detail = [timing, reminder.listName]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
 
         return RankedItem(
             rank: rank,

--- a/OpenGlasses/Sources/Services/MyDay/MyDayModels.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDayModels.swift
@@ -91,9 +91,33 @@ struct MyDaySnapshot: Equatable, Sendable {
     let generatedAt: Date
     let period: MyDayPeriod
     let headline: String
+    /// What the card and every budgeted consumer (the spoken briefing, the digest, the HUD) draw
+    /// from: ranked, cleared rows removed, capped.
     let items: [MyDayItem]
+    /// What the cap left out, still ranked and still the wearer's day.
+    ///
+    /// It exists because the cap used to be *invisible*: clearing a row let the next-ranked one
+    /// appear, which reads as items materialising out of nowhere rather than as a list that was
+    /// always longer than the card. The full-day surface shows these; nothing that speaks or
+    /// summarises does, because that is what the cap is for.
+    let overflowItems: [MyDayItem]
     let sourceStates: [MyDaySourceState]
     let nextRefreshAt: Date?
+
+    /// Everything the day actually holds, in rank order — what "See all N" must count and open.
+    var allItems: [MyDayItem] { items + overflowItems }
+
+    init(generatedAt: Date, period: MyDayPeriod, headline: String, items: [MyDayItem],
+         overflowItems: [MyDayItem] = [], sourceStates: [MyDaySourceState],
+         nextRefreshAt: Date?) {
+        self.generatedAt = generatedAt
+        self.period = period
+        self.headline = headline
+        self.items = items
+        self.overflowItems = overflowItems
+        self.sourceStates = sourceStates
+        self.nextRefreshAt = nextRefreshAt
+    }
 }
 
 struct MyDayCalendarEvent: Equatable, Sendable {
@@ -111,6 +135,22 @@ struct MyDayReminder: Equatable, Sendable {
     let dueDate: Date?
     let hasTime: Bool
     let priority: Int
+    /// The Reminders list this came from ("Shopping", "Work").
+    ///
+    /// Carried because a day's reminders arrive from every list at once and, without it, a row is
+    /// just a title with no way to tell which part of your life it belongs to. It is the wearer's
+    /// own words: it belongs on the row and in what VoiceOver reads, and in no log line.
+    let listName: String?
+
+    init(id: String, title: String, dueDate: Date?, hasTime: Bool, priority: Int,
+         listName: String? = nil) {
+        self.id = id
+        self.title = title
+        self.dueDate = dueDate
+        self.hasTime = hasTime
+        self.priority = priority
+        self.listName = listName
+    }
 }
 
 struct MyDayWeather: Equatable, Sendable {

--- a/OpenGlasses/Sources/Services/MyDay/MyDaySources.swift
+++ b/OpenGlasses/Sources/Services/MyDay/MyDaySources.swift
@@ -75,7 +75,8 @@ extension EventKitDayStore: RemindersDaySource {
                     title: $0.title,
                     dueDate: $0.dueDate,
                     hasTime: $0.hasTime,
-                    priority: $0.priority
+                    priority: $0.priority,
+                    listName: $0.listName
                 )
             }
             return .init(value: reminders, state: .available(.reminders))

--- a/OpenGlasses/Sources/Utils/UITestSupport.swift
+++ b/OpenGlasses/Sources/Utils/UITestSupport.swift
@@ -29,6 +29,9 @@ enum UITestSupport {
         /// My Day set up and loaded with a full card's worth of rows — the state that needs a
         /// calendar, a permission grant and a real morning to reach otherwise.
         case seedMyDay = "-OGUITestSeedMyDay"
+        /// Stored conversations, one of them long — the state the dock's conversation page needs
+        /// to be looked at at all, and which otherwise takes a real session per thread to reach.
+        case seedConversations = "-OGUITestSeedConversations"
         /// A delete-and-reinstall: the Keychain kept a provider key, `UserDefaults` kept nothing.
         case reinstall = "-OGUITestReinstall"
     }
@@ -134,6 +137,10 @@ enum UITestSupport {
             appState.myDayService.seedForUITest(seededDay())
         }
 
+        if isSet(.seedConversations) {
+            seedConversations(appState)
+        }
+
         if isSet(.seedCaptions) {
             seedCaptions(appState)
             // Re-applied on a tick rather than written once. With no glasses to talk to, the app
@@ -185,6 +192,51 @@ enum UITestSupport {
             nextRefreshAt: now.addingTimeInterval(900)
         )
     }
+
+    /// Two finished conversations, the older one long enough to have to scroll.
+    ///
+    /// Written through the store's own `startThread`/`appendMessage`, so what lands on disk is
+    /// exactly what a real session would have left — and then ended, which is the state a wearer
+    /// is actually in when they reach for the switcher: a thread worth resuming and nothing
+    /// active.
+    ///
+    /// Deterministic: the conversations file lives in Documents and outlives the defaults wipe, so
+    /// this clears before it seeds rather than piling a fresh pair on every launch.
+    @MainActor
+    private static func seedConversations(_ appState: AppState) {
+        let store = appState.conversationStore
+        guard !store.isLocked else { return }
+        store.deleteAllThreads()
+
+        store.startThread(mode: AppMode.direct.rawValue)
+        for (question, answer) in longExchange {
+            store.appendMessage(role: "user", content: question)
+            store.appendMessage(role: "assistant", content: answer)
+        }
+        store.endThread()
+
+        store.startThread(mode: AppMode.direct.rawValue)
+        store.appendMessage(role: "user", content: "What time does the hardware store close?")
+        store.appendMessage(role: "assistant",
+                            content: "It closes at 5:30 today, and it's about eleven minutes away.")
+        store.endThread()
+    }
+
+    /// Long enough that the panel's page has to scroll, with one reply that wraps to several
+    /// lines — the two things a fixed-height transcript has to survive.
+    private static let longExchange: [(String, String)] = [
+        ("What's the flashing on the roof made of?",
+         "It's galvanised steel, and the section above the valley has started to lift."),
+        ("Is that something I can fix myself?",
+         "The lifted section can be re-fastened with roofing screws and butyl tape, which is a "
+         + "morning's work if you're comfortable on the roof. The valley itself is worth leaving "
+         + "to a roofer: if the underlay below it has torn, re-fastening the flashing over the "
+         + "top just hides the leak until the next heavy rain."),
+        ("What would a roofer charge for that?",
+         "For a single valley, usually a call-out plus an hour or two of labour."),
+        ("Remind me what tape you said.",
+         "Butyl tape — the black rubbery kind, not the foil-faced flashing tape."),
+    ]
 
     /// The lines a real session would have produced. Two of the three carry a diarized speaker, so
     /// the speaker chip is on screen for the audit to measure — without one the chip never renders

--- a/OpenGlassesTests/ConversationContinuityTests.swift
+++ b/OpenGlassesTests/ConversationContinuityTests.swift
@@ -242,6 +242,95 @@ final class ConversationContinuityTests: XCTestCase {
         XCTAssertEqual(ConversationContinuity.recentThreads(in: store, limit: 1).map(\.id), [newer])
     }
 
+    // MARK: What the page draws (EB device round 2)
+
+    /// The defect, at the seam that caused it: resuming a thread changed the store and the model's
+    /// context and nothing else, because the page could only ever draw the live turn. A resumed
+    /// thread has to *be* what the page draws.
+    func testAResumedThreadIsWhatThePageDraws() {
+        let (older, _) = seedTwoThreads()
+        ConversationContinuity.resume(older, in: store) { _ in }
+
+        XCTAssertEqual(
+            ConversationContinuity.pageContent(store: store, isRealtimeSession: false,
+                                               liveUserText: "", liveAssistantText: ""),
+            .history(threadId: older),
+            "A resumed conversation with messages in it still isn't what the page shows"
+        )
+    }
+
+    /// The empty state is for a conversation with nothing in it — not for one the page merely
+    /// cannot render.
+    func testTheEmptyStateOnlyAppliesWhenNothingHasBeenSaid() {
+        XCTAssertEqual(
+            ConversationContinuity.pageContent(store: store, isRealtimeSession: false,
+                                               liveUserText: "", liveAssistantText: ""),
+            .empty)
+
+        let fresh = store.startThread(mode: "direct")
+        XCTAssertEqual(
+            ConversationContinuity.pageContent(store: store, isRealtimeSession: false,
+                                               liveUserText: "", liveAssistantText: ""),
+            .empty,
+            "A thread with no messages is genuinely empty")
+
+        store.appendMessage(role: "user", content: "first thing")
+        XCTAssertEqual(
+            ConversationContinuity.pageContent(store: store, isRealtimeSession: false,
+                                               liveUserText: "", liveAssistantText: ""),
+            .history(threadId: fresh.id))
+    }
+
+    /// Before the first turn is persisted — and after a voice session has ended its thread — the
+    /// live cards are the only thing there is to draw, and the page keeps drawing them.
+    func testTheLiveTurnStillShowsWhenNoThreadHoldsIt() {
+        XCTAssertEqual(
+            ConversationContinuity.pageContent(
+                activeThreadId: nil, activeThreadMessageCount: 0, isRealtimeSession: false,
+                hasLiveUserText: true, hasLiveAssistantText: false),
+            .liveTurn,
+            "A turn with conversation history switched off has nowhere else to be shown")
+
+        let (_, newer) = seedTwoThreads()
+        store.endThread()
+        XCTAssertEqual(
+            ConversationContinuity.pageContent(store: store, isRealtimeSession: false,
+                                               liveUserText: "", liveAssistantText: "The fence is fine."),
+            .liveTurn,
+            "The reply the wearer is still reading vanished when its thread ended")
+        // And taking the carry-on offer puts the conversation itself back on the page.
+        ConversationContinuity.resume(newer, in: store) { _ in }
+        XCTAssertEqual(
+            ConversationContinuity.pageContent(store: store, isRealtimeSession: false,
+                                               liveUserText: "", liveAssistantText: "The fence is fine."),
+            .history(threadId: newer))
+    }
+
+    /// A realtime session's transcript belongs to the session and is never persisted, so the live
+    /// cards stay the honest view there however many stored threads exist.
+    func testARealtimeSessionKeepsTheLiveCards() {
+        let (older, _) = seedTwoThreads()
+        ConversationContinuity.resume(older, in: store) { _ in }
+
+        XCTAssertEqual(
+            ConversationContinuity.pageContent(store: store, isRealtimeSession: true,
+                                               liveUserText: "what is this",
+                                               liveAssistantText: "A fuse box."),
+            .liveTurn)
+        XCTAssertEqual(
+            ConversationContinuity.pageContent(store: store, isRealtimeSession: true,
+                                               liveUserText: "", liveAssistantText: ""),
+            .empty)
+    }
+
+    /// Whitespace is not something said.
+    func testBlankLiveTextIsNotATurn() {
+        XCTAssertEqual(
+            ConversationContinuity.pageContent(store: store, isRealtimeSession: false,
+                                               liveUserText: "  ", liveAssistantText: "\n"),
+            .empty)
+    }
+
     // MARK: Copy
 
     /// Delete-all states the count, and neither modal blurs deletion with the view-level clearing

--- a/OpenGlassesTests/MyDayComposerTests.swift
+++ b/OpenGlassesTests/MyDayComposerTests.swift
@@ -56,10 +56,102 @@ final class MyDayComposerTests: XCTestCase {
                 weather: .init(summary: "Rain this afternoon.", isDecisionRelevant: true)
             ), now: now)
 
+        // "someday" is undated, and an undated reminder is not part of a day. It stays in
+        // Reminders rather than taking a slot from something with a time on it.
         XCTAssertEqual(snapshot.items.map(\.id.rawValue),
-                       ["imminent", "overdue", "due", "current", "later", "someday"])
+                       ["imminent", "overdue", "due", "current", "later"])
         XCTAssertEqual(snapshot.items.first?.urgency, .immediate)
-        XCTAssertEqual(snapshot.items.count, 6)
+        XCTAssertEqual(snapshot.items.count, 5)
+    }
+
+    // MARK: - Which reminders belong to a day (EB device round 2)
+
+    /// The policy in one table: overdue and due-today are the day; undated and future are not.
+    func testOnlyOverdueAndDueTodayRemindersReachTheCard() {
+        let snapshot = MyDayComposer(calendar: calendar).compose(
+            inputs: inputs(reminders: [
+                reminder("someday", due: nil),
+                reminder("tomorrow", due: date(10, day: 31)),
+                reminder("today", due: date(15)),
+                reminder("overdue", due: date(8))
+            ]),
+            now: date(9)
+        )
+
+        let ids = snapshot.allItems.map(\.id.rawValue)
+        XCTAssertEqual(ids, ["overdue", "today"])
+        XCTAssertFalse(ids.contains("someday"), "An undated reminder is not a day's work")
+        XCTAssertFalse(ids.contains("tomorrow"), "Tomorrow's task displaced today's")
+    }
+
+    /// A date-only reminder for tomorrow lands exactly on the boundary the filter uses, which is
+    /// the case an off-by-one gets wrong in the direction that matters.
+    func testTomorrowsDateOnlyReminderIsNotTodays() {
+        let snapshot = MyDayComposer(calendar: calendar).compose(
+            inputs: inputs(reminders: [
+                .init(id: "tomorrow", title: "Bin day", dueDate: date(0, day: 31),
+                      hasTime: false, priority: 0)
+            ]),
+            now: date(9)
+        )
+        XCTAssertTrue(snapshot.allItems.isEmpty)
+    }
+
+    /// Which list a task came from is the difference between a legible day and a pile of titles.
+    func testAReminderSaysWhichListItCameFrom() {
+        let snapshot = MyDayComposer(calendar: calendar, locale: Locale(identifier: "en_NZ"))
+            .compose(inputs: inputs(reminders: [
+                .init(id: "milk", title: "Milk", dueDate: date(15), hasTime: true,
+                      priority: 0, listName: "Shopping"),
+                .init(id: "invoice", title: "Send the invoice", dueDate: date(8), hasTime: true,
+                      priority: 0, listName: "Work"),
+                .init(id: "unlisted", title: "Water plants", dueDate: date(0), hasTime: false,
+                      priority: 0)
+            ]), now: date(9))
+
+        let details = Dictionary(uniqueKeysWithValues:
+            snapshot.allItems.map { ($0.id.rawValue, $0.detail ?? "") })
+        XCTAssertEqual(details["invoice"], "Overdue · Work")
+        XCTAssertTrue(details["milk"]?.hasSuffix(" · Shopping") == true,
+                      "A due time lost its list: \(details["milk"] ?? "nil")")
+        XCTAssertEqual(details["unlisted"], "Due today",
+                       "A reminder with no list must not grow a stray separator")
+    }
+
+    /// The cap still decides what the card carries, but what it left out travels with the
+    /// snapshot — the difference between "a longer list" and rows materialising when one is
+    /// cleared.
+    func testWhatTheCapLeavesOutIsCarriedRatherThanLost() {
+        let reminders = (0..<8).map { reminder("r\($0)", due: date(9, minute: $0 * 5)) }
+        let snapshot = MyDayComposer(calendar: calendar, maxItems: 3)
+            .compose(inputs: inputs(reminders: reminders), now: date(8))
+
+        XCTAssertEqual(snapshot.items.count, 3)
+        XCTAssertEqual(snapshot.overflowItems.count, 5)
+        XCTAssertEqual(snapshot.allItems.count, 8)
+        XCTAssertEqual(snapshot.allItems.map(\.id.rawValue),
+                       (0..<8).map { "r\($0)" },
+                       "The overflow is the rest of the same ranking, not a re-sorted tail")
+        // And the spoken/HUD budget is untouched: those read `items`, which the cap still bounds.
+        XCTAssertEqual(snapshot.items.map(\.id.rawValue), ["r0", "r1", "r2"])
+    }
+
+    /// Clearing a row promotes the next one — which was always the intent — and the total the card
+    /// reports falls by exactly one, so nothing appears from nowhere.
+    func testClearingARowPromotesTheNextAndTheTotalDrops() {
+        let reminders = (0..<5).map { reminder("r\($0)", due: date(9, minute: $0 * 5)) }
+        let composer = MyDayComposer(calendar: calendar, maxItems: 3)
+        let before = composer.compose(inputs: inputs(reminders: reminders), now: date(8))
+        XCTAssertEqual(before.allItems.count, 5)
+
+        let cleared = before.items[0]
+        let after = composer.compose(
+            inputs: inputs(reminders: reminders,
+                           dismissals: [cleared.id.dismissalKey: cleared.dismissalFingerprint]),
+            now: date(8))
+
+        XCTAssertEqual(after.allItems.count, 4)
+        XCTAssertEqual(after.items.map(\.id.rawValue), ["r1", "r2", "r3"])
     }
 
     func testRoutineWeatherNeverDisplacesHigherPriorityItems() {

--- a/OpenGlassesUITests/AccessibilityAudit.swift
+++ b/OpenGlassesUITests/AccessibilityAudit.swift
@@ -10,6 +10,7 @@ enum LaunchState: String {
     case configured = "-OGUITestConfigured"
     case showAllSettings = "-OGUITestShowAllSettings"
     case seedCaptions = "-OGUITestSeedCaptions"
+    case seedConversations = "-OGUITestSeedConversations"
     case reinstall = "-OGUITestReinstall"
 }
 

--- a/OpenGlassesUITests/ConversationPageTests.swift
+++ b/OpenGlassesUITests/ConversationPageTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+
+/// The dock's conversation page, driven the way a wearer drives it.
+///
+/// This exists because of a device report the unit suite could not have caught: picking an earlier
+/// conversation from the switcher left the page reading "Nothing said yet." The store had been
+/// resumed and the model had its history — the page simply never rendered a stored message, only
+/// the live turn's two cards. Everything about that is invisible to a headless test, because both
+/// halves were individually correct.
+final class ConversationPageTests: AccessibilityAuditCase {
+
+    /// A line from the older seeded conversation (see `UITestSupport.longExchange`).
+    private let seededReply = "It's galvanised steel"
+    private let seededQuestion = "What's the flashing on the roof made of?"
+
+    func testPickingAConversationShowsWhatWasSaidInIt() {
+        let app = launch([.configured, .seedConversations])
+        awaitScreen(app.tabBars.buttons["Voice"], named: "The tab bar")
+
+        openConversationPage(app)
+        let header = conversationHeader(app)
+        XCTAssertTrue(header.waitForExistence(timeout: 10),
+                      "The conversation page has no header naming the conversation")
+        header.tap()
+
+        let row = app.buttons.containing(
+            NSPredicate(format: "label CONTAINS[c] %@", "flashing")
+        ).firstMatch
+        XCTAssertTrue(row.waitForExistence(timeout: 10),
+                      "The switcher does not list the seeded conversation")
+        row.tap()
+
+        // The whole point: after picking it, the page shows what is *in* it.
+        XCTAssertTrue(
+            waitForText(app, containing: seededReply, timeout: 15),
+            "Picking a conversation left the page showing none of its messages — the resumed "
+            + "thread is active invisibly, which is exactly the reported defect."
+        )
+        XCTAssertTrue(
+            waitForText(app, containing: seededQuestion, timeout: 5),
+            "The wearer's own side of the resumed conversation is missing"
+        )
+        XCTAssertFalse(app.staticTexts["Nothing said yet."].exists,
+                       "A conversation with messages in it is still drawing the empty state")
+    }
+
+    /// The other half of the same mechanism: a finished voice turn ends its thread, so the page
+    /// offers to carry on with it. Taking the offer has to render the conversation too.
+    func testCarryingOnWithTheLastConversationShowsIt() {
+        let app = launch([.configured, .seedConversations])
+        awaitScreen(app.tabBars.buttons["Voice"], named: "The tab bar")
+
+        openConversationPage(app)
+        let carryOn = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH[c] %@", "Carry on with")
+        ).firstMatch
+        XCTAssertTrue(carryOn.waitForExistence(timeout: 10),
+                      "With conversations stored and none active, the page offers no way back "
+                      + "into the last one")
+        carryOn.tap()
+
+        // An assistant line, deliberately: a thread's *title* is generated from its first user
+        // message, so asserting on the question would pass on the header alone and prove nothing
+        // about the transcript.
+        XCTAssertTrue(waitForText(app, containing: "It closes at 5:30", timeout: 15),
+                      "Carrying on with the last conversation showed none of it")
+    }
+
+    // MARK: - Driving the pager
+
+    /// The grid is the pager's home page and the conversation is one swipe left of it.
+    ///
+    /// Swiped up to three times before giving up. A paging `TabView` under a loaded machine drops
+    /// the occasional gesture, and a dropped swipe is not the thing this file is here to catch —
+    /// it would fail as "no header", which reads exactly like the bug and is not it.
+    private func openConversationPage(_ app: XCUIApplication) {
+        let dock = app.otherElements["Dock"]
+        XCTAssertTrue(dock.waitForExistence(timeout: 30), "The dock panel never appeared")
+        for _ in 0..<3 {
+            if conversationHeader(app).waitForExistence(timeout: 3) { return }
+            dock.swipeRight()
+        }
+    }
+
+    private func conversationHeader(_ app: XCUIApplication) -> XCUIElement {
+        app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH[c] %@", "Conversation:")
+        ).firstMatch
+    }
+
+    /// Text on this surface is drawn as static text and, inside a bubble, reaches the tree as the
+    /// bubble's own combined label — so both are worth asking.
+    private func waitForText(_ app: XCUIApplication, containing needle: String,
+                             timeout: TimeInterval) -> Bool {
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", needle)
+        let text = app.staticTexts.matching(predicate).firstMatch
+        if text.waitForExistence(timeout: timeout) { return true }
+        return app.descendants(matching: .any).matching(predicate).firstMatch.exists
+    }
+}

--- a/docs/plans/EA-voice-home-grid.md
+++ b/docs/plans/EA-voice-home-grid.md
@@ -241,6 +241,36 @@ event absent from `items` but still in the inputs and the headline count; a clea
 slot; a rescheduled event returning; dismissals surviving every refresh in a day and lapsing at the
 rollover; keys namespaced by source.
 
+### P7a — Reminders are a *day's* reminders (device round 2, 2026-09-02)
+
+Phone use of the shipped card found three faults in how it treated reminders, and all three are one
+policy question: what belongs on a card called My Day.
+
+1. **Only overdue and due-today reminders enter the ranking.** The card took every incomplete
+   reminder and ranked the undated ones last, which on a real account is most of them — a "someday"
+   pile with no date attached is not a day's work, and it crowded out the things that were. Undated
+   reminders now stay in Reminders, which is the app for them; future-dated ones (previously also in
+   that last rank) are excluded outright so tomorrow's task cannot displace today's. This is the
+   morning-only all-day rule again, in the other source: **the card curates, the source app keeps
+   everything.** Nothing is completed, deleted or hidden anywhere but on the card.
+2. **A row says which list it came from.** `MyDayReminder` carries `listName`
+   (`EKReminder.calendar.title`) and the detail reads "Overdue · Work" / "Due 3:00 pm · Shopping".
+   Without it the day's reminders arrive from every list at once as a pile of bare titles with no
+   way to tell which part of your life each belongs to. A list name is the wearer's own words: it
+   belongs on the row and in what VoiceOver reads, and **in no log line** — the same rule the store
+   and home categories already follow. The compact card draws no detail, so its rows carry an
+   explicit accessibility label rather than relying on what happens to be rendered.
+3. **The cap stopped being invisible.** `items` is still ranked-then-capped, because the spoken
+   briefing, the digest and the HUD all budget against it — but what the cap left out now travels
+   with the snapshot as `overflowItems`, and the full-day screen shows `allItems`. "See all N items"
+   counts the whole day. Clearing a row promoting the next one was always the intent; it read as
+   items materialising only because nothing on screen could say the list was longer than the card.
+
+**Tests.** Undated absent, due-tomorrow absent (including the date-only boundary case), due-today
+and overdue present; the detail carries the list name and grows no stray separator without one; the
+overflow is the same ranking's tail and `items` stays bounded; clearing a row promotes the next and
+drops the reported total by exactly one.
+
 ## P8 — The clip the four-row panel caused ✅
 
 Reported from the phone as "the My Day panel is cut off at the bottom", and **reproduced in the


### PR DESCRIPTION
## Summary

Two on-device findings from the first EB build in hand, one round:

**The picked conversation was invisible.** The conversation page drew exactly two live-turn strings (`currentTranscription`/`lastResponse`) and nothing ever read the store — so a resumed thread was active, in the model's context, and showed as its title floating over "Nothing said yet." The fix is structural: `ConversationContinuity.PageContent` is the pure missing decision (`.history` when an active thread has messages, `.liveTurn` when a turn exists that no thread yet holds, live cards always in realtime modes whose transcripts are never persisted, `.empty` only when nothing was said), and the page now renders threads with the Chat tab's own bubbles — shared, not copied — streaming reply appending, newest-scrolled, no new gestures (vertical scroll composes with the pager per the established axis rule). The append-target test and the new page-draws-the-same-thread test cover the two halves that were individually correct and jointly broken. A UI assertion subtlety worth recording: thread *titles* are generated from first user messages, so asserting on a title false-passes exactly this bug — the UI proofs key on assistant lines.

**My Day reminders curate to the day.** Only overdue or due-today reminders enter the ranking — the undated "someday" tier is gone, and *future-dated* reminders (found leaking in at the same dead rank) are excluded. Rows carry their list ("Overdue · Work", "Due 3:00 pm · Shopping"; no stray separator when unlisted; list names have nowhere to reach logs — My Day has zero PrivacyLog sites and pure-counter metrics). The cap's remainder travels on the snapshot (`overflowItems`): see-all counts and renders the whole day, clearing a row promotes the next and the total drops by one, and the capped `items` keeps bounding the spoken/digest/HUD budgets (pinned by test). EA plan doc gains P7a with the policy and reasoning.

## Verification

- Unit suite: **4052 executed, 0 real failures** — two CPU-starvation flakes (another session's full suite shared the machine; a snapshot test took 539s contended vs instant alone) both 12/12 green in isolation
- +10 unit tests, +2 UI tests; the carry-on UI proof **passed on the fixed build** (assistant-line assertion). The pick-a-conversation UI test still owes a clean pass — its failure was a dropped pager swipe under contention, retry-hardened, to be re-run on a quiet machine
- Release build (generic iOS): green
- Device-eyes: transcript at accessibility sizes in the fixed panel; long reply streaming during auto-flip; "Overdue · Work" legibility at caption size

🤖 Generated with [Claude Code](https://claude.com/claude-code)