### PR TITLE
Publish the first signed vault-pack catalog

### DIFF
--- a/vaultpacks/catalog.json
+++ b/vaultpacks/catalog.json
@@ -1,0 +1,1 @@
+{"payload":"eyJ2ZXJzaW9uIjoxLCJwYWNrcyI6W119Cg==","signature":"+doHsBIs6x0rDwbvDAFfIoLmUQBYGAF2DXYbdwZQi6FHuWnsyK8LGz+PJgF\/yAo4c\/pHQ3hUG6eErfjs\/dK9Bw=="}


### PR DESCRIPTION
## Summary

Adds `vaultpacks/catalog.json`: an empty index signed with the vendor key, served by the existing GitHub Pages deployment at the app's default catalog URL. With it in place the Packs list in Custom Vaults shows "No packs are published yet" instead of an unreachable-catalog error. Packs are added through the flow in `vaultpacks/README.md`.

## Test plan

- [x] Envelope signature verified against the embedded `SkillPackSignature.productionPublicKeyBase64`; index decodes as version 1 with zero packs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)