### PR TITLE
Track a gateway run when its response is routed, not when the caller wakes

### DIFF
--- a/OpenGlasses/Sources/Services/OpenClaw/GatewayWire.swift
+++ b/OpenGlasses/Sources/Services/OpenClaw/GatewayWire.swift
@@ -52,6 +52,10 @@ enum GatewayWire {
         "channels.send", "channels.list",
         "agent.start", "agent.status", "agent.cancel", "agent.respond",
     ]
+
+    /// Methods whose response carries a `runId` — the reply arrives later as `chat` events, so
+    /// the run has to be tracked the moment its response is routed.
+    static let runStartingMethods: Set<String> = ["sessions.send", "chat.send"]
 }
 
 // MARK: - connect.challenge

--- a/OpenGlasses/Sources/Services/OpenClawBridge.swift
+++ b/OpenGlasses/Sources/Services/OpenClawBridge.swift
@@ -73,7 +73,14 @@ class OpenClawBridge: ObservableObject {
     private let socketFactory: GatewaySocketFactory
     private var socket: GatewaySocket?
     private var wsConnected = false
-    private var pendingResponses: [String: CheckedContinuation<String, Error>] = [:]
+    /// An in-flight request: the method it asked for, kept alongside the waiter so the receive
+    /// loop can act on the response before the caller is resumed.
+    private struct PendingRequest {
+        let method: String
+        let continuation: CheckedContinuation<String, Error>
+    }
+
+    private var pendingResponses: [String: PendingRequest] = [:]
 
     /// Correlates `chat` events with the requests that started them.
     let runTracker = ChatRunTracker()
@@ -455,8 +462,8 @@ class OpenClawBridge: ObservableObject {
                     guard self.socket === socket else { return }
                     self.wsConnected = false
                     // Fail all pending requests
-                    for (_, cont) in self.pendingResponses {
-                        cont.resume(throwing: error)
+                    for (_, pending) in self.pendingResponses {
+                        pending.continuation.resume(throwing: error)
                     }
                     self.pendingResponses.removeAll()
                     break
@@ -468,8 +475,16 @@ class OpenClawBridge: ObservableObject {
     private func route(frame json: [String: Any], rawText: String) {
         switch json["type"] as? String {
         case "res":
-            if let id = json["id"] as? String, let cont = pendingResponses.removeValue(forKey: id) {
-                cont.resume(returning: rawText)
+            if let id = json["id"] as? String, let pending = pendingResponses.removeValue(forKey: id) {
+                // Track a started run here, not where the caller resumes: the caller wakes on a
+                // later turn of this actor, and the run's `chat` events are routed in between.
+                // A run that finishes fast would otherwise reach the tracker as an unknown run,
+                // its terminal state dropped and its waiter left to time out.
+                if GatewayWire.runStartingMethods.contains(pending.method),
+                   let runId = (json["payload"] as? [String: Any])?["runId"] as? String, !runId.isEmpty {
+                    runTracker.register(runId: runId)
+                }
+                pending.continuation.resume(returning: rawText)
             }
         case "event":
             let event = json["event"] as? String ?? ""
@@ -559,15 +574,15 @@ class OpenClawBridge: ObservableObject {
         // actor too, and a gateway that answers within the same turn (or a scripted one that
         // answers synchronously) would otherwise route the reply before anyone was waiting.
         let responseText: String = try await withCheckedThrowingContinuation { continuation in
-            pendingResponses[reqId] = continuation
+            pendingResponses[reqId] = PendingRequest(method: method, continuation: continuation)
 
             Task {
                 do {
                     try await socket.send(text)
                 } catch {
                     await MainActor.run {
-                        if let cont = self.pendingResponses.removeValue(forKey: reqId) {
-                            cont.resume(throwing: error)
+                        if let pending = self.pendingResponses.removeValue(forKey: reqId) {
+                            pending.continuation.resume(throwing: error)
                         }
                     }
                 }
@@ -577,8 +592,8 @@ class OpenClawBridge: ObservableObject {
             Task {
                 try? await Task.sleep(nanoseconds: 120_000_000_000)
                 await MainActor.run {
-                    if let cont = self.pendingResponses.removeValue(forKey: reqId) {
-                        cont.resume(throwing: NSError(domain: "OpenClaw", code: -3, userInfo: [NSLocalizedDescriptionKey: "Request timed out"]))
+                    if let pending = self.pendingResponses.removeValue(forKey: reqId) {
+                        pending.continuation.resume(throwing: NSError(domain: "OpenClaw", code: -3, userInfo: [NSLocalizedDescriptionKey: "Request timed out"]))
                     }
                 }
             }
@@ -597,8 +612,8 @@ class OpenClawBridge: ObservableObject {
         socket?.cancel()
         socket = nil
         gatewayHello = nil
-        for (_, cont) in pendingResponses {
-            cont.resume(throwing: NSError(domain: "OpenClaw", code: -5, userInfo: [NSLocalizedDescriptionKey: "Disconnected"]))
+        for (_, pending) in pendingResponses {
+            pending.continuation.resume(throwing: NSError(domain: "OpenClaw", code: -5, userInfo: [NSLocalizedDescriptionKey: "Disconnected"]))
         }
         pendingResponses.removeAll()
     }

--- a/OpenGlassesTests/OpenClawScriptedSocketTests.swift
+++ b/OpenGlassesTests/OpenClawScriptedSocketTests.swift
@@ -170,6 +170,17 @@ final class OpenClawBridgeScriptedSocketTests: XCTestCase {
         return (bridge, socket)
     }
 
+    /// Poll a condition fed by a fire-and-forget task. Returns as soon as it holds, so a
+    /// passing run costs nothing; the deadline only bounds a broken one.
+    private func waitUntil(_ description: String, timeout: TimeInterval = 10,
+                           _ condition: () -> Bool) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTAssertTrue(condition(), "timed out waiting for \(description)")
+    }
+
     func testDelegateTaskCorrelatesTheAnswerByRunId() async throws {
         let (bridge, socket) = makeBridge { id, _ in
             [GatewayScript.ok(replyTo: id, payload: ["runId": "run-1", "status": "ok"]),
@@ -216,8 +227,8 @@ final class OpenClawBridgeScriptedSocketTests: XCTestCase {
              GatewayScript.chat(runId: "r", seq: 1, state: "final", text: "ok")]
         }
         _ = await bridge.delegateTask(task: "x")
-        // The catalog query is fire-and-forget after connect; give it a moment.
-        for _ in 0..<50 where bridge.availableToolNames.isEmpty { try? await Task.sleep(nanoseconds: 10_000_000) }
+        // The catalog query is fire-and-forget after connect; wait for it, don't race it.
+        await waitUntil("the tool catalog") { !bridge.availableToolNames.isEmpty }
         XCTAssertEqual(bridge.availableToolNames, ["web_search"])
         XCTAssertEqual(socket.sentRequests(method: "tools.effective").count, 1)
     }
@@ -241,14 +252,28 @@ final class OpenClawBridgeScriptedSocketTests: XCTestCase {
         XCTAssertEqual(lateText, "Here is your week.")
     }
 
+    /// The gateway aborts the run in the same breath as accepting it: the `chat` event is on the
+    /// wire before `delegateTask` resumes to look at the response. The run must already be tracked
+    /// by then — the bridge registers it as the response is routed — or the terminal state lands on
+    /// an unknown run, is dropped, and the caller waits out `replyTimeout` for an answer that
+    /// already came and went.
     func testAbortedRunIsAFailure() async {
         let (bridge, _) = makeBridge { id, _ in
             [GatewayScript.ok(replyTo: id, payload: ["runId": "a", "status": "ok"]),
              GatewayScript.chat(runId: "a", seq: 1, state: "aborted", text: nil)]
         }
+        // Nothing here waits on a clock: the abort is queued before the send returns. The bound
+        // exists so a dropped terminal event fails in seconds instead of parking for two minutes.
+        bridge.replyTimeout = 5
+
         let result = await bridge.delegateTask(task: "x")
-        guard case .failure(let message) = result else { return XCTFail("expected failure") }
+
+        guard case .failure(let message) = result else {
+            return XCTFail("expected failure, got \(result) — the abort was not correlated to the run")
+        }
         XCTAssertTrue(message.contains("stopped"))
+        XCTAssertEqual(bridge.runTracker.state(runId: "a"),
+                       ChatRunTracker.RunState(phase: .aborted), "the abort is recorded against the run")
     }
 
     func testOversizeImageIsDroppedNotSent() async throws {


### PR DESCRIPTION
## The failure

`OpenClawBridgeScriptedSocketTests.testAbortedRunIsAFailure` failed on GitHub Actions on 2026-09-04 with "failed - expected failure" after **120.210 seconds**, while the whole seven-test class runs in 0.55s locally.

120.2s is not an expectation timeout — it is `OpenClawBridge.replyTimeout` (default 120) expiring. The abort never reached the waiter at all, so `delegateTask` returned its *parked* `.success(...)` and the `guard case .failure` fired. Raising a timeout would not have helped; the event was already gone.

## The race

It is a real race in the bridge, not only in the test:

1. The `sessions.send` response and the run's `chat` events arrive on one socket, response first.
2. The receive loop routes the response and resumes the caller — but the caller only wakes on a **later** turn of the MainActor.
3. `runTracker.register(runId:)` lived in `delegateTask`, on that later turn.
4. A gateway that accepts and then aborts in the same breath puts the terminal `chat` frame on the wire behind the response. If the loop routes it before the caller wakes, `ChatRunTracker.handle` finds no such run, returns `.unknownRun` — the "another client's run in this session" path — and drops the terminal state. The waiter then sits out the full two minutes.

A fast M-series Mac wins that race every time; a loaded CI runner did not.

## The fix

Register the run where the response frame is routed, before any later frame can reach the tracker. `pendingResponses` now carries each request's method alongside its continuation so `route` can tell a run-starting response from any other.

Ordering is fixed rather than scheduled: whichever way the two jobs interleave, the terminal state lands on a tracked run — either waking the waiter directly, or being stored so `wait(runId:)` returns it immediately.

## Tests

- `testAbortedRunIsAFailure` now pins the correlation itself (`runTracker.state(runId:) == .aborted`), and bounds `replyTimeout` to 5s so a regression fails in seconds instead of parking for two minutes. Its wait is not clock-dependent: the abort is queued before the send returns.
- The sibling catalog test waited a fixed 500ms for a fire-and-forget query; it now waits on its condition and returns as soon as it holds.

## Verification

- `-only-testing:OpenGlassesTests/OpenClawBridgeScriptedSocketTests` — 7/7 pass in 0.55s (`testAbortedRunIsAFailure` in 0.052s).
- Full `OpenGlassesTests` suite — **4264 tests, 0 failures**, 4 skipped, 64s.

Both under the Xcode beta toolchain, since only an iOS 27 simulator runtime is installed on this machine.

I did not manage a slow-runner reproduction: the box was saturated by unrelated work (load average ~1000 from booted simulator runtimes) and CoreSimulator could not even enumerate a destination under that load. The fix removes the scheduling dependence rather than making the losing order less likely, so the reproduction would have been supporting evidence, not the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)