### PR TITLE
Let the panel take the height the screen affords, on every page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ Vendor/MediaPipeTasks/Frameworks/
 *.crt
 *.key
 .dd-agent/
+
+# Per-agent isolated DerivedData (worktree only)
+.dd-agent/

--- a/OpenGlasses/Sources/App/Views/BottomControlBar.swift
+++ b/OpenGlasses/Sources/App/Views/BottomControlBar.swift
@@ -140,9 +140,14 @@ struct BottomControlBar: View {
     /// One frame, three pages. The frame is the row-snapped grid height plus the room the page
     /// control needs, so every page is the same size whatever it holds and the panel never resizes
     /// under a swipe.
+    ///
+    /// The frame is now as tall as the screen affords rather than capped at four rows, which is
+    /// what gives the conversation page room to be read. Deliberately *not* a per-page height: the
+    /// tall frame is the panel's, and the conversation inherits it by sharing the frame. Only two
+    /// things move it — My Day collapsing, and the existing state-driven yields — and both of those
+    /// already animate outside the pager, so a swipe still lands on a frame that has not moved.
     private var panel: some View {
         let rows = DockGridMetrics.restingRows(
-            slotCount: slots.count, columns: columnCount,
             availableHeight: availableHeight, rowHeight: tileHeight,
             surfaceAboveIsCompact: myDayCollapsed || !myDayEnabled)
         let pageHeight = DockGridMetrics.gridHeight(rows: rows, tileHeight: tileHeight)
@@ -170,6 +175,10 @@ struct BottomControlBar: View {
         // reliable ground. `.always` gives them their own, in both themes.
         .indexViewStyle(.page(backgroundDisplayMode: .always))
         .frame(height: pageHeight + DockGridMetrics.pageIndicatorHeight)
+        // The two things that move this frame — My Day collapsing, and the first real tile
+        // measurement replacing the opening guess — are both worth a settle rather than a jump.
+        // Keyed on the height itself, so a swipe (which cannot change it) animates nothing.
+        .animation(.easeInOut(duration: 0.25), value: pageHeight)
         // The page control is an adjustable element, which is a poor way to reach a named
         // destination. Every page is also one named action from wherever focus happens to be.
         .accessibilityElement(children: .contain)

--- a/OpenGlasses/Sources/App/Views/BottomControlBar.swift
+++ b/OpenGlasses/Sources/App/Views/BottomControlBar.swift
@@ -45,6 +45,15 @@ struct BottomControlBar: View {
     /// purpose: the panel sizes itself from the screen, and the conversation zone then takes what
     /// is left — the reverse would be circular.
     var availableHeight: CGFloat = 0
+    /// The measured height of the surface the panel sits under: the status card, My Day in
+    /// whatever state the wearer left it, the captions and notices held above the dock, and the
+    /// zone's own padding. `nil` until the first layout has reported it.
+    ///
+    /// Still one-way, and still not circular: what is measured is the *modules'* own heights,
+    /// which depend on the width they are given and not on what the panel does with the height.
+    /// The panel divides the screen by what those modules drew — it no longer guesses at a share
+    /// of the screen and leaves whatever it over-reserved on the glass as a gap.
+    var heightAboveDock: CGFloat? = nil
 
     @State private var runningActionId: String?
     @State private var pager = DockPagerState()
@@ -74,11 +83,6 @@ struct BottomControlBar: View {
     /// Not read for its value — `Config.quickActions` owns that. This is the republish, so an
     /// action made on the edit page appears on the grid the moment the sheet closes.
     @AppStorage("quickActions") private var quickActionsBeacon = Data()
-    /// My Day's own state, read rather than plumbed. The panel's resting height is a function of
-    /// what the surface above it needs, and these two keys are exactly that signal — a collapsed or
-    /// unconfigured My Day hands back the height the fourth row needs.
-    @AppStorage("myDayCollapsed") private var myDayCollapsed = false
-    @AppStorage("myDayEnabled") private var myDayEnabled = false
 
     private var photoDisabledForLocalModel: Bool {
         guard let model = Config.activeModel, model.llmProvider == .local else { return false }
@@ -125,14 +129,41 @@ struct BottomControlBar: View {
         return max(DockGridMetrics.tileMinHeight, content)
     }
 
+    /// The capsule's glyph box, for the one frame before a real capsule has reported its height.
+    @ScaledMetric(relativeTo: .title3) private var capsuleGlyphBox: CGFloat
+        = DockGridMetrics.capsuleGlyphBox
+
+    /// What the capsule actually measured, once it has been laid out.
+    @State private var measuredCapsuleHeight: CGFloat?
+
+    /// The capsule's height — the same measure-don't-predict rule the row takes, and for the same
+    /// reason: `ActionCapsule` sizes itself to its content, so predicting it is predicting a font.
+    /// It can never be squeezed below its own touch-target floor, which is what keeps this from
+    /// feeding back into the panel height that sits above it.
+    private var capsuleHeight: CGFloat {
+        if let measuredCapsuleHeight, measuredCapsuleHeight > 0 { return measuredCapsuleHeight }
+        return max(OGMetrics.minTouchTarget,
+                   capsuleGlyphBox + DockGridMetrics.capsuleVerticalPadding)
+    }
+
+    /// Everything the dock draws that is not a grid row, in the order `body` stacks it: the padding
+    /// above the panel and below the capsule, the gap between them, the panel's own inset top and
+    /// bottom, the room the page dots need, and the capsule itself.
+    private var dockChromeHeight: CGFloat {
+        DockGridMetrics.dockOuterPadding * 2
+            + DockGridMetrics.dockStackSpacing
+            + DockGridMetrics.panelInset * 2
+            + DockGridMetrics.pageIndicatorHeight
+            + capsuleHeight
+    }
+
     var body: some View {
         // Bottom-most control last: the paging panel, then the capsule beneath it.
-        VStack(spacing: 8) {
+        VStack(spacing: DockGridMetrics.dockStackSpacing) {
             panel
             capsule
         }
-        .padding(.top, 8)
-        .padding(.bottom, 8)
+        .padding(.vertical, DockGridMetrics.dockOuterPadding)
     }
 
     // MARK: - Panel
@@ -144,12 +175,18 @@ struct BottomControlBar: View {
     /// The frame is now as tall as the screen affords rather than capped at four rows, which is
     /// what gives the conversation page room to be read. Deliberately *not* a per-page height: the
     /// tall frame is the panel's, and the conversation inherits it by sharing the frame. Only two
-    /// things move it — My Day collapsing, and the existing state-driven yields — and both of those
-    /// already animate outside the pager, so a swipe still lands on a frame that has not moved.
+    /// things move it — the surface above changing height, and the existing state-driven yields —
+    /// and both of those already animate outside the pager, so a swipe still lands on a frame that
+    /// has not moved.
+    ///
+    /// What the panel affords is the screen minus everything measured above it and everything the
+    /// dock itself draws around the rows. My Day expanding or collapsing moves the frame the same
+    /// way a caption arriving does: by changing the measurement, not by naming a share.
     private var panel: some View {
         let rows = DockGridMetrics.restingRows(
-            availableHeight: availableHeight, rowHeight: tileHeight,
-            surfaceAboveIsCompact: myDayCollapsed || !myDayEnabled)
+            availableHeight: availableHeight,
+            reservedHeight: heightAboveDock.map { $0 + dockChromeHeight },
+            rowHeight: tileHeight)
         let pageHeight = DockGridMetrics.gridHeight(rows: rows, tileHeight: tileHeight)
 
         return TabView(selection: pageSelection) {
@@ -175,9 +212,10 @@ struct BottomControlBar: View {
         // reliable ground. `.always` gives them their own, in both themes.
         .indexViewStyle(.page(backgroundDisplayMode: .always))
         .frame(height: pageHeight + DockGridMetrics.pageIndicatorHeight)
-        // The two things that move this frame — My Day collapsing, and the first real tile
-        // measurement replacing the opening guess — are both worth a settle rather than a jump.
-        // Keyed on the height itself, so a swipe (which cannot change it) animates nothing.
+        // The things that move this frame — the surface above changing height (My Day collapsing,
+        // captions arriving) and the first real measurements replacing the opening guesses — are
+        // all worth a settle rather than a jump. Keyed on the height itself, so a swipe (which
+        // cannot change it) animates nothing.
         .animation(.easeInOut(duration: 0.25), value: pageHeight)
         // The page control is an adjustable element, which is a poor way to reach a named
         // destination. Every page is also one named action from wherever focus happens to be.
@@ -189,7 +227,7 @@ struct BottomControlBar: View {
                 Button(page.showActionName) { move(to: page) }
             }
         }
-        .padding(14)
+        .padding(DockGridMetrics.panelInset)
         .glassEffect(in: .rect(cornerRadius: 28))
         .padding(.horizontal, 12)
         .onChange(of: voiceState) { previous, next in
@@ -288,6 +326,12 @@ struct BottomControlBar: View {
         }
     }
 
+    private var capsuleHeightReader: some View {
+        GeometryReader { proxy in
+            Color.clear.preference(key: DockCapsuleHeightKey.self, value: proxy.size.height)
+        }
+    }
+
     // MARK: - Capsule
 
     /// The primary control, on its own glass at the bottom of the reach.
@@ -312,6 +356,13 @@ struct BottomControlBar: View {
                 appState.micMuted.toggle()
             }
             .padding(.horizontal, 12)
+            // The panel above divides what is left of the screen after this, so the capsule reports
+            // what it drew rather than being predicted from a font.
+            .background(capsuleHeightReader)
+            .onPreferenceChange(DockCapsuleHeightKey.self) { height in
+                guard let height, height > 0, height != measuredCapsuleHeight else { return }
+                measuredCapsuleHeight = height
+            }
     }
 
     // MARK: - Slots
@@ -831,6 +882,18 @@ private struct LocalModelTile: View {
 /// One tile's measured height, so the panel snaps rows to what was drawn rather than to a
 /// prediction of it.
 private struct DockTileHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat? { nil }
+
+    static func reduce(value: inout CGFloat?, nextValue: () -> CGFloat?) {
+        value = value ?? nextValue()
+    }
+}
+
+/// The hero capsule's measured height. The panel's rows are what the screen has left once this and
+/// the surface above the dock have had theirs, so it is measured for the same reason the tile is —
+/// a capsule sized to its own content is a font's line height plus padding, and predicting that is
+/// how the arithmetic drifts at the text sizes nobody tested.
+private struct DockCapsuleHeightKey: PreferenceKey {
     static var defaultValue: CGFloat? { nil }
 
     static func reduce(value: inout CGFloat?, nextValue: () -> CGFloat?) {

--- a/OpenGlasses/Sources/App/Views/BottomControlBar.swift
+++ b/OpenGlasses/Sources/App/Views/BottomControlBar.swift
@@ -146,48 +146,71 @@ struct BottomControlBar: View {
                    capsuleGlyphBox + DockGridMetrics.capsuleVerticalPadding)
     }
 
-    /// Everything the dock draws that is not a grid row, in the order `body` stacks it: the padding
-    /// above the panel and below the capsule, the gap between them, the panel's own inset top and
-    /// bottom, the room the page dots need, and the capsule itself.
+    /// Everything the dock draws that is not a page, in the order `body` stacks it: the module gap
+    /// above the panel, the module gap between panel and capsule, the capsule, the padding under
+    /// it, and the panel's own inset top and bottom inside its glass.
+    ///
+    /// The page dots are deliberately *not* here — they sit inside the pages' frame, which is what
+    /// `panelPagesHeight` returns.
     private var dockChromeHeight: CGFloat {
-        DockGridMetrics.dockOuterPadding * 2
-            + DockGridMetrics.dockStackSpacing
+        DockGridMetrics.moduleGap * 2
+            + DockGridMetrics.dockBottomPadding
             + DockGridMetrics.panelInset * 2
-            + DockGridMetrics.pageIndicatorHeight
             + capsuleHeight
     }
 
+    /// The pages' frame inside the glass: pure subtraction, so every point the screen has left
+    /// belongs to the panel rather than to a gap above it.
+    private var pagesHeight: CGFloat {
+        DockGridMetrics.panelPagesHeight(
+            availableHeight: availableHeight,
+            reservedHeight: heightAboveDock.map { $0 + dockChromeHeight },
+            rowHeight: tileHeight)
+    }
+
+    /// What a page has above the dots — the room the grid's viewport is snapped inside.
+    private var pageBodyHeight: CGFloat {
+        max(0, pagesHeight - DockGridMetrics.pageIndicatorHeight)
+    }
+
+    /// The grid's scroll viewport: whole rows, and never the fraction of one that the glass now
+    /// keeps as empty space beneath it. This is P8's no-sliced-tile rule, at the edge that clips.
+    private var gridViewportHeight: CGFloat {
+        let rows = DockGridMetrics.viewportRows(availableHeight: pageBodyHeight,
+                                                rowHeight: tileHeight)
+        return DockGridMetrics.gridHeight(rows: rows, tileHeight: tileHeight)
+    }
+
     var body: some View {
-        // Bottom-most control last: the paging panel, then the capsule beneath it.
-        VStack(spacing: DockGridMetrics.dockStackSpacing) {
+        // Bottom-most control last: the paging panel, then the capsule beneath it. One gap between
+        // them and one above, the same 16 pt the modules above the dock stack at — the dock is
+        // part of the tab's rhythm, not a surface with a rhythm of its own.
+        VStack(spacing: DockGridMetrics.moduleGap) {
             panel
             capsule
         }
-        .padding(.vertical, DockGridMetrics.dockOuterPadding)
+        .padding(.top, DockGridMetrics.moduleGap)
+        .padding(.bottom, DockGridMetrics.dockBottomPadding)
     }
 
     // MARK: - Panel
 
-    /// One frame, three pages. The frame is the row-snapped grid height plus the room the page
-    /// control needs, so every page is the same size whatever it holds and the panel never resizes
-    /// under a swipe.
+    /// One frame, three pages, and the frame is simply what the screen has left. Every page is the
+    /// same size whatever it holds, and the panel never resizes under a swipe.
     ///
-    /// The frame is now as tall as the screen affords rather than capped at four rows, which is
-    /// what gives the conversation page room to be read. Deliberately *not* a per-page height: the
-    /// tall frame is the panel's, and the conversation inherits it by sharing the frame. Only two
-    /// things move it — the surface above changing height, and the existing state-driven yields —
-    /// and both of those already animate outside the pager, so a swipe still lands on a frame that
-    /// has not moved.
+    /// The glass absorbs the remainder rather than snapping to whole rows. Snapping the frame put
+    /// up to a row of leftover *between* the card and the panel, sitting next to gaps that are all
+    /// 16 pt — a rhythm broken by arithmetic. Now every module gap is the rhythm and the leftover
+    /// lands inside the glass, under the last row, where it reads as calm space. The whole-row rule
+    /// moved to the grid's scroll viewport, which is the edge a tile could actually be sliced at.
     ///
-    /// What the panel affords is the screen minus everything measured above it and everything the
-    /// dock itself draws around the rows. My Day expanding or collapsing moves the frame the same
-    /// way a caption arriving does: by changing the measurement, not by naming a share.
+    /// Deliberately *not* a per-page height: the tall frame is the panel's, and the conversation
+    /// inherits it by sharing the frame. Only the surface above changing height and the existing
+    /// state-driven yields move it, and both animate outside the pager, so a swipe still lands on a
+    /// frame that has not moved. My Day expanding or collapsing moves it the same way a caption
+    /// arriving does: by changing the measurement, not by naming a share.
     private var panel: some View {
-        let rows = DockGridMetrics.restingRows(
-            availableHeight: availableHeight,
-            reservedHeight: heightAboveDock.map { $0 + dockChromeHeight },
-            rowHeight: tileHeight)
-        let pageHeight = DockGridMetrics.gridHeight(rows: rows, tileHeight: tileHeight)
+        let pageHeight = pagesHeight
 
         return TabView(selection: pageSelection) {
             conversationPage
@@ -211,12 +234,18 @@ struct BottomControlBar: View {
         // The dots sit on a translucent panel over an animating ambience, where a bare dot has no
         // reliable ground. `.always` gives them their own, in both themes.
         .indexViewStyle(.page(backgroundDisplayMode: .always))
-        .frame(height: pageHeight + DockGridMetrics.pageIndicatorHeight)
-        // The things that move this frame — the surface above changing height (My Day collapsing,
-        // captions arriving) and the first real measurements replacing the opening guesses — are
-        // all worth a settle rather than a jump. Keyed on the height itself, so a swipe (which
-        // cannot change it) animates nothing.
-        .animation(.easeInOut(duration: 0.25), value: pageHeight)
+        .frame(height: pageHeight)
+        // **Deliberately not animated here.** The frame tracks the measurement directly, and that
+        // is what makes the card growing and the panel giving way one motion instead of two.
+        //
+        // A second animation on this side was the bug: while My Day animates its own height, the
+        // reader above reports a new value every frame, and an `.animation(value: pageHeight)`
+        // restarts a fresh ease toward each of them — the panel arrives late and mushy behind a
+        // card that has already stopped. Tracking instead means the two surfaces sum to the screen
+        // on every single frame, which is exactly what a "height exchange" is. The changes that
+        // have no motion of their own to ride — the opening guess giving way to the first real
+        // measurement, a caption arriving — carry `DockGridMetrics.heightSettle` at their source
+        // instead, so they settle without ever being animated twice.
         // The page control is an adjustable element, which is a poor way to reach a named
         // destination. Every page is also one named action from wherever focus happens to be.
         .accessibilityElement(children: .contain)
@@ -282,37 +311,53 @@ struct BottomControlBar: View {
     }
 
     /// The one grid: controls and content actions, wrapping into rows and scrolling vertically past
-    /// four of them. Nothing is ever cut off — a tile past the fourth row is a scroll away, never a
-    /// sliver at the panel's edge, and VoiceOver walks the same order either way.
+    /// what fits. Nothing is ever cut off — a tile past the last visible row is a scroll away,
+    /// never a sliver at the viewport's edge, and VoiceOver walks the same order either way.
+    ///
+    /// The scroll view takes a **row-snapped** height rather than the whole page, and the space
+    /// under it is where the glass's remainder now lives. That is the whole of the P8 rule: the
+    /// edge a tile is clipped against is its scroll view's, so that is the edge that must land on a
+    /// row boundary. A short grid simply draws its tiles at the top and leaves the rest calm.
     private var gridPage: some View {
-        ScrollView(.vertical) {
-            LazyVGrid(
-                columns: Array(repeating: GridItem(.flexible(), spacing: DockGridMetrics.rowSpacing),
-                               count: columnCount),
-                spacing: DockGridMetrics.rowSpacing
-            ) {
-                // Slots render in the user's arranged order (Settings → Quick Actions → Bar
-                // Layout); contextual ones still gate themselves.
-                ForEach(Array(slots.enumerated()), id: \.element.id) { index, slot in
-                    dockView(for: slot)
-                        // One tile reports its height and the panel snaps to it. Measuring the
-                        // first is enough: a row is as tall as its tallest tile, and every tile in
-                        // this grid is the same `BarButton` with a one-line caption.
-                        .background(index == 0 ? tileHeightReader : nil)
+        VStack(spacing: 0) {
+            ScrollView(.vertical) {
+                LazyVGrid(
+                    columns: Array(repeating: GridItem(.flexible(),
+                                                       spacing: DockGridMetrics.rowSpacing),
+                                   count: columnCount),
+                    spacing: DockGridMetrics.rowSpacing
+                ) {
+                    // Slots render in the user's arranged order (Settings → Quick Actions → Bar
+                    // Layout); contextual ones still gate themselves.
+                    ForEach(Array(slots.enumerated()), id: \.element.id) { index, slot in
+                        dockView(for: slot)
+                            // One tile reports its height and the viewport snaps to it. Measuring
+                            // the first is enough: a row is as tall as its tallest tile, and every
+                            // tile in this grid is the same `BarButton` with a one-line caption.
+                            .background(index == 0 ? tileHeightReader : nil)
+                    }
                 }
+                .padding(.horizontal, 4)
             }
-            .padding(.horizontal, 4)
+            .frame(height: gridViewportHeight, alignment: .top)
+            // Short grids should not become scroll views: bouncing a grid that already fits reads
+            // as the panel coming loose from the tab.
+            .scrollBounceBehavior(.basedOnSize)
+
+            // The sub-row remainder, and the rows a short grid does not need. Calm empty glass
+            // under the tiles — which is where a leftover belongs, rather than between two cards.
+            Spacer(minLength: 0)
         }
         .onPreferenceChange(DockTileHeightKey.self) { height in
             guard let height, height > 0, height != measuredTileHeight else { return }
-            measuredTileHeight = height
+            // The opening guess giving way to a real tile: a height change with no motion of its
+            // own, so it settles here rather than being chased by the frame.
+            withAnimation(DockGridMetrics.heightSettle) { measuredTileHeight = height }
         }
-        // Short grids should not become scroll views: bouncing a grid that already fits reads as
-        // the panel coming loose from the tab.
-        .scrollBounceBehavior(.basedOnSize)
-        // The sighted shortcut to the edit page, on the grid's *background* — behind the tiles, so
-        // it answers a press on the gaps and never fires alongside a tile's action. It flips the
-        // pager rather than presenting a sheet now that editing is a page of its own.
+        // The sighted shortcut to the edit page, on the page's *background* — behind the tiles, so
+        // it answers a press on the gaps and never fires alongside a tile's action. On the whole
+        // page rather than the viewport, so the empty glass under a short grid answers it too. It
+        // flips the pager rather than presenting a sheet now that editing is a page of its own.
         .background(
             Color.clear
                 .contentShape(Rectangle())
@@ -361,7 +406,7 @@ struct BottomControlBar: View {
             .background(capsuleHeightReader)
             .onPreferenceChange(DockCapsuleHeightKey.self) { height in
                 guard let height, height > 0, height != measuredCapsuleHeight else { return }
-                measuredCapsuleHeight = height
+                withAnimation(DockGridMetrics.heightSettle) { measuredCapsuleHeight = height }
             }
     }
 

--- a/OpenGlasses/Sources/App/Views/MyDayView.swift
+++ b/OpenGlasses/Sources/App/Views/MyDayView.swift
@@ -247,12 +247,26 @@ struct MyDayHomeView: View {
     let compact: Bool
 
     @Environment(\.appAccent) private var accent
+    @Environment(\.openURL) private var openURL
     @State private var showDetail = false
 
     /// The user's own collapse, remembered across launches. Distinct from `compact`, which the
     /// session state imposes for as long as the mic is open: this one is a choice, so it outranks
     /// the compact form and holds until the user reverses it.
     @AppStorage("myDayCollapsed") private var isCollapsed = false
+
+    /// The whole day, in the card, in place of the three-item summary.
+    ///
+    /// Deliberately **not** persisted, unlike `isCollapsed`. Collapsing is a standing preference
+    /// about how much of the home surface My Day should occupy; expanding is a momentary "show me
+    /// the rest", and a card that came back full-height on every launch would be making a lasting
+    /// decision out of a glance. It also resets when the card is collapsed, so the chevron always
+    /// returns to a card the wearer recognises.
+    @State private var isExpanded = false
+
+    /// The result of an item action, which has nowhere else to be said now that the full day is
+    /// drawn in the card rather than on a screen with its own alert.
+    @State private var actionMessage: String?
 
     var body: some View {
         Group {
@@ -279,8 +293,31 @@ struct MyDayHomeView: View {
         .onReceive(NotificationCenter.default.publisher(for: .EKEventStoreChanged)) { _ in
             refreshInBackground()
         }
+        // The full day is drawn in the card now, so this screen is no longer where "show me the
+        // rest" goes. It survives for the one job the card cannot do inline: repairing a source.
+        // Those rows carry per-source messages and a Settings deep link, and they are reached from
+        // the availability line — the thing they repair — rather than from the expand control.
         .sheet(isPresented: $showDetail) {
             MyDayView(service: service)
+        }
+        .alert("My Day", isPresented: Binding(
+            get: { actionMessage != nil },
+            set: { if !$0 { actionMessage = nil } }
+        )) {
+            Button("OK") { actionMessage = nil }
+        } message: {
+            Text(actionMessage ?? "")
+        }
+    }
+
+    /// Completing a reminder from the expanded card — the same call the full screen makes, so an
+    /// action that moved to the card did not become a weaker version of itself.
+    private func complete(_ item: MyDayItem) async {
+        do {
+            let title = try await service.completeReminder(id: item.id.rawValue)
+            if title == nil { actionMessage = "That reminder is no longer available." }
+        } catch {
+            actionMessage = "The reminder could not be completed."
         }
     }
 
@@ -345,7 +382,11 @@ struct MyDayHomeView: View {
                 }
             }
         }
-        .animation(.easeInOut(duration: 0.2), value: isCollapsed)
+        // Both height changes ride the surface's one settle curve. The panel below does not
+        // animate at all — it tracks the height this card reports — so this *is* the motion of
+        // the exchange, and the two move as one.
+        .animation(DockGridMetrics.heightSettle, value: isCollapsed)
+        .animation(DockGridMetrics.heightSettle, value: isExpanded)
     }
 
     /// The card's one always-present row. Collapsed, it is the whole card — the title, today's
@@ -379,19 +420,31 @@ struct MyDayHomeView: View {
                 .foregroundStyle(accent)
                 .accessibilityLabel("Refresh My Day")
 
+                // Grows the card in place rather than presenting the day somewhere else. The
+                // arrows point the way the card is about to move, which is why this is no longer
+                // the "↗" that meant "open elsewhere".
                 Button {
-                    showDetail = true
+                    isExpanded.toggle()
                 } label: {
-                    Image(systemName: "arrow.up.right")
+                    Image(systemName: isExpanded
+                          ? "arrow.down.right.and.arrow.up.left"
+                          : "arrow.up.left.and.arrow.down.right")
                         .frame(width: OGMetrics.minTouchTarget, height: OGMetrics.minTouchTarget)
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(accent)
-                .accessibilityLabel("Open full My Day")
+                .accessibilityLabel(isExpanded ? "Show the My Day summary"
+                                               : "Show the full day in My Day")
+                .accessibilityHint(isExpanded
+                                   ? "Returns the card to the first few items."
+                                   : "Grows the card to today's whole list.")
             }
 
             Button {
                 isCollapsed.toggle()
+                // A collapsed card always reopens as the summary it is recognised by — expansion
+                // is a glance, not a setting, so it does not survive being put away.
+                if isCollapsed { isExpanded = false }
             } label: {
                 Image(systemName: "chevron.down")
                     .rotationEffect(.degrees(isCollapsed ? -90 : 0))
@@ -409,7 +462,10 @@ struct MyDayHomeView: View {
         .background(
             Color.clear
                 .contentShape(Rectangle())
-                .onTapGesture { isCollapsed.toggle() }
+                .onTapGesture {
+                    isCollapsed.toggle()
+                    if isCollapsed { isExpanded = false }
+                }
         )
     }
 
@@ -449,45 +505,62 @@ struct MyDayHomeView: View {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             } else {
-                let visibleItems = Array(snapshot.items.prefix(compact ? 1 : 3))
+                // Expanded, the card *is* the full day — the whole list, not the card's share of
+                // it, which is what the modal used to be for.
+                let visibleItems = isExpanded && !compact
+                    ? snapshot.allItems
+                    : Array(snapshot.items.prefix(compact ? 1 : 3))
                 ForEach(visibleItems) { item in
                     MyDaySwipeToClear(label: item.title) {
                         Task { await service.dismiss(item) }
                     } content: {
-                        Button {
-                            showDetail = true
-                        } label: {
-                            HStack(alignment: .top, spacing: 10) {
-                                Image(systemName: icon(for: item.kind))
-                                    .foregroundStyle(OGTheme.tintedAccentLabel(accent))
-                                    .frame(width: 20)
-                                    .accessibilityHidden(true)
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text(item.title)
-                                        .font(.footnote.weight(item.urgency >= .important ? .semibold : .regular))
-                                        .foregroundStyle(.primary)
-                                        .fixedSize(horizontal: false, vertical: true)
-                                    if !compact, let detail = item.detail {
-                                        Text(detail)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
+                        HStack(alignment: .top, spacing: 10) {
+                            Button {
+                                // Tapping a row is "show me more", which now happens here rather
+                                // than by leaving for a screen. Already expanded, the row's own
+                                // action button is the thing to press, so this settles to a no-op.
+                                isExpanded = true
+                            } label: {
+                                HStack(alignment: .top, spacing: 10) {
+                                    Image(systemName: icon(for: item.kind))
+                                        .foregroundStyle(OGTheme.tintedAccentLabel(accent))
+                                        .frame(width: 20)
+                                        .accessibilityHidden(true)
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(item.title)
+                                            .font(.footnote.weight(item.urgency >= .important ? .semibold : .regular))
+                                            .foregroundStyle(.primary)
                                             .fixedSize(horizontal: false, vertical: true)
+                                        if !compact, let detail = item.detail {
+                                            Text(detail)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                                .fixedSize(horizontal: false, vertical: true)
+                                        }
                                     }
+                                    Spacer(minLength: 4)
                                 }
-                                Spacer(minLength: 4)
+                                .contentShape(Rectangle())
                             }
-                            .contentShape(Rectangle())
+                            .buttonStyle(.plain)
+                            .disabled(isExpanded)
+                            // The detail carries which Reminders list a task came from, and the
+                            // compact card does not draw it — so it is spoken explicitly rather
+                            // than left to whatever happened to be rendered.
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityLabel([item.title, item.detail]
+                                .compactMap { $0 }
+                                .joined(separator: ", "))
+                            .accessibilityAddTraits(isExpanded ? [] : .isButton)
+                            .accessibilityHint(isExpanded ? "" : "Shows the full day in the card.")
+
+                            // Expanded, each row carries the action the full screen used to own —
+                            // completing a reminder, directions, opening an event. Moving the list
+                            // into the card without these would have made "in place" a downgrade.
+                            if isExpanded && !compact {
+                                actionButton(for: item)
+                            }
                         }
-                        .buttonStyle(.plain)
-                        // The detail carries which Reminders list a task came from, and the
-                        // compact card does not draw it — so it is spoken explicitly rather than
-                        // left to whatever happened to be rendered.
-                        .accessibilityElement(children: .ignore)
-                        .accessibilityLabel([item.title, item.detail]
-                            .compactMap { $0 }
-                            .joined(separator: ", "))
-                        .accessibilityAddTraits(.isButton)
-                        .accessibilityHint("Opens My Day")
                     }
                 }
 
@@ -496,12 +569,12 @@ struct MyDayHomeView: View {
                 // it had materialised, when it had been on the list the whole time and nothing on
                 // screen could say so.
                 let total = snapshot.allItems.count
-                if !compact, total > visibleItems.count {
+                if !compact, !isExpanded, total > visibleItems.count {
                     Button("See all \(total) items") {
-                        showDetail = true
+                        isExpanded = true
                     }
                     .font(.footnote.weight(.semibold))
-                    .accessibilityHint("Opens the full day. \(total - visibleItems.count) more than the card shows.")
+                    .accessibilityHint("Grows the card to today's whole list. \(total - visibleItems.count) more than the card shows.")
                 }
             }
 
@@ -510,18 +583,79 @@ struct MyDayHomeView: View {
                     $0.availability != .available
                 }.count
                 if unavailableCount > 0 {
-                    Label(
-                        unavailableCount == 1 ? "1 source needs attention" : "\(unavailableCount) sources need attention",
-                        systemImage: "exclamationmark.triangle"
-                    )
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    // The one thing the card still sends elsewhere, and the only reason the full
+                    // screen survives: repairing a source needs its own message and a Settings
+                    // deep link per source. Reached from the line that reports the problem, which
+                    // is where a wearer looks for it — not from the expand control.
+                    Button {
+                        showDetail = true
+                    } label: {
+                        Label(
+                            unavailableCount == 1 ? "1 source needs attention" : "\(unavailableCount) sources need attention",
+                            systemImage: "exclamationmark.triangle"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityHint("Opens the sources that need attention.")
                 }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
+    }
+
+    /// The action a row carries once the card is expanded — the same set, and the same calls, the
+    /// full screen offers. Ported rather than reimplemented so "in place" costs the wearer nothing.
+    @ViewBuilder
+    private func actionButton(for item: MyDayItem) -> some View {
+        if item.actions.contains(.complete) {
+            Button {
+                Task { await complete(item) }
+            } label: {
+                Image(systemName: "checkmark.circle")
+                    .frame(width: OGMetrics.minTouchTarget, height: OGMetrics.minTouchTarget)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(accent)
+            .accessibilityLabel("Complete \(item.title)")
+        } else if item.actions.contains(.directions),
+                  let url = service.directionsURL(for: item.id) {
+            Button {
+                service.recordAction(.startDirections)
+                openURL(url)
+            } label: {
+                Image(systemName: "arrow.triangle.turn.up.right.diamond")
+                    .frame(width: OGMetrics.minTouchTarget, height: OGMetrics.minTouchTarget)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(accent)
+            .accessibilityLabel("Start directions for \(item.title)")
+        } else if item.actions.contains(.dismiss) {
+            Button {
+                Task { await service.dismissDigestItem(id: item.id.rawValue) }
+            } label: {
+                Image(systemName: "xmark.circle")
+                    .frame(width: OGMetrics.minTouchTarget, height: OGMetrics.minTouchTarget)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(accent)
+            .accessibilityLabel("Dismiss \(item.title)")
+        } else if item.actions.contains(.open), let dueAt = item.dueAt {
+            Button {
+                service.recordAction(.openEvent)
+                let seconds = dueAt.timeIntervalSinceReferenceDate
+                if let url = URL(string: "calshow:\(seconds)") { openURL(url) }
+            } label: {
+                Image(systemName: "arrow.up.right.square")
+                    .frame(width: OGMetrics.minTouchTarget, height: OGMetrics.minTouchTarget)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(accent)
+            .accessibilityLabel("Open \(item.title) in Calendar")
+        }
     }
 
     private func progressRow(_ label: String) -> some View {

--- a/OpenGlasses/Sources/App/Views/TranscriptOverlay.swift
+++ b/OpenGlasses/Sources/App/Views/TranscriptOverlay.swift
@@ -144,6 +144,11 @@ struct SessionNoticeOverlay: View {
                 }
                 .transition(.move(edge: .bottom).combined(with: .opacity))
                 .padding(.horizontal, 16)
+                // The card carries its own gap to the module above it, rather than taking one from
+                // a parent stack's spacing. A stack allocates spacing around a child that draws
+                // nothing, so a silent notice would otherwise leave a phantom gap on a surface
+                // whose rule is that every module gap is the same.
+                .padding(.top, DockGridMetrics.moduleGap)
             }
         }
         .animation(.easeInOut(duration: 0.3), value: errorText)

--- a/OpenGlasses/Sources/App/Views/VoiceTab.swift
+++ b/OpenGlasses/Sources/App/Views/VoiceTab.swift
@@ -29,10 +29,9 @@ struct VoiceTab: View {
     /// gap this replaces. Measuring cannot over-reserve, because the number is the height.
     @State private var surfaceAboveDock: CGFloat?
 
-    /// The two 16 pt gaps that used to come from the module stack's own spacing, now the flexible
-    /// spacer's floor. Constant rather than measured on purpose: it makes the zone's height exactly
-    /// the measured groups plus this, with nothing left to estimate.
-    private static let conversationZoneSpacerGap: CGFloat = 32
+    /// The zone's top padding, above the first module. The gaps *between* modules — and the gap
+    /// down to the dock — are all `DockGridMetrics.moduleGap`, which is the tab's one rhythm.
+    private static let conversationZoneTopPadding: CGFloat = 12
 
     private var session: GeminiLiveSessionManager { appState.geminiLiveSession }
     private var openAISession: OpenAIRealtimeSessionManager { appState.openAIRealtimeSession }
@@ -81,9 +80,7 @@ struct VoiceTab: View {
                                 mode: appState.currentMode),
                             voiceState: voiceState,
                             availableHeight: tab.size.height,
-                            heightAboveDock: surfaceAboveDock.map {
-                                $0 + Self.conversationZoneSpacerGap
-                            }
+                            heightAboveDock: surfaceAboveDock
                         )
                     }
                 }
@@ -97,15 +94,30 @@ struct VoiceTab: View {
             // panel divides the screen by what was drawn.
             .onPreferenceChange(ConversationSurfaceHeightKey.self) { total in
                 guard total > 0 else { return }
-                // Sub-point jitter under an animating ambience is not a layout change; anything
-                // larger is, and settles through the panel's own keyed animation.
+                // Sub-point jitter under an animating ambience is not a layout change.
                 if let current = surfaceAboveDock, abs(current - total) < 0.5 { return }
+
+                guard surfaceAboveDock != nil else {
+                    // The opening guess giving way to the first real measurement. The one height
+                    // change on this surface with no motion of its own to ride, so it settles.
+                    withAnimation(DockGridMetrics.heightSettle) { surfaceAboveDock = total }
+                    return
+                }
+                // Every later change is already inside somebody's animation — My Day growing, a
+                // caption arriving — and tracking it *without* a second animation is what makes
+                // the two surfaces one motion. The card takes the height and the panel gives it
+                // back on the same frame, because together they are always the whole screen.
                 surfaceAboveDock = total
             }
             }
         }
         }
-        .onReceive(appState.ambientCaptions.$isActive) { captionsActive = $0 }
+        // Animated at the source: captions arriving or leaving changes the zone's height, and the
+        // panel tracks that measurement rather than animating separately. Settling it here is what
+        // makes the caption block and the panel one exchange instead of two.
+        .onReceive(appState.ambientCaptions.$isActive) { active in
+            withAnimation(DockGridMetrics.heightSettle) { captionsActive = active }
+        }
         .fullScreenCover(isPresented: $showPreview) {
             LivePreviewView()
                 .environmentObject(appState)
@@ -137,25 +149,22 @@ struct VoiceTab: View {
     /// with the flexible spacer holding the transcript against the dock whenever the content is
     /// short enough for that to mean anything.
     ///
-    /// The modules are grouped rather than listed so that each group can report the height it
-    /// actually drew. The rhythm is unchanged — the stack's own 16 pt spacing became the spacer's
-    /// floor, which is the same two gaps in the same two places — but the zone's height is now the
-    /// sum of two measurements plus one constant, with nothing left to estimate.
+    /// **One flow, one rhythm.** Every module sits in the same stack at the same `moduleGap`, and
+    /// the gap down to the dock is that same number, produced by the dock's own top padding. There
+    /// is no flexible spacer any more: the panel's glass absorbs whatever the screen has left, so
+    /// there is nothing left over for a spacer to hold. Captions and notices join the flow rather
+    /// than being pinned to the bottom of the zone — with the leftover gone, "pinned to the bottom"
+    /// and "next in the flow" are the same place, and the flow keeps the gaps even.
+    ///
+    /// The whole stack reports one height, which is the number the panel subtracts.
     @ViewBuilder
     private func conversationZone(_ voiceState: VoiceVisualState) -> some View {
         GeometryReader { proxy in
             ScrollView {
-                VStack(spacing: 0) {
-                    topModules(voiceState)
-
-                    Spacer(minLength: Self.conversationZoneSpacerGap)
-
-                    bottomModules
-                }
-                // Exactly the viewport when the content is shorter, so a short surface keeps the
-                // old rhythm — top-aligned modules, transcript held down against the dock — and
-                // does not become a scroll view for no reason.
-                .frame(minHeight: proxy.size.height, alignment: .top)
+                zoneModules(voiceState)
+                    // Exactly the viewport when the content is shorter, so a short surface stays
+                    // top-aligned and does not become a scroll view for no reason.
+                    .frame(minHeight: proxy.size.height, alignment: .top)
             }
             .scrollBounceBehavior(.basedOnSize)
             // And when it scrolls, it says so. A surface whose only cue was a flush-cut card is
@@ -164,47 +173,45 @@ struct VoiceTab: View {
         }
     }
 
-    /// The modules pinned to the top of the zone, and the half of the measurement My Day moves.
+    /// The zone's modules, in order, at the one rhythm — and the height the panel is sized from.
     @ViewBuilder
-    private func topModules(_ voiceState: VoiceVisualState) -> some View {
-        VStack(spacing: 16) {
-            // Status card — one status surface: state, mode, persona, and the connection
-            // pills (formerly their own band above the card).
-            StatusIndicator(session: session, openAISession: openAISession,
-                            openClawBridge: appState.openClawBridge)
+    private func zoneModules(_ voiceState: VoiceVisualState) -> some View {
+        VStack(spacing: 0) {
+            VStack(spacing: DockGridMetrics.moduleGap) {
+                // Status card — one status surface: state, mode, persona, and the connection
+                // pills (formerly their own band above the card).
+                StatusIndicator(session: session, openAISession: openAISession,
+                                openClawBridge: appState.openClawBridge)
 
-            if HomeSurfaceVisibility.showsMyDay(state: voiceState,
-                                                captionsActive: captionsActive) {
-                MyDayHomeView(
-                    service: appState.myDayService,
-                    isEnabled: $myDayEnabled,
-                    compact: voiceState == .listening
-                )
-                .transition(.opacity.combined(with: .scale(scale: 0.98)))
-            }
-        }
-        .padding(.top, 12)
-        .background(surfaceHeightReader)
-    }
+                if HomeSurfaceVisibility.showsMyDay(state: voiceState,
+                                                    captionsActive: captionsActive) {
+                    MyDayHomeView(
+                        service: appState.myDayService,
+                        isEnabled: $myDayEnabled,
+                        compact: voiceState == .listening
+                    )
+                    .transition(.opacity.combined(with: .scale(scale: 0.98)))
+                }
 
-    /// Captions and notices — held against the dock by the spacer above them, and measured with the
-    /// rest so the panel can never take the height a live caption needs.
-    private var bottomModules: some View {
-        VStack(spacing: 16) {
-            if captionsActive {
-                AmbientCaptionOverlay(captionService: appState.ambientCaptions)
+                if captionsActive {
+                    AmbientCaptionOverlay(captionService: appState.ambientCaptions)
+                }
             }
 
-            // The transcript moved into the dock's conversation page. The error card did
-            // not: the panel pages, and a failure the wearer has to see must not be one
-            // swipe from invisible.
+            // The transcript moved into the dock's conversation page. The error card did not: the
+            // panel pages, and a failure the wearer has to see must not be one swipe from
+            // invisible.
+            //
+            // Outside the spaced stack, because a `VStack` allocates its spacing around every child
+            // it holds — including one whose body resolves to nothing. Left in there, a *silent*
+            // notice still cost a 16 pt gap, which is precisely the uneven rhythm this pass exists
+            // to remove. The card carries its own leading gap instead, so absent it costs nothing
+            // and present it matches every other module. The overlay keeps its own observation of
+            // the sessions and the notice centre; gating it from here would have moved that
+            // decision to a view that does not watch either.
             SessionNoticeOverlay(session: session, openAISession: openAISession)
         }
-        // Content never ends flush against the dock. When the zone does have to scroll, the clip
-        // line landed exactly on the panel's edge and read as a card that had been cut in half
-        // rather than one with more below it — the gap is what makes "there is more here" legible
-        // at a glance.
-        .padding(.bottom, 16)
+        .padding(.top, Self.conversationZoneTopPadding)
         .background(surfaceHeightReader)
     }
 

--- a/OpenGlasses/Sources/App/Views/VoiceTab.swift
+++ b/OpenGlasses/Sources/App/Views/VoiceTab.swift
@@ -19,6 +19,21 @@ struct VoiceTab: View {
     @AppStorage("myDayEnabled") private var myDayEnabled = false
     @ScaledMetric(relativeTo: .caption) private var recordingDot: CGFloat = 8
 
+    /// What the surface above the dock actually drew — the recording badge, the status card, My Day
+    /// in whatever state the wearer left it, and the captions and notices held down against the
+    /// dock. Summed from every module group that reports one; `nil` until the first layout.
+    ///
+    /// The dock used to take a *share* of the tab instead, margined so that the tallest plausible
+    /// My Day card could never be clipped. Whenever the real card came in shorter than that
+    /// reservation, the slack rendered as dead glass between the card and the panel — which is the
+    /// gap this replaces. Measuring cannot over-reserve, because the number is the height.
+    @State private var surfaceAboveDock: CGFloat?
+
+    /// The two 16 pt gaps that used to come from the module stack's own spacing, now the flexible
+    /// spacer's floor. Constant rather than measured on purpose: it makes the zone's height exactly
+    /// the measured groups plus this, with nothing left to estimate.
+    private static let conversationZoneSpacerGap: CGFloat = 32
+
     private var session: GeminiLiveSessionManager { appState.geminiLiveSession }
     private var openAISession: OpenAIRealtimeSessionManager { appState.openAIRealtimeSession }
 
@@ -33,14 +48,17 @@ struct VoiceTab: View {
             VoiceAmbience(state: voiceState).ignoresSafeArea()
 
             // The tab's usable height, read once and handed down to the dock, which sizes its
-            // resting rows from it. One-way: the panel decides from the screen, the conversation
-            // zone takes what is left. The reverse would be circular.
+            // resting rows from it minus what the surface above it measured. One-way: the panel
+            // decides from the screen, the conversation zone takes what is left. The measurement
+            // does not make that circular — what is measured is the modules' own heights, which
+            // answer to the width they are given and not to what the panel does with the height.
             GeometryReader { tab in
             VStack(spacing: 0) {
                 // Recording indicator
                 if appState.videoRecorder.isRecording {
                     recordingBadge
                         .padding(.top, 8)
+                        .background(surfaceHeightReader)
                 }
 
                 conversationZone(voiceState)
@@ -62,7 +80,10 @@ struct VoiceTab: View {
                             showsActions: HomeSurfaceVisibility.showsActionTiles(
                                 mode: appState.currentMode),
                             voiceState: voiceState,
-                            availableHeight: tab.size.height
+                            availableHeight: tab.size.height,
+                            heightAboveDock: surfaceAboveDock.map {
+                                $0 + Self.conversationZoneSpacerGap
+                            }
                         )
                     }
                 }
@@ -71,6 +92,15 @@ struct VoiceTab: View {
                 // vertical axis, and leaving the split to the default meant the dock could be
                 // squeezed — which is the shape the overflow regression took.
                 .layoutPriority(1)
+            }
+            // Every module group above the dock reports its own height and they sum here, so the
+            // panel divides the screen by what was drawn.
+            .onPreferenceChange(ConversationSurfaceHeightKey.self) { total in
+                guard total > 0 else { return }
+                // Sub-point jitter under an animating ambience is not a layout change; anything
+                // larger is, and settles through the panel's own keyed animation.
+                if let current = surfaceAboveDock, abs(current - total) < 0.5 { return }
+                surfaceAboveDock = total
             }
             }
         }
@@ -106,43 +136,22 @@ struct VoiceTab: View {
     /// every tile stays on screen and tappable; the `minHeight` keeps the old top-aligned rhythm,
     /// with the flexible spacer holding the transcript against the dock whenever the content is
     /// short enough for that to mean anything.
+    ///
+    /// The modules are grouped rather than listed so that each group can report the height it
+    /// actually drew. The rhythm is unchanged — the stack's own 16 pt spacing became the spacer's
+    /// floor, which is the same two gaps in the same two places — but the zone's height is now the
+    /// sum of two measurements plus one constant, with nothing left to estimate.
     @ViewBuilder
     private func conversationZone(_ voiceState: VoiceVisualState) -> some View {
         GeometryReader { proxy in
             ScrollView {
-                VStack(spacing: 16) {
-                    // Status card — one status surface: state, mode, persona, and the connection
-                    // pills (formerly their own band above the card).
-                    StatusIndicator(session: session, openAISession: openAISession,
-                                    openClawBridge: appState.openClawBridge)
+                VStack(spacing: 0) {
+                    topModules(voiceState)
 
-                    if HomeSurfaceVisibility.showsMyDay(state: voiceState,
-                                                        captionsActive: captionsActive) {
-                        MyDayHomeView(
-                            service: appState.myDayService,
-                            isEnabled: $myDayEnabled,
-                            compact: voiceState == .listening
-                        )
-                        .transition(.opacity.combined(with: .scale(scale: 0.98)))
-                    }
+                    Spacer(minLength: Self.conversationZoneSpacerGap)
 
-                    Spacer(minLength: 0)
-
-                    if captionsActive {
-                        AmbientCaptionOverlay(captionService: appState.ambientCaptions)
-                    }
-
-                    // The transcript moved into the dock's conversation page. The error card did
-                    // not: the panel pages, and a failure the wearer has to see must not be one
-                    // swipe from invisible.
-                    SessionNoticeOverlay(session: session, openAISession: openAISession)
+                    bottomModules
                 }
-                .padding(.top, 12)
-                // Content never ends flush against the dock. When the zone does have to scroll,
-                // the clip line landed exactly on the panel's edge and read as a card that had
-                // been cut in half rather than one with more below it — the gap is what makes
-                // "there is more here" legible at a glance.
-                .padding(.bottom, 16)
                 // Exactly the viewport when the content is shorter, so a short surface keeps the
                 // old rhythm — top-aligned modules, transcript held down against the dock — and
                 // does not become a scroll view for no reason.
@@ -152,6 +161,57 @@ struct VoiceTab: View {
             // And when it scrolls, it says so. A surface whose only cue was a flush-cut card is
             // the surface this fix exists for.
             .scrollIndicators(.automatic)
+        }
+    }
+
+    /// The modules pinned to the top of the zone, and the half of the measurement My Day moves.
+    @ViewBuilder
+    private func topModules(_ voiceState: VoiceVisualState) -> some View {
+        VStack(spacing: 16) {
+            // Status card — one status surface: state, mode, persona, and the connection
+            // pills (formerly their own band above the card).
+            StatusIndicator(session: session, openAISession: openAISession,
+                            openClawBridge: appState.openClawBridge)
+
+            if HomeSurfaceVisibility.showsMyDay(state: voiceState,
+                                                captionsActive: captionsActive) {
+                MyDayHomeView(
+                    service: appState.myDayService,
+                    isEnabled: $myDayEnabled,
+                    compact: voiceState == .listening
+                )
+                .transition(.opacity.combined(with: .scale(scale: 0.98)))
+            }
+        }
+        .padding(.top, 12)
+        .background(surfaceHeightReader)
+    }
+
+    /// Captions and notices — held against the dock by the spacer above them, and measured with the
+    /// rest so the panel can never take the height a live caption needs.
+    private var bottomModules: some View {
+        VStack(spacing: 16) {
+            if captionsActive {
+                AmbientCaptionOverlay(captionService: appState.ambientCaptions)
+            }
+
+            // The transcript moved into the dock's conversation page. The error card did
+            // not: the panel pages, and a failure the wearer has to see must not be one
+            // swipe from invisible.
+            SessionNoticeOverlay(session: session, openAISession: openAISession)
+        }
+        // Content never ends flush against the dock. When the zone does have to scroll, the clip
+        // line landed exactly on the panel's edge and read as a card that had been cut in half
+        // rather than one with more below it — the gap is what makes "there is more here" legible
+        // at a glance.
+        .padding(.bottom, 16)
+        .background(surfaceHeightReader)
+    }
+
+    private var surfaceHeightReader: some View {
+        GeometryReader { proxy in
+            Color.clear.preference(key: ConversationSurfaceHeightKey.self,
+                                   value: proxy.size.height)
         }
     }
 
@@ -180,6 +240,23 @@ struct VoiceTab: View {
         .accessibilityLabel("Recording video")
         .accessibilityValue(appState.videoRecorder.formattedDuration)
         .accessibilityAddTraits(.updatesFrequently)
+    }
+}
+
+// MARK: - Measured surface height
+
+/// The height of the surface above the dock, summed from every module group that reports one.
+///
+/// Sums rather than takes the first, because the surface is two groups with a flexible gap between
+/// them and the panel needs the whole of what they drew — a group left out of the total is a group
+/// the panel would grow over. The reduction is the whole reason this is a preference key and not a
+/// single `GeometryReader`: the groups do not know about each other, and the total arrives at the
+/// one view that has to hand it down.
+private struct ConversationSurfaceHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value += nextValue()
     }
 }
 
@@ -224,6 +301,7 @@ private struct VoiceTabControls: View {
     let showsActions: Bool
     let voiceState: VoiceVisualState
     let availableHeight: CGFloat
+    let heightAboveDock: CGFloat?
 
     var body: some View {
         BottomControlBar(
@@ -235,7 +313,8 @@ private struct VoiceTabControls: View {
             showChatInput: $showChatInput,
             showsActions: showsActions,
             voiceState: voiceState,
-            availableHeight: availableHeight
+            availableHeight: availableHeight,
+            heightAboveDock: heightAboveDock
         )
     }
 }

--- a/OpenGlasses/Sources/Models/HomeGridCatalog.swift
+++ b/OpenGlasses/Sources/Models/HomeGridCatalog.swift
@@ -209,6 +209,11 @@ enum HomeGridCatalog {
 /// tall frame rather than negotiating for one. A height that depended on the page would grow and
 /// shrink under every swipe, which is the round-4 invariant this restores rather than revises: the
 /// pager moves between pages; the frame does not move at all.
+///
+/// **Everything here is measured.** The row is the tile a tile actually drew, and what the panel
+/// subtracts from the screen is the height the surface above it actually took. Nothing in this
+/// file estimates a layout any more except the one frame before the first measurement arrives —
+/// which is what the `default…WithoutMeasurement` names mark.
 enum DockGridMetrics {
     /// `BarButton`'s height floor — the fingertip minimum, before Dynamic Type grows the content
     /// past it.
@@ -250,31 +255,36 @@ enum DockGridMetrics {
     /// where the panel guesses.
     static let defaultRowsWithoutMeasurement = 4
 
-    /// The share of the tab's height the panel takes, and the reason it is two numbers.
-    ///
-    /// It is the whole of what is left once the surface above and the capsule below have had
-    /// theirs: the status card, My Day *in whatever state the wearer left it*, and the capsule
-    /// that never pages. Two numbers because My Day's card is the one thing above the panel whose
-    /// height the wearer controls — collapsing it hands back most of a card, and the panel takes
-    /// it. Nothing else moves these: not the selected page, not how many tiles the grid holds.
-    ///
-    /// They are estimates of a layout, deliberately. The alternative is measuring the zone and
-    /// sizing the panel from it, which is the circular dependency this file's one-way rule exists
-    /// to prevent — the panel sizes itself from the screen, and the zone above takes what is left.
-    /// Both are bounded by P8's rule rather than by taste: **the surface above is never clipped at
-    /// the panel's edge.** The panel also carries the page control on top of these rows and the
-    /// capsule below it, so the share is not the whole of what the dock takes.
-    ///
-    /// Measured in the simulator on a 6.3" phone rather than chosen: a status card is ~116 pt and
-    /// a collapsed My Day ~50 pt, which is what 0.52 leaves whole with a gap under it — a greedier
-    /// number was tried first and cut the collapsed card by a few points, flush against the glass,
-    /// which is P8's exact failure. An *expanded* My Day card is ~280 pt more, and 0.24 is what
-    /// that arithmetic leaves. The asymmetry is the honest one: a phone cannot hold an open My Day
-    /// and a tall panel at once, and the collapse control is how a wearer says which they want.
-    static let heightShare: CGFloat = 0.24
-    static let heightShareWhenSurfaceAboveIsCompact: CGFloat = 0.52
+    /// The dock's own furniture, so the two views that stack it and the arithmetic that reserves
+    /// room for it cannot drift apart: 8 pt above the panel and below the capsule, 8 pt between
+    /// them, and the panel's 14 pt inset on every side.
+    static let dockOuterPadding: CGFloat = 8
+    static let dockStackSpacing: CGFloat = 8
+    static let panelInset: CGFloat = 14
 
-    /// Rows the panel is tall: as many whole ones as its share of the screen affords.
+    /// The hero capsule's glyph box and the padding around it, at the default text size — the
+    /// capsule's height before a real one has been measured, on the same terms as the tile's.
+    /// `ActionCapsule` draws 14 pt of padding above and below its content and floors the result at
+    /// the touch-target minimum.
+    static let capsuleGlyphBox: CGFloat = 22
+    static let capsuleVerticalPadding: CGFloat = 28
+
+    /// Rows the panel is tall: as many whole ones as the screen still has once everything that is
+    /// *not* a row has been measured out of it.
+    ///
+    /// `reservedHeight` is the real, rendered height of the rest of the tab — the status card, My
+    /// Day in whatever state the wearer left it, the captions and notices held below them, the
+    /// zone's own padding, and the dock's own furniture with the capsule under it. `nil` until the
+    /// first layout has reported it.
+    ///
+    /// **Measured, not apportioned.** This used to be a share of the screen — 0.24 with My Day
+    /// open, 0.52 collapsed — margined so that the tallest plausible card was never clipped. The
+    /// margin is the bug: whenever the real card came in shorter than the reservation implied, the
+    /// slack rendered as dead glass between the card's bottom and the panel's top, which is what a
+    /// phone reported (a 6.6" screen, My Day open and short, ~190 pt of nothing). Measuring closes
+    /// both failure shapes at once. Clipping is impossible by construction, because the number
+    /// subtracted *is* the height the surface drew; and the residual gap can only ever be the
+    /// sub-row remainder, which is breathing room rather than a hole.
     ///
     /// **Not a function of the page, and not a function of how many tiles there are.** Both were
     /// tried and both were wrong in the same way. Sizing per page made the frame grow and shrink
@@ -285,11 +295,16 @@ enum DockGridMetrics {
     ///
     /// Whole rows by construction: the truncation *is* the snap, and it is why a tile is never
     /// sliced across the panel's edge.
-    static func restingRows(availableHeight: CGFloat, rowHeight: CGFloat,
-                            surfaceAboveIsCompact: Bool) -> Int {
-        guard rowHeight > 0, availableHeight > 0 else { return defaultRowsWithoutMeasurement }
-        let share = surfaceAboveIsCompact ? heightShareWhenSurfaceAboveIsCompact : heightShare
-        return max(1, Int((availableHeight * share) / rowHeight))
+    static func restingRows(availableHeight: CGFloat, reservedHeight: CGFloat?,
+                            rowHeight: CGFloat) -> Int {
+        guard rowHeight > 0, availableHeight > 0, let reservedHeight else {
+            return defaultRowsWithoutMeasurement
+        }
+        let budget = availableHeight - reservedHeight
+        guard budget > 0 else { return 1 }
+        // Every row past the first also costs the gap above it. The share arithmetic divided by the
+        // row alone, and `n - 1` gaps is exactly the number of points the last row then overran by.
+        return max(1, Int((budget + rowSpacing) / (rowHeight + rowSpacing)))
     }
 
     static func rowsNeeded(slotCount: Int, columns: Int) -> Int {

--- a/OpenGlasses/Sources/Models/HomeGridCatalog.swift
+++ b/OpenGlasses/Sources/Models/HomeGridCatalog.swift
@@ -1,5 +1,8 @@
 import CoreGraphics
 import Foundation
+// For `Animation` only: the settle curve belongs with the metrics it settles, so the card and the
+// panel cannot drift onto two different motions.
+import SwiftUI
 
 /// One shipped action on the Voice tab's home grid.
 ///
@@ -255,11 +258,25 @@ enum DockGridMetrics {
     /// where the panel guesses.
     static let defaultRowsWithoutMeasurement = 4
 
-    /// The dock's own furniture, so the two views that stack it and the arithmetic that reserves
-    /// room for it cannot drift apart: 8 pt above the panel and below the capsule, 8 pt between
-    /// them, and the panel's 14 pt inset on every side.
-    static let dockOuterPadding: CGFloat = 8
-    static let dockStackSpacing: CGFloat = 8
+    /// **The one vertical rhythm.** Every gap between two stacked modules on the Voice tab is this,
+    /// and there is no second number: status card ↕ My Day ↕ panel ↕ capsule. A surface whose gaps
+    /// are 16, 16 and then whatever the arithmetic happened to leave over does not read as a
+    /// rhythm, it reads as a mistake — which is exactly what the sub-row remainder looked like when
+    /// it rendered *between* the card and the panel rather than inside the glass.
+    static let moduleGap: CGFloat = 16
+    /// Below the capsule, where the next thing is the tab bar rather than another module. Not a
+    /// module gap, so deliberately not `moduleGap`: the capsule belongs nearest the thumb.
+    static let dockBottomPadding: CGFloat = 8
+
+    /// **The one curve every height change on this surface settles on.**
+    ///
+    /// Shared so that a card growing and the panel giving way are the *same* motion rather than two
+    /// that merely resemble each other. The card and the panel always sum to the screen, so when
+    /// only one of them animates and the other simply tracks the measurement, the exchange is exact
+    /// and frame-perfect. Two independent animations on the same pair of surfaces is what reads as
+    /// jumping, and it is what this constant exists to prevent.
+    static let heightSettle: Animation = .easeInOut(duration: 0.25)
+    /// The panel's own inset, inside its glass.
     static let panelInset: CGFloat = 14
 
     /// The hero capsule's glyph box and the padding around it, at the default text size — the
@@ -269,42 +286,65 @@ enum DockGridMetrics {
     static let capsuleGlyphBox: CGFloat = 22
     static let capsuleVerticalPadding: CGFloat = 28
 
-    /// Rows the panel is tall: as many whole ones as the screen still has once everything that is
-    /// *not* a row has been measured out of it.
+    /// The panel's pages: everything the screen has left, and nothing else in the expression.
     ///
     /// `reservedHeight` is the real, rendered height of the rest of the tab — the status card, My
-    /// Day in whatever state the wearer left it, the captions and notices held below them, the
-    /// zone's own padding, and the dock's own furniture with the capsule under it. `nil` until the
-    /// first layout has reported it.
+    /// Day in whatever state the wearer left it, the captions and notices below them, the zone's
+    /// own padding, and the dock's own rhythm with the capsule under it. `nil` until the first
+    /// layout has reported it.
     ///
     /// **Measured, not apportioned.** This used to be a share of the screen — 0.24 with My Day
     /// open, 0.52 collapsed — margined so that the tallest plausible card was never clipped. The
     /// margin is the bug: whenever the real card came in shorter than the reservation implied, the
     /// slack rendered as dead glass between the card's bottom and the panel's top, which is what a
-    /// phone reported (a 6.6" screen, My Day open and short, ~190 pt of nothing). Measuring closes
-    /// both failure shapes at once. Clipping is impossible by construction, because the number
-    /// subtracted *is* the height the surface drew; and the residual gap can only ever be the
-    /// sub-row remainder, which is breathing room rather than a hole.
+    /// phone reported (a 6.6" screen, My Day open and short, ~190 pt of nothing).
+    ///
+    /// **And the remainder belongs inside the glass, not between the modules.** Measuring the
+    /// surface fixed the size of the reservation but not the *place* the leftover landed: snapping
+    /// the frame to whole rows left up to a row of it sitting between the card and the panel, next
+    /// to gaps that are all 16 pt. So the frame no longer snaps at all — it is pure subtraction,
+    /// the glass absorbs every remaining point, and the sub-row remainder now shows as calm empty
+    /// space under the last row of tiles where nobody reads it as a broken gap. The whole-row rule
+    /// did not go away; it moved to `viewportRows`, which is where it actually bites.
     ///
     /// **Not a function of the page, and not a function of how many tiles there are.** Both were
     /// tried and both were wrong in the same way. Sizing per page made the frame grow and shrink
     /// under every swipe; sizing to the content meant a wearer with a short grid got a short panel
     /// — and the conversation page, which shares that frame, became a two-line window onto a
     /// conversation. One height, held for every page, is what makes the transcript readable and
-    /// the pager honest at the same time.
-    ///
-    /// Whole rows by construction: the truncation *is* the snap, and it is why a tile is never
-    /// sliced across the panel's edge.
-    static func restingRows(availableHeight: CGFloat, reservedHeight: CGFloat?,
-                            rowHeight: CGFloat) -> Int {
-        guard rowHeight > 0, availableHeight > 0, let reservedHeight else {
-            return defaultRowsWithoutMeasurement
+    /// the pager honest at the same time. Pure subtraction makes that stronger, not weaker: there
+    /// is now no term in the expression a page or a slot count could reach.
+    static func panelPagesHeight(availableHeight: CGFloat, reservedHeight: CGFloat?,
+                                 rowHeight: CGFloat) -> CGFloat {
+        let floorHeight = minimumPagesHeight(rowHeight: rowHeight)
+        guard availableHeight > 0, let reservedHeight else {
+            // The one frame before anything has been measured, in the units the frame now takes.
+            return gridHeight(rows: defaultRowsWithoutMeasurement, tileHeight: rowHeight)
+                + pageIndicatorHeight
         }
-        let budget = availableHeight - reservedHeight
-        guard budget > 0 else { return 1 }
-        // Every row past the first also costs the gap above it. The share arithmetic divided by the
-        // row alone, and `n - 1` gaps is exactly the number of points the last row then overran by.
-        return max(1, Int((budget + rowSpacing) / (rowHeight + rowSpacing)))
+        return max(floorHeight, availableHeight - reservedHeight)
+    }
+
+    /// One row and the dots. A panel shorter than this is a panel with no controls, so the zone
+    /// above scrolls instead — the same floor the row arithmetic used to hold, in the new units.
+    static func minimumPagesHeight(rowHeight: CGFloat) -> CGFloat {
+        max(rowHeight, tileMinHeight) + pageIndicatorHeight
+    }
+
+    /// Whole rows the grid's **scroll viewport** shows, inside a glass that is no longer snapped.
+    ///
+    /// This is where P8's rule now lives, and it is where it always bit: a partial tile is not a
+    /// smaller control, it is an unreachable one, and the edge a tile can be sliced at is the edge
+    /// its scroll view clips against. Snapping the *frame* also satisfied that, but at the cost of
+    /// pushing the leftover out between the modules — so the viewport snaps and the glass keeps
+    /// the remainder as empty space below it.
+    ///
+    /// Whole rows by construction: the truncation *is* the snap.
+    static func viewportRows(availableHeight: CGFloat, rowHeight: CGFloat) -> Int {
+        guard rowHeight > 0, availableHeight > 0 else { return defaultRowsWithoutMeasurement }
+        // Every row past the first also costs the gap above it. Dividing by the row alone is how
+        // the last row ends up overrunning by exactly the `n - 1` gaps nobody subtracted.
+        return max(1, Int((availableHeight + rowSpacing) / (rowHeight + rowSpacing)))
     }
 
     static func rowsNeeded(slotCount: Int, columns: Int) -> Int {

--- a/OpenGlasses/Sources/Models/HomeGridCatalog.swift
+++ b/OpenGlasses/Sources/Models/HomeGridCatalog.swift
@@ -202,6 +202,13 @@ enum HomeGridCatalog {
 /// a scroll rather than a crop. That only stays true while the row height the panel snaps to is the
 /// tile height the tile actually draws, which is why the floor and the spacing live here rather than
 /// as literals inside `BarButton`.
+///
+/// **One frame, and the page is not an input to it.** The panel is as tall as the screen affords it
+/// at all times, on every page. That started as a grid rule — whole rows, nothing sliced — and it is
+/// now also what makes the conversation page readable, because the transcript simply inherits the
+/// tall frame rather than negotiating for one. A height that depended on the page would grow and
+/// shrink under every swipe, which is the round-4 invariant this restores rather than revises: the
+/// pager moves between pages; the frame does not move at all.
 enum DockGridMetrics {
     /// `BarButton`'s height floor — the fingertip minimum, before Dynamic Type grows the content
     /// past it.
@@ -239,46 +246,55 @@ enum DockGridMetrics {
     /// Gap between tiles, in both axes.
     static let rowSpacing: CGFloat = 4
 
-    /// The most rows the grid ever rests at. Beyond that it scrolls.
-    static let defaultVisibleRows = 4
+    /// Rows to assume before anything has been measured — the first frame, and the only frame
+    /// where the panel guesses.
+    static let defaultRowsWithoutMeasurement = 4
 
-    /// The share of the tab's height the panel may take at rest, and the reason it is two numbers.
+    /// The share of the tab's height the panel takes, and the reason it is two numbers.
     ///
-    /// The panel is the bottom of a screen that still has a status card and My Day on it, and on a
-    /// phone those three cannot all have what they want: four rows plus an expanded My Day is more
-    /// than a 6.9" screen has, and the surface that lost was My Day — clipped mid-card at the
-    /// panel's edge. So the ceiling is four rows and the *floor of the screen* decides how many of
-    /// them are affordable. Collapsing My Day gives its height back, and the panel is allowed to
-    /// take it: that is what the collapse control is for, and it is the one state where a phone
-    /// genuinely affords the full four.
-    static let restingHeightShare: CGFloat = 0.20
-    static let restingHeightShareWhenSurfaceAboveIsCompact: CGFloat = 0.30
+    /// It is the whole of what is left once the surface above and the capsule below have had
+    /// theirs: the status card, My Day *in whatever state the wearer left it*, and the capsule
+    /// that never pages. Two numbers because My Day's card is the one thing above the panel whose
+    /// height the wearer controls — collapsing it hands back most of a card, and the panel takes
+    /// it. Nothing else moves these: not the selected page, not how many tiles the grid holds.
+    ///
+    /// They are estimates of a layout, deliberately. The alternative is measuring the zone and
+    /// sizing the panel from it, which is the circular dependency this file's one-way rule exists
+    /// to prevent — the panel sizes itself from the screen, and the zone above takes what is left.
+    /// Both are bounded by P8's rule rather than by taste: **the surface above is never clipped at
+    /// the panel's edge.** The panel also carries the page control on top of these rows and the
+    /// capsule below it, so the share is not the whole of what the dock takes.
+    ///
+    /// Measured in the simulator on a 6.3" phone rather than chosen: a status card is ~116 pt and
+    /// a collapsed My Day ~50 pt, which is what 0.52 leaves whole with a gap under it — a greedier
+    /// number was tried first and cut the collapsed card by a few points, flush against the glass,
+    /// which is P8's exact failure. An *expanded* My Day card is ~280 pt more, and 0.24 is what
+    /// that arithmetic leaves. The asymmetry is the honest one: a phone cannot hold an open My Day
+    /// and a tall panel at once, and the collapse control is how a wearer says which they want.
+    static let heightShare: CGFloat = 0.24
+    static let heightShareWhenSurfaceAboveIsCompact: CGFloat = 0.52
 
-    /// Rows the panel rests at: never more than the content needs, never more than the ceiling, and
-    /// never more than the screen can spare for it.
-    static func restingRows(slotCount: Int, columns: Int, availableHeight: CGFloat,
-                            rowHeight: CGFloat, surfaceAboveIsCompact: Bool) -> Int {
-        let needed = rowsNeeded(slotCount: slotCount, columns: columns)
-        guard rowHeight > 0, availableHeight > 0 else {
-            return max(1, min(defaultVisibleRows, needed))
-        }
-        let share = surfaceAboveIsCompact
-            ? restingHeightShareWhenSurfaceAboveIsCompact
-            : restingHeightShare
-        let affordable = Int((availableHeight * share) / rowHeight)
-        return max(1, min(min(defaultVisibleRows, affordable), needed))
+    /// Rows the panel is tall: as many whole ones as its share of the screen affords.
+    ///
+    /// **Not a function of the page, and not a function of how many tiles there are.** Both were
+    /// tried and both were wrong in the same way. Sizing per page made the frame grow and shrink
+    /// under every swipe; sizing to the content meant a wearer with a short grid got a short panel
+    /// — and the conversation page, which shares that frame, became a two-line window onto a
+    /// conversation. One height, held for every page, is what makes the transcript readable and
+    /// the pager honest at the same time.
+    ///
+    /// Whole rows by construction: the truncation *is* the snap, and it is why a tile is never
+    /// sliced across the panel's edge.
+    static func restingRows(availableHeight: CGFloat, rowHeight: CGFloat,
+                            surfaceAboveIsCompact: Bool) -> Int {
+        guard rowHeight > 0, availableHeight > 0 else { return defaultRowsWithoutMeasurement }
+        let share = surfaceAboveIsCompact ? heightShareWhenSurfaceAboveIsCompact : heightShare
+        return max(1, Int((availableHeight * share) / rowHeight))
     }
 
     static func rowsNeeded(slotCount: Int, columns: Int) -> Int {
         guard slotCount > 0, columns > 0 else { return 0 }
         return (slotCount + columns - 1) / columns
-    }
-
-    /// Rows the panel shows before it starts scrolling. Fewer slots than that shrink the panel —
-    /// yielding the content tiles takes rows away, and the conversation zone gets the height back.
-    static func visibleRows(slotCount: Int, columns: Int,
-                            limit: Int = defaultVisibleRows) -> Int {
-        max(1, min(limit, rowsNeeded(slotCount: slotCount, columns: columns)))
     }
 
     /// The panel's viewport for `rows` complete rows: `n` tiles and the `n - 1` gaps between them,

--- a/OpenGlassesTests/DockPagerTests.swift
+++ b/OpenGlassesTests/DockPagerTests.swift
@@ -107,6 +107,23 @@ final class DockPagerTests: XCTestCase {
         XCTAssertEqual(Set(DockPage.allCases.map(\.showActionName)).count, DockPage.allCases.count)
     }
 
+    /// "The panel never resizes under a swipe" is round 4's promise, and after the reading-height
+    /// report it is a promise *kept* rather than traded away: the panel is tall on every page, so
+    /// the conversation gets its height by sharing the frame rather than by asking for a different
+    /// one. Moving the pager moves the page and nothing else — there is no size in `DockPagerState`
+    /// to move, and `DockGridMetrics.restingRows` takes no page (`HomeGridTests` holds that half).
+    func testMovingThePagerChangesThePageAndNothingElse() {
+        var state = DockPagerState()
+        for page in DockPage.allCases {
+            let moved = DockPagerPolicy.userMoved(state, to: page)
+            XCTAssertEqual(moved.page, page)
+            XCTAssertTrue(moved.userMovedThisTurn)
+            state = moved
+        }
+        // The whole of what a page change carries: a page, and the "do not argue with me" flag.
+        XCTAssertEqual(state, DockPagerState(page: .edit, userMovedThisTurn: true))
+    }
+
     func testTurnActivityIsThinkingAndSpeakingOnly() {
         for state in states {
             XCTAssertEqual(DockPagerPolicy.isTurnActive(state),

--- a/OpenGlassesTests/HomeGridTests.swift
+++ b/OpenGlassesTests/HomeGridTests.swift
@@ -344,84 +344,102 @@ final class HomeGridTests: XCTestCase {
                        ["control:disconnect", "control:micMode"])
     }
 
-    // MARK: - Row-snapped panel height
+    // MARK: - The panel's one height (EB device round 3)
 
-    /// The panel's ceiling is four complete rows; more than that scrolls.
-    func testThePanelRestsAtFourRowsAndScrollsPastThem() {
-        XCTAssertEqual(DockGridMetrics.visibleRows(slotCount: 20, columns: 4), 4)
-        XCTAssertEqual(DockGridMetrics.visibleRows(slotCount: 16, columns: 4), 4)
-        XCTAssertEqual(DockGridMetrics.rowsNeeded(slotCount: 20, columns: 4), 5,
-                       "The rows past the fourth still exist — they are scrolled, not dropped")
+    /// The truth table the panel's height is: My Day's state and the screen, and nothing else.
+    ///
+    /// The measured numbers are from the device this was reported on — an 874 pt tab and a ~52 pt
+    /// row. Whole rows in every cell, because the truncation is the snap.
+    func testPanelHeightIsMyDayStateTimesTheScreenAndNothingElse() {
+        let cases: [(available: CGFloat, row: CGFloat, compact: Bool, rows: Int)] = [
+            // A phone, My Day expanded and then collapsed: collapsing hands back its card and the
+            // panel takes it — in whole rows, which is the point of the ceiling being gone.
+            (874, 52, false, 4),
+            (874, 52, true, 8),
+            // A smaller phone. Fewer rows, same rule.
+            (667, 52, false, 3),
+            (667, 52, true, 6),
+            // An accessibility text size grows the row, so the same screen affords fewer.
+            (874, 120, false, 1),
+            (874, 120, true, 3),
+        ]
+        for expectation in cases {
+            XCTAssertEqual(
+                DockGridMetrics.restingRows(availableHeight: expectation.available,
+                                            rowHeight: expectation.row,
+                                            surfaceAboveIsCompact: expectation.compact),
+                expectation.rows,
+                "\(expectation.available)pt tab, \(expectation.row)pt row, compact=\(expectation.compact)")
+        }
     }
 
-    // MARK: - What the screen can spare
+    /// Collapsing My Day is the one control a wearer has over the panel's height, and it must buy
+    /// *whole rows* — the gap it used to leave was the report that started this.
+    func testCollapsingMyDayBuysWholeRowsAndNotAGap() {
+        for available in stride(from: CGFloat(600), through: 1000, by: 20) {
+            for row in [CGFloat(48), 52, 64, 96] {
+                let expanded = DockGridMetrics.restingRows(
+                    availableHeight: available, rowHeight: row, surfaceAboveIsCompact: false)
+                let collapsed = DockGridMetrics.restingRows(
+                    availableHeight: available, rowHeight: row, surfaceAboveIsCompact: true)
+                XCTAssertGreaterThanOrEqual(collapsed, expanded,
+                                            "Collapsing My Day cost the panel height")
 
-    /// A phone cannot give four rows *and* an expanded My Day, and the surface that lost was My Day
-    /// — clipped mid-card at the panel's edge. The ceiling stays four; the screen decides how many
-    /// of them are affordable, and collapsing My Day is what buys the fourth back.
-    func testAPhoneWithAnExpandedMyDayRestsAtThreeRows() {
-        // The measured numbers from the device this regressed on: an 874 pt tab, a ~52 pt row.
-        let expanded = DockGridMetrics.restingRows(
-            slotCount: 15, columns: 4, availableHeight: 874, rowHeight: 52,
-            surfaceAboveIsCompact: false)
-        XCTAssertEqual(expanded, 3)
-
-        let collapsed = DockGridMetrics.restingRows(
-            slotCount: 15, columns: 4, availableHeight: 874, rowHeight: 52,
-            surfaceAboveIsCompact: true)
-        XCTAssertEqual(collapsed, DockGridMetrics.defaultVisibleRows,
-                       "Collapsing My Day hands back its height and the panel does not take it")
+                // What the panel took is never more than the share it was given, so the surface
+                // above always keeps its own.
+                let share = DockGridMetrics.heightShareWhenSurfaceAboveIsCompact
+                XCTAssertLessThanOrEqual(CGFloat(collapsed) * row, available * share + 0.001,
+                                         "The panel took more than its share of the screen")
+            }
+        }
     }
 
-    /// The ceiling is a ceiling: a taller canvas does not grow the panel past four.
-    func testTheCeilingHoldsOnALargeCanvas() {
-        XCTAssertEqual(DockGridMetrics.restingRows(slotCount: 40, columns: 4,
-                                                   availableHeight: 2000, rowHeight: 52,
-                                                   surfaceAboveIsCompact: true),
-                       DockGridMetrics.defaultVisibleRows)
+    /// The invariant, stated as arithmetic: the height function has no page parameter, so no swipe
+    /// can change the frame. This is the round-4 promise restored rather than revised — a per-page
+    /// height was tried on paper and is exactly what "it keeps growing and shrinking" describes.
+    func testTheFrameCannotDependOnThePage() {
+        let heights = DockPage.allCases.map { _ in
+            DockGridMetrics.restingRows(availableHeight: 874, rowHeight: 52,
+                                        surfaceAboveIsCompact: false)
+        }
+        XCTAssertEqual(Set(heights).count, 1,
+                       "Every page resolves to the same frame — the page is not an input")
     }
 
-    /// Content still wins when there is less of it: a short grid shrinks the panel rather than
-    /// padding it out to whatever the screen would allow.
-    func testTheContentStillCapsTheRestingRows() {
-        XCTAssertEqual(DockGridMetrics.restingRows(slotCount: 6, columns: 4,
-                                                   availableHeight: 874, rowHeight: 52,
-                                                   surfaceAboveIsCompact: true),
-                       2)
+    /// Nor does the content: a wearer with four tiles gets the same frame as one with forty,
+    /// because the conversation page shares it and a short grid must not shrink the transcript to
+    /// a two-line window.
+    func testAShortGridKeepsTheTallFrame() {
+        let tall = DockGridMetrics.restingRows(availableHeight: 874, rowHeight: 52,
+                                               surfaceAboveIsCompact: true)
+        XCTAssertGreaterThan(tall, 4, "The old four-row ceiling is still capping the panel")
+        // The rows the *content* needs are a separate question, and still answerable — the grid
+        // scrolls past what the frame shows.
+        XCTAssertEqual(DockGridMetrics.rowsNeeded(slotCount: 6, columns: 4), 2)
+        XCTAssertEqual(DockGridMetrics.rowsNeeded(slotCount: 40, columns: 4), 10)
     }
 
-    /// Before the first layout there is no measured height to divide by. The panel falls back to
-    /// the ceiling rather than to zero rows.
-    func testAnUnmeasuredScreenFallsBackToTheCeiling() {
-        XCTAssertEqual(DockGridMetrics.restingRows(slotCount: 20, columns: 4,
-                                                   availableHeight: 0, rowHeight: 52,
-                                                   surfaceAboveIsCompact: false),
-                       DockGridMetrics.defaultVisibleRows)
+    /// Before the first layout there is no measured height to divide by. The panel opens at a
+    /// sensible guess rather than at zero rows, and the first real measurement settles it.
+    func testAnUnmeasuredScreenFallsBackToAGuess() {
+        for (available, row) in [(CGFloat(0), CGFloat(52)), (874, 0), (0, 0)] {
+            XCTAssertEqual(DockGridMetrics.restingRows(availableHeight: available, rowHeight: row,
+                                                       surfaceAboveIsCompact: false),
+                           DockGridMetrics.defaultRowsWithoutMeasurement)
+        }
     }
 
     /// Never zero, whatever the arithmetic says: a panel with no rows is a panel with no controls.
     func testAVeryShortScreenStillGetsARow() {
-        XCTAssertEqual(DockGridMetrics.restingRows(slotCount: 20, columns: 4,
-                                                   availableHeight: 200, rowHeight: 52,
+        XCTAssertEqual(DockGridMetrics.restingRows(availableHeight: 100, rowHeight: 52,
                                                    surfaceAboveIsCompact: false),
                        1)
-    }
-
-    /// Fewer slots shrink the panel rather than leaving it three rows of empty glass. Yielding the
-    /// content tiles is the common case, and the height it frees goes back to the conversation.
-    func testAShortGridShrinksThePanel() {
-        XCTAssertEqual(DockGridMetrics.visibleRows(slotCount: 6, columns: 4), 2)
-        XCTAssertEqual(DockGridMetrics.visibleRows(slotCount: 4, columns: 4), 1)
-        XCTAssertEqual(DockGridMetrics.visibleRows(slotCount: 1, columns: 4), 1)
-        // Never zero-height glass: an empty grid still draws one row's worth of panel.
-        XCTAssertEqual(DockGridMetrics.visibleRows(slotCount: 0, columns: 4), 1)
     }
 
     /// Two columns at accessibility sizes means the same slots need more rows — and still snap.
     func testTheAccessibilityColumnCountChangesRowsNotTheSnap() {
         XCTAssertEqual(DockGridMetrics.rowsNeeded(slotCount: 6, columns: 2), 3)
-        XCTAssertEqual(DockGridMetrics.visibleRows(slotCount: 6, columns: 2), 3)
-        XCTAssertEqual(DockGridMetrics.visibleRows(slotCount: 12, columns: 2), 4)
+        XCTAssertEqual(DockGridMetrics.rowsNeeded(slotCount: 12, columns: 2), 6)
     }
 
     /// The bug this arithmetic exists to prevent: a height that lands mid-tile, so the row below

--- a/OpenGlassesTests/HomeGridTests.swift
+++ b/OpenGlassesTests/HomeGridTests.swift
@@ -344,98 +344,145 @@ final class HomeGridTests: XCTestCase {
                        ["control:disconnect", "control:micMode"])
     }
 
-    // MARK: - The panel's one height (EB device rounds 3–4)
+    // MARK: - The panel's one height (EB device rounds 3–5)
 
-    /// The truth table the panel's height is: what the screen has, what the surface above it
-    /// *measured*, and the row height. Nothing else — no share, no page, no slot count.
+    /// The frame is subtraction and nothing else: what the screen has, minus what the surface above
+    /// it *measured*. No share, no page, no slot count — and, since round 5, no row term either.
     ///
     /// The reserved numbers stand for the two states a wearer moves between: ~400 pt for a status
-    /// card over a short or collapsed My Day plus the dock's own furniture, ~600 pt with the card
-    /// open. They are inputs here rather than constants in the code, which is the whole point of
-    /// the change: the panel divides by whatever was drawn.
+    /// card over a short or collapsed My Day plus the dock's own rhythm, ~600 pt with the card
+    /// open. They are inputs here rather than constants in the code, which is the whole point: the
+    /// panel is sized by whatever was drawn.
     func testPanelHeightIsTheScreenMinusWhatTheSurfaceAboveMeasured() {
-        let cases: [(available: CGFloat, reserved: CGFloat, row: CGFloat, rows: Int)] = [
-            // A phone, My Day open and then short: the shorter surface hands back its card and the
-            // panel takes it — in whole rows, which is the point of the ceiling being gone.
-            (874, 600, 52, 4),
-            (874, 400, 52, 8),
-            // A smaller phone. Fewer rows, same rule.
-            (667, 600, 52, 1),
-            (667, 400, 52, 4),
-            // An accessibility text size grows the row, so the same screen affords fewer.
-            (874, 600, 120, 2),
-            (874, 400, 120, 3),
+        let cases: [(available: CGFloat, reserved: CGFloat, row: CGFloat, height: CGFloat)] = [
+            // A phone, My Day open and then short. Every point the surface hands back is a point
+            // the glass takes — not "as many whole rows as fit", which is what left a gap.
+            (874, 600, 52, 274),
+            (874, 400, 52, 474),
+            // A smaller phone. Same rule, less of it — and the first cell is the floor winning,
+            // because 67 pt of budget is less than one row and the dots.
+            (667, 600, 52, 92),
+            (667, 400, 52, 267),
+            // An accessibility text size does not enter the frame at all any more. It only moves
+            // the floor, and neither of these is near it.
+            (874, 600, 120, 274),
+            (874, 400, 120, 474),
         ]
         for expectation in cases {
             XCTAssertEqual(
-                DockGridMetrics.restingRows(availableHeight: expectation.available,
-                                            reservedHeight: expectation.reserved,
-                                            rowHeight: expectation.row),
-                expectation.rows,
+                DockGridMetrics.panelPagesHeight(availableHeight: expectation.available,
+                                                 reservedHeight: expectation.reserved,
+                                                 rowHeight: expectation.row),
+                expectation.height,
+                accuracy: 0.001,
                 "\(expectation.available)pt tab, \(expectation.reserved)pt reserved, "
                     + "\(expectation.row)pt row")
         }
     }
 
-    /// The bug the measurement replaced, stated as arithmetic: the panel never takes more than the
-    /// screen has left, and what it leaves behind is never more than one row's worth.
+    /// The rhythm rule, stated as arithmetic: **nothing is left over between the modules.**
     ///
-    /// Both halves matter and they are the two failure shapes. Taking more than is left clips the
-    /// card at the panel's edge (P8). Leaving more than a row behind is dead glass under the card
-    /// — which is what a share margined for the tallest plausible card produced, and what a phone
-    /// reported as a gap.
-    func testThePanelNeverOverrunsTheSurfaceAboveNorLeavesARowBehind() {
+    /// This is the round-5 report and it is the strict version of round 4's. Measuring the surface
+    /// fixed the size of the reservation; snapping the *frame* to whole rows then put up to a row
+    /// of the leftover back between the card and the panel, beside gaps that are all `moduleGap`.
+    /// Pure subtraction means the sum is exact: the surface, the panel and the dock's own rhythm
+    /// account for the entire screen, so the only gaps a wearer sees are the ones we chose.
+    func testNothingIsLeftOverBetweenTheModules() {
         for available in stride(from: CGFloat(600), through: 1000, by: 20) {
             for reserved in stride(from: CGFloat(200), through: 560, by: 20) {
                 for row in [CGFloat(48), 52, 64, 96] {
-                    let rows = DockGridMetrics.restingRows(availableHeight: available,
-                                                           reservedHeight: reserved,
-                                                           rowHeight: row)
-                    let panel = DockGridMetrics.gridHeight(rows: rows, tileHeight: row)
-                    let budget = available - reserved
+                    let pages = DockGridMetrics.panelPagesHeight(availableHeight: available,
+                                                                 reservedHeight: reserved,
+                                                                 rowHeight: row)
                     let context = "\(available)pt tab, \(reserved)pt reserved, \(row)pt row"
 
-                    // Below one row the floor of one wins — a panel with no rows is a panel with
-                    // no controls, and the zone scrolls rather than the dock vanishing.
-                    if budget >= row {
-                        XCTAssertLessThanOrEqual(panel + reserved, available + 0.001,
-                                                 "The panel took height the surface above had drawn: \(context)")
-                    }
-                    XCTAssertLessThan(budget - panel, row + DockGridMetrics.rowSpacing,
-                                      "A whole further row fitted and the panel left it as a gap: \(context)")
+                    // Above the floor, every point is accounted for. Not "within a row of it" —
+                    // exactly. Below it the panel refuses to shrink further and the zone scrolls,
+                    // which its own test covers.
+                    guard available - reserved >= DockGridMetrics.minimumPagesHeight(rowHeight: row)
+                    else { continue }
+                    XCTAssertEqual(reserved + pages, available, accuracy: 0.001,
+                                   "The screen did not add up, so the difference is a gap: \(context)")
                 }
             }
         }
     }
 
+    /// The panel still refuses to vanish. Below its floor the arithmetic stops subtracting and the
+    /// zone above scrolls instead — a dock with no controls is not a smaller dock.
+    func testThePanelFloorsRatherThanVanishing() {
+        for row in [CGFloat(48), 52, 64, 120] {
+            let floor = DockGridMetrics.minimumPagesHeight(rowHeight: row)
+            XCTAssertGreaterThanOrEqual(
+                DockGridMetrics.panelPagesHeight(availableHeight: 400, reservedHeight: 500,
+                                                 rowHeight: row),
+                floor,
+                "A surface taller than the tab took the panel below its floor")
+            XCTAssertGreaterThanOrEqual(
+                DockGridMetrics.panelPagesHeight(availableHeight: 300, reservedHeight: 290,
+                                                 rowHeight: row),
+                floor)
+            // One row and the dots, so a floored panel is still a usable one.
+            XCTAssertGreaterThanOrEqual(floor, row)
+            XCTAssertGreaterThanOrEqual(floor, DockGridMetrics.pageIndicatorHeight)
+        }
+    }
+
     /// Collapsing My Day — or a day with less in it — is the wearer's one control over the panel's
-    /// height, and it must buy *whole rows*. Restated for the measurement: a shorter surface above
-    /// never costs the panel a row, and the freed height comes back as rows rather than as a gap.
-    func testAShorterSurfaceAboveNeverCostsThePanelARow() {
+    /// height. Restated for round 5: a shorter surface above always buys the panel height, point
+    /// for point, and never costs it any.
+    func testAShorterSurfaceAboveAlwaysBuysThePanelHeight() {
         for available in stride(from: CGFloat(600), through: 1000, by: 20) {
             for row in [CGFloat(48), 52, 64, 96] {
-                var previous = 0
-                // Walking the surface *down* in height: every step affords at least as many rows.
+                var previous: CGFloat = 0
+                // Walking the surface *down* in height: every step affords at least as much panel.
                 for reserved in stride(from: CGFloat(560), through: 200, by: -20) {
-                    let rows = DockGridMetrics.restingRows(availableHeight: available,
-                                                           reservedHeight: reserved,
-                                                           rowHeight: row)
+                    let pages = DockGridMetrics.panelPagesHeight(availableHeight: available,
+                                                                 reservedHeight: reserved,
+                                                                 rowHeight: row)
                     XCTAssertGreaterThanOrEqual(
-                        rows, previous,
+                        pages, previous,
                         "A shorter surface above cost the panel height: \(available)pt tab, "
                             + "\(reserved)pt reserved, \(row)pt row")
-                    previous = rows
+                    previous = pages
                 }
+            }
+        }
+    }
+
+    // MARK: - Where the snap went (EB device round 5)
+
+    /// P8's rule, at the edge it actually bites: the grid's **scroll viewport**. The frame no
+    /// longer snaps, so the sub-row remainder sits under the tiles as empty glass — but a tile is
+    /// still never sliced, because the edge that clips one is its scroll view's, and that edge
+    /// lands on a row boundary.
+    func testTheGridViewportShowsWholeRowsAndNeverSlicesATile() {
+        for body in stride(from: CGFloat(60), through: 700, by: 10) {
+            for row in [CGFloat(48), 52, 64, 96, 130] {
+                let rows = DockGridMetrics.viewportRows(availableHeight: body, rowHeight: row)
+                let viewport = DockGridMetrics.gridHeight(rows: rows, tileHeight: row)
+                let context = "\(body)pt page body, \(row)pt row"
+
+                XCTAssertGreaterThanOrEqual(rows, 1, "A viewport with no rows: \(context)")
+                if body >= row {
+                    XCTAssertLessThanOrEqual(viewport, body + 0.001,
+                                             "The viewport overran the page: \(context)")
+                }
+                // One more row would not have fitted, so nothing of it can peek at the edge.
+                let oneMore = DockGridMetrics.gridHeight(rows: rows + 1, tileHeight: row)
+                XCTAssertGreaterThan(oneMore, body,
+                                     "Another whole row fitted and the viewport did not show it: \(context)")
             }
         }
     }
 
     /// The invariant, stated as arithmetic: the height function has no page parameter, so no swipe
-    /// can change the frame. This is the round-4 promise restored rather than revised — a per-page
-    /// height was tried on paper and is exactly what "it keeps growing and shrinking" describes.
+    /// can change the frame. Round 4's promise, and pure subtraction makes it stronger rather than
+    /// weaker — there is no longer a term in the expression a page could reach.
     func testTheFrameCannotDependOnThePage() {
         let heights = DockPage.allCases.map { _ in
-            DockGridMetrics.restingRows(availableHeight: 874, reservedHeight: 400, rowHeight: 52)
+            DockGridMetrics.panelPagesHeight(availableHeight: 874, reservedHeight: 400,
+                                             rowHeight: 52)
         }
         XCTAssertEqual(Set(heights).count, 1,
                        "Every page resolves to the same frame — the page is not an input")
@@ -443,47 +490,53 @@ final class HomeGridTests: XCTestCase {
 
     /// Nor does the content: a wearer with four tiles gets the same frame as one with forty,
     /// because the conversation page shares it and a short grid must not shrink the transcript to
-    /// a two-line window.
+    /// a two-line window. The short grid's unused rows are empty glass, not a shorter panel.
     func testAShortGridKeepsTheTallFrame() {
-        let tall = DockGridMetrics.restingRows(availableHeight: 874, reservedHeight: 400,
-                                               rowHeight: 52)
-        XCTAssertGreaterThan(tall, 4, "The old four-row ceiling is still capping the panel")
+        let tall = DockGridMetrics.panelPagesHeight(availableHeight: 874, reservedHeight: 400,
+                                                    rowHeight: 52)
+        XCTAssertGreaterThan(tall, DockGridMetrics.gridHeight(rows: 4, tileHeight: 52),
+                             "The old four-row ceiling is still capping the panel")
         // The rows the *content* needs are a separate question, and still answerable — the grid
-        // scrolls past what the frame shows.
+        // scrolls past what the viewport shows.
         XCTAssertEqual(DockGridMetrics.rowsNeeded(slotCount: 6, columns: 4), 2)
         XCTAssertEqual(DockGridMetrics.rowsNeeded(slotCount: 40, columns: 4), 10)
     }
 
-    /// Before the first layout there is nothing measured to divide by — no screen, no row, and no
-    /// surface above. The panel opens at a sensible guess rather than at zero rows, and the first
-    /// real measurement settles it.
+    /// Before the first layout there is nothing measured to subtract — no screen, and no surface
+    /// above. The panel opens at a sensible guess rather than at nothing, and the first real
+    /// measurement settles it.
     func testAnUnmeasuredScreenFallsBackToAGuess() {
-        let unmeasured: [(available: CGFloat, reserved: CGFloat?, row: CGFloat)] = [
-            (0, 400, 52),
-            (874, 400, 0),
-            (0, 400, 0),
-            // The surface above has not reported yet, which is the frame this fix added.
-            (874, nil, 52),
+        let guess = DockGridMetrics.gridHeight(rows: DockGridMetrics.defaultRowsWithoutMeasurement,
+                                               tileHeight: 52)
+            + DockGridMetrics.pageIndicatorHeight
+        let unmeasured: [(available: CGFloat, reserved: CGFloat?)] = [
+            (0, 400),
+            (0, nil),
+            // The surface above has not reported yet, which is the frame the measurement added.
+            (874, nil),
         ]
         for state in unmeasured {
-            XCTAssertEqual(DockGridMetrics.restingRows(availableHeight: state.available,
-                                                       reservedHeight: state.reserved,
-                                                       rowHeight: state.row),
-                           DockGridMetrics.defaultRowsWithoutMeasurement,
-                           "\(state.available)pt tab, \(String(describing: state.reserved)) reserved, "
-                               + "\(state.row)pt row")
+            XCTAssertEqual(DockGridMetrics.panelPagesHeight(availableHeight: state.available,
+                                                            reservedHeight: state.reserved,
+                                                            rowHeight: 52),
+                           guess,
+                           accuracy: 0.001,
+                           "\(state.available)pt tab, \(String(describing: state.reserved)) reserved")
         }
     }
 
-    /// Never zero, whatever the arithmetic says: a panel with no rows is a panel with no controls.
-    /// Including the case the measurement makes reachable — a surface above taller than the tab.
-    func testAVeryShortScreenStillGetsARow() {
-        XCTAssertEqual(DockGridMetrics.restingRows(availableHeight: 100, reservedHeight: 60,
-                                                   rowHeight: 52),
-                       1)
-        XCTAssertEqual(DockGridMetrics.restingRows(availableHeight: 400, reservedHeight: 500,
-                                                   rowHeight: 52),
-                       1)
+    /// One curve for the whole exchange. The card grows and the panel gives way on the same motion
+    /// because there is only one to be on — a second animation on the panel is what made the two
+    /// surfaces look like they were moving independently.
+    func testThereIsOneSettleCurveForEveryHeightChange() {
+        XCTAssertEqual(DockGridMetrics.heightSettle, .easeInOut(duration: 0.25))
+    }
+
+    /// The rhythm is one number, and the dock is part of it rather than a surface with its own.
+    func testTheModuleGapIsTheOneRhythm() {
+        XCTAssertEqual(DockGridMetrics.moduleGap, 16)
+        // Below the capsule is the tab bar, not another module — deliberately not the module gap.
+        XCTAssertNotEqual(DockGridMetrics.dockBottomPadding, DockGridMetrics.moduleGap)
     }
 
     /// Two columns at accessibility sizes means the same slots need more rows — and still snap.

--- a/OpenGlassesTests/HomeGridTests.swift
+++ b/OpenGlassesTests/HomeGridTests.swift
@@ -344,52 +344,88 @@ final class HomeGridTests: XCTestCase {
                        ["control:disconnect", "control:micMode"])
     }
 
-    // MARK: - The panel's one height (EB device round 3)
+    // MARK: - The panel's one height (EB device rounds 3–4)
 
-    /// The truth table the panel's height is: My Day's state and the screen, and nothing else.
+    /// The truth table the panel's height is: what the screen has, what the surface above it
+    /// *measured*, and the row height. Nothing else — no share, no page, no slot count.
     ///
-    /// The measured numbers are from the device this was reported on — an 874 pt tab and a ~52 pt
-    /// row. Whole rows in every cell, because the truncation is the snap.
-    func testPanelHeightIsMyDayStateTimesTheScreenAndNothingElse() {
-        let cases: [(available: CGFloat, row: CGFloat, compact: Bool, rows: Int)] = [
-            // A phone, My Day expanded and then collapsed: collapsing hands back its card and the
+    /// The reserved numbers stand for the two states a wearer moves between: ~400 pt for a status
+    /// card over a short or collapsed My Day plus the dock's own furniture, ~600 pt with the card
+    /// open. They are inputs here rather than constants in the code, which is the whole point of
+    /// the change: the panel divides by whatever was drawn.
+    func testPanelHeightIsTheScreenMinusWhatTheSurfaceAboveMeasured() {
+        let cases: [(available: CGFloat, reserved: CGFloat, row: CGFloat, rows: Int)] = [
+            // A phone, My Day open and then short: the shorter surface hands back its card and the
             // panel takes it — in whole rows, which is the point of the ceiling being gone.
-            (874, 52, false, 4),
-            (874, 52, true, 8),
+            (874, 600, 52, 4),
+            (874, 400, 52, 8),
             // A smaller phone. Fewer rows, same rule.
-            (667, 52, false, 3),
-            (667, 52, true, 6),
+            (667, 600, 52, 1),
+            (667, 400, 52, 4),
             // An accessibility text size grows the row, so the same screen affords fewer.
-            (874, 120, false, 1),
-            (874, 120, true, 3),
+            (874, 600, 120, 2),
+            (874, 400, 120, 3),
         ]
         for expectation in cases {
             XCTAssertEqual(
                 DockGridMetrics.restingRows(availableHeight: expectation.available,
-                                            rowHeight: expectation.row,
-                                            surfaceAboveIsCompact: expectation.compact),
+                                            reservedHeight: expectation.reserved,
+                                            rowHeight: expectation.row),
                 expectation.rows,
-                "\(expectation.available)pt tab, \(expectation.row)pt row, compact=\(expectation.compact)")
+                "\(expectation.available)pt tab, \(expectation.reserved)pt reserved, "
+                    + "\(expectation.row)pt row")
         }
     }
 
-    /// Collapsing My Day is the one control a wearer has over the panel's height, and it must buy
-    /// *whole rows* — the gap it used to leave was the report that started this.
-    func testCollapsingMyDayBuysWholeRowsAndNotAGap() {
+    /// The bug the measurement replaced, stated as arithmetic: the panel never takes more than the
+    /// screen has left, and what it leaves behind is never more than one row's worth.
+    ///
+    /// Both halves matter and they are the two failure shapes. Taking more than is left clips the
+    /// card at the panel's edge (P8). Leaving more than a row behind is dead glass under the card
+    /// — which is what a share margined for the tallest plausible card produced, and what a phone
+    /// reported as a gap.
+    func testThePanelNeverOverrunsTheSurfaceAboveNorLeavesARowBehind() {
+        for available in stride(from: CGFloat(600), through: 1000, by: 20) {
+            for reserved in stride(from: CGFloat(200), through: 560, by: 20) {
+                for row in [CGFloat(48), 52, 64, 96] {
+                    let rows = DockGridMetrics.restingRows(availableHeight: available,
+                                                           reservedHeight: reserved,
+                                                           rowHeight: row)
+                    let panel = DockGridMetrics.gridHeight(rows: rows, tileHeight: row)
+                    let budget = available - reserved
+                    let context = "\(available)pt tab, \(reserved)pt reserved, \(row)pt row"
+
+                    // Below one row the floor of one wins — a panel with no rows is a panel with
+                    // no controls, and the zone scrolls rather than the dock vanishing.
+                    if budget >= row {
+                        XCTAssertLessThanOrEqual(panel + reserved, available + 0.001,
+                                                 "The panel took height the surface above had drawn: \(context)")
+                    }
+                    XCTAssertLessThan(budget - panel, row + DockGridMetrics.rowSpacing,
+                                      "A whole further row fitted and the panel left it as a gap: \(context)")
+                }
+            }
+        }
+    }
+
+    /// Collapsing My Day — or a day with less in it — is the wearer's one control over the panel's
+    /// height, and it must buy *whole rows*. Restated for the measurement: a shorter surface above
+    /// never costs the panel a row, and the freed height comes back as rows rather than as a gap.
+    func testAShorterSurfaceAboveNeverCostsThePanelARow() {
         for available in stride(from: CGFloat(600), through: 1000, by: 20) {
             for row in [CGFloat(48), 52, 64, 96] {
-                let expanded = DockGridMetrics.restingRows(
-                    availableHeight: available, rowHeight: row, surfaceAboveIsCompact: false)
-                let collapsed = DockGridMetrics.restingRows(
-                    availableHeight: available, rowHeight: row, surfaceAboveIsCompact: true)
-                XCTAssertGreaterThanOrEqual(collapsed, expanded,
-                                            "Collapsing My Day cost the panel height")
-
-                // What the panel took is never more than the share it was given, so the surface
-                // above always keeps its own.
-                let share = DockGridMetrics.heightShareWhenSurfaceAboveIsCompact
-                XCTAssertLessThanOrEqual(CGFloat(collapsed) * row, available * share + 0.001,
-                                         "The panel took more than its share of the screen")
+                var previous = 0
+                // Walking the surface *down* in height: every step affords at least as many rows.
+                for reserved in stride(from: CGFloat(560), through: 200, by: -20) {
+                    let rows = DockGridMetrics.restingRows(availableHeight: available,
+                                                           reservedHeight: reserved,
+                                                           rowHeight: row)
+                    XCTAssertGreaterThanOrEqual(
+                        rows, previous,
+                        "A shorter surface above cost the panel height: \(available)pt tab, "
+                            + "\(reserved)pt reserved, \(row)pt row")
+                    previous = rows
+                }
             }
         }
     }
@@ -399,8 +435,7 @@ final class HomeGridTests: XCTestCase {
     /// height was tried on paper and is exactly what "it keeps growing and shrinking" describes.
     func testTheFrameCannotDependOnThePage() {
         let heights = DockPage.allCases.map { _ in
-            DockGridMetrics.restingRows(availableHeight: 874, rowHeight: 52,
-                                        surfaceAboveIsCompact: false)
+            DockGridMetrics.restingRows(availableHeight: 874, reservedHeight: 400, rowHeight: 52)
         }
         XCTAssertEqual(Set(heights).count, 1,
                        "Every page resolves to the same frame — the page is not an input")
@@ -410,8 +445,8 @@ final class HomeGridTests: XCTestCase {
     /// because the conversation page shares it and a short grid must not shrink the transcript to
     /// a two-line window.
     func testAShortGridKeepsTheTallFrame() {
-        let tall = DockGridMetrics.restingRows(availableHeight: 874, rowHeight: 52,
-                                               surfaceAboveIsCompact: true)
+        let tall = DockGridMetrics.restingRows(availableHeight: 874, reservedHeight: 400,
+                                               rowHeight: 52)
         XCTAssertGreaterThan(tall, 4, "The old four-row ceiling is still capping the panel")
         // The rows the *content* needs are a separate question, and still answerable — the grid
         // scrolls past what the frame shows.
@@ -419,20 +454,35 @@ final class HomeGridTests: XCTestCase {
         XCTAssertEqual(DockGridMetrics.rowsNeeded(slotCount: 40, columns: 4), 10)
     }
 
-    /// Before the first layout there is no measured height to divide by. The panel opens at a
-    /// sensible guess rather than at zero rows, and the first real measurement settles it.
+    /// Before the first layout there is nothing measured to divide by — no screen, no row, and no
+    /// surface above. The panel opens at a sensible guess rather than at zero rows, and the first
+    /// real measurement settles it.
     func testAnUnmeasuredScreenFallsBackToAGuess() {
-        for (available, row) in [(CGFloat(0), CGFloat(52)), (874, 0), (0, 0)] {
-            XCTAssertEqual(DockGridMetrics.restingRows(availableHeight: available, rowHeight: row,
-                                                       surfaceAboveIsCompact: false),
-                           DockGridMetrics.defaultRowsWithoutMeasurement)
+        let unmeasured: [(available: CGFloat, reserved: CGFloat?, row: CGFloat)] = [
+            (0, 400, 52),
+            (874, 400, 0),
+            (0, 400, 0),
+            // The surface above has not reported yet, which is the frame this fix added.
+            (874, nil, 52),
+        ]
+        for state in unmeasured {
+            XCTAssertEqual(DockGridMetrics.restingRows(availableHeight: state.available,
+                                                       reservedHeight: state.reserved,
+                                                       rowHeight: state.row),
+                           DockGridMetrics.defaultRowsWithoutMeasurement,
+                           "\(state.available)pt tab, \(String(describing: state.reserved)) reserved, "
+                               + "\(state.row)pt row")
         }
     }
 
     /// Never zero, whatever the arithmetic says: a panel with no rows is a panel with no controls.
+    /// Including the case the measurement makes reachable — a surface above taller than the tab.
     func testAVeryShortScreenStillGetsARow() {
-        XCTAssertEqual(DockGridMetrics.restingRows(availableHeight: 100, rowHeight: 52,
-                                                   surfaceAboveIsCompact: false),
+        XCTAssertEqual(DockGridMetrics.restingRows(availableHeight: 100, reservedHeight: 60,
+                                                   rowHeight: 52),
+                       1)
+        XCTAssertEqual(DockGridMetrics.restingRows(availableHeight: 400, reservedHeight: 500,
+                                                   rowHeight: 52),
                        1)
     }
 

--- a/docs/plans/EA-voice-home-grid.md
+++ b/docs/plans/EA-voice-home-grid.md
@@ -3,9 +3,10 @@
 **Status:** ✅ Shipped P1–P3, then revised on device (2026-08-31). The dock-fit criterion closed the
 same day — the model tile dropped its model-name label for a provider glyph + constant caption (full
 name stays in the accessibility label), and the dock's strip wraps into rows of four instead of
-scrolling horizontally. Four phone rounds then rewrote most of the plan's decisions — the dock is a
-three-page pager and My Day rows can be cleared. See **P4**–**P7** below. The pattern is the plan's
-real lesson: every one of those rounds found something no amount of headless reasoning had.
+scrolling horizontally. Five phone rounds then rewrote most of the plan's decisions — the dock is a
+three-page pager, My Day rows can be cleared, and the panel's height is measured rather than
+apportioned. See **P4**–**P8b** below. The pattern is the plan's real lesson: every one of those
+rounds found something no amount of headless reasoning had.
 **Origin:** On-device design review of the shipped My Day home surface (2026-08-31): inconsistent
 vertical gaps around the My Day card, and a bottom-dock utility row that scrolls because it carries
 both controls and the user's quick actions.
@@ -356,6 +357,61 @@ its share, swept across screen sizes; a short grid keeps the tall frame; the unm
 falls back to a guess; a very short screen still gets one row; and — stated as arithmetic — the
 height function has no page input, with the pager's own test showing a page change carries a page
 and nothing else.
+
+> **Superseded by P8b.** The two shares below are gone. Everything else in P8a — the tall frame,
+> the retired ceiling, whole rows, the page-is-not-an-input invariant — stands.
+
+### P8b — The shares became a measurement (device round 4, 2026-09-02)
+
+Reported from the phone with the tall panel approved: **with My Day expanded there is a visible gap
+between the card's bottom and the panel's top.** Reproduced in the simulator first, on a screen the
+size of the one it was reported from — an open My Day whose day happened to be a light one, and
+~190 pt of empty glass under it.
+
+**Mechanism, and it is the shares' own margin.** P8a chose 0.24 and 0.52 by measuring a *plausible*
+surface — a ~116 pt status card, a ~50 pt collapsed My Day, a ~280 pt open one — and then rounded
+down so the tallest of those was never clipped at the panel's edge (P8's rule). A margin against
+clipping is dead space whenever the real card comes in shorter than the estimate, and a My Day card
+is exactly the module whose height nobody can predict: it is as tall as the day is busy. The same
+arithmetic produced the opposite failure at the other end, also reproduced: with My Day *off* the
+compact share applied, but the setup card it draws instead is far taller than the ~50 pt collapsed
+card the number was fitted to, and it was clipped flush against the panel.
+
+**What shipped instead: the panel subtracts a measurement, not a share.**
+
+1. **`DockGridMetrics.restingRows(availableHeight:reservedHeight:rowHeight:)`** — `reservedHeight`
+   is the height everything that is not a grid row actually drew. `heightShare` and
+   `heightShareWhenSurfaceAboveIsCompact` are deleted, and with them the dock's reads of
+   `myDayEnabled` / `myDayCollapsed`: My Day's state reaches the panel by changing the measurement,
+   which is also how a caption arriving reaches it, and how anything added to that surface later
+   will. **Both failure shapes close at once.** Clipping is impossible by construction, because the
+   number subtracted *is* the height the surface drew. The residual gap can only be the sub-row
+   remainder — under one row, which is breathing room rather than a hole.
+2. **Two measured groups, summed by a preference key.** `ConversationSurfaceHeightKey` reduces by
+   addition, and the zone's modules report in two groups — the status card and My Day above the
+   flexible spacer, the captions and notices held below it — because the panel needs the whole of
+   what they drew and a group left out is a group the panel would grow over. The stack's own 16 pt
+   spacing became the spacer's `minLength`, so the two gaps around it are a constant rather than
+   something else to estimate: the zone's height is two measurements plus 32.
+3. **The capsule is measured too**, on the tile's terms and for the tile's reason (`DockCapsuleHeightKey`).
+   It was the last predicted number in the reservation, and predicting it is predicting a font's
+   line height at text sizes nobody sweeps by hand. Its touch-target floor is what keeps the
+   measurement from feeding back into the panel above it.
+4. **The row arithmetic now pays for its gaps.** Rows are `floor((budget + rowSpacing) ÷ (rowHeight
+   + rowSpacing))`, not `floor(budget ÷ rowHeight)`: `n` rows also cost the `n − 1` gaps between
+   them, and those points were exactly what the last row used to overrun by.
+5. **Everything else is untouched by design.** Whole-row snapping, the one-row floor, the
+   first-frame fallback before any measurement arrives, the 0.25 s settle keyed on the height
+   itself, and the page-is-not-an-input invariant.
+
+**Tests.** The truth table's inputs become measured ones (reserved height × screen × row height →
+whole rows) at two phone sizes and an accessibility row height. Two sweeps replace the share bound:
+the panel never takes height the surface above drew, *and* never leaves a whole further row behind
+as a gap — the two failure shapes as one property. The collapse pin is restated in measurement
+terms: walking the surface above down in height never costs the panel a row. Page-independence, the
+short-grid frame, the one-row floor (including a surface taller than the tab, which measuring makes
+reachable) and the unmeasured first frame all stand, the last now including "the surface has not
+reported yet".
 
 ## Rollout and exit criteria
 

--- a/docs/plans/EA-voice-home-grid.md
+++ b/docs/plans/EA-voice-home-grid.md
@@ -308,6 +308,55 @@ and the page dots overlapped its captions.
 **Verified on device-sized simulator across states:** expanded (3 rows, card whole, gap before the
 panel), collapsed (4 rows, all captions intact, dots clear), and the grid page's own scroll.
 
+### P8a — One tall frame, and the four-row ceiling retired (device round 3, 2026-09-02)
+
+Reported from the phone once the conversation page could finally show a conversation: *"you get a
+very small space… by having full height, the conversation can be properly reviewed."* The panel was
+sized as a **grid** — at most four rows, and fewer when the grid held fewer tiles — and the
+conversation page shares that frame, so a transcript was being read through a two-line window.
+
+The first design considered was a per-page reading height: expand on the conversation page, return
+to the row-snapped height on the others. It was **rejected before it was built**, and the reason is
+the report it would have produced next — *"it keeps growing and shrinking."* A frame that depends on
+the selected page moves under every swipe, and no amount of animating it on settle makes a surface
+that changes size three times a gesture feel still.
+
+**What shipped instead: the panel is as tall as the screen affords it, at all times, on every page.**
+
+1. **`DockGridMetrics.restingRows(availableHeight:rowHeight:surfaceAboveIsCompact:)`** — the page is
+   not a parameter and neither is the slot count. Rows are `floor(share × available ÷ rowHeight)`:
+   the four-row ceiling is gone, and so is the "never more rows than the content needs" clamp that
+   used to shrink the panel for a wearer with a short speed dial. Whole rows by construction, so P8's
+   no-sliced-tile guarantee is untouched — the truncation *is* the snap.
+2. **Two shares, because My Day is the one thing above the panel whose height the wearer controls.**
+   0.24 with the card expanded (was 0.20 under a four-row ceiling), 0.52 collapsed (was 0.30) —
+   what is left once the status card, My Day in its current state, the page control and the capsule
+   have had theirs. Both are bounded by P8's rule rather than by taste: the surface above is never
+   clipped at the panel's edge. A greedier pair was tried **in the simulator first** and cut the
+   collapsed card by a few points, which is P8's exact failure shape, so the shares came down until
+   the card was whole with a gap under it, and the expanded number follows the same arithmetic
+   against a ~280 pt open card. The asymmetry is deliberate and is the honest one: a phone cannot
+   hold an open My Day *and* a tall panel, and the collapse control is how a wearer says which they
+   want. With My Day off — the shipped default — the compact branch applies, so the tall panel is
+   what a new install gets. This is also the answer to the separate report that a collapsed card
+   left dead space: the freed height now returns as whole rows rather than as a gap under the last.
+3. **The invariant is restored, not revised.** Round 4 promised *"the panel never resizes under a
+   swipe."* It now holds absolutely: **the frame is not a function of the page, so a swipe cannot
+   change it.** The two things that do change it — collapsing My Day, and the first real tile
+   measurement replacing the opening guess — both originate outside the pager and settle with a
+   0.25 s animation keyed on the height itself.
+4. **The grid page's consequence is accepted deliberately.** More visible rows and less scrolling;
+   a wearer with few tiles gets empty glass below them rather than a short panel. That trade is the
+   whole point — the frame belongs to all three pages, and the one that needs height most is the
+   one that cannot ask for it.
+
+**Tests.** The height as a truth table (My Day state × screen × row height → whole rows) at two
+phone sizes and an accessibility row height; collapsing My Day never costs rows and never exceeds
+its share, swept across screen sizes; a short grid keeps the tall frame; the unmeasured first frame
+falls back to a guess; a very short screen still gets one row; and — stated as arithmetic — the
+height function has no page input, with the pager's own test showing a page change carries a page
+and nothing else.
+
 ## Rollout and exit criteria
 
 Pure UI/composition — no new permissions, no new network. Rollback is reverting the PR. Complete

--- a/docs/plans/EA-voice-home-grid.md
+++ b/docs/plans/EA-voice-home-grid.md
@@ -4,9 +4,9 @@
 same day — the model tile dropped its model-name label for a provider glyph + constant caption (full
 name stays in the accessibility label), and the dock's strip wraps into rows of four instead of
 scrolling horizontally. Five phone rounds then rewrote most of the plan's decisions — the dock is a
-three-page pager, My Day rows can be cleared, and the panel's height is measured rather than
-apportioned. See **P4**–**P8b** below. The pattern is the plan's real lesson: every one of those
-rounds found something no amount of headless reasoning had.
+three-page pager, My Day rows can be cleared, the panel's height is measured rather than apportioned,
+and My Day expands in place instead of into a modal. See **P4**–**P8d** below. The pattern is the
+plan's real lesson: every one of those rounds found something no amount of headless reasoning had.
 **Origin:** On-device design review of the shipped My Day home surface (2026-08-31): inconsistent
 vertical gaps around the My Day card, and a bottom-dock utility row that scrolls because it carries
 both controls and the user's quick actions.
@@ -358,7 +358,8 @@ falls back to a guess; a very short screen still gets one row; and — stated as
 height function has no page input, with the pager's own test showing a page change carries a page
 and nothing else.
 
-> **Superseded by P8b.** The two shares below are gone. Everything else in P8a — the tall frame,
+> **Superseded by P8b and P8c.** The two shares below are gone, and so is the row-snapped frame.
+> Everything else in P8a — the tall frame,
 > the retired ceiling, whole rows, the page-is-not-an-input invariant — stands.
 
 ### P8b — The shares became a measurement (device round 4, 2026-09-02)
@@ -412,6 +413,67 @@ terms: walking the surface above down in height never costs the panel a row. Pag
 short-grid frame, the one-row floor (including a surface taller than the tab, which measuring makes
 reachable) and the unmeasured first frame all stand, the last now including "the surface has not
 reported yet".
+
+### P8c — One rhythm, and the remainder moves inside the glass (device round 5, 2026-09-02)
+
+P8b's arithmetic was right and its *placement* was wrong. Screenshots from the phone, both My Day
+states: the leftover — the spacer floor plus the sub-row remainder, ~70–80 pt together — rendered
+**between** My Day and the panel, while every other gap on the surface is 16 pt. The rule the report
+states is the right one: *"The gap between should be similar as the other vertical gaps. This should
+be consistent across all panels for good UI design."*
+
+Measuring fixed how much was reserved. It did not stop the frame from *rounding*, and a frame that
+snaps to whole rows has to put the rounding somewhere.
+
+1. **Every inter-module gap is `DockGridMetrics.moduleGap` (16).** Status card ↕ My Day ↕ panel ↕
+   capsule, one number, no second one. The zone's flexible spacer is gone — with the glass absorbing
+   the remainder there is nothing left for a spacer to hold — and the captions/notices block joins
+   the flow rather than being pinned to the bottom, because with no leftover those are the same
+   place. Below the capsule stays 8: the next thing there is the tab bar, not a module.
+2. **The glass absorbs everything left.** `panelPagesHeight(availableHeight:reservedHeight:rowHeight:)`
+   is pure subtraction with a floor of one row plus the dots — no row term in the frame at all. The
+   sum is now *exact*: surface + panel + the dock's rhythm = the screen, which is what the test
+   asserts instead of "within a row".
+3. **The whole-row rule moved to where it bites.** `viewportRows` snaps the grid's **scroll
+   viewport** inside the glass. The edge that can slice a tile is its scroll view's, so that is the
+   edge that lands on a row boundary; the remainder sits below it as calm empty glass, which the
+   wearer has seen and accepts. Conversation and edit pages simply fill the glass.
+4. **One settle curve, and only one animation.** `DockGridMetrics.heightSettle` is shared, and the
+   panel's frame is now **deliberately not animated** — it tracks the measurement. A second
+   animation there was the mushy part: while My Day animates its own height the reader reports a new
+   value every frame, and `.animation(value:)` restarts an ease toward each one, so the panel
+   arrived late behind a card that had already stopped. Tracking means card and panel sum to the
+   screen on *every frame* — an exact height exchange. The changes with no motion of their own to
+   ride (the opening guess giving way to the first measurement, a caption arriving, the tile and
+   capsule measurements landing) carry the settle at their source instead.
+
+### P8d — My Day expands in place; ↗ was a modal (device round 5)
+
+Reported alongside the rhythm: *"should be a nice transition when my day opens and closes, maybe the
+my day summary opens up taller rather than in a modal."*
+
+**What ↗ was.** `arrow.up.right` presented `MyDayView` as a **sheet** — a full `NavigationStack`
+screen with the whole list, per-item actions, an Availability section and pull-to-refresh. The row
+tap and "See all N items" opened the same sheet.
+
+**What it became.** A third card state, `isExpanded`, drawn in the flow:
+
+- **Chevron** = collapsed ↔ summary, as before, and a collapse resets the expansion — expansion is a
+  glance, not a setting, so it is `@State` rather than `@AppStorage`.
+- **↗ became ⤢** (`arrow.up.left.and.arrow.down.right` / its inverse): grows the card in place to
+  today's whole list. The arrows point the way the card is about to move, which the old ↗ — the
+  universal "open elsewhere" — actively contradicted. "See all N items" and a row tap do the same.
+- **The row actions came with it.** Complete, directions, dismiss and open-in-Calendar are ported
+  into the expanded rows, so moving the list into the card is not a quieter version of it.
+- **The card grows to whatever the day needs** and the zone — already a scroll view — scrolls when
+  the day is longer than the screen. Deliberately *not* a nested scroll view inside the card: it
+  would fight the zone's gesture and make the card's measured height ambiguous, which is the number
+  the panel is sized from. The panel floors at one row plus the dots, as its own test pins.
+
+**The modal survives for one named reason.** Repairing a source needs per-source messages and a
+Settings deep link, which is a genuinely different screen from a list of today's items. It is now
+reached from the availability line — the thing it repairs — instead of from the expand control, and
+that line became a button. VoiceOver labels follow the new behaviour throughout.
 
 ## Rollout and exit criteria
 


### PR DESCRIPTION
## Summary

Device-feedback round on the pager: "you get a very small space [for conversation history]… by having full height, the conversation can be properly reviewed" + "the panel should grow anyway whichever page is shown, otherwise it keeps growing and shrinking."

- **The frame is a function of what sits above it — nothing else.** Page selection and slot count both dropped as height inputs: a per-page reading mode would move the frame under every swipe, and clamping to `rowsNeeded` let a short speed dial shrink the frame all three pages share (the conversation page is the one that needs height and cannot ask for it). A short grid now leaves calm empty glass instead of shrinking the panel.
- **Ceiling gone, whole rows by construction**: `rows = floor(share × available ÷ rowHeight)`, min 1 — the truncation *is* the no-sliced-tile guarantee. Panel goes ~4 rows → ~8 on an iPhone Air with My Day collapsed (the shipped default state gets the tall branch).
- **Shares measured, not chosen**: 0.24 expanded / 0.52 collapsed. The first attempt (0.58) was built, caught in the simulator clipping the collapsed My Day card flush against the glass — the exact failure shape the whole-rows rule exists to prevent — and backed off with before/after screenshots.
- **The round-4 invariant is restored, not revised**: "the panel never resizes under a swipe" is now arithmetic (the page isn't an input) rather than discipline, pinned by a test that a page change carries a page and nothing else. Height moves only on My Day collapse or the first real tile measurement, both settling on a height-keyed animation outside the pager. EA plan doc gains P8a with the rejected design recorded.

## Verification

- Full suite: **4052 executed, 0 failures** (4 env-gated skips); height truth table across My Day states × phone sizes × accessibility row heights
- Release build: green (after supplying the worktree's gitignored signing config — first gate run failed on signing, not code)
- Device-eyes: streaming reply at full height during auto-flip; the expanded-My-Day share in practice (derived arithmetically — sim seeding was blocked by a permission prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)