### PR TITLE
Always stream ChatGPT-subscription Responses calls

### DIFF
--- a/OpenGlasses/Sources/Services/LLM/ResponsesTranslator.swift
+++ b/OpenGlasses/Sources/Services/LLM/ResponsesTranslator.swift
@@ -12,15 +12,20 @@ enum ResponsesTranslator {
     // MARK: - Request building
 
     /// Full request body: system prompt rides `instructions`; history becomes `input` items.
+    ///
+    /// Always streams. The backend rejects non-streaming requests outright
+    /// (`400 {"detail":"Stream must be set to true"}`), matching the upstream client, which
+    /// hardwires `stream: true`; callers that don't need live tokens still read the SSE and
+    /// take the `response.completed` payload.
     static func requestBody(model: String, instructions: String, history: [[String: Any]],
-                            tools: [[String: Any]]?, stream: Bool) -> [String: Any] {
+                            tools: [[String: Any]]?) -> [String: Any] {
         var body: [String: Any] = [
             "model": model,
             "instructions": instructions,
             "input": inputItems(history: history),
             // The backend keeps no server-side state for us — we resend history each turn.
             "store": false,
-            "stream": stream,
+            "stream": true,
         ]
         if let tools, !tools.isEmpty {
             body["tools"] = responseTools(fromChatTools: tools)

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -1948,30 +1948,20 @@ class LLMService: ObservableObject {
                 request.httpMethod = "POST"
                 request.setValue("application/json", forHTTPHeaderField: "Content-Type")
                 ChatGPTAuth.apply(credential: token, accountID: accountID, to: &request)
-                let streaming = onToken != nil
                 let historyForRequest = self.requestHistory(for: .chatgpt, smallContext: smallContext)
                 let body = ResponsesTranslator.requestBody(
                     model: config.model, instructions: systemPrompt,
-                    history: historyForRequest, tools: tools, stream: streaming)
+                    history: historyForRequest, tools: tools)
                 request.httpBody = try JSONSerialization.data(withJSONObject: body)
                 request.timeoutInterval = 120
 
-                let responseJSON: [String: Any]
-                if streaming, let onToken {
+                // The backend only serves streamed responses; without a token sink we still read
+                // the SSE and use the completed payload.
+                if onToken != nil {
                     // New tool-loop iteration: clear the caller's accumulated bubble first (BM P9).
                     onStreamReset?()
-                    responseJSON = try await self.streamResponsesTurn(request: request, onToken: onToken)
-                } else {
-                    let (data, response) = try await URLSession.shared.data(for: request)
-                    let status = (response as? HTTPURLResponse)?.statusCode ?? 0
-                    guard status == 200 else {
-                        let bodyText = String(data: data, encoding: .utf8) ?? ""
-                        PrivacyLog.model(.apiError, provider: PrivacyToken("chatgpt"),
-                                         status: status, bytes: data.count)
-                        throw LLMError.apiError(provider: "ChatGPT", statusCode: status, message: String(bodyText.prefix(300)))
-                    }
-                    responseJSON = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
                 }
+                let responseJSON = try await self.streamResponsesTurn(request: request, onToken: onToken)
 
                 let parsed = ResponsesTranslator.parseOutput(responseJSON)
                 // The parse-vs-sent diagnostic seam — where "tool_call returned but nothing
@@ -2011,11 +2001,14 @@ class LLMService: ObservableObject {
                                      setStatus: { [weak self] in self?.toolCallStatus = $0 })
     }
 
-    /// One streamed Responses turn: SSE events → `onToken` text deltas; returns the
-    /// authoritative `response.completed` payload (a shed delta is cosmetic, never corrupting).
-    /// Events are fed to the parser only at blank-line boundaries so a network chunk can't
-    /// shear a multi-byte character or a JSON payload.
-    private func streamResponsesTurn(request: URLRequest, onToken: @escaping (String) -> Void) async throws -> [String: Any] {
+    /// One streamed Responses turn: SSE events → `onToken` text deltas (nil when the caller
+    /// only wants the final payload); returns the authoritative `response.completed` payload
+    /// (a shed delta is cosmetic, never corrupting). Events are fed to the parser only at
+    /// blank-line boundaries so a network chunk can't shear a multi-byte character or a JSON
+    /// payload.
+    // Internal (not private) so the streaming fixture tests can drive it through a stubbed
+    // `streamingSession`.
+    func streamResponsesTurn(request: URLRequest, onToken: ((String) -> Void)?) async throws -> [String: Any] {
         let (bytes, response) = try await streamingSession.bytes(for: request)
         let status = (response as? HTTPURLResponse)?.statusCode ?? 0
         guard status == 200 else {
@@ -2025,6 +2018,8 @@ class LLMService: ObservableObject {
                 if errorBody.count > 2048 { break }
             }
             let text = String(data: errorBody, encoding: .utf8) ?? ""
+            PrivacyLog.model(.apiError, provider: PrivacyToken("chatgpt"),
+                             status: status, bytes: errorBody.count)
             throw LLMError.apiError(provider: "ChatGPT", statusCode: status, message: String(text.prefix(300)))
         }
 
@@ -2036,7 +2031,7 @@ class LLMService: ObservableObject {
             var events = parser.consume(chunk)
             if flush { events += parser.flush() }
             for event in events {
-                if let delta = accumulator.consume(event) {
+                if let delta = accumulator.consume(event), let onToken {
                     TurnRecorder.markFirstToken()
                     onToken(delta)
                 }
@@ -2073,7 +2068,7 @@ class LLMService: ObservableObject {
               let url = URL(string: ChatGPTOAuth.backendResponsesURL) else { return nil }
         var body = ResponsesTranslator.requestBody(
             model: model, instructions: instructions,
-            history: [["role": "user", "content": userContent]], tools: nil, stream: false)
+            history: [["role": "user", "content": userContent]], tools: nil)
         if let responseTools {
             body["tools"] = responseTools
             if let forcedToolName {
@@ -2086,12 +2081,9 @@ class LLMService: ObservableObject {
         ChatGPTAuth.apply(credential: token, accountID: ChatGPTOAuthService.shared.accountID, to: &request)
         request.timeoutInterval = timeout
         request.httpBody = try? JSONSerialization.data(withJSONObject: body)
-        guard let (data, response) = try? await URLSession.shared.data(for: request),
-              (response as? HTTPURLResponse)?.statusCode == 200,
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            return nil
-        }
-        return json
+        // Streamed like every other backend call (it refuses `stream: false`); no token sink,
+        // just the completed payload.
+        return try? await streamResponsesTurn(request: request, onToken: nil)
     }
 
     /// Structured variant (BW P4): forced function call → the tool's arguments object, with the

--- a/OpenGlassesTests/LLMStreamingTests.swift
+++ b/OpenGlassesTests/LLMStreamingTests.swift
@@ -261,6 +261,87 @@ final class LLMStreamingTests: XCTestCase {
     }
 }
 
+// MARK: - ChatGPT Responses backend (always streamed)
+
+/// The ChatGPT-subscription backend refuses non-streaming requests
+/// (`400 {"detail":"Stream must be set to true"}`), so every Responses call — including the
+/// stateless summariser/structured paths that have no token sink — reads SSE and takes the
+/// `response.completed` payload.
+@MainActor
+final class ResponsesStreamingTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        SSEQueueProtocol.queue = []
+    }
+
+    private func service() -> LLMService {
+        let s = LLMService()
+        s.streamingSession = SSEQueueProtocol.session()
+        return s
+    }
+
+    private var request: URLRequest { URLRequest(url: URL(string: "https://api.test/responses")!) }
+
+    private let completedTurn = """
+    event: response.created
+    data: {"type":"response.created","response":{"id":"resp_1"}}
+
+    event: response.output_text.delta
+    data: {"type":"response.output_text.delta","delta":"It is "}
+
+    event: response.output_text.delta
+    data: {"type":"response.output_text.delta","delta":"sunny."}
+
+    event: response.completed
+    data: {"type":"response.completed","response":{"id":"resp_1","output":[{"type":"message","content":[{"type":"output_text","text":"It is sunny."}]}],"usage":{"input_tokens":3,"output_tokens":4}}}
+
+    """
+
+    func testNoTokenSinkStillReturnsCompletedPayload() async throws {
+        SSEQueueProtocol.queue = [(200, completedTurn)]
+        let json = try await service().streamResponsesTurn(request: request, onToken: nil)
+        XCTAssertEqual(ResponsesTranslator.parseOutput(json).text, "It is sunny.")
+        XCTAssertEqual((json["usage"] as? [String: Any])?["output_tokens"] as? Int, 4)
+    }
+
+    func testTokenSinkReceivesDeltasAndCompletedPayload() async throws {
+        SSEQueueProtocol.queue = [(200, completedTurn)]
+        var tokens = ""
+        let json = try await service().streamResponsesTurn(request: request) { tokens += $0 }
+        XCTAssertEqual(tokens, "It is sunny.")
+        XCTAssertEqual(json["id"] as? String, "resp_1")
+    }
+
+    func testStreamRejectionSurfacesBackendDetail() async {
+        SSEQueueProtocol.queue = [(400, #"{"detail":"Stream must be set to true"}"#)]
+        do {
+            _ = try await service().streamResponsesTurn(request: request, onToken: nil)
+            XCTFail("expected a thrown API error")
+        } catch let LLMError.apiError(provider, statusCode, message) {
+            XCTAssertEqual(provider, "ChatGPT")
+            XCTAssertEqual(statusCode, 400)
+            XCTAssertEqual(message?.contains("Stream must be set to true"), true)
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testPrematureEOFWithoutCompletionThrows() async {
+        SSEQueueProtocol.queue = [(200, """
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","delta":"half"}
+
+        """)]
+        do {
+            _ = try await service().streamResponsesTurn(request: request, onToken: nil)
+            XCTFail("expected a thrown error")
+        } catch {
+            XCTAssertTrue("\(error)".contains("stream ended without completion"), "\(error)")
+        }
+    }
+}
+
 // MARK: - SSE stub (queue of canned responses, popped per request)
 
 final class SSEQueueProtocol: URLProtocol {

--- a/OpenGlassesTests/ResponsesTranslatorTests.swift
+++ b/OpenGlassesTests/ResponsesTranslatorTests.swift
@@ -83,10 +83,10 @@ final class ResponsesTranslatorTests: XCTestCase {
         let body = ResponsesTranslator.requestBody(
             model: "test-model", instructions: "be brief",
             history: [["role": "user", "content": "hi"]],
-            tools: [["type": "function", "function": ["name": "t", "description": "d"] as [String: Any]]],
-            stream: true)
+            tools: [["type": "function", "function": ["name": "t", "description": "d"] as [String: Any]]])
         XCTAssertEqual(body["model"] as? String, "test-model")
         XCTAssertEqual(body["instructions"] as? String, "be brief")
+        // The backend answers `400 Stream must be set to true` to anything else.
         XCTAssertEqual(body["stream"] as? Bool, true)
         XCTAssertEqual(body["store"] as? Bool, false)
         XCTAssertEqual((body["input"] as? [[String: Any]])?.count, 1)

--- a/project.base.yml
+++ b/project.base.yml
@@ -132,7 +132,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "361"
+        CURRENT_PROJECT_VERSION: "362"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -247,7 +247,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "361"
+        CURRENT_PROJECT_VERSION: "362"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -285,7 +285,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "361"
+        CURRENT_PROJECT_VERSION: "362"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "361"
+        CURRENT_PROJECT_VERSION: "362"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.8"
-        CURRENT_PROJECT_VERSION: "361"
+        CURRENT_PROJECT_VERSION: "362"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
## Summary

The ChatGPT-subscription backend now refuses non-streaming requests outright:

```
ChatGPT error 400: {"detail":"Stream must be set to true"}
```

That broke every subscription turn that had no live token sink: voice/glasses turns through the tool loop, plus the stateless summariser and structured-vision paths. Only the Chat tab (which streams tokens) still worked. The upstream client has always hardwired `stream: true`; the backend just started enforcing it.

## Changes

- `ResponsesTranslator.requestBody` hardwires `stream: true` and drops the `stream` parameter so no caller can regress it.
- `streamResponsesTurn` takes an optional token sink. The tool loop always streams and only resets the chat bubble when a sink exists. The stateless path reads the same SSE and takes the `response.completed` payload.
- Non-200 streamed responses log through `PrivacyLog` as the removed non-streaming branch did.
- New `ResponsesStreamingTests` fixtures (stubbed `streamingSession`): no-sink completed payload + usage, sink deltas, the 400 rejection surfacing the backend detail, premature EOF throwing.
- Build 361 → 362.

## Caveat

A custom base URL on a ChatGPT model config must now support SSE; there is no non-streaming fallback.

## Verification

- `ResponsesTranslatorTests`, `ResponsesStreamingTests`, `LLMStreamingTests`: 25 tests, 0 failures (iPhone 17 Pro sim, Xcode beta toolchain).
- Full `OpenGlassesTests` suite: 4056 tests, 4 skipped, 0 failures (after one CoreSimulator runner-hang flake, recovered by erasing the sim).
- Release build: result posted as a comment when it finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
