### PR TITLE
Read streamed output items — the completed envelope went slim (ChatGPT)

### DIFF
--- a/OpenGlasses/Sources/Services/LLM/ResponsesTranslator.swift
+++ b/OpenGlasses/Sources/Services/LLM/ResponsesTranslator.swift
@@ -140,6 +140,22 @@ enum ResponsesTranslator {
     struct StreamAccumulator {
         private(set) var completedResponse: [String: Any]?
         private(set) var failureMessage: String?
+        /// Output items collected from `response.output_item.done` as they stream. The backend's
+        /// `response.completed` envelope has slimmed to metadata/usage — the upstream client never
+        /// reads `output` from it, and neither can we: the items arrive one event each, done-side.
+        private(set) var doneItems: [[String: Any]] = []
+
+        /// The response to hand `parseOutput`: the completed payload with the streamed items
+        /// substituted in whenever the envelope's own `output` is missing or empty. A fat
+        /// envelope (fixtures, older backends) still wins when it actually carries items.
+        var effectiveResponse: [String: Any]? {
+            guard var response = completedResponse else { return nil }
+            let envelopeOutput = response["output"] as? [[String: Any]] ?? []
+            if envelopeOutput.isEmpty && !doneItems.isEmpty {
+                response["output"] = doneItems
+            }
+            return response
+        }
 
         /// Consume one SSE event; returns a text delta to surface, or nil.
         mutating func consume(_ event: SSEEvent) -> String? {
@@ -151,8 +167,13 @@ enum ResponsesTranslator {
             switch type {
             case "response.output_text.delta":
                 return json["delta"] as? String
+            case "response.output_item.done":
+                if let item = json["item"] as? [String: Any] {
+                    doneItems.append(item)
+                }
+                return nil
             case "response.completed":
-                completedResponse = json["response"] as? [String: Any]
+                completedResponse = json["response"] as? [String: Any] ?? [:]
                 return nil
             case "response.failed", "error":
                 let error = (json["response"] as? [String: Any])?["error"] as? [String: Any]

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -2067,7 +2067,7 @@ class LLMService: ObservableObject {
         if let failure = accumulator.failureMessage {
             throw LLMError.apiError(provider: "ChatGPT", statusCode: 200, message: failure)
         }
-        guard let completed = accumulator.completedResponse else {
+        guard let completed = accumulator.effectiveResponse else {
             throw LLMError.invalidResponse("ChatGPT (stream ended without completion)")
         }
         return completed

--- a/OpenGlassesTests/ResponsesTranslatorTests.swift
+++ b/OpenGlassesTests/ResponsesTranslatorTests.swift
@@ -175,6 +175,54 @@ final class ResponsesTranslatorTests: XCTestCase {
         XCTAssertNil(accumulator.failureMessage)
     }
 
+    /// The backend slimmed `response.completed` to metadata/usage — no `output` array — which
+    /// made every reply parse to empty text and zero tool calls, silently (seen on device
+    /// 2026-09-04, gpt-5.6-terra; the upstream client never reads output from the envelope,
+    /// collecting `response.output_item.done` instead). The accumulator must do the same.
+    func testSlimCompletedEnvelopeUsesStreamedOutputItems() {
+        var accumulator = ResponsesTranslator.StreamAccumulator()
+        for event in SSEEventParser.parse("""
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"type":"reasoning","summary":[]}}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"type":"message","content":[{"type":"output_text","text":"Hello from items"}]}}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"type":"function_call","name":"get_weather","call_id":"c1","arguments":"{}"}}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_1","usage":{"input_tokens":10,"output_tokens":5}}}
+
+        """) {
+            _ = accumulator.consume(event)
+        }
+        let final = ResponsesTranslator.parseOutput(accumulator.effectiveResponse ?? [:])
+        XCTAssertEqual(final.text, "Hello from items")
+        XCTAssertEqual(final.toolCalls.count, 1)
+        XCTAssertEqual(final.toolCalls.first?.name, "get_weather")
+        // Usage from the slim envelope survives alongside the substituted items.
+        XCTAssertNotNil(accumulator.effectiveResponse?["usage"])
+    }
+
+    /// A fat envelope that genuinely carries output still wins over streamed items — older
+    /// backends and every existing fixture keep their meaning.
+    func testFatCompletedEnvelopeStillAuthoritative() {
+        var accumulator = ResponsesTranslator.StreamAccumulator()
+        for event in SSEEventParser.parse("""
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","item":{"type":"message","content":[{"type":"output_text","text":"from items"}]}}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":"from envelope"}]}]}}
+
+        """) {
+            _ = accumulator.consume(event)
+        }
+        let final = ResponsesTranslator.parseOutput(accumulator.effectiveResponse ?? [:])
+        XCTAssertEqual(final.text, "from envelope")
+    }
+
     func testStreamAccumulatorCapturesFailure() {
         var accumulator = ResponsesTranslator.StreamAccumulator()
         for event in SSEEventParser.parse("""


### PR DESCRIPTION
## Summary

Third ChatGPT wire-drift of the week, and the quietest: every voice turn completed *successfully* with no reply — no error, no tool calls, no text. The on-device diagnostics ring (DM P3, doing exactly its job) told the story: `turnStarted provider=chatgpt` → four seconds of stream → `toolCallsParsed count=0` → silence, while Claude turns on the same build spoke fine.

**Root cause**: the backend's `response.completed` envelope has slimmed to metadata/usage — no `output` array. The upstream client never reads output from the envelope at all; it collects `response.output_item.done` events as they stream (its `ResponseCompleted` struct doesn't even have an output field). Our accumulator waited for envelope output that no longer exists, so `parseOutput` received an empty array and the reply vanished errorlessly — invisible to fixtures built on the old fat envelope.

**Fix**: the accumulator collects done items as they stream; `effectiveResponse` substitutes them whenever the envelope's own `output` is missing or empty. A fat envelope that genuinely carries output still wins, so older backends and every existing fixture keep their meaning; usage from the slim envelope survives alongside the substituted items. Two new fixtures pin both directions, including the reasoning-item-then-message sequence the current model family sends.

## Verification

- Full suite: **4263 tests, 0 failures** (4 skipped); `ResponsesTranslatorTests` 12/12 with the new slim/fat fixtures
- Release build (generic iOS): green
- Device retest is the true proof — installing on the test phone alongside this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)