### PR TITLE
Load and generate from GGUF weights through the runtime seam (DZ P1/PR3)

### DIFF
--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -182,7 +182,14 @@ class LLMService: ObservableObject {
 
     private func coordinator(for service: LocalLLMService) -> LocalInferenceCoordinator {
         if let localCoordinator { return localCoordinator }
-        let created = LocalInferenceCoordinator(backends: [MLXLocalInferenceBackend(service: service)])
+        // Both runtimes are registered; neither is *enabled* by registration. The GGUF backend
+        // refuses every load with `.runtimeDisabled` while `Config.ggufModelsEnabled` is off, and
+        // constructing it touches nothing native — so registering it here cannot change what an
+        // MLX user's turn does, and the flag stays effective without a relaunch.
+        let created = LocalInferenceCoordinator(backends: [
+            MLXLocalInferenceBackend(service: service),
+            LlamaCppLocalInferenceBackend(),
+        ])
         localCoordinator = created
         return created
     }

--- a/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/GGUFMetadataValidator.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/GGUFMetadataValidator.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+/// What a GGUF file says about itself, and the arithmetic that turns it into a context window.
+///
+/// Every value here comes from the file's own key/value metadata. Plan DZ's non-goal is explicit —
+/// "Guessing chat templates, architecture, capability, context, or projector compatibility from
+/// names" — so there is no filename parsing anywhere in this file, and none is wanted: a repack of
+/// the same weights under a different name must resolve to the same architecture.
+///
+/// Pure, so the whole clamping truth table and the over-context refusal are exercised headlessly.
+
+/// The architectural facts needed to size a context.
+struct GGUFModelMetadata: Equatable, Sendable {
+    /// `general.architecture`, e.g. `llama`, `qwen3`, `gemma3`. Also the prefix of every
+    /// architecture-scoped key.
+    let architecture: String
+    /// `<arch>.context_length` — what the model was trained for. `0` when the file omits it.
+    let trainingContextTokens: Int
+    /// `<arch>.block_count` — transformer layers.
+    let blockCount: Int?
+    /// `<arch>.embedding_length`.
+    let embeddingLength: Int?
+    /// `<arch>.attention.head_count`.
+    let headCount: Int?
+    /// `<arch>.attention.head_count_kv`. Absent means multi-head attention, i.e. equal to
+    /// `headCount` — that is the GGUF convention, not an assumption of ours.
+    let headCountKV: Int?
+
+    /// Bytes one token of KV cache costs, or `nil` when the file does not describe its own shape
+    /// well enough to say.
+    ///
+    /// `2` for the K and V halves, times layers, times the per-layer KV width, times the element
+    /// size. Returning `nil` rather than a guess matters: an invented number would silently clamp
+    /// a working model's context, and a wrong clamp is indistinguishable from a broken model.
+    func kvCacheBytesPerToken(bytesPerElement: Int = 2) -> Int64? {
+        guard let blockCount, blockCount > 0,
+              let embeddingLength, embeddingLength > 0,
+              let headCount, headCount > 0 else { return nil }
+        let kvHeads = headCountKV ?? headCount
+        guard kvHeads > 0 else { return nil }
+        let headDimension = embeddingLength / headCount
+        guard headDimension > 0 else { return nil }
+        return Int64(2 * blockCount * headDimension * kvHeads * bytesPerElement)
+    }
+}
+
+/// Why a file's metadata cannot be trusted to configure a runtime.
+enum GGUFMetadataFault: Error, Equatable, Sendable {
+    /// No `general.architecture`. Without it there is no architecture-scoped key to read, and the
+    /// file is not a GGUF this runtime can configure.
+    case missingArchitecture
+}
+
+/// Which of the four ceilings actually decided the context length.
+enum LlamaContextConstraint: String, Equatable, Sendable {
+    /// Nothing clamped the caller — the requested window was already the smallest.
+    case requested
+    /// The model's own trained context length.
+    case modelCapability
+    /// The bundled descriptor's policy for this model.
+    case descriptorPolicy
+    /// What the KV cache can afford in the memory left to this process.
+    case memoryBudget
+}
+
+/// The context window a load will actually create, and why.
+struct LlamaContextPlan: Equatable, Sendable {
+    /// Used when no ceiling is known at all — every input was unset. Small enough to be safe on
+    /// any device that can hold the weights, large enough for a real turn.
+    static let defaultContextTokens = 4096
+    /// Below this a context cannot hold a system prompt and one exchange, so a load that clamps
+    /// here is refused rather than created and immediately found useless.
+    static let minimumViableContextTokens = 512
+
+    let contextTokens: Int
+    let binding: LlamaContextConstraint
+
+    var isViable: Bool { contextTokens >= Self.minimumViableContextTokens }
+}
+
+/// The preflight that keeps an oversized prompt away from `llama_decode`.
+struct LlamaPromptAdmission: Equatable, Sendable {
+    let promptTokens: Int
+    /// Tokens held back for the answer.
+    let reserveTokens: Int
+    let contextTokens: Int
+
+    var fits: Bool { promptTokens + reserveTokens <= contextTokens }
+    /// How many tokens over the window the request is. `0` when it fits.
+    var overflowTokens: Int { max(0, promptTokens + reserveTokens - contextTokens) }
+}
+
+enum GGUFMetadataValidator {
+
+    /// GGUF's architecture key. The one key whose name is not architecture-scoped.
+    static let architectureKey = "general.architecture"
+
+    /// Read the architectural facts through a key lookup — the engine's metadata accessor in
+    /// production, a dictionary in tests.
+    static func metadata(lookup: (String) -> String?) -> Result<GGUFModelMetadata, GGUFMetadataFault> {
+        guard let architecture = lookup(architectureKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !architecture.isEmpty else {
+            return .failure(.missingArchitecture)
+        }
+        func scoped(_ suffix: String) -> Int? {
+            lookup("\(architecture).\(suffix)").flatMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        }
+        return .success(GGUFModelMetadata(
+            architecture: architecture,
+            trainingContextTokens: scoped("context_length") ?? 0,
+            blockCount: scoped("block_count"),
+            embeddingLength: scoped("embedding_length"),
+            headCount: scoped("attention.head_count"),
+            headCountKV: scoped("attention.head_count_kv")))
+    }
+
+    /// How many tokens of KV cache `bytes` buys. `0` means "no memory-derived ceiling" — either
+    /// the budget is unknown (simulator, Mac) or the file did not describe its own shape.
+    static func affordableContextTokens(bytes: Int64, metadata: GGUFModelMetadata) -> Int {
+        guard bytes > 0, let perToken = metadata.kvCacheBytesPerToken(), perToken > 0 else { return 0 }
+        return Int(bytes / perToken)
+    }
+
+    /// Clamp to the smallest of the ceilings that are known (Plan DZ load step 5). A ceiling of
+    /// `0` or less is *unknown*, not *zero*, and is skipped — refusing on unknown would brick the
+    /// simulator, exactly as `MemoryHeadroom` already argues for its own gate.
+    ///
+    /// Ties resolve toward `.requested`: if the caller asked for precisely the model's trained
+    /// length, nothing clamped them and saying otherwise would be reporting a constraint that did
+    /// no work.
+    static func contextPlan(requested: Int,
+                            modelCapability: Int,
+                            descriptorPolicy: Int,
+                            memoryBudgetTokens: Int) -> LlamaContextPlan {
+        var resolved: Int?
+        var binding: LlamaContextConstraint = .requested
+
+        func consider(_ candidate: Int, _ constraint: LlamaContextConstraint) {
+            guard candidate > 0 else { return }
+            guard let current = resolved else {
+                resolved = candidate
+                binding = constraint
+                return
+            }
+            if candidate < current {
+                resolved = candidate
+                binding = constraint
+            }
+        }
+
+        consider(requested, .requested)
+        consider(modelCapability, .modelCapability)
+        consider(descriptorPolicy, .descriptorPolicy)
+        consider(memoryBudgetTokens, .memoryBudget)
+
+        guard let resolved else {
+            return LlamaContextPlan(contextTokens: LlamaContextPlan.defaultContextTokens,
+                                    binding: .requested)
+        }
+        return LlamaContextPlan(contextTokens: resolved, binding: binding)
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaCppChatTemplate.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaCppChatTemplate.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// The embedded chat template, validated once at load and then applied to every turn.
+///
+/// Plan DZ invariant 5: "The model's embedded chat template is authoritative." Two consequences
+/// live here. First, a model whose template cannot render a minimal system/user/assistant exchange
+/// is refused at load rather than discovered to be broken mid-conversation. Second, a template that
+/// silently *drops* the system role — Gemma's does, folding it into the first user turn — is
+/// detected by probe rather than by architecture name, and the system text is merged into the first
+/// user turn so it is never lost.
+///
+/// Everything except `validate`'s single injected `apply` closure is pure.
+
+/// Why a template cannot be used for chat.
+enum LlamaChatTemplateFault: Error, Equatable, Sendable {
+    /// The GGUF carries no template at all.
+    case absent
+    /// The engine refused to render the probe exchange.
+    case renderFailed
+    /// It rendered, but to nothing.
+    case emptyRender
+    /// The user turn's text did not survive rendering.
+    case dropsUserContent
+    /// The assistant turn's text did not survive rendering.
+    case dropsAssistantContent
+    /// Asking for the assistant header produced the same text as not asking, so there is no way to
+    /// tell the model it is its turn to speak.
+    case noAssistantHeader
+}
+
+/// What the probe learned about a usable template.
+struct LlamaChatTemplateProfile: Equatable, Sendable {
+    let template: String
+    /// Whether a `system` turn's text survives rendering. When false the caller must merge system
+    /// text into the first user turn or the model never sees it.
+    let rendersSystemRole: Bool
+
+    var mergesSystemIntoFirstUser: Bool { !rendersSystemRole }
+}
+
+enum LlamaCppChatTemplate {
+
+    // Probe strings. Deliberately unlike anything a template emits of its own accord, so a
+    // `contains` check cannot be satisfied by the template's own boilerplate. Never user-visible.
+    private static let systemProbe = "OGPROBE-SYSTEM-4C1F"
+    private static let userProbe = "OGPROBE-USER-4C1F"
+    private static let assistantProbe = "OGPROBE-ASSISTANT-4C1F"
+
+    /// Render a minimal system/user/assistant exchange and check the template can carry a
+    /// conversation (Plan DZ load step 4).
+    ///
+    /// `apply` is the engine's template renderer: `(template, turns, addAssistantHeader)`.
+    static func validate(
+        _ template: String?,
+        apply: (String, [LlamaChatTurn], Bool) throws -> String
+    ) -> Result<LlamaChatTemplateProfile, LlamaChatTemplateFault> {
+        guard let template, !template.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .failure(.absent)
+        }
+        let probe = [
+            LlamaChatTurn(role: "system", content: systemProbe),
+            LlamaChatTurn(role: "user", content: userProbe),
+            LlamaChatTurn(role: "assistant", content: assistantProbe),
+        ]
+
+        let rendered: String
+        let withHeader: String
+        do {
+            rendered = try apply(template, probe, false)
+            withHeader = try apply(template, probe, true)
+        } catch {
+            return .failure(.renderFailed)
+        }
+
+        guard !rendered.isEmpty else { return .failure(.emptyRender) }
+        guard rendered.contains(userProbe) else { return .failure(.dropsUserContent) }
+        guard rendered.contains(assistantProbe) else { return .failure(.dropsAssistantContent) }
+        guard withHeader.count > rendered.count else { return .failure(.noAssistantHeader) }
+
+        return .success(LlamaChatTemplateProfile(template: template,
+                                                 rendersSystemRole: rendered.contains(systemProbe)))
+    }
+
+    /// Turn the seam's messages into template turns, applying the two policies the template's own
+    /// shape decides.
+    ///
+    /// **System hoisting.** Every template in circulation accepts at most one leading system turn;
+    /// a system instruction appearing mid-conversation is not portable. Rather than drop it or hand
+    /// it to a template that would refuse it, all system messages are joined in order into one
+    /// leading turn. The user/assistant turns keep their order untouched.
+    ///
+    /// **System merging.** When the template does not render the system role, the system text is
+    /// prefixed to the first user turn. No `User:`/`Assistant:` labels are added: the template owns
+    /// the turn markers, and inventing text labels inside a turn is how a model starts answering as
+    /// the wrong speaker.
+    static func turns(from messages: [LocalChatMessage],
+                      mergingSystemIntoFirstUser: Bool) -> [LlamaChatTurn] {
+        var systemParts: [String] = []
+        var conversation: [LlamaChatTurn] = []
+
+        for message in messages {
+            switch message.role {
+            case .system:
+                let trimmed = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { systemParts.append(message.content) }
+            case .user:
+                conversation.append(LlamaChatTurn(role: "user", content: message.content))
+            case .assistant:
+                conversation.append(LlamaChatTurn(role: "assistant", content: message.content))
+            }
+        }
+
+        let systemText = systemParts.joined(separator: "\n\n")
+        guard !systemText.isEmpty else { return conversation }
+
+        if !mergingSystemIntoFirstUser {
+            return [LlamaChatTurn(role: "system", content: systemText)] + conversation
+        }
+        guard let firstUser = conversation.firstIndex(where: { $0.role == "user" }) else {
+            // No user turn to merge into. A lone system instruction becomes the user turn rather
+            // than being dropped — the alternative is a prompt the model never sees.
+            return [LlamaChatTurn(role: "user", content: systemText)] + conversation
+        }
+        conversation[firstUser] = LlamaChatTurn(
+            role: "user",
+            content: systemText + "\n\n" + conversation[firstUser].content)
+        return conversation
+    }
+
+    /// Whether the tokenizer should add its own special tokens to an already-rendered template.
+    ///
+    /// Templates differ: some emit the BOS token as text, some leave it to the tokenizer. Adding it
+    /// on top of a template that already wrote one gives the model two, which every model reads as
+    /// a malformed prompt. The rendered text is the evidence — not the architecture, not the name.
+    static func shouldAddSpecialTokens(rendered: String,
+                                       bosPiece: String?,
+                                       vocabularyAddsBOS: Bool) -> Bool {
+        guard vocabularyAddsBOS else { return false }
+        guard let bosPiece, !bosPiece.isEmpty else { return true }
+        return !rendered.hasPrefix(bosPiece)
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaCppEngine.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaCppEngine.swift
@@ -1,0 +1,333 @@
+import Foundation
+import LlamaCppWrapper
+
+/// `LlamaEngine` over the vendored C ABI. The only file in the app that calls `og_llama_*`.
+///
+/// It contains no policy: no clamping, no admission, no template choice, no stop handling. Every
+/// decision lives in `LlamaCppLocalInferenceBackend` and its pure helpers, so that the decisions
+/// are testable and this file stays a transcription of the header.
+///
+/// ### Buffer convention
+/// The ABI fills caller-owned buffers and answers with the count *written*, the negative count
+/// *needed*, or `OG_LLAMA_NOT_FOUND` for a key that does not exist. `fetchString` and `fetchTokens`
+/// are the two places that convention is decoded; everything else consumes their results.
+final class LlamaCppEngine: LlamaEngine, @unchecked Sendable {
+
+    /// Initial buffer for a metadata or template read. Sized so the common case is one call and a
+    /// long Jinja template is two.
+    private static let initialTextCapacity: Int32 = 4096
+
+    /// The header's `OG_LLAMA_NOT_FOUND`, restated. It is `#define OG_LLAMA_NOT_FOUND INT32_MIN`,
+    /// and a macro defined in terms of another macro's arithmetic does not survive the Clang
+    /// importer — so the value is written out here, pinned to the header's text by
+    /// `LlamaCppRuntimeTests`.
+    static let notFound: Int32 = Int32.min
+
+    /// Constructing this type touches nothing native, deliberately: the app registers a GGUF
+    /// backend whether or not `Config.ggufModelsEnabled` is on, and "linked is not enabled" has to
+    /// stay true. The wrapper initializes the ggml backends lazily inside `og_llama_model_load` and
+    /// `og_llama_context_create`, and its engine logging — which would otherwise write model paths
+    /// and tensor names to the device log — is off unless a developer turns it on.
+    init() {}
+
+    // MARK: - Handle bridging
+
+    private func model(_ handle: LlamaModelHandle) -> OpaquePointer? {
+        OpaquePointer(bitPattern: handle.bits)
+    }
+
+    private func context(_ handle: LlamaContextHandle) -> OpaquePointer? {
+        OpaquePointer(bitPattern: handle.bits)
+    }
+
+    private func sampler(_ handle: LlamaSamplerHandle) -> OpaquePointer? {
+        OpaquePointer(bitPattern: handle.bits)
+    }
+
+    // MARK: - Model lifecycle
+
+    func loadModel(atPath path: String, options: LlamaModelOptions) throws -> LlamaModelHandle {
+        var native = og_llama_model_options_default()
+        native.n_gpu_layers = options.gpuLayers
+        native.load_mode = options.useMemoryMapping ? OGLlamaLoadModeMmap : OGLlamaLoadModeNone
+        native.vocab_only = options.vocabularyOnly
+        native.check_tensors = options.checkTensors
+
+        var handle: OpaquePointer?
+        let status = path.withCString { cPath in
+            withUnsafePointer(to: &native) { optionsPointer in
+                og_llama_model_load(cPath, optionsPointer, nil, nil, &handle)
+            }
+        }
+        guard status == OGLlamaStatusOK, let handle else {
+            throw LlamaEngineError(status: Int32(truncatingIfNeeded: status.rawValue))
+        }
+        return LlamaModelHandle(bits: UInt(bitPattern: handle))
+    }
+
+    func freeModel(_ model: LlamaModelHandle) {
+        og_llama_model_free(self.model(model))
+    }
+
+    // MARK: - Metadata
+
+    func metadataValue(_ model: LlamaModelHandle, key: String) -> String? {
+        let handle = self.model(model)
+        return key.withCString { cKey in
+            Self.fetchString { buffer, capacity in
+                og_llama_model_metadata_value(handle, cKey, buffer, capacity)
+            }
+        }
+    }
+
+    func chatTemplate(_ model: LlamaModelHandle, named name: String?) -> String? {
+        let handle = self.model(model)
+        guard let name else {
+            return Self.fetchString { buffer, capacity in
+                og_llama_model_chat_template(handle, nil, buffer, capacity)
+            }
+        }
+        return name.withCString { cName in
+            Self.fetchString { buffer, capacity in
+                og_llama_model_chat_template(handle, cName, buffer, capacity)
+            }
+        }
+    }
+
+    func trainingContextTokens(_ model: LlamaModelHandle) -> Int {
+        Int(og_llama_model_train_context_length(self.model(model)))
+    }
+
+    func vocabularyAddsBOS(_ model: LlamaModelHandle) -> Bool {
+        og_llama_vocab_adds_bos(self.model(model))
+    }
+
+    func beginningOfSequencePiece(_ model: LlamaModelHandle) -> String? {
+        let handle = self.model(model)
+        let token = og_llama_token_bos(handle)
+        guard token >= 0 else { return nil }
+        let bytes = tokenBytes(model, token: token, renderSpecial: true)
+        guard !bytes.isEmpty else { return nil }
+        return String(decoding: bytes, as: UTF8.self)
+    }
+
+    func isEndOfGeneration(_ model: LlamaModelHandle, token: LlamaToken) -> Bool {
+        og_llama_token_is_eog(self.model(model), token)
+    }
+
+    // MARK: - Template and tokenization
+
+    func applyChatTemplate(_ template: String,
+                           turns: [LlamaChatTurn],
+                           addAssistantHeader: Bool) throws -> String {
+        // Each role/content pair must outlive the whole call, and a pointer taken inside a
+        // `withUnsafeBufferPointer` would not — so the strings are copied onto the heap here and
+        // released on the way out. Nesting scoped accessors per message is the bug this avoids.
+        var owned: [UnsafeMutablePointer<CChar>] = []
+        defer { owned.forEach { free($0) } }
+
+        var messages: [OGLlamaChatMessage] = []
+        messages.reserveCapacity(turns.count)
+        for turn in turns {
+            guard let role = strdup(turn.role), let content = strdup(turn.content) else {
+                throw LlamaEngineError.allocationFailed
+            }
+            owned.append(role)
+            owned.append(content)
+            messages.append(OGLlamaChatMessage(role: UnsafePointer(role),
+                                               content: UnsafePointer(content)))
+        }
+
+        let rendered = template.withCString { cTemplate -> String? in
+            messages.withUnsafeBufferPointer { messagePointer in
+                Self.fetchString { buffer, capacity in
+                    og_llama_chat_apply_template(cTemplate,
+                                                 messagePointer.baseAddress,
+                                                 size_t(messagePointer.count),
+                                                 addAssistantHeader,
+                                                 buffer, capacity)
+                }
+            }
+        }
+        guard let rendered else { throw LlamaEngineError.templateFailed }
+        return rendered
+    }
+
+    func tokenize(_ model: LlamaModelHandle,
+                  text: String,
+                  addSpecial: Bool,
+                  parseSpecial: Bool) throws -> [LlamaToken] {
+        let handle = self.model(model)
+        let utf8 = Array(text.utf8)
+        // An empty prompt is a caller bug, not a tokenizer fault, and the ABI rejects a NULL text
+        // pointer — so it is answered here rather than sent down.
+        guard !utf8.isEmpty else { return [] }
+        let tokens: [LlamaToken]? = text.withCString { cText in
+            // The length is the UTF-8 byte count, not the C string's: the ABI takes an explicit
+            // length precisely so an embedded NUL cannot truncate a prompt.
+            Self.fetchTokens { buffer, capacity in
+                og_llama_tokenize(handle, cText, Int32(utf8.count),
+                                  addSpecial, parseSpecial, buffer, capacity)
+            }
+        }
+        guard let tokens else { throw LlamaEngineError.tokenizeFailed }
+        return tokens
+    }
+
+    func tokenBytes(_ model: LlamaModelHandle, token: LlamaToken) -> [UInt8] {
+        tokenBytes(model, token: token, renderSpecial: false)
+    }
+
+    /// Special tokens are rendered only when the caller is *inspecting* the vocabulary (the BOS
+    /// probe). Streamed output never renders them: a control token printed into an assistant reply
+    /// is text the wearer did not write and the model did not mean.
+    private func tokenBytes(_ model: LlamaModelHandle,
+                            token: LlamaToken,
+                            renderSpecial: Bool) -> [UInt8] {
+        let handle = self.model(model)
+        var buffer = [CChar](repeating: 0, count: 64)
+        var written = buffer.withUnsafeMutableBufferPointer { pointer in
+            og_llama_token_to_piece(handle, token, pointer.baseAddress, Int32(pointer.count),
+                                    renderSpecial)
+        }
+        if written == Self.notFound { return [] }
+        if written < 0 {
+            buffer = [CChar](repeating: 0, count: Int(-written))
+            written = buffer.withUnsafeMutableBufferPointer { pointer in
+                og_llama_token_to_piece(handle, token, pointer.baseAddress, Int32(pointer.count),
+                                        renderSpecial)
+            }
+            if written < 0 { return [] }
+        }
+        return buffer.prefix(Int(written)).map { UInt8(bitPattern: $0) }
+    }
+
+    // MARK: - Context lifecycle
+
+    func createContext(_ model: LlamaModelHandle,
+                       options: LlamaContextOptions) throws -> LlamaContextHandle {
+        var native = og_llama_context_options_default()
+        native.n_ctx = UInt32(max(0, options.contextTokens))
+        native.n_batch = UInt32(max(1, options.batchTokens))
+        // The physical batch never exceeds the logical one; a larger ubatch would allocate compute
+        // buffers for work that can never arrive.
+        native.n_ubatch = min(native.n_ubatch, native.n_batch)
+        native.offload_kqv = options.offloadKVCache
+
+        var handle: OpaquePointer?
+        let status = withUnsafePointer(to: &native) { optionsPointer in
+            og_llama_context_create(self.model(model), optionsPointer, &handle)
+        }
+        guard status == OGLlamaStatusOK, let handle else {
+            throw LlamaEngineError(status: Int32(truncatingIfNeeded: status.rawValue))
+        }
+        return LlamaContextHandle(bits: UInt(bitPattern: handle))
+    }
+
+    func freeContext(_ context: LlamaContextHandle) {
+        og_llama_context_free(self.context(context))
+    }
+
+    func contextTokens(_ context: LlamaContextHandle) -> Int {
+        Int(og_llama_context_length(self.context(context)))
+    }
+
+    func batchTokens(_ context: LlamaContextHandle) -> Int {
+        Int(og_llama_context_batch_size(self.context(context)))
+    }
+
+    func clearMemory(_ context: LlamaContextHandle) {
+        og_llama_context_clear_memory(self.context(context))
+    }
+
+    func setCancelled(_ context: LlamaContextHandle, _ cancelled: Bool) {
+        og_llama_context_set_cancelled(self.context(context), cancelled)
+    }
+
+    func synchronize(_ context: LlamaContextHandle) {
+        og_llama_context_synchronize(self.context(context))
+    }
+
+    func decode(_ context: LlamaContextHandle,
+                tokens: [LlamaToken],
+                position: Int,
+                wantsLogitsForLast: Bool) throws {
+        let status = tokens.withUnsafeBufferPointer { pointer in
+            og_llama_decode(self.context(context), pointer.baseAddress, Int32(pointer.count),
+                            Int32(position), wantsLogitsForLast)
+        }
+        guard status == OGLlamaStatusOK else { throw LlamaEngineError(status: Int32(truncatingIfNeeded: status.rawValue)) }
+    }
+
+    // MARK: - Sampling
+
+    func createSampler(_ model: LlamaModelHandle,
+                       options: LlamaSamplerOptions) throws -> LlamaSamplerHandle {
+        var native = og_llama_sampler_options_default()
+        native.seed = options.seed
+        native.temperature = options.temperature
+        native.top_k = options.topK
+        native.top_p = options.topP
+        native.min_p = options.minP
+        native.penalty_last_n = options.penaltyWindow
+        native.penalty_repeat = options.penaltyRepeat
+
+        var handle: OpaquePointer?
+        let status = withUnsafePointer(to: &native) { optionsPointer in
+            og_llama_sampler_create(self.model(model), optionsPointer, &handle)
+        }
+        guard status == OGLlamaStatusOK, let handle else {
+            throw LlamaEngineError(status: Int32(truncatingIfNeeded: status.rawValue))
+        }
+        return LlamaSamplerHandle(bits: UInt(bitPattern: handle))
+    }
+
+    func freeSampler(_ sampler: LlamaSamplerHandle) {
+        og_llama_sampler_free(self.sampler(sampler))
+    }
+
+    func resetSampler(_ sampler: LlamaSamplerHandle) {
+        og_llama_sampler_reset(self.sampler(sampler))
+    }
+
+    func sample(_ sampler: LlamaSamplerHandle, context: LlamaContextHandle) throws -> LlamaToken {
+        var token: LlamaToken = 0
+        let status = og_llama_sampler_sample(self.sampler(sampler), self.context(context), -1, &token)
+        guard status == OGLlamaStatusOK else { throw LlamaEngineError(status: Int32(truncatingIfNeeded: status.rawValue)) }
+        return token
+    }
+
+    // MARK: - Buffer convention
+
+    /// Runs a buffer-filling call, growing once if the first attempt was short. `nil` means the
+    /// key or template is absent — which is a different answer from an empty string, and callers
+    /// depend on the difference.
+    private static func fetchString(
+        _ fill: (UnsafeMutablePointer<CChar>?, Int32) -> Int32
+    ) -> String? {
+        var buffer = [CChar](repeating: 0, count: Int(initialTextCapacity))
+        var written = buffer.withUnsafeMutableBufferPointer { fill($0.baseAddress, Int32($0.count)) }
+        if written == Self.notFound { return nil }
+        if written < 0 {
+            buffer = [CChar](repeating: 0, count: Int(-written))
+            written = buffer.withUnsafeMutableBufferPointer { fill($0.baseAddress, Int32($0.count)) }
+            if written < 0 { return nil }
+        }
+        return String(decoding: buffer.prefix(Int(written)).map { UInt8(bitPattern: $0) },
+                      as: UTF8.self)
+    }
+
+    private static func fetchTokens(
+        _ fill: (UnsafeMutablePointer<LlamaToken>?, Int32) -> Int32
+    ) -> [LlamaToken]? {
+        var buffer = [LlamaToken](repeating: 0, count: Int(initialTextCapacity))
+        var written = buffer.withUnsafeMutableBufferPointer { fill($0.baseAddress, Int32($0.count)) }
+        if written == Self.notFound { return nil }
+        if written < 0 {
+            buffer = [LlamaToken](repeating: 0, count: Int(-written))
+            written = buffer.withUnsafeMutableBufferPointer { fill($0.baseAddress, Int32($0.count)) }
+            if written < 0 { return nil }
+        }
+        return Array(buffer.prefix(Int(written)))
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaCppLocalInferenceBackend.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaCppLocalInferenceBackend.swift
@@ -1,0 +1,706 @@
+import Foundation
+
+/// Typed faults from the GGUF runtime, in the same spirit as `LocalLLMError` for MLX: every case is
+/// something the wearer or the caller can act on, and none of them carries prompt text.
+enum LlamaBackendError: LocalizedError, Equatable {
+    /// `Config.ggufModelsEnabled` is off. MLX is unaffected.
+    case runtimeDisabled
+    /// The manifest no longer describes what is on disk.
+    case installationIncomplete(LocalModelID)
+    /// The manifest names no weights file, or names one that is not there.
+    case weightsMissing(LocalModelID)
+    /// The file does not describe its own architecture, so nothing can be configured from it.
+    case unsupportedArchitecture
+    /// The embedded chat template cannot carry a conversation.
+    case unsupportedChatTemplate(LlamaChatTemplateFault)
+    /// Every ceiling together left a context too small to hold an exchange.
+    case contextTooSmall(tokens: Int)
+    case insufficientMemory(neededBytes: Int64, availableBytes: Int64)
+    case notLoaded
+    case alreadyGenerating
+    /// Refused *before* decode. Counts only — never the prompt.
+    case promptTooLong(promptTokens: Int, reserveTokens: Int, contextTokens: Int)
+    case tokenizationFailed
+    case engine(LlamaEngineError)
+
+    var errorDescription: String? {
+        switch self {
+        case .runtimeDisabled:
+            return "GGUF models are turned off. Turn them on in Settings → AI Models, or pick a "
+                + "different on-device model."
+        case .installationIncomplete(let id):
+            return "The installed files for \(id.rawValue) are incomplete. Download the model again."
+        case .weightsMissing(let id):
+            return "The model file for \(id.rawValue) is missing. Download the model again."
+        case .unsupportedArchitecture:
+            return "This model file doesn't say what architecture it is, so it can't be loaded."
+        case .unsupportedChatTemplate:
+            return "This model doesn't carry a usable chat template, so it can't be used for "
+                + "conversation. It stays installed, but it can't be selected for chat."
+        case .contextTooSmall(let tokens):
+            return "There isn't enough memory to give this model a usable context window "
+                + "(\(tokens) tokens). Close other apps, or switch to a cloud model."
+        case .insufficientMemory(let needed, let available):
+            let gb = { (bytes: Int64) in String(format: "%.1f", Double(bytes) / 1_073_741_824) }
+            return "Not enough memory to load the on-device model — it needs about \(gb(needed)) GB "
+                + "but only \(gb(available)) GB is available. Free up memory by closing other apps, "
+                + "or switch to a cloud model."
+        case .notLoaded:
+            return "No local model is loaded. Download one in Settings → AI Models."
+        case .alreadyGenerating:
+            return "The on-device model is already generating a response. Wait for it to finish."
+        case .promptTooLong(let prompt, let reserve, let context):
+            return "This conversation is too long for the on-device model "
+                + "(\(prompt) tokens plus \(reserve) for the reply; the limit is \(context)). Start "
+                + "a new conversation, or switch to a cloud model."
+        case .tokenizationFailed:
+            return "The on-device model couldn't read that prompt."
+        case .engine:
+            return "The on-device model failed while generating. Try again, or switch to a cloud "
+                + "model."
+        }
+    }
+}
+
+/// The GGUF runtime behind the backend-neutral seam (Plan DZ P1/PR3).
+///
+/// ### Why an actor, and why the decode loop leaves it
+/// The wrapper's own rule is "nothing here is thread-safe; the owning actor is the synchronization",
+/// so model, context and sampler handles are actor state and every call that touches them is
+/// serialized here. The one deliberate exception is the decode/sample loop: a generation runs for
+/// tens of seconds, and if it held the actor for its whole duration, `cancelGeneration()` — which
+/// is an actor method — could not run until the generation it is trying to stop had finished. So
+/// the loop runs on its own task with a snapshot of the handles, and the actor holds only the task.
+/// That is safe for exactly one reason, and it is a property of the wrapper rather than a hope:
+/// cancellation is an atomic flag on the context (`og_llama_context_set_cancelled`), which is the
+/// only call made concurrently with the loop. Nothing frees a handle until `cancelGeneration()` has
+/// awaited the loop's completion and synchronized the accelerator.
+///
+/// ### What is not here
+/// Downloading, catalog policy, conversation storage and the tool loop — all seam invariants from
+/// PR1, unchanged. The coordinator, not this actor, decides who is resident.
+actor LlamaCppLocalInferenceBackend: LocalInferenceBackend {
+
+    let runtime: LocalModelRuntime = .llamaCpp
+
+    /// Prompt tokens per decode call when the caller states no preference. The context reports its
+    /// own batch size after creation and that is what the loop partitions against.
+    static let defaultBatchTokens = 512
+    /// Output allowance when the request names none.
+    static let defaultOutputTokens = 512
+
+    // MARK: - Injected environment
+
+    private let engine: any LlamaEngine
+    /// Where an installation's files live. Injected so the actor never needs a repository.
+    private let directoryForInstallation: @Sendable (InstalledLocalModel) -> URL
+    private let fileManager: FileManager
+    private let availableProcessBytes: @Sendable () -> Int64
+    private let appFootprintBytes: @Sendable () -> Int64
+    private let thermalState: @Sendable () -> ProcessInfo.ThermalState
+    private let monotonicNanoseconds: @Sendable () -> UInt64
+    /// Whether GGUF is switched on. Injected so a test does not mutate a global default.
+    private let isRuntimeEnabled: @Sendable () -> Bool
+
+    // MARK: - Resident state
+
+    /// Everything a loaded model owns. Created model → context → sampler; destroyed in reverse.
+    private struct Resources {
+        let installation: InstalledLocalModel
+        let model: LlamaModelHandle
+        let context: LlamaContextHandle
+        /// Rebuilt when a request asks for sampling the resident chain was not built for — a
+        /// sampler chain is small, and rebuilding it is the only way `LocalGenerationRequest`'s
+        /// seed and temperature can reach the runtime.
+        var sampler: LlamaSamplerHandle
+        var samplerOptions: LlamaSamplerOptions
+        let templateProfile: LlamaChatTemplateProfile
+        let contextTokens: Int
+        let batchTokens: Int
+        let vocabularyAddsBOS: Bool
+        let bosPiece: String?
+        let loaded: LocalLoadedModel
+        /// Headroom at the moment the load finished, so a generation can report the delta.
+        let headroomAfterLoadBytes: Int64
+    }
+
+    /// Handles created so far during a load. The failure path frees exactly what exists, in reverse.
+    private struct PartialLoad {
+        var model: LlamaModelHandle?
+        var context: LlamaContextHandle?
+        var sampler: LlamaSamplerHandle?
+    }
+
+    private var resources: Resources?
+    private var activeGeneration: Task<Void, Never>?
+
+    init(engine: any LlamaEngine = LlamaCppEngine(),
+         directoryForInstallation: (@Sendable (InstalledLocalModel) -> URL)? = nil,
+         fileManager: FileManager = .default,
+         availableProcessBytes: @escaping @Sendable () -> Int64 = { MemoryHeadroom.availableBytes() },
+         appFootprintBytes: @escaping @Sendable () -> Int64 = { MemoryHeadroom.appFootprintBytes() },
+         thermalState: @escaping @Sendable () -> ProcessInfo.ThermalState
+            = { ProcessInfo.processInfo.thermalState },
+         monotonicNanoseconds: @escaping @Sendable () -> UInt64
+            = { DispatchTime.now().uptimeNanoseconds },
+         isRuntimeEnabled: @escaping @Sendable () -> Bool = { Config.ggufModelsEnabled }) {
+        self.engine = engine
+        self.directoryForInstallation = directoryForInstallation ?? { installation in
+            LocalModelRepository.defaultDirectory(for: installation)
+        }
+        self.fileManager = fileManager
+        self.availableProcessBytes = availableProcessBytes
+        self.appFootprintBytes = appFootprintBytes
+        self.thermalState = thermalState
+        self.monotonicNanoseconds = monotonicNanoseconds
+        self.isRuntimeEnabled = isRuntimeEnabled
+    }
+
+    var loadedModel: LocalLoadedModel? { resources?.loaded }
+
+    // MARK: - Load
+
+    /// Plan DZ's seven-step load flow, in order.
+    func load(_ installation: InstalledLocalModel,
+              configuration: LocalLoadConfiguration) async throws -> LocalLoadedModel {
+        guard isRuntimeEnabled() else { throw LlamaBackendError.runtimeDisabled }
+        guard installation.runtime == .llamaCpp else {
+            throw LocalInferenceError.noBackend(installation.runtime)
+        }
+        // Idempotent for the resident model: tearing down a working model to rebuild it identically
+        // is a multi-gigabyte round trip for no change.
+        if let resources, resources.installation.id == installation.id {
+            return resources.loaded
+        }
+        // A *different* model resident here means the caller bypassed the coordinator, which
+        // normally evicts first. Releasing it before allocating the next one is the same invariant
+        // either way — two multi-gigabyte allocations must never be resident together.
+        if resources != nil { await unload() }
+
+        // 1. Resolve a completed installation and validate the manifest again. "Again" is the
+        //    point: the repository validated it when it was written, and files can disappear.
+        let weightsURL = try resolveWeights(installation)
+
+        // 2. Residency is the coordinator's (it is what called us). What is left of step 2 is the
+        //    memory-admission policy, run against live headroom rather than install-time numbers.
+        let available = availableProcessBytes()
+        let admission = LocalModelBudget.admit(.init(
+            runtime: .llamaCpp,
+            declaredWeightsBytes: installation.descriptor.estimatedWeightsBytes,
+            configuredContextTokens: configuration.contextLength,
+            policyContextTokens: installation.descriptor.contextLength,
+            availableProcessBytes: available,
+            safetyReserveBytes: installation.descriptor.minimumHeadroomBytes))
+        if case .refuse(let refusal) = admission {
+            switch refusal {
+            case .insufficientHeadroom(let needed, let availableBytes):
+                throw LlamaBackendError.insufficientMemory(neededBytes: needed,
+                                                           availableBytes: availableBytes)
+            }
+        }
+
+        let startedAt = monotonicNanoseconds()
+        var partial = PartialLoad()
+        do {
+            // 3. Load the file and read what it says about itself. No filename is parsed anywhere
+            //    on this path.
+            let model = try engine.loadModel(atPath: weightsURL.path, options: LlamaModelOptions())
+            partial.model = model
+
+            let metadataResult = GGUFMetadataValidator.metadata { key in
+                engine.metadataValue(model, key: key)
+            }
+            guard case .success(let metadata) = metadataResult else {
+                throw LlamaBackendError.unsupportedArchitecture
+            }
+
+            // 4. The embedded template is authoritative, so it is proved usable here rather than
+            //    discovered to be broken on the wearer's first question.
+            let templateResult = LlamaCppChatTemplate.validate(engine.chatTemplate(model, named: nil)) {
+                try engine.applyChatTemplate($0, turns: $1, addAssistantHeader: $2)
+            }
+            let templateProfile: LlamaChatTemplateProfile
+            switch templateResult {
+            case .success(let profile):
+                templateProfile = profile
+            case .failure(let fault):
+                throw LlamaBackendError.unsupportedChatTemplate(fault)
+            }
+
+            // 5. Clamp to the smallest known ceiling.
+            let memoryBudgetTokens = GGUFMetadataValidator.affordableContextTokens(
+                bytes: contextBudgetBytes(available: available, installation: installation),
+                metadata: metadata)
+            let plan = GGUFMetadataValidator.contextPlan(
+                requested: configuration.contextLength,
+                modelCapability: engine.trainingContextTokens(model),
+                descriptorPolicy: installation.descriptor.contextLength,
+                memoryBudgetTokens: memoryBudgetTokens)
+            guard plan.isViable else {
+                throw LlamaBackendError.contextTooSmall(tokens: plan.contextTokens)
+            }
+
+            // 6. Context, then sampler. Nothing is published until both exist.
+            let requestedBatch = configuration.batchSize > 0 ? configuration.batchSize
+                                                             : Self.defaultBatchTokens
+            let context = try engine.createContext(model, options: LlamaContextOptions(
+                contextTokens: plan.contextTokens,
+                batchTokens: min(requestedBatch, plan.contextTokens)))
+            partial.context = context
+
+            let samplerOptions = LlamaSamplerOptions(.conservative)
+            let sampler = try engine.createSampler(model, options: samplerOptions)
+            partial.sampler = sampler
+
+            // The context is the authority on its own sizes: it may round a request down.
+            let actualContext = max(1, engine.contextTokens(context))
+            let actualBatch = max(1, engine.batchTokens(context))
+
+            var capabilities: Set<LocalModelCapability> = [.text]
+            // Text-only phase: vision is never advertised, whatever the descriptor claims.
+            if installation.descriptor.supportsTools { capabilities.insert(.toolFriendly) }
+
+            let loaded = LocalLoadedModel(id: installation.id,
+                                          runtime: .llamaCpp,
+                                          contextLength: actualContext,
+                                          capabilities: capabilities)
+            resources = Resources(installation: installation,
+                                  model: model,
+                                  context: context,
+                                  sampler: sampler,
+                                  samplerOptions: samplerOptions,
+                                  templateProfile: templateProfile,
+                                  contextTokens: actualContext,
+                                  batchTokens: actualBatch,
+                                  vocabularyAddsBOS: engine.vocabularyAddsBOS(model),
+                                  bosPiece: engine.beginningOfSequencePiece(model),
+                                  loaded: loaded,
+                                  headroomAfterLoadBytes: availableProcessBytes())
+
+            PrivacyLog.localModel(.loaded,
+                                  model: PrivacyToken(installation.id.rawValue),
+                                  vision: false,
+                                  tokens: actualContext,
+                                  footprintMegabytes: megabytes(appFootprintBytes()),
+                                  headroomMegabytes: megabytes(availableProcessBytes()),
+                                  detail: PrivacyToken("gguf-\(plan.binding.rawValue)"),
+                                  milliseconds: milliseconds(since: startedAt),
+                                  state: thermalToken())
+            return loaded
+        } catch {
+            // 7. Reverse-order teardown of whatever was created, then a typed error. A raw engine
+            //    status is wrapped rather than propagated: callers act on this backend's
+            //    vocabulary, and `OGLlamaStatus` is an implementation detail of the wrapper.
+            tearDown(partial)
+            let typed = (error as? LlamaEngineError).map(LlamaBackendError.engine) ?? error
+            PrivacyLog.localModel(.loadFailed,
+                                  model: PrivacyToken(installation.id.rawValue),
+                                  detail: PrivacyToken("gguf"),
+                                  milliseconds: milliseconds(since: startedAt),
+                                  error: SafeErrorSummary(typed))
+            throw typed
+        }
+    }
+
+    func unload() async {
+        await cancelGeneration()
+        guard let resources else { return }
+        self.resources = nil
+        tearDown(PartialLoad(model: resources.model,
+                             context: resources.context,
+                             sampler: resources.sampler))
+        PrivacyLog.localModel(.unloaded,
+                              model: PrivacyToken(resources.installation.id.rawValue),
+                              headroomMegabytes: megabytes(availableProcessBytes()),
+                              detail: PrivacyToken("gguf"))
+    }
+
+    /// Free what exists, in the reverse of creation order, with the accelerator drained first.
+    ///
+    /// The order is not cosmetic: the sampler holds vocabulary-sized buffers derived from the
+    /// model, the context holds graph state that points into it, and Metal work outlives the call
+    /// that queued it. Freeing a model out from under either is a GPU-side use-after-free.
+    private func tearDown(_ partial: PartialLoad) {
+        if let context = partial.context { engine.synchronize(context) }
+        if let sampler = partial.sampler { engine.freeSampler(sampler) }
+        if let context = partial.context { engine.freeContext(context) }
+        if let model = partial.model { engine.freeModel(model) }
+    }
+
+    // MARK: - Generation
+
+    nonisolated func generate(_ request: LocalGenerationRequest) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let starter = Task { await self.startGeneration(request, continuation: continuation) }
+            continuation.onTermination = { termination in
+                // A consumer that walks away must stop the GPU too — otherwise a barge-in leaves
+                // the model decoding to completion, burning battery on an answer nobody will read.
+                guard case .cancelled = termination else { return }
+                starter.cancel()
+                Task { await self.cancelGeneration() }
+            }
+        }
+    }
+
+    /// The isolated half of a generation: everything that touches resident state, ending with the
+    /// launch of the off-actor decode loop.
+    private func startGeneration(_ request: LocalGenerationRequest,
+                                 continuation: AsyncThrowingStream<String, Error>.Continuation) {
+        guard let resources else {
+            continuation.finish(throwing: LlamaBackendError.notLoaded)
+            return
+        }
+        guard activeGeneration == nil else {
+            continuation.finish(throwing: LlamaBackendError.alreadyGenerating)
+            return
+        }
+        // 1. Text-only phase.
+        guard request.images.isEmpty else {
+            continuation.finish(throwing: LocalInferenceError.visionNotAvailable)
+            return
+        }
+
+        let promptStartedAt = monotonicNanoseconds()
+        let promptTokens: [LlamaToken]
+        let reserveTokens: Int
+        do {
+            // 2. Seam messages become template turns, with the system-merge policy the template's
+            //    own probe decided at load.
+            let turns = LlamaCppChatTemplate.turns(
+                from: request.messages,
+                mergingSystemIntoFirstUser: resources.templateProfile.mergesSystemIntoFirstUser)
+
+            // 3. Apply the template, then tokenize with the special-token handling the rendered
+            //    text calls for, and work out the output reserve.
+            let rendered = try engine.applyChatTemplate(resources.templateProfile.template,
+                                                        turns: turns,
+                                                        addAssistantHeader: true)
+            let addSpecial = LlamaCppChatTemplate.shouldAddSpecialTokens(
+                rendered: rendered,
+                bosPiece: resources.bosPiece,
+                vocabularyAddsBOS: resources.vocabularyAddsBOS)
+            promptTokens = try engine.tokenize(resources.model,
+                                               text: rendered,
+                                               addSpecial: addSpecial,
+                                               parseSpecial: true)
+            let requested = request.maxOutputTokens > 0 ? request.maxOutputTokens
+                                                        : Self.defaultOutputTokens
+            reserveTokens = max(1, min(requested, resources.contextTokens - 1))
+        } catch let error as LlamaEngineError {
+            continuation.finish(throwing: LlamaBackendError.engine(error))
+            return
+        } catch {
+            continuation.finish(throwing: LlamaBackendError.tokenizationFailed)
+            return
+        }
+
+        guard !promptTokens.isEmpty else {
+            continuation.finish(throwing: LlamaBackendError.tokenizationFailed)
+            return
+        }
+
+        // 4. Refuse before decode, with counts and never the prompt.
+        let admission = LlamaPromptAdmission(promptTokens: promptTokens.count,
+                                             reserveTokens: reserveTokens,
+                                             contextTokens: resources.contextTokens)
+        guard admission.fits else {
+            PrivacyLog.localModel(.generationFailed,
+                                  model: PrivacyToken(resources.installation.id.rawValue),
+                                  count: admission.overflowTokens,
+                                  total: resources.contextTokens,
+                                  tokens: admission.promptTokens,
+                                  detail: PrivacyToken("gguf-over-context"))
+            continuation.finish(throwing: LlamaBackendError.promptTooLong(
+                promptTokens: admission.promptTokens,
+                reserveTokens: admission.reserveTokens,
+                contextTokens: admission.contextTokens))
+            return
+        }
+
+        // Per-request sampling. The MLX adapter ignores `request.sampling` because MLX derives its
+        // own; this runtime has no such existing policy, so the request's temperature and seed are
+        // authoritative — and a pinned seed is what makes a generation reproducible in a test.
+        // The replacement is built before the old chain is freed: a failed create must not leave a
+        // resident model pointing at a freed sampler.
+        let desiredSampling = LlamaSamplerOptions(request.sampling)
+        var sampler = resources.sampler
+        if desiredSampling != resources.samplerOptions {
+            do {
+                let replacement = try engine.createSampler(resources.model, options: desiredSampling)
+                engine.freeSampler(resources.sampler)
+                sampler = replacement
+                self.resources?.sampler = replacement
+                self.resources?.samplerOptions = desiredSampling
+            } catch let error as LlamaEngineError {
+                continuation.finish(throwing: LlamaBackendError.engine(error))
+                return
+            } catch {
+                continuation.finish(throwing: error)
+                return
+            }
+        }
+
+        PrivacyLog.localModel(.generationStarted,
+                              model: PrivacyToken(resources.installation.id.rawValue),
+                              tokens: admission.promptTokens,
+                              detail: PrivacyToken("gguf"),
+                              state: thermalToken())
+
+        let plan = GenerationPlan(installationID: resources.installation.id,
+                                  model: resources.model,
+                                  context: resources.context,
+                                  sampler: sampler,
+                                  promptTokens: promptTokens,
+                                  batchTokens: resources.batchTokens,
+                                  contextTokens: resources.contextTokens,
+                                  maxOutputTokens: reserveTokens,
+                                  stopSequences: request.stopSequences,
+                                  headroomAfterLoadBytes: resources.headroomAfterLoadBytes,
+                                  promptStartedAt: promptStartedAt)
+
+        // The assignment below happens before this method suspends or returns, so the loop's own
+        // `finishGeneration()` — which needs this actor — cannot observe a nil slot and leave the
+        // backend permanently "already generating".
+        activeGeneration = Task { [weak self] in
+            guard let self else { return }
+            await self.runLoop(plan, sampling: request.sampling, preview: request.previewSink,
+                               continuation: continuation)
+            await self.finishGeneration()
+        }
+    }
+
+    private func finishGeneration() {
+        activeGeneration = nil
+    }
+
+    /// Everything the decode loop needs, captured so the loop can run off the actor.
+    private struct GenerationPlan: Sendable {
+        let installationID: LocalModelID
+        let model: LlamaModelHandle
+        let context: LlamaContextHandle
+        let sampler: LlamaSamplerHandle
+        let promptTokens: [LlamaToken]
+        let batchTokens: Int
+        let contextTokens: Int
+        let maxOutputTokens: Int
+        let stopSequences: [String]
+        let headroomAfterLoadBytes: Int64
+        let promptStartedAt: UInt64
+    }
+
+    /// Steps 5–10, off the actor so a cancel can reach it.
+    private nonisolated func runLoop(_ plan: GenerationPlan,
+                                     sampling: LocalSamplingConfiguration,
+                                     preview: ((String) -> Void)?,
+                                     continuation: AsyncThrowingStream<String, Error>.Continuation) async {
+        // 5. Clear the KV cache for every request. Plan DZ's cache policy is full-history-per-call;
+        //    the sampler's penalty history is reset with it, or the previous turn's tokens would
+        //    keep penalising this one.
+        engine.clearMemory(plan.context)
+        engine.resetSampler(plan.sampler)
+
+        var accumulator = LlamaUTF8Accumulator()
+        var matcher = LlamaStopSequenceMatcher(stopSequences: plan.stopSequences)
+        var position = 0
+        var generated = 0
+        var firstTokenAt: UInt64?
+
+        func emit(_ text: String) -> Bool {
+            guard !text.isEmpty else { return false }
+            let (safe, stop) = matcher.consume(text)
+            if !safe.isEmpty {
+                preview?(safe)
+                continuation.yield(safe)
+            }
+            return stop
+        }
+
+        do {
+            // 6. Prompt decode, partitioned to the context's own batch size, with a cancellation
+            //    check between chunks.
+            var offset = 0
+            while offset < plan.promptTokens.count {
+                if Task.isCancelled { throw CancellationError() }
+                let end = min(offset + plan.batchTokens, plan.promptTokens.count)
+                let chunk = Array(plan.promptTokens[offset..<end])
+                try engine.decode(plan.context,
+                                  tokens: chunk,
+                                  position: position,
+                                  wantsLogitsForLast: end == plan.promptTokens.count)
+                position += chunk.count
+                offset = end
+            }
+            let promptDecodedAt = monotonicNanoseconds()
+            PrivacyLog.localModel(.promptDecoded,
+                                  model: PrivacyToken(plan.installationID.rawValue),
+                                  count: (plan.promptTokens.count + plan.batchTokens - 1)
+                                      / plan.batchTokens,
+                                  tokens: plan.promptTokens.count,
+                                  detail: PrivacyToken("gguf"),
+                                  milliseconds: Int((promptDecodedAt &- plan.promptStartedAt)
+                                                    / 1_000_000))
+
+            // 7. One token at a time, stopping on end-of-generation, a stop sequence, cancellation,
+            //    the output cap, or a full context.
+            while generated < plan.maxOutputTokens {
+                if Task.isCancelled { throw CancellationError() }
+                let token = try engine.sample(plan.sampler, context: plan.context)
+                if engine.isEndOfGeneration(plan.model, token: token) { break }
+
+                generated += 1
+                if firstTokenAt == nil { firstTokenAt = monotonicNanoseconds() }
+
+                // 8. Bytes, not characters: the accumulator holds a split sequence until it is whole.
+                if emit(accumulator.append(engine.tokenBytes(plan.model, token: token))) { break }
+
+                guard position < plan.contextTokens else { break }
+                try engine.decode(plan.context, tokens: [token], position: position,
+                                  wantsLogitsForLast: true)
+                position += 1
+            }
+
+            if !matcher.hasStopped {
+                _ = emit(accumulator.flush())
+                let tail = matcher.flush()
+                if !tail.isEmpty {
+                    preview?(tail)
+                    continuation.yield(tail)
+                }
+            }
+            // 10. Drain the accelerator before anyone can free what it is still reading.
+            engine.synchronize(plan.context)
+            recordCompletion(plan, generated: generated, firstTokenAt: firstTokenAt,
+                             position: position)
+            continuation.finish()
+        } catch is CancellationError {
+            engine.synchronize(plan.context)
+            PrivacyLog.localModel(.generationFailed,
+                                  model: PrivacyToken(plan.installationID.rawValue),
+                                  count: generated,
+                                  detail: PrivacyToken("gguf-cancelled"))
+            continuation.finish(throwing: CancellationError())
+        } catch let error as LlamaEngineError {
+            engine.synchronize(plan.context)
+            let mapped: Error = error == .cancelled ? CancellationError()
+                                                    : LlamaBackendError.engine(error)
+            PrivacyLog.localModel(.generationFailed,
+                                  model: PrivacyToken(plan.installationID.rawValue),
+                                  count: generated,
+                                  detail: PrivacyToken("gguf"),
+                                  error: SafeErrorSummary(mapped))
+            continuation.finish(throwing: mapped)
+        } catch {
+            engine.synchronize(plan.context)
+            continuation.finish(throwing: error)
+        }
+    }
+
+    /// 9. Load and decode timings, token counts, context usage, headroom delta and thermal state —
+    /// counts and enums only. Tokens per second is deliberately not a field: it is `count` over
+    /// `duration`, and a derived number is one more thing that can disagree with its inputs.
+    private nonisolated func recordCompletion(_ plan: GenerationPlan,
+                                              generated: Int,
+                                              firstTokenAt: UInt64?,
+                                              position: Int) {
+        let headroomNow = availableProcessBytes()
+        let usage = plan.contextTokens > 0 ? (position * 100) / plan.contextTokens : 0
+        PrivacyLog.localModel(.generationCompleted,
+                              model: PrivacyToken(plan.installationID.rawValue),
+                              count: generated,
+                              total: plan.contextTokens,
+                              tokens: plan.promptTokens.count,
+                              footprintMegabytes: megabytes(appFootprintBytes()),
+                              headroomMegabytes: megabytes(headroomNow - plan.headroomAfterLoadBytes),
+                              detail: PrivacyToken("gguf"),
+                              milliseconds: milliseconds(since: plan.promptStartedAt),
+                              firstTokenMilliseconds: firstTokenAt.map {
+                                  Int(($0 &- plan.promptStartedAt) / 1_000_000)
+                              },
+                              percent: usage,
+                              state: thermalToken())
+    }
+
+    // MARK: - Cancellation
+
+    /// Stop the in-flight generation and wait until it has actually stopped — the coordinator
+    /// unloads immediately after this returns.
+    func cancelGeneration() async {
+        guard let task = activeGeneration else { return }
+        activeGeneration = nil
+        if let resources { engine.setCancelled(resources.context, true) }
+        task.cancel()
+        // Awaiting the task suspends this actor, which is what lets the loop's own
+        // `finishGeneration()` hop back in. The alternative — spinning — would deadlock.
+        await task.value
+        if let resources {
+            // 10. The flag stops new work; synchronize is what makes the *outstanding* work safe
+            //     to free. Clearing the flag afterwards leaves the context usable for the next turn.
+            engine.synchronize(resources.context)
+            engine.setCancelled(resources.context, false)
+        }
+    }
+
+    // MARK: - Installation
+
+    /// Re-validate the manifest and return the weights file's URL.
+    ///
+    /// The digest is *not* recomputed here: rehashing several gigabytes on every load would add
+    /// seconds to a cold start for a check the installer already made against the same bytes. What
+    /// is checked is what can change after installation — presence, containment, and size.
+    private func resolveWeights(_ installation: InstalledLocalModel) throws -> URL {
+        let files = installation.validatedFiles.isEmpty ? installation.descriptor.files
+                                                        : installation.validatedFiles
+        // Sorted so a sharded model resolves to its first shard deterministically; the engine
+        // follows the split from there.
+        let weights = files.filter { $0.role == .weights }
+            .sorted { $0.relativePath < $1.relativePath }
+        guard let first = weights.first else {
+            throw LlamaBackendError.weightsMissing(installation.id)
+        }
+        let root = directoryForInstallation(installation)
+        guard let url = LocalModelPath.resolve(first.relativePath, under: root) else {
+            throw LlamaBackendError.installationIncomplete(installation.id)
+        }
+        guard fileManager.fileExists(atPath: url.path) else {
+            throw LlamaBackendError.weightsMissing(installation.id)
+        }
+        if first.byteCount > 0 {
+            let attributes = try? fileManager.attributesOfItem(atPath: url.path)
+            let size = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+            guard size == first.byteCount else {
+                throw LlamaBackendError.installationIncomplete(installation.id)
+            }
+        }
+        return url
+    }
+
+    /// Bytes the KV cache may claim: what the process can still allocate, less the weights it is
+    /// about to resident and the runtime's own working set. `0` when there is no budget to speak of
+    /// (simulator, Mac), which leaves the context unclamped by memory — the same "unknown is not
+    /// zero" rule `MemoryHeadroom` already applies.
+    private func contextBudgetBytes(available: Int64, installation: InstalledLocalModel) -> Int64 {
+        guard available > 0 else { return 0 }
+        let committed = installation.descriptor.estimatedWeightsBytes
+            + LocalModelBudget.workingSetBytes(for: .llamaCpp)
+            + max(0, installation.descriptor.minimumHeadroomBytes)
+        return max(0, available - committed)
+    }
+
+    // MARK: - Diagnostics helpers
+
+    private nonisolated func megabytes(_ bytes: Int64) -> Int { Int(bytes / (1024 * 1024)) }
+
+    private nonisolated func milliseconds(since start: UInt64) -> Int {
+        Int((monotonicNanoseconds() &- start) / 1_000_000)
+    }
+
+    private nonisolated func thermalToken() -> PrivacyToken {
+        switch thermalState() {
+        case .nominal: return PrivacyToken("nominal")
+        case .fair: return PrivacyToken("fair")
+        case .serious: return PrivacyToken("serious")
+        case .critical: return PrivacyToken("critical")
+        @unknown default: return PrivacyToken("unknown")
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaCppTokenDecoder.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaCppTokenDecoder.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// Turning a stream of token *bytes* into a stream of correct Swift strings, and stopping it on the
+/// caller's stop sequences.
+///
+/// Both problems are the same shape and both are boundary problems, which is why they are pure
+/// value types tested directly rather than logic buried in the generation loop.
+
+/// Accumulates token bytes and emits only whole UTF-8 scalars (Plan DZ generation step 8).
+///
+/// A byte-pair-encoding vocabulary happily splits a multi-byte character across two tokens: an
+/// emoji arrives as four tokens of one byte each, and a naive `String(decoding:)` per token turns
+/// each of them into `U+FFFD`. So bytes are held until the sequence they belong to is complete.
+/// Nothing is ever dropped: a byte that is genuinely invalid — not merely incomplete — is emitted
+/// through UTF-8's own replacement behaviour rather than accumulated forever.
+struct LlamaUTF8Accumulator {
+
+    /// Bytes belonging to a sequence that has not finished arriving. Never longer than 3.
+    private var pending: [UInt8] = []
+
+    init() {}
+
+    /// True while bytes are held back waiting for the rest of their sequence.
+    var hasPendingBytes: Bool { !pending.isEmpty }
+
+    /// Append token bytes and return whatever is now complete. May legitimately return `""`.
+    mutating func append<Bytes: Sequence>(_ bytes: Bytes) -> String where Bytes.Element == UInt8 {
+        pending.append(contentsOf: bytes)
+        let boundary = Self.completeBoundary(in: pending)
+        guard boundary > 0 else { return "" }
+        let complete = pending[..<boundary]
+        pending.removeFirst(boundary)
+        return String(decoding: complete, as: UTF8.self)
+    }
+
+    /// Emit anything still held. Called once at the end of a generation so a truncated final
+    /// sequence surfaces as a replacement character instead of vanishing.
+    mutating func flush() -> String {
+        guard !pending.isEmpty else { return "" }
+        let remainder = pending
+        pending.removeAll()
+        return String(decoding: remainder, as: UTF8.self)
+    }
+
+    /// Index one past the last byte that can be decoded now.
+    ///
+    /// Scans back from the end for the lead byte of the final sequence. If that sequence is short
+    /// of its declared length, the boundary is its start; otherwise everything is complete. More
+    /// than three trailing continuation bytes with no lead byte is malformed input, not an
+    /// incomplete sequence, so it is released rather than held.
+    static func completeBoundary(in bytes: [UInt8]) -> Int {
+        guard !bytes.isEmpty else { return 0 }
+        let maxLookback = min(4, bytes.count)
+        for step in 1...maxLookback {
+            let index = bytes.count - step
+            let byte = bytes[index]
+            if byte < 0x80 { return bytes.count }           // ASCII: nothing outstanding
+            if byte < 0xC0 { continue }                      // continuation: keep scanning back
+            let expected = sequenceLength(leadByte: byte)
+            // An invalid lead byte (0xF8…0xFF) declares no length; releasing it lets UTF-8's own
+            // replacement handle it instead of stalling the stream on a byte that never completes.
+            guard expected > 0 else { return bytes.count }
+            return step < expected ? index : bytes.count
+        }
+        return bytes.count
+    }
+
+    /// Total byte length a UTF-8 sequence with this lead byte occupies, or `0` when it is not a
+    /// valid lead byte.
+    static func sequenceLength(leadByte: UInt8) -> Int {
+        switch leadByte {
+        case 0x00...0x7F: return 1
+        case 0xC2...0xDF: return 2
+        case 0xE0...0xEF: return 3
+        case 0xF0...0xF4: return 4
+        default: return 0
+        }
+    }
+}
+
+/// Holds back just enough text to recognise a stop sequence that straddles token boundaries.
+///
+/// A stop sequence rarely arrives as one token: `</tool>` can come as `<`, `/`, `too`, `l>`. If the
+/// loop emitted each piece as it arrived, the wearer would see the start of the marker before the
+/// match completed. So the matcher keeps a suffix of `longestStop - 1` characters back, which is
+/// the most that can turn out to belong to a stop sequence.
+struct LlamaStopSequenceMatcher {
+
+    private let stopSequences: [String]
+    private let holdBack: Int
+    private var buffer = ""
+    private var stopped = false
+
+    init(stopSequences: [String]) {
+        // Empty stops would match everywhere; they are a caller mistake, not a request to stop
+        // immediately.
+        let usable = stopSequences.filter { !$0.isEmpty }
+        self.stopSequences = usable
+        self.holdBack = max(0, (usable.map(\.count).max() ?? 0) - 1)
+    }
+
+    /// True once a stop sequence has matched. No further text is emitted.
+    var hasStopped: Bool { stopped }
+
+    /// Feed newly decoded text. Returns the text safe to emit now, and whether generation should
+    /// stop. Text at and after the stop sequence is never emitted.
+    mutating func consume(_ text: String) -> (emit: String, stop: Bool) {
+        guard !stopped else { return ("", true) }
+        guard !stopSequences.isEmpty else { return (text, false) }
+        buffer += text
+
+        if let match = earliestMatch() {
+            stopped = true
+            let emit = String(buffer[buffer.startIndex..<match])
+            buffer = ""
+            return (emit, true)
+        }
+        guard buffer.count > holdBack else { return ("", false) }
+        let emitCount = buffer.count - holdBack
+        let splitIndex = buffer.index(buffer.startIndex, offsetBy: emitCount)
+        let emit = String(buffer[buffer.startIndex..<splitIndex])
+        buffer = String(buffer[splitIndex...])
+        return (emit, false)
+    }
+
+    /// Release the held-back tail. Called when generation ends for any reason other than a match.
+    mutating func flush() -> String {
+        guard !stopped else { return "" }
+        let remainder = buffer
+        buffer = ""
+        return remainder
+    }
+
+    /// Start index of the earliest stop sequence in the buffer, if any.
+    private func earliestMatch() -> String.Index? {
+        var earliest: String.Index?
+        for stop in stopSequences {
+            guard let range = buffer.range(of: stop) else { continue }
+            if earliest == nil || range.lowerBound < earliest! { earliest = range.lowerBound }
+        }
+        return earliest
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaEngine.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaEngine.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+/// The vendored engine's C ABI, restated in Swift terms (Plan DZ P1/PR3).
+///
+/// The backend talks to *this*, never to `LlamaCppWrapper` directly. That indirection buys the one
+/// thing the simulator cannot give us: the load flow's teardown ordering, the decode partitioning,
+/// the over-context refusal and the byte accumulator are all exercised against a fake engine, on a
+/// machine where no Metal graph can run. Without the seam those paths would only ever be reachable
+/// on a phone, which is where they are least observable.
+///
+/// Everything here is `Sendable` by construction — handles are opaque bit patterns rather than
+/// pointers — because the generation loop deliberately runs off the owning actor (see
+/// `LlamaCppLocalInferenceBackend`) so that cancellation can reach it.
+
+typealias LlamaToken = Int32
+
+// MARK: - Handles
+
+/// A live `llama_model`. The bit pattern is the wrapper's handle pointer in the real engine and an
+/// arbitrary counter in a fake; nothing outside the engine implementation may interpret it.
+struct LlamaModelHandle: Hashable, Sendable {
+    let bits: UInt
+    init(bits: UInt) { self.bits = bits }
+}
+
+struct LlamaContextHandle: Hashable, Sendable {
+    let bits: UInt
+    init(bits: UInt) { self.bits = bits }
+}
+
+struct LlamaSamplerHandle: Hashable, Sendable {
+    let bits: UInt
+    init(bits: UInt) { self.bits = bits }
+}
+
+// MARK: - Options
+
+struct LlamaModelOptions: Hashable, Sendable {
+    /// Layers placed on the GPU. Negative means all of them.
+    var gpuLayers: Int32
+    var useMemoryMapping: Bool
+    /// Metadata and vocabulary only — no weights.
+    var vocabularyOnly: Bool
+    /// Validate tensor data while loading. Slower; catches a corrupt file.
+    var checkTensors: Bool
+
+    init(gpuLayers: Int32 = -1,
+         useMemoryMapping: Bool = true,
+         vocabularyOnly: Bool = false,
+         checkTensors: Bool = false) {
+        self.gpuLayers = gpuLayers
+        self.useMemoryMapping = useMemoryMapping
+        self.vocabularyOnly = vocabularyOnly
+        self.checkTensors = checkTensors
+    }
+}
+
+struct LlamaContextOptions: Hashable, Sendable {
+    let contextTokens: Int
+    let batchTokens: Int
+    /// Keep the KV cache on the GPU. Off trades speed for headroom.
+    let offloadKVCache: Bool
+
+    init(contextTokens: Int, batchTokens: Int, offloadKVCache: Bool = true) {
+        self.contextTokens = contextTokens
+        self.batchTokens = batchTokens
+        self.offloadKVCache = offloadKVCache
+    }
+}
+
+/// App-owned sampling parameters. The defaults are conservative and live here rather than in a
+/// call site, and per-model overrides arrive through `LocalSamplingConfiguration` from the bundled
+/// descriptor — never from a filename.
+struct LlamaSamplerOptions: Hashable, Sendable {
+    /// The engine's "draw a fresh seed" sentinel. A test injects a real seed instead.
+    static let randomSeed: UInt32 = 0xFFFF_FFFF
+
+    static let defaultTopK: Int32 = 40
+    static let defaultMinP: Float = 0.05
+    static let defaultRepeatPenalty: Float = 1.1
+    /// Tokens of history the repetition penalty looks back over.
+    static let defaultPenaltyWindow: Int32 = 64
+
+    var seed: UInt32
+    var temperature: Float
+    var topK: Int32
+    var topP: Float
+    var minP: Float
+    var penaltyWindow: Int32
+    var penaltyRepeat: Float
+
+    init(seed: UInt32 = LlamaSamplerOptions.randomSeed,
+         temperature: Float = 0.7,
+         topK: Int32 = LlamaSamplerOptions.defaultTopK,
+         topP: Float = 0.9,
+         minP: Float = LlamaSamplerOptions.defaultMinP,
+         penaltyWindow: Int32 = LlamaSamplerOptions.defaultPenaltyWindow,
+         penaltyRepeat: Float = LlamaSamplerOptions.defaultRepeatPenalty) {
+        self.seed = seed
+        self.temperature = temperature
+        self.topK = topK
+        self.topP = topP
+        self.minP = minP
+        self.penaltyWindow = penaltyWindow
+        self.penaltyRepeat = penaltyRepeat
+    }
+
+    /// Translate the seam's request-level configuration, filling every value the caller left open
+    /// with the app default rather than with whatever the engine happens to ship.
+    init(_ sampling: LocalSamplingConfiguration) {
+        // Truncating is correct rather than lossy-by-accident: the engine's seed is 32-bit, and a
+        // test that pins a seed cares that the *same* input yields the same stream, not that all
+        // 64 bits survive.
+        self.init(seed: sampling.seed.map { UInt32(truncatingIfNeeded: $0) } ?? Self.randomSeed,
+                  temperature: sampling.temperature,
+                  topK: sampling.topK.map { Int32(clamping: $0) } ?? Self.defaultTopK,
+                  topP: sampling.topP,
+                  minP: Self.defaultMinP,
+                  penaltyWindow: Self.defaultPenaltyWindow,
+                  penaltyRepeat: sampling.repetitionPenalty ?? Self.defaultRepeatPenalty)
+    }
+}
+
+/// One turn as the chat template sees it. Roles are the template's own vocabulary (`system`,
+/// `user`, `assistant`), which is why this is a string and not `LocalChatMessage.Role`.
+struct LlamaChatTurn: Hashable, Sendable {
+    let role: String
+    let content: String
+
+    init(role: String, content: String) {
+        self.role = role
+        self.content = content
+    }
+}
+
+// MARK: - Errors
+
+/// The wrapper's `OGLlamaStatus`, as a Swift error. One case per status so a caller can act on
+/// "the prompt did not fit" differently from "the file would not open".
+enum LlamaEngineError: Error, Equatable {
+    case invalidArgument
+    case modelLoadFailed
+    case contextCreateFailed
+    case samplerCreateFailed
+    case tokenizeFailed
+    /// `llama_decode` could not find a KV slot — the batch does not fit the context.
+    case contextExhausted
+    case decodeFailed
+    case noChatTemplate
+    case templateFailed
+    case cancelled
+    case allocationFailed
+    case unknown(Int32)
+
+    /// Maps a raw status. `0` is success and must never reach here.
+    init(status: Int32) {
+        switch status {
+        case 1: self = .invalidArgument
+        case 2: self = .modelLoadFailed
+        case 3: self = .contextCreateFailed
+        case 4: self = .samplerCreateFailed
+        case 5: self = .tokenizeFailed
+        case 6: self = .contextExhausted
+        case 7: self = .decodeFailed
+        case 8: self = .noChatTemplate
+        case 9: self = .templateFailed
+        case 10: self = .cancelled
+        case 11: self = .allocationFailed
+        default: self = .unknown(status)
+        }
+    }
+}
+
+// MARK: - Engine
+
+/// Model, context, sampler, tokenizer and template, as the backend needs them.
+///
+/// Deliberately *not* thread-safe by contract — matching the wrapper's own statement that the
+/// owning actor is the synchronization. The single exception is `setCancelled`, which the wrapper
+/// implements as an atomic precisely so a cancel can reach an in-flight decode.
+protocol LlamaEngine: Sendable {
+
+    // Model lifecycle
+    func loadModel(atPath path: String, options: LlamaModelOptions) throws -> LlamaModelHandle
+    func freeModel(_ model: LlamaModelHandle)
+
+    // Metadata — the only source of architecture and chat format
+    func metadataValue(_ model: LlamaModelHandle, key: String) -> String?
+    func chatTemplate(_ model: LlamaModelHandle, named name: String?) -> String?
+    func trainingContextTokens(_ model: LlamaModelHandle) -> Int
+    func vocabularyAddsBOS(_ model: LlamaModelHandle) -> Bool
+    /// The rendered text of the BOS token, used to tell whether a template already emits one.
+    func beginningOfSequencePiece(_ model: LlamaModelHandle) -> String?
+    func isEndOfGeneration(_ model: LlamaModelHandle, token: LlamaToken) -> Bool
+
+    // Template and tokenization
+    func applyChatTemplate(_ template: String,
+                           turns: [LlamaChatTurn],
+                           addAssistantHeader: Bool) throws -> String
+    func tokenize(_ model: LlamaModelHandle,
+                  text: String,
+                  addSpecial: Bool,
+                  parseSpecial: Bool) throws -> [LlamaToken]
+    /// Raw bytes of one token. Bytes, not characters: a token can end mid-UTF-8.
+    func tokenBytes(_ model: LlamaModelHandle, token: LlamaToken) -> [UInt8]
+
+    // Context lifecycle
+    func createContext(_ model: LlamaModelHandle, options: LlamaContextOptions) throws -> LlamaContextHandle
+    func freeContext(_ context: LlamaContextHandle)
+    func contextTokens(_ context: LlamaContextHandle) -> Int
+    func batchTokens(_ context: LlamaContextHandle) -> Int
+    func clearMemory(_ context: LlamaContextHandle)
+    func setCancelled(_ context: LlamaContextHandle, _ cancelled: Bool)
+    func synchronize(_ context: LlamaContextHandle)
+    func decode(_ context: LlamaContextHandle,
+                tokens: [LlamaToken],
+                position: Int,
+                wantsLogitsForLast: Bool) throws
+
+    // Sampling
+    func createSampler(_ model: LlamaModelHandle, options: LlamaSamplerOptions) throws -> LlamaSamplerHandle
+    func freeSampler(_ sampler: LlamaSamplerHandle)
+    func resetSampler(_ sampler: LlamaSamplerHandle)
+    func sample(_ sampler: LlamaSamplerHandle, context: LlamaContextHandle) throws -> LlamaToken
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelRepository.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelRepository.swift
@@ -102,6 +102,30 @@ final class LocalModelRepository {
         installedRoot.appendingPathComponent(id.storageComponent, isDirectory: true)
     }
 
+    /// Where an installation's *files* are, which is not always where its record is: a legacy MLX
+    /// discovery still points at the hub cache directory it was found in, because PR1 records
+    /// without moving anything.
+    func directory(for installation: InstalledLocalModel) -> URL {
+        Self.directory(for: installation, root: root)
+    }
+
+    /// The same rule against the default root, for callers that hold no repository — the GGUF
+    /// backend resolves a weights path this way rather than taking a dependency on the store.
+    static func defaultDirectory(for installation: InstalledLocalModel,
+                                 fileManager: FileManager = .default) -> URL {
+        directory(for: installation, root: defaultRoot(fileManager: fileManager))
+    }
+
+    private static func directory(for installation: InstalledLocalModel, root: URL) -> URL {
+        switch installation.storage {
+        case .legacyHubSnapshot(let name):
+            return root.appendingPathComponent(name, isDirectory: true)
+        case .managed(let name):
+            return root.appendingPathComponent(installedDirectoryName, isDirectory: true)
+                .appendingPathComponent(name, isDirectory: true)
+        }
+    }
+
     // MARK: - Reading
 
     /// Every complete installation, ordered by id so the result is stable.

--- a/OpenGlasses/Sources/Utils/PrivacyLog.swift
+++ b/OpenGlasses/Sources/Utils/PrivacyLog.swift
@@ -1409,6 +1409,9 @@ enum PrivacyLog {
         case downloaded, downloadCancelled, deleted, tempsSwept
         case loaded, loadFailed, unloaded, visionDemoted, imageRefused
         case generationStarted, generationCompleted, generationFailed, stalled
+        /// The prompt finished its batched prefill. Separate from `generationStarted` because
+        /// prefill time and first-token latency are different diagnostics with different causes.
+        case promptDecoded
         case historyTrimmed, toolCall, reasoningProduced, tokenShape
         /// Installed-model records (Plan DZ P0). These carry **counts only** — a compatibility
         /// descriptor's id is whatever the user typed into the model field, which makes it
@@ -1427,6 +1430,8 @@ enum PrivacyLog {
                            footprintMegabytes: Int? = nil, headroomMegabytes: Int? = nil,
                            kilobytes: Int? = nil,
                            tool: PrivacyToken? = nil, detail: PrivacyToken? = nil,
+                           milliseconds: Int? = nil, firstTokenMilliseconds: Int? = nil,
+                           percent: Int? = nil, state: PrivacyToken? = nil,
                            error: SafeErrorSummary? = nil) -> PrivacyEvent {
         var fields: [PrivacyEvent.Field] = [.init(.event, .token(PrivacyToken(event.rawValue)))]
         if let model { fields.append(.init(.model, .token(model))) }
@@ -1447,6 +1452,12 @@ enum PrivacyLog {
         if let kilobytes { fields.append(.init(.kilobytes, .count(kilobytes))) }
         if let tool { fields.append(.init(.tool, .token(tool))) }
         if let detail { fields.append(.init(.detail, .token(detail))) }
+        if let milliseconds { fields.append(.init(.duration, .milliseconds(milliseconds))) }
+        if let firstTokenMilliseconds {
+            fields.append(.init(.elapsed, .milliseconds(firstTokenMilliseconds)))
+        }
+        if let percent { fields.append(.init(.percent, .count(percent))) }
+        if let state { fields.append(.init(.state, .token(state))) }
         if let error { fields.append(.init(.error, .summary(error))) }
         return emit(.init(.model, .localModel, fields))
     }

--- a/OpenGlassesTests/LlamaCppBackendTests.swift
+++ b/OpenGlassesTests/LlamaCppBackendTests.swift
@@ -1,0 +1,837 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DZ P1/PR3 — the GGUF backend's load and generation flows, driven against a fake engine.
+///
+/// A fake at the `LlamaEngine` seam is the only instrument that can prove these properties here:
+/// the simulator cannot run a Metal graph, and the things that most need proving — that a partial
+/// load frees what it created in reverse order, that the KV cache is cleared on *every* request,
+/// that an over-context prompt never reaches `llama_decode` — are statements about calls made and
+/// not made, which no amount of real inference would let you observe.
+///
+/// What this file therefore does **not** claim: that a real GGUF file loads, that Metal works, or
+/// that generated text is correct. Those are device evidence and stay outstanding.
+final class LlamaCppBackendTests: XCTestCase {
+
+    // MARK: - Fake engine
+
+    private final class FakeLlamaEngine: LlamaEngine, @unchecked Sendable {
+
+        enum Call: Equatable {
+            case loadModel(String)
+            case createContext(tokens: Int, batch: Int)
+            case createSampler(seed: UInt32, temperature: Float)
+            case applyTemplate(addAssistantHeader: Bool)
+            case tokenize(addSpecial: Bool, parseSpecial: Bool)
+            case clearMemory
+            case resetSampler
+            case decode(count: Int, position: Int, wantsLogits: Bool)
+            case sample
+            case setCancelled(Bool)
+            case synchronize
+            case freeSampler
+            case freeContext
+            case freeModel
+        }
+
+        enum Failure: Hashable {
+            case modelLoad, contextCreate, samplerCreate, templateRender, tokenize, decode
+        }
+
+        private let lock = NSLock()
+        private var _calls: [Call] = []
+        private var _turnsByApplication: [[LlamaChatTurn]] = []
+        private var _cancelled = false
+        private var _allowance = 0
+        private var _sampleIndex = 0
+
+        // Configuration
+        var metadata: [String: String] = [
+            "general.architecture": "llama",
+            "llama.context_length": "8192",
+            "llama.block_count": "16",
+            "llama.embedding_length": "1024",
+            "llama.attention.head_count": "16",
+            "llama.attention.head_count_kv": "4",
+        ]
+        var template: String? = "{{ messages }}"
+        var trainingContext = 8192
+        var contextTokensOverride: Int?
+        var batchTokensOverride: Int?
+        /// Fixed token count for a rendered prompt. `nil` uses one token per four characters.
+        var promptTokenCount: Int?
+        /// Bytes each successive sampled token produces. Exhausting the list ends generation.
+        var outputPieces: [[UInt8]] = [Array("Hello".utf8), Array(" there".utf8)]
+        var failures: Set<Failure> = []
+        var vocabularyAddsBOSValue = false
+        var bosPieceValue: String?
+        /// When true, `sample` waits for an allowance before returning — the hook a cancellation
+        /// test uses to stop a generation mid-stream deterministically.
+        var gateSamples = false
+
+        private static let endOfGenerationToken: LlamaToken = 9_999
+
+        var calls: [Call] {
+            lock.lock(); defer { lock.unlock() }
+            return _calls
+        }
+
+        /// The turns handed to each `applyChatTemplate` call, in order. The probe exchange the
+        /// template validator renders at load is included; generation calls follow it.
+        var turnsByApplication: [[LlamaChatTurn]] {
+            lock.lock(); defer { lock.unlock() }
+            return _turnsByApplication
+        }
+
+        func allow(_ samples: Int) {
+            lock.lock(); _allowance += samples; lock.unlock()
+        }
+
+        private func note(_ call: Call) {
+            lock.lock(); _calls.append(call); lock.unlock()
+        }
+
+        // Model lifecycle
+
+        func loadModel(atPath path: String, options: LlamaModelOptions) throws -> LlamaModelHandle {
+            note(.loadModel(path))
+            if failures.contains(.modelLoad) { throw LlamaEngineError.modelLoadFailed }
+            return LlamaModelHandle(bits: 1)
+        }
+
+        func freeModel(_ model: LlamaModelHandle) { note(.freeModel) }
+
+        // Metadata
+
+        func metadataValue(_ model: LlamaModelHandle, key: String) -> String? { metadata[key] }
+        func chatTemplate(_ model: LlamaModelHandle, named name: String?) -> String? { template }
+        func trainingContextTokens(_ model: LlamaModelHandle) -> Int { trainingContext }
+        func vocabularyAddsBOS(_ model: LlamaModelHandle) -> Bool { vocabularyAddsBOSValue }
+        func beginningOfSequencePiece(_ model: LlamaModelHandle) -> String? { bosPieceValue }
+
+        func isEndOfGeneration(_ model: LlamaModelHandle, token: LlamaToken) -> Bool {
+            token == Self.endOfGenerationToken
+        }
+
+        // Template and tokenization
+
+        func applyChatTemplate(_ template: String,
+                               turns: [LlamaChatTurn],
+                               addAssistantHeader: Bool) throws -> String {
+            note(.applyTemplate(addAssistantHeader: addAssistantHeader))
+            lock.lock(); _turnsByApplication.append(turns); lock.unlock()
+            if failures.contains(.templateRender) { throw LlamaEngineError.templateFailed }
+            var out = ""
+            for turn in turns { out += "<|start|>\(turn.role)\n\(turn.content)<|end|>\n" }
+            if addAssistantHeader { out += "<|start|>assistant\n" }
+            return out
+        }
+
+        func tokenize(_ model: LlamaModelHandle,
+                      text: String,
+                      addSpecial: Bool,
+                      parseSpecial: Bool) throws -> [LlamaToken] {
+            note(.tokenize(addSpecial: addSpecial, parseSpecial: parseSpecial))
+            if failures.contains(.tokenize) { throw LlamaEngineError.tokenizeFailed }
+            let count = promptTokenCount ?? max(1, text.count / 4)
+            return (0..<count).map { LlamaToken($0) }
+        }
+
+        func tokenBytes(_ model: LlamaModelHandle, token: LlamaToken) -> [UInt8] {
+            let index = Int(token)
+            guard index >= 0, index < outputPieces.count else { return [] }
+            return outputPieces[index]
+        }
+
+        // Context lifecycle
+
+        func createContext(_ model: LlamaModelHandle,
+                           options: LlamaContextOptions) throws -> LlamaContextHandle {
+            note(.createContext(tokens: options.contextTokens, batch: options.batchTokens))
+            if failures.contains(.contextCreate) { throw LlamaEngineError.contextCreateFailed }
+            contextTokensOverride = contextTokensOverride ?? options.contextTokens
+            batchTokensOverride = batchTokensOverride ?? options.batchTokens
+            return LlamaContextHandle(bits: 2)
+        }
+
+        func freeContext(_ context: LlamaContextHandle) { note(.freeContext) }
+        func contextTokens(_ context: LlamaContextHandle) -> Int { contextTokensOverride ?? 0 }
+        func batchTokens(_ context: LlamaContextHandle) -> Int { batchTokensOverride ?? 0 }
+        func clearMemory(_ context: LlamaContextHandle) { note(.clearMemory) }
+        func synchronize(_ context: LlamaContextHandle) { note(.synchronize) }
+
+        func setCancelled(_ context: LlamaContextHandle, _ cancelled: Bool) {
+            note(.setCancelled(cancelled))
+            lock.lock(); _cancelled = cancelled; lock.unlock()
+        }
+
+        func decode(_ context: LlamaContextHandle,
+                    tokens: [LlamaToken],
+                    position: Int,
+                    wantsLogitsForLast: Bool) throws {
+            note(.decode(count: tokens.count, position: position, wantsLogits: wantsLogitsForLast))
+            if failures.contains(.decode) { throw LlamaEngineError.decodeFailed }
+        }
+
+        // Sampling
+
+        func createSampler(_ model: LlamaModelHandle,
+                           options: LlamaSamplerOptions) throws -> LlamaSamplerHandle {
+            note(.createSampler(seed: options.seed, temperature: options.temperature))
+            if failures.contains(.samplerCreate) { throw LlamaEngineError.samplerCreateFailed }
+            return LlamaSamplerHandle(bits: 3)
+        }
+
+        func freeSampler(_ sampler: LlamaSamplerHandle) { note(.freeSampler) }
+
+        func resetSampler(_ sampler: LlamaSamplerHandle) {
+            note(.resetSampler)
+            lock.lock(); _sampleIndex = 0; lock.unlock()
+        }
+
+        func sample(_ sampler: LlamaSamplerHandle, context: LlamaContextHandle) throws -> LlamaToken {
+            note(.sample)
+            if gateSamples {
+                // Spins rather than blocking on a semaphore so a cancellation can always break the
+                // wait; the loop runs on its own task, so only that task is held here.
+                while true {
+                    lock.lock()
+                    let cancelled = _cancelled
+                    let permitted = _allowance > 0
+                    if permitted { _allowance -= 1 }
+                    lock.unlock()
+                    if cancelled || permitted { break }
+                    Thread.sleep(forTimeInterval: 0.002)
+                }
+            }
+            lock.lock()
+            let cancelled = _cancelled
+            let index = _sampleIndex
+            _sampleIndex += 1
+            lock.unlock()
+            if cancelled { throw LlamaEngineError.cancelled }
+            return index < outputPieces.count ? LlamaToken(index) : Self.endOfGenerationToken
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gguf-backend-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    /// Writes a stand-in weights file and returns a matching installation record.
+    @discardableResult
+    private func makeInstallation(id: String = "gguf/test-model",
+                                  runtime: LocalModelRuntime = .llamaCpp,
+                                  contextLength: Int = 4096,
+                                  declaredByteCount: Int64? = nil,
+                                  writeWeights: Bool = true,
+                                  capabilities: Set<LocalModelCapability> = [.text])
+        throws -> InstalledLocalModel {
+        let weights = directory.appendingPathComponent("model.gguf")
+        let bytes = Data(repeating: 0x47, count: 1024)
+        if writeWeights { try bytes.write(to: weights) }
+        let file = LocalModelFile(relativePath: "model.gguf",
+                                  byteCount: declaredByteCount ?? Int64(bytes.count),
+                                  sha256: String(repeating: "a", count: 64),
+                                  role: .weights)
+        return InstalledLocalModel(
+            descriptor: LocalModelDescriptor(id: LocalModelID(id),
+                                             displayName: "Test",
+                                             runtime: runtime,
+                                             repositoryID: id,
+                                             revision: "abc123",
+                                             files: [file],
+                                             capabilities: capabilities,
+                                             contextLength: contextLength,
+                                             estimatedWeightsBytes: 1_000,
+                                             estimatedWorkingBytes: 1_000,
+                                             minimumHeadroomBytes: 0),
+            storage: .managed(directoryName: LocalModelID(id).storageComponent),
+            installedAt: Date(timeIntervalSince1970: 0),
+            validatedFiles: [file])
+    }
+
+    private func makeBackend(_ engine: FakeLlamaEngine,
+                             enabled: Bool = true,
+                             availableBytes: Int64 = 0) -> LlamaCppLocalInferenceBackend {
+        let root = directory!
+        return LlamaCppLocalInferenceBackend(
+            engine: engine,
+            directoryForInstallation: { _ in root },
+            availableProcessBytes: { availableBytes },
+            appFootprintBytes: { 0 },
+            thermalState: { .nominal },
+            monotonicNanoseconds: { 0 },
+            isRuntimeEnabled: { enabled })
+    }
+
+    private let configuration = LocalLoadConfiguration(contextLength: 4096, batchSize: 512)
+
+    private func request(_ messages: [LocalChatMessage],
+                         maxOutputTokens: Int = 64,
+                         sampling: LocalSamplingConfiguration = .conservative,
+                         stopSequences: [String] = [],
+                         images: [LocalImageInput] = []) -> LocalGenerationRequest {
+        LocalGenerationRequest(messages: messages,
+                               images: images,
+                               maxOutputTokens: maxOutputTokens,
+                               sampling: sampling,
+                               stopSequences: stopSequences)
+    }
+
+    private func collect(_ stream: AsyncThrowingStream<String, Error>) async throws -> String {
+        var text = ""
+        for try await chunk in stream { text += chunk }
+        return text
+    }
+
+    private let oneTurn: [LocalChatMessage] = [.system("Be brief."), .user("Hello?")]
+
+    // MARK: - Load flow
+
+    func testLoadCreatesModelThenContextThenSampler() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        let loaded = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        XCTAssertEqual(loaded.runtime, .llamaCpp)
+        XCTAssertFalse(loaded.supportsVision, "the text-only phase never advertises vision")
+        let creations = engine.calls.filter {
+            if case .loadModel = $0 { return true }
+            if case .createContext = $0 { return true }
+            if case .createSampler = $0 { return true }
+            return false
+        }
+        XCTAssertEqual(creations.count, 3)
+        guard case .loadModel = creations[0], case .createContext = creations[1],
+              case .createSampler = creations[2] else {
+            return XCTFail("resources must be created model → context → sampler")
+        }
+    }
+
+    /// The exit criterion's teardown property, made observable by failing the last creation step.
+    func testAFailedSamplerCreateTearsDownInReverseOrder() async throws {
+        let engine = FakeLlamaEngine()
+        engine.failures = [.samplerCreate]
+        let backend = makeBackend(engine)
+
+        do {
+            _ = try await backend.load(try makeInstallation(), configuration: configuration)
+            XCTFail("expected the load to fail")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError, .engine(.samplerCreateFailed))
+        }
+        XCTAssertEqual(engine.calls.suffix(3), [.synchronize, .freeContext, .freeModel],
+                       "the accelerator drains first, then resources free in reverse creation order")
+        XCTAssertFalse(engine.calls.contains(.freeSampler), "nothing was created to free")
+        let resident = await backend.loadedModel
+        XCTAssertNil(resident)
+    }
+
+    func testAFailedContextCreateFreesOnlyTheModel() async throws {
+        let engine = FakeLlamaEngine()
+        engine.failures = [.contextCreate]
+        let backend = makeBackend(engine)
+
+        do {
+            _ = try await backend.load(try makeInstallation(), configuration: configuration)
+            XCTFail("expected the load to fail")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError, .engine(.contextCreateFailed))
+        }
+        XCTAssertEqual(engine.calls.last, .freeModel)
+        XCTAssertFalse(engine.calls.contains(.freeContext))
+        XCTAssertFalse(engine.calls.contains(.synchronize),
+                       "there is no context whose accelerator work needs draining")
+    }
+
+    func testAModelWithNoUsableChatTemplateIsRefusedAndUnloaded() async throws {
+        let engine = FakeLlamaEngine()
+        engine.template = nil
+        let backend = makeBackend(engine)
+
+        do {
+            _ = try await backend.load(try makeInstallation(), configuration: configuration)
+            XCTFail("expected the load to fail")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError, .unsupportedChatTemplate(.absent))
+        }
+        XCTAssertEqual(engine.calls.last, .freeModel)
+        XCTAssertFalse(engine.calls.contains { if case .createContext = $0 { return true }; return false },
+                       "a model that cannot chat must not pay for a context")
+    }
+
+    func testATemplateThatCannotRenderTheProbeIsRefused() async throws {
+        let engine = FakeLlamaEngine()
+        engine.failures = [.templateRender]
+        let backend = makeBackend(engine)
+
+        do {
+            _ = try await backend.load(try makeInstallation(), configuration: configuration)
+            XCTFail("expected the load to fail")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError, .unsupportedChatTemplate(.renderFailed))
+        }
+    }
+
+    func testAFileThatDoesNotDeclareItsArchitectureIsRefused() async throws {
+        let engine = FakeLlamaEngine()
+        engine.metadata = ["llama.block_count": "16"]
+        let backend = makeBackend(engine)
+
+        do {
+            _ = try await backend.load(try makeInstallation(), configuration: configuration)
+            XCTFail("expected the load to fail")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError, .unsupportedArchitecture)
+        }
+        XCTAssertEqual(engine.calls.last, .freeModel)
+    }
+
+    func testContextIsClampedToTheModelsTrainedLength() async throws {
+        let engine = FakeLlamaEngine()
+        engine.trainingContext = 2048
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(contextLength: 32_768),
+                                   configuration: LocalLoadConfiguration(contextLength: 16_384,
+                                                                         batchSize: 512))
+        XCTAssertTrue(engine.calls.contains(.createContext(tokens: 2048, batch: 512)))
+    }
+
+    func testTheBatchNeverExceedsTheContext() async throws {
+        let engine = FakeLlamaEngine()
+        engine.trainingContext = 768
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(contextLength: 768),
+                                   configuration: LocalLoadConfiguration(contextLength: 768,
+                                                                         batchSize: 4096))
+        XCTAssertTrue(engine.calls.contains(.createContext(tokens: 768, batch: 768)))
+    }
+
+    func testReloadingTheResidentModelDoesNotRebuildIt() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        let installation = try makeInstallation()
+        _ = try await backend.load(installation, configuration: configuration)
+        let before = engine.calls.count
+        _ = try await backend.load(installation, configuration: configuration)
+        XCTAssertEqual(engine.calls.count, before)
+    }
+
+    // MARK: - Load refusals that never reach the engine
+
+    func testWithTheFlagOffNothingTouchesTheEngine() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine, enabled: false)
+
+        do {
+            _ = try await backend.load(try makeInstallation(), configuration: configuration)
+            XCTFail("expected a refusal")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError, .runtimeDisabled)
+        }
+        XCTAssertTrue(engine.calls.isEmpty,
+                      "a disabled runtime must not open a model file, let alone load one")
+    }
+
+    func testAnMLXInstallationIsRefusedByRuntime() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        do {
+            _ = try await backend.load(try makeInstallation(runtime: .mlx),
+                                       configuration: configuration)
+            XCTFail("expected a refusal")
+        } catch {
+            XCTAssertEqual(error as? LocalInferenceError, .noBackend(.mlx))
+        }
+        XCTAssertTrue(engine.calls.isEmpty)
+    }
+
+    func testAMissingWeightsFileIsRefusedBeforeTheEngineIsAsked() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        do {
+            _ = try await backend.load(try makeInstallation(writeWeights: false),
+                                       configuration: configuration)
+            XCTFail("expected a refusal")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError,
+                           .weightsMissing(LocalModelID("gguf/test-model")))
+        }
+        XCTAssertTrue(engine.calls.isEmpty)
+    }
+
+    func testAFileWhoseSizeDisagreesWithTheManifestIsRefused() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        do {
+            _ = try await backend.load(try makeInstallation(declaredByteCount: 999_999),
+                                       configuration: configuration)
+            XCTFail("expected a refusal")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError,
+                           .installationIncomplete(LocalModelID("gguf/test-model")))
+        }
+    }
+
+    func testALoadThatDoesNotFitAvailableMemoryIsRefused() async throws {
+        let engine = FakeLlamaEngine()
+        // A budget far below the runtime's working set: admission must refuse before any file work.
+        let backend = makeBackend(engine, availableBytes: 8 * 1024 * 1024)
+        do {
+            _ = try await backend.load(try makeInstallation(), configuration: configuration)
+            XCTFail("expected a refusal")
+        } catch {
+            guard case .insufficientMemory = (error as? LlamaBackendError) else {
+                return XCTFail("expected a typed memory refusal, got \(error)")
+            }
+        }
+        XCTAssertTrue(engine.calls.isEmpty)
+    }
+
+    // MARK: - Generation flow
+
+    func testGenerationStreamsTheConcatenatedTokenPieces() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        let text = try await collect(backend.generate(request(oneTurn)))
+        XCTAssertEqual(text, "Hello there")
+    }
+
+    /// The byte accumulator, exercised through the real loop rather than in isolation: each token
+    /// carries one byte of a four-byte scalar.
+    func testSplitMultiByteTokensReachTheStreamWhole() async throws {
+        let engine = FakeLlamaEngine()
+        engine.outputPieces = Array("🙂".utf8).map { [$0] } + [Array("!".utf8)]
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        let text = try await collect(backend.generate(request(oneTurn)))
+        XCTAssertEqual(text, "🙂!")
+        XCTAssertFalse(text.contains("\u{FFFD}"))
+    }
+
+    func testEveryRequestClearsTheKVCacheAndThePenaltyHistory() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        _ = try await collect(backend.generate(request(oneTurn)))
+        _ = try await collect(backend.generate(request(oneTurn + [.assistant("Hi."), .user("More?")])))
+
+        XCTAssertEqual(engine.calls.filter { $0 == .clearMemory }.count, 2)
+        XCTAssertEqual(engine.calls.filter { $0 == .resetSampler }.count, 2)
+    }
+
+    /// The exit criterion: "a second turn contains exactly one copy of each prior message". Asserted
+    /// on the assembled prompt, because that is where a duplicate would be introduced — the output
+    /// looking plausible would prove nothing.
+    func testASecondTurnRendersEachPriorMessageExactlyOnce() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        _ = try await collect(backend.generate(request(oneTurn)))
+        let secondTurn = oneTurn + [.assistant("Hello there"), .user("And again?")]
+        _ = try await collect(backend.generate(request(secondTurn)))
+
+        // The last application is the second turn's; the earlier ones are the load-time probe and
+        // the first turn.
+        let turns = try XCTUnwrap(engine.turnsByApplication.last)
+        XCTAssertEqual(turns.map(\.role), ["system", "user", "assistant", "user"])
+        for message in secondTurn {
+            XCTAssertEqual(turns.filter { $0.content == message.content }.count, 1,
+                           "\(message.content) must appear exactly once")
+        }
+    }
+
+    func testAPromptLongerThanTheBatchIsDecodedInChunks() async throws {
+        let engine = FakeLlamaEngine()
+        engine.promptTokenCount = 1_100
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        _ = try await collect(backend.generate(request(oneTurn)))
+
+        let promptDecodes = engine.calls.compactMap { call -> (Int, Int, Bool)? in
+            guard case .decode(let count, let position, let wantsLogits) = call else { return nil }
+            return (count, position, wantsLogits)
+        }.prefix(3)
+        XCTAssertEqual(promptDecodes.map(\.0), [512, 512, 76])
+        XCTAssertEqual(promptDecodes.map(\.1), [0, 512, 1024])
+        XCTAssertEqual(promptDecodes.map(\.2), [false, false, true],
+                       "only the final chunk needs logits")
+        XCTAssertTrue(promptDecodes.allSatisfy { $0.0 <= 512 })
+    }
+
+    func testAnOverContextPromptFailsBeforeAnyDecode() async throws {
+        let engine = FakeLlamaEngine()
+        engine.trainingContext = 1024
+        engine.promptTokenCount = 1_000
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(contextLength: 1024),
+                                   configuration: LocalLoadConfiguration(contextLength: 1024,
+                                                                         batchSize: 512))
+
+        do {
+            _ = try await collect(backend.generate(request(oneTurn, maxOutputTokens: 256)))
+            XCTFail("expected a refusal")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError,
+                           .promptTooLong(promptTokens: 1_000, reserveTokens: 256,
+                                          contextTokens: 1024))
+        }
+        XCTAssertFalse(engine.calls.contains { if case .decode = $0 { return true }; return false },
+                       "the refusal must land before the native decode, not inside it")
+    }
+
+    func testImagesAreRefusedInTheTextOnlyPhase() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        do {
+            _ = try await collect(backend.generate(
+                request(oneTurn, images: [LocalImageInput(data: Data([0x01]))])))
+            XCTFail("expected a refusal")
+        } catch {
+            XCTAssertEqual(error as? LocalInferenceError, .visionNotAvailable)
+        }
+    }
+
+    func testGeneratingWithNothingResidentIsRefused() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        do {
+            _ = try await collect(backend.generate(request(oneTurn)))
+            XCTFail("expected a refusal")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError, .notLoaded)
+        }
+    }
+
+    func testAStopSequenceEndsGenerationWithoutEmittingIt() async throws {
+        let engine = FakeLlamaEngine()
+        engine.outputPieces = [Array("Answer".utf8), Array("<|halt|>".utf8), Array(" more".utf8)]
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        let text = try await collect(backend.generate(request(oneTurn, stopSequences: ["<|halt|>"])))
+        XCTAssertEqual(text, "Answer")
+    }
+
+    func testOutputIsCappedAtTheRequestedTokenCount() async throws {
+        let engine = FakeLlamaEngine()
+        engine.outputPieces = (0..<50).map { Array("\($0) ".utf8) }
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        _ = try await collect(backend.generate(request(oneTurn, maxOutputTokens: 5)))
+        XCTAssertEqual(engine.calls.filter { $0 == .sample }.count, 5)
+    }
+
+    func testADecodeFailureSurfacesAsATypedEngineError() async throws {
+        let engine = FakeLlamaEngine()
+        engine.failures = [.decode]
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        do {
+            _ = try await collect(backend.generate(request(oneTurn)))
+            XCTFail("expected a failure")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError, .engine(.decodeFailed))
+        }
+    }
+
+    // MARK: - Sampling
+
+    func testAPinnedSeedReachesTheSamplerForThatRequest() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        _ = try await collect(backend.generate(
+            request(oneTurn, sampling: LocalSamplingConfiguration(temperature: 0.1, seed: 4_242))))
+
+        XCTAssertTrue(engine.calls.contains(.createSampler(seed: 4_242, temperature: 0.1)),
+                      "a pinned seed is what makes a generation reproducible")
+        // The old chain is freed only after the replacement exists.
+        let samplerCalls = engine.calls.filter { call in
+            if case .createSampler = call { return true }
+            return call == .freeSampler
+        }
+        XCTAssertEqual(samplerCalls.count, 3)
+        XCTAssertEqual(samplerCalls.last, .freeSampler)
+    }
+
+    func testTheDefaultSamplerIsNotRebuiltForADefaultRequest() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+        _ = try await collect(backend.generate(request(oneTurn)))
+
+        let creations = engine.calls.filter { if case .createSampler = $0 { return true }; return false }
+        XCTAssertEqual(creations.count, 1, "an unchanged sampler must not be rebuilt per turn")
+    }
+
+    // MARK: - Cancellation and unload
+
+    func testCancellationStopsDeliveryAndLeavesTheBackendUsable() async throws {
+        let engine = FakeLlamaEngine()
+        engine.gateSamples = true
+        engine.outputPieces = (0..<50).map { Array("\($0) ".utf8) }
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+
+        engine.allow(1)
+        // The stream is held for the whole test: dropping it while iterating would terminate the
+        // continuation as `.cancelled` and cancel the very generation this test means to cancel
+        // explicitly.
+        let stream = backend.generate(request(oneTurn, maxOutputTokens: 50))
+        var iterator = stream.makeAsyncIterator()
+        let first = try await iterator.next()
+        XCTAssertEqual(first, "0 ")
+
+        await backend.cancelGeneration()
+
+        do {
+            while try await iterator.next() != nil {}
+            XCTFail("expected the stream to end in cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError, "got \(error)")
+        }
+        XCTAssertTrue(engine.calls.contains(.setCancelled(true)))
+        XCTAssertTrue(engine.calls.contains(.setCancelled(false)),
+                      "the flag is cleared so the context stays usable for the next turn")
+        XCTAssertLessThan(engine.calls.filter { $0 == .sample }.count, 50)
+        // The model is still resident: cancelling a turn is not unloading a model.
+        let resident = await backend.loadedModel
+        XCTAssertNotNil(resident)
+    }
+
+    func testUnloadCancelsFirstThenFreesInReverseOrder() async throws {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        _ = try await backend.load(try makeInstallation(), configuration: configuration)
+        _ = try await collect(backend.generate(request(oneTurn)))
+
+        await backend.unload()
+
+        XCTAssertEqual(engine.calls.suffix(3), [.freeSampler, .freeContext, .freeModel])
+        let resident = await backend.loadedModel
+        XCTAssertNil(resident)
+    }
+
+    func testUnloadingWithNothingResidentIsSafe() async {
+        let engine = FakeLlamaEngine()
+        let backend = makeBackend(engine)
+        await backend.unload()
+        XCTAssertTrue(engine.calls.isEmpty)
+    }
+
+    // MARK: - Coordinator integration
+
+    /// The residency exit criterion, minus the device: switching runtimes must leave exactly one
+    /// allocation, and the outgoing backend must have been torn down before the incoming load.
+    func testSwitchingGGUFToMLXToGGUFLeavesOneResidentAllocation() async throws {
+        let engine = FakeLlamaEngine()
+        let gguf = makeBackend(engine)
+        let mlx = RecordingBackend(runtime: .mlx)
+        let coordinator = LocalInferenceCoordinator(backends: [gguf, mlx])
+
+        let ggufModel = try makeInstallation(id: "gguf/one")
+        let mlxModel = try makeInstallation(id: "mlx/one", runtime: .mlx)
+
+        _ = try await coordinator.load(ggufModel, configuration: configuration)
+        _ = try await coordinator.load(mlxModel, configuration: configuration)
+        XCTAssertEqual(engine.calls.suffix(3), [.freeSampler, .freeContext, .freeModel],
+                       "the GGUF allocation is released before MLX takes residency")
+        let afterMLX = await gguf.loadedModel
+        XCTAssertNil(afterMLX)
+
+        _ = try await coordinator.load(ggufModel, configuration: configuration)
+        XCTAssertEqual(mlx.calls.suffix(2), [.cancel, .unload])
+        let resident = await coordinator.loadedModel
+        XCTAssertEqual(resident?.id, LocalModelID("gguf/one"))
+        let ggufResident = await gguf.loadedModel
+        XCTAssertNotNil(ggufResident)
+    }
+
+    /// With GGUF off, the MLX route is untouched — the rollback promise, stated as a test.
+    func testWithGGUFOffTheMLXRouteIsUnaffected() async throws {
+        let engine = FakeLlamaEngine()
+        let gguf = makeBackend(engine, enabled: false)
+        let mlx = RecordingBackend(runtime: .mlx)
+        let coordinator = LocalInferenceCoordinator(backends: [gguf, mlx])
+
+        let loaded = try await coordinator.load(try makeInstallation(id: "mlx/one", runtime: .mlx),
+                                                configuration: configuration)
+        XCTAssertEqual(loaded.runtime, .mlx)
+        XCTAssertTrue(engine.calls.isEmpty)
+
+        do {
+            _ = try await coordinator.load(try makeInstallation(id: "gguf/one"),
+                                           configuration: configuration)
+            XCTFail("expected the disabled runtime to refuse")
+        } catch {
+            XCTAssertEqual(error as? LlamaBackendError, .runtimeDisabled)
+        }
+    }
+
+    /// A stand-in for the other runtime. Only its call order matters here.
+    private final class RecordingBackend: LocalInferenceBackend, @unchecked Sendable {
+        enum Call: Equatable { case load, cancel, unload }
+
+        let runtime: LocalModelRuntime
+        private let lock = NSLock()
+        private var _calls: [Call] = []
+        private var _resident: LocalLoadedModel?
+
+        init(runtime: LocalModelRuntime) { self.runtime = runtime }
+
+        var calls: [Call] {
+            lock.lock(); defer { lock.unlock() }
+            return _calls
+        }
+
+        var loadedModel: LocalLoadedModel? {
+            lock.lock(); defer { lock.unlock() }
+            return _resident
+        }
+
+        func load(_ installation: InstalledLocalModel,
+                  configuration: LocalLoadConfiguration) async throws -> LocalLoadedModel {
+            lock.lock(); _calls.append(.load); lock.unlock()
+            let loaded = LocalLoadedModel(id: installation.id, runtime: runtime,
+                                          contextLength: configuration.contextLength,
+                                          capabilities: [.text])
+            lock.lock(); _resident = loaded; lock.unlock()
+            return loaded
+        }
+
+        func generate(_ request: LocalGenerationRequest) -> AsyncThrowingStream<String, Error> {
+            AsyncThrowingStream { $0.finish() }
+        }
+
+        func cancelGeneration() async {
+            lock.lock(); _calls.append(.cancel); lock.unlock()
+        }
+
+        func unload() async {
+            lock.lock(); _calls.append(.unload); _resident = nil; lock.unlock()
+        }
+    }
+}

--- a/OpenGlassesTests/LlamaCppRuntimeTests.swift
+++ b/OpenGlassesTests/LlamaCppRuntimeTests.swift
@@ -1,0 +1,454 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DZ P1/PR3 — the pure decisions the GGUF runtime makes before, during and after a
+/// generation: what the file says about itself, how wide a context that buys, whether the template
+/// can carry a conversation, and how token bytes become text.
+///
+/// None of this needs an engine, which is the point: the simulator cannot run a Metal graph, so
+/// every rule that *can* be decided without one is decided in a value type and pinned here.
+final class LlamaCppRuntimeTests: XCTestCase {
+
+    // MARK: - Metadata, read from the file rather than its name
+
+    private func metadataLookup(_ pairs: [String: String]) -> (String) -> String? {
+        { pairs[$0] }
+    }
+
+    func testArchitectureAndShapeComeFromMetadataKeys() throws {
+        let result = GGUFMetadataValidator.metadata(lookup: metadataLookup([
+            "general.architecture": "qwen3",
+            "qwen3.context_length": "32768",
+            "qwen3.block_count": "28",
+            "qwen3.embedding_length": "1024",
+            "qwen3.attention.head_count": "16",
+            "qwen3.attention.head_count_kv": "8",
+        ]))
+        let metadata = try XCTUnwrap(try? result.get())
+        XCTAssertEqual(metadata.architecture, "qwen3")
+        XCTAssertEqual(metadata.trainingContextTokens, 32768)
+        XCTAssertEqual(metadata.blockCount, 28)
+        XCTAssertEqual(metadata.headCountKV, 8)
+    }
+
+    /// The scoped keys are prefixed by whatever `general.architecture` says, so a file that renames
+    /// its architecture is read with the new prefix and never with a guessed one.
+    func testScopedKeysFollowTheDeclaredArchitecture() throws {
+        let result = GGUFMetadataValidator.metadata(lookup: metadataLookup([
+            "general.architecture": "llama",
+            // Deliberately present under a *different* architecture's prefix. A reader that
+            // pattern-matched on a filename would pick these up; this one must not.
+            "qwen3.context_length": "32768",
+            "llama.context_length": "8192",
+        ]))
+        let metadata = try XCTUnwrap(try? result.get())
+        XCTAssertEqual(metadata.trainingContextTokens, 8192)
+    }
+
+    func testMissingArchitectureIsAFault() {
+        let result = GGUFMetadataValidator.metadata(lookup: metadataLookup(["llama.block_count": "32"]))
+        guard case .failure(let fault) = result else { return XCTFail("expected a fault") }
+        XCTAssertEqual(fault, .missingArchitecture)
+    }
+
+    func testKVCacheSizeIsNilWhenTheFileDoesNotDescribeItsShape() {
+        let partial = GGUFModelMetadata(architecture: "llama",
+                                        trainingContextTokens: 4096,
+                                        blockCount: 32,
+                                        embeddingLength: nil,
+                                        headCount: 32,
+                                        headCountKV: nil)
+        XCTAssertNil(partial.kvCacheBytesPerToken(),
+                     "an invented KV size would silently clamp a working model's context")
+    }
+
+    func testKVCacheSizeUsesGroupedQueryHeadsWhenDeclared() throws {
+        let grouped = GGUFModelMetadata(architecture: "qwen3",
+                                        trainingContextTokens: 32768,
+                                        blockCount: 28,
+                                        embeddingLength: 1024,
+                                        headCount: 16,
+                                        headCountKV: 8)
+        // 2 halves x 28 layers x (1024/16) head dim x 8 KV heads x 2 bytes.
+        XCTAssertEqual(try XCTUnwrap(grouped.kvCacheBytesPerToken()), 2 * 28 * 64 * 8 * 2)
+
+        // Absent head_count_kv means multi-head attention, i.e. one KV head per query head.
+        let multiHead = GGUFModelMetadata(architecture: "qwen3",
+                                          trainingContextTokens: 32768,
+                                          blockCount: 28,
+                                          embeddingLength: 1024,
+                                          headCount: 16,
+                                          headCountKV: nil)
+        XCTAssertEqual(try XCTUnwrap(multiHead.kvCacheBytesPerToken()), 2 * 28 * 64 * 16 * 2)
+    }
+
+    func testAffordableContextIsZeroWhenThereIsNoBudget() {
+        let metadata = GGUFModelMetadata(architecture: "llama", trainingContextTokens: 4096,
+                                         blockCount: 32, embeddingLength: 4096,
+                                         headCount: 32, headCountKV: 8)
+        XCTAssertEqual(GGUFMetadataValidator.affordableContextTokens(bytes: 0, metadata: metadata), 0,
+                       "no budget means unknown, not zero tokens")
+    }
+
+    // MARK: - Context clamping truth table
+
+    func testContextClampsToTheSmallestKnownCeiling() {
+        let cases: [(requested: Int, model: Int, policy: Int, memory: Int,
+                     expected: Int, binding: LlamaContextConstraint)] = [
+            // Nothing clamps: the request is already the tightest.
+            (2048, 8192, 4096, 16384, 2048, .requested),
+            // The model's trained length wins.
+            (32768, 8192, 16384, 65536, 8192, .modelCapability),
+            // The descriptor's policy is tighter than the model.
+            (32768, 32768, 4096, 65536, 4096, .descriptorPolicy),
+            // Memory is the binding constraint.
+            (8192, 32768, 16384, 2048, 2048, .memoryBudget),
+            // Unknown ceilings (0) are skipped rather than treated as zero.
+            (4096, 0, 0, 0, 4096, .requested),
+            // A tie reports `requested`: nothing actually clamped the caller.
+            (8192, 8192, 8192, 8192, 8192, .requested),
+        ]
+        for testCase in cases {
+            let plan = GGUFMetadataValidator.contextPlan(requested: testCase.requested,
+                                                         modelCapability: testCase.model,
+                                                         descriptorPolicy: testCase.policy,
+                                                         memoryBudgetTokens: testCase.memory)
+            XCTAssertEqual(plan.contextTokens, testCase.expected, "\(testCase)")
+            XCTAssertEqual(plan.binding, testCase.binding, "\(testCase)")
+        }
+    }
+
+    func testContextFallsBackWhenNoCeilingIsKnownAtAll() {
+        let plan = GGUFMetadataValidator.contextPlan(requested: 0, modelCapability: 0,
+                                                     descriptorPolicy: 0, memoryBudgetTokens: 0)
+        XCTAssertEqual(plan.contextTokens, LlamaContextPlan.defaultContextTokens)
+        XCTAssertTrue(plan.isViable)
+    }
+
+    func testAContextClampedBelowOneExchangeIsNotViable() {
+        let plan = GGUFMetadataValidator.contextPlan(requested: 8192, modelCapability: 8192,
+                                                     descriptorPolicy: 0, memoryBudgetTokens: 64)
+        XCTAssertEqual(plan.contextTokens, 64)
+        XCTAssertFalse(plan.isViable,
+                       "a 64-token window is not a small context, it is an unusable one")
+    }
+
+    // MARK: - Over-context arithmetic
+
+    func testPromptAdmissionCountsTheReserveAgainstTheWindow() {
+        let fits = LlamaPromptAdmission(promptTokens: 1000, reserveTokens: 512, contextTokens: 2048)
+        XCTAssertTrue(fits.fits)
+        XCTAssertEqual(fits.overflowTokens, 0)
+
+        // Exactly full is still admissible; one more token is not.
+        let exact = LlamaPromptAdmission(promptTokens: 1536, reserveTokens: 512, contextTokens: 2048)
+        XCTAssertTrue(exact.fits)
+
+        let over = LlamaPromptAdmission(promptTokens: 1537, reserveTokens: 512, contextTokens: 2048)
+        XCTAssertFalse(over.fits)
+        XCTAssertEqual(over.overflowTokens, 1)
+    }
+
+    // MARK: - Chat template
+
+    /// A template stand-in with the shape real templates have: turn markers around role and
+    /// content, and an assistant header when generation is being prompted.
+    private func chatMLRenderer(dropSystem: Bool = false,
+                                emitAssistantHeader: Bool = true)
+        -> (String, [LlamaChatTurn], Bool) throws -> String {
+        { _, turns, addAssistant in
+            var out = ""
+            for turn in turns {
+                if dropSystem, turn.role == "system" { continue }
+                out += "<|im_start|>\(turn.role)\n\(turn.content)<|im_end|>\n"
+            }
+            if addAssistant, emitAssistantHeader { out += "<|im_start|>assistant\n" }
+            return out
+        }
+    }
+
+    func testAUsableTemplateIsAcceptedAndReportsItsSystemSupport() throws {
+        let result = LlamaCppChatTemplate.validate("{{ messages }}", apply: chatMLRenderer())
+        let profile = try XCTUnwrap(try? result.get())
+        XCTAssertTrue(profile.rendersSystemRole)
+        XCTAssertFalse(profile.mergesSystemIntoFirstUser)
+    }
+
+    /// The Gemma shape: the system turn is not rendered at all. That is usable — but only if the
+    /// caller knows to merge, which is why it is detected by probe rather than by architecture.
+    func testATemplateThatDropsTheSystemRoleIsUsableButFlagged() throws {
+        let result = LlamaCppChatTemplate.validate("{{ messages }}",
+                                                   apply: chatMLRenderer(dropSystem: true))
+        let profile = try XCTUnwrap(try? result.get())
+        XCTAssertFalse(profile.rendersSystemRole)
+        XCTAssertTrue(profile.mergesSystemIntoFirstUser)
+    }
+
+    func testTemplateFaultsAreTyped() {
+        func fault(_ result: Result<LlamaChatTemplateProfile, LlamaChatTemplateFault>)
+            -> LlamaChatTemplateFault? {
+            guard case .failure(let fault) = result else { return nil }
+            return fault
+        }
+
+        XCTAssertEqual(fault(LlamaCppChatTemplate.validate(nil, apply: chatMLRenderer())), .absent)
+        XCTAssertEqual(fault(LlamaCppChatTemplate.validate("   ", apply: chatMLRenderer())), .absent)
+        XCTAssertEqual(fault(LlamaCppChatTemplate.validate("{{ x }}") { _, _, _ in
+            throw LlamaEngineError.templateFailed
+        }), .renderFailed)
+        XCTAssertEqual(fault(LlamaCppChatTemplate.validate("{{ x }}") { _, _, _ in "" }), .emptyRender)
+        // Renders something, but the wearer's words never reach the model.
+        XCTAssertEqual(fault(LlamaCppChatTemplate.validate("{{ x }}") { _, _, _ in
+            "<|im_start|>assistant\n"
+        }), .dropsUserContent)
+        XCTAssertEqual(
+            fault(LlamaCppChatTemplate.validate("{{ x }}",
+                                                apply: chatMLRenderer(emitAssistantHeader: false))),
+            .noAssistantHeader)
+    }
+
+    // MARK: - Prompt assembly
+
+    private let conversation: [LocalChatMessage] = [
+        .system("Be brief."),
+        .user("First question."),
+        .assistant("First answer."),
+        .user("Second question."),
+    ]
+
+    func testAssemblyKeepsExactlyOneCopyOfEachPriorMessage() {
+        let turns = LlamaCppChatTemplate.turns(from: conversation, mergingSystemIntoFirstUser: false)
+        XCTAssertEqual(turns, [
+            LlamaChatTurn(role: "system", content: "Be brief."),
+            LlamaChatTurn(role: "user", content: "First question."),
+            LlamaChatTurn(role: "assistant", content: "First answer."),
+            LlamaChatTurn(role: "user", content: "Second question."),
+        ])
+        // The property the exit criterion names, stated as a count rather than as an eyeball:
+        // every message appears once and only once.
+        for message in conversation {
+            XCTAssertEqual(turns.filter { $0.content.contains(message.content) }.count, 1,
+                           "\(message.content) must appear exactly once in the assembled prompt")
+        }
+    }
+
+    func testMergingFoldsSystemTextIntoTheFirstUserTurnWithoutRoleLabels() {
+        let turns = LlamaCppChatTemplate.turns(from: conversation, mergingSystemIntoFirstUser: true)
+        XCTAssertEqual(turns.count, 3, "the system turn is merged, not appended")
+        XCTAssertEqual(turns[0].role, "user")
+        XCTAssertEqual(turns[0].content, "Be brief.\n\nFirst question.")
+        // A `User:` label inside a turn is how a model starts answering as the wrong speaker.
+        XCTAssertFalse(turns.contains { $0.content.contains("User:") || $0.content.contains("Assistant:") })
+        XCTAssertEqual(turns.filter { $0.content.contains("First question.") }.count, 1)
+    }
+
+    func testSystemTurnsAreHoistedRatherThanDroppedOrLeftMidConversation() {
+        let messages: [LocalChatMessage] = [
+            .system("One."),
+            .user("Hi."),
+            .system("Two."),
+            .assistant("Hello."),
+        ]
+        let turns = LlamaCppChatTemplate.turns(from: messages, mergingSystemIntoFirstUser: false)
+        XCTAssertEqual(turns.first, LlamaChatTurn(role: "system", content: "One.\n\nTwo."))
+        XCTAssertEqual(turns.dropFirst().map(\.role), ["user", "assistant"],
+                       "the conversation's own order is untouched")
+    }
+
+    func testASystemOnlyPromptBecomesAUserTurnWhenTheTemplateCannotCarryIt() {
+        let turns = LlamaCppChatTemplate.turns(from: [.system("Only this.")],
+                                               mergingSystemIntoFirstUser: true)
+        XCTAssertEqual(turns, [LlamaChatTurn(role: "user", content: "Only this.")])
+    }
+
+    func testBlankSystemTextIsNotRendered() {
+        let turns = LlamaCppChatTemplate.turns(from: [.system("   "), .user("Hi.")],
+                                               mergingSystemIntoFirstUser: false)
+        XCTAssertEqual(turns, [LlamaChatTurn(role: "user", content: "Hi.")])
+    }
+
+    // MARK: - Special-token handling
+
+    func testSpecialTokensAreNotAddedTwiceWhenTheTemplateAlreadyEmittedBOS() {
+        XCTAssertFalse(LlamaCppChatTemplate.shouldAddSpecialTokens(
+            rendered: "<bos>user\nHi", bosPiece: "<bos>", vocabularyAddsBOS: true))
+        XCTAssertTrue(LlamaCppChatTemplate.shouldAddSpecialTokens(
+            rendered: "user\nHi", bosPiece: "<bos>", vocabularyAddsBOS: true))
+        // A vocabulary that adds no BOS never gets one added on its behalf.
+        XCTAssertFalse(LlamaCppChatTemplate.shouldAddSpecialTokens(
+            rendered: "user\nHi", bosPiece: "<bos>", vocabularyAddsBOS: false))
+        // No BOS piece to compare against: fall back to the vocabulary's own answer.
+        XCTAssertTrue(LlamaCppChatTemplate.shouldAddSpecialTokens(
+            rendered: "user\nHi", bosPiece: nil, vocabularyAddsBOS: true))
+    }
+
+    // MARK: - UTF-8 byte accumulator
+
+    /// Every byte of a multi-byte scalar arriving as its own token — which is exactly what a
+    /// byte-level BPE vocabulary does with an emoji.
+    func testSplitMultiByteSequencesAreEmittedOnceAndWhole() {
+        let text = "café 🙂 naïve"
+        var accumulator = LlamaUTF8Accumulator()
+        var out = ""
+        for byte in Array(text.utf8) {
+            out += accumulator.append([byte])
+        }
+        out += accumulator.flush()
+        XCTAssertEqual(out, text)
+        XCTAssertFalse(out.contains("\u{FFFD}"), "a split scalar must never surface as a replacement")
+    }
+
+    func testBytesAreHeldOnlyUntilTheirSequenceCompletes() {
+        var accumulator = LlamaUTF8Accumulator()
+        // First two bytes of a three-byte scalar: nothing is emittable yet.
+        XCTAssertEqual(accumulator.append([0xE2, 0x82]), "")
+        XCTAssertTrue(accumulator.hasPendingBytes)
+        XCTAssertEqual(accumulator.append([0xAC]), "€")
+        XCTAssertFalse(accumulator.hasPendingBytes)
+    }
+
+    func testAsciiTailIsNeverHeldBack() {
+        var accumulator = LlamaUTF8Accumulator()
+        XCTAssertEqual(accumulator.append(Array("hello".utf8)), "hello")
+        XCTAssertFalse(accumulator.hasPendingBytes)
+    }
+
+    /// A byte that can never begin a valid sequence must be released rather than accumulated
+    /// forever — the stream stalling is a worse failure than one replacement character.
+    func testInvalidBytesAreReleasedRatherThanStallingTheStream() {
+        var accumulator = LlamaUTF8Accumulator()
+        let emitted = accumulator.append([0xFF, 0xFE])
+        XCTAssertFalse(emitted.isEmpty)
+        XCTAssertFalse(accumulator.hasPendingBytes)
+    }
+
+    func testFlushSurfacesATruncatedTrailingSequence() {
+        var accumulator = LlamaUTF8Accumulator()
+        XCTAssertEqual(accumulator.append([0xF0, 0x9F]), "")
+        // One replacement, not two: UTF-8 recovery replaces the whole maximal subpart of an
+        // ill-formed sequence, and `0xF0 0x9F` is one such truncated four-byte prefix. What matters
+        // is that the tail is reported at all rather than silently dropped.
+        XCTAssertEqual(accumulator.flush(), "\u{FFFD}",
+                       "a truncated tail is reported, never silently dropped")
+    }
+
+    func testChunkedAppendMatchesWholeAppend() {
+        let text = "汉字 with 🇳🇿 flags and é"
+        var whole = LlamaUTF8Accumulator()
+        let expected = whole.append(Array(text.utf8)) + whole.flush()
+
+        var chunked = LlamaUTF8Accumulator()
+        var out = ""
+        let bytes = Array(text.utf8)
+        for start in stride(from: 0, to: bytes.count, by: 3) {
+            out += chunked.append(bytes[start..<min(start + 3, bytes.count)])
+        }
+        out += chunked.flush()
+        XCTAssertEqual(out, expected)
+        XCTAssertEqual(out, text)
+    }
+
+    // MARK: - Stop sequences
+
+    func testAStopSequenceSplitAcrossTokensStillMatchesAndIsNotEmitted() {
+        var matcher = LlamaStopSequenceMatcher(stopSequences: ["</tool>"])
+        var emitted = ""
+        var stopped = false
+        for piece in ["Here it is", "<", "/to", "ol", ">", " and more"] {
+            let (safe, stop) = matcher.consume(piece)
+            emitted += safe
+            if stop { stopped = true; break }
+        }
+        XCTAssertTrue(stopped)
+        XCTAssertEqual(emitted, "Here it is")
+        XCTAssertFalse(emitted.contains("<"), "no part of the stop sequence may reach the wearer")
+    }
+
+    func testTextIsHeldBackOnlyAsFarAsAStopSequenceCouldReach() {
+        var matcher = LlamaStopSequenceMatcher(stopSequences: ["END"])
+        // Two characters could still turn out to be the start of "END", so they wait.
+        XCTAssertEqual(matcher.consume("hello").emit, "hel")
+        XCTAssertEqual(matcher.flush(), "lo")
+    }
+
+    func testWithNoStopSequencesEverythingIsEmittedImmediately() {
+        var matcher = LlamaStopSequenceMatcher(stopSequences: [])
+        XCTAssertEqual(matcher.consume("streaming").emit, "streaming")
+        XCTAssertFalse(matcher.hasStopped)
+    }
+
+    func testTheEarliestStopSequenceWins() {
+        var matcher = LlamaStopSequenceMatcher(stopSequences: ["ZZZ", "B"])
+        let (emit, stop) = matcher.consume("aaBccZZZ")
+        XCTAssertTrue(stop)
+        XCTAssertEqual(emit, "aa")
+    }
+
+    func testEmptyStopSequencesAreIgnoredRatherThanMatchingEverywhere() {
+        var matcher = LlamaStopSequenceMatcher(stopSequences: [""])
+        let (emit, stop) = matcher.consume("text")
+        XCTAssertFalse(stop)
+        XCTAssertEqual(emit, "text")
+    }
+
+    // MARK: - Sampling defaults and seed injection
+
+    func testConservativeDefaultsAreAppOwned() {
+        let options = LlamaSamplerOptions(.conservative)
+        XCTAssertEqual(options.temperature, 0.7)
+        XCTAssertEqual(options.topP, 0.9)
+        XCTAssertEqual(options.topK, LlamaSamplerOptions.defaultTopK)
+        XCTAssertEqual(options.penaltyRepeat, LlamaSamplerOptions.defaultRepeatPenalty)
+        XCTAssertEqual(options.penaltyWindow, LlamaSamplerOptions.defaultPenaltyWindow)
+        XCTAssertEqual(options.seed, LlamaSamplerOptions.randomSeed,
+                       "production draws a fresh seed; only a test pins one")
+    }
+
+    func testASuppliedSeedReachesTheSampler() {
+        let pinned = LlamaSamplerOptions(LocalSamplingConfiguration(seed: 4242))
+        XCTAssertEqual(pinned.seed, 4242)
+        XCTAssertNotEqual(pinned.seed, LlamaSamplerOptions.randomSeed)
+    }
+
+    func testPerModelOverridesReplaceTheDefaultsTheyName() {
+        let overridden = LlamaSamplerOptions(LocalSamplingConfiguration(
+            temperature: 0.2, topP: 0.5, topK: 10, repetitionPenalty: 1.3, seed: 7))
+        XCTAssertEqual(overridden.temperature, 0.2)
+        XCTAssertEqual(overridden.topK, 10)
+        XCTAssertEqual(overridden.penaltyRepeat, 1.3)
+        // Untouched values keep the app default rather than whatever the engine ships.
+        XCTAssertEqual(overridden.minP, LlamaSamplerOptions.defaultMinP)
+    }
+
+    // MARK: - ABI constants restated in Swift
+
+    /// `OG_LLAMA_NOT_FOUND` is `#define OG_LLAMA_NOT_FOUND INT32_MIN`, and a macro defined through
+    /// another macro's arithmetic does not survive the Clang importer — so `LlamaCppEngine` writes
+    /// the value out. This is what stops the two from drifting apart silently: a header that
+    /// changed the sentinel would keep compiling while every "key absent" answer became a size.
+    func testTheNotFoundSentinelStillMatchesTheVendoredHeader() throws {
+        let header = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Vendor/LlamaCpp/Sources/LlamaCppWrapper/include/LlamaCppWrapper.h")
+        let text = try String(contentsOf: header, encoding: .utf8)
+        XCTAssertTrue(text.contains("#define OG_LLAMA_NOT_FOUND INT32_MIN"),
+                      "the header's sentinel changed; LlamaCppEngine.notFound must change with it")
+        XCTAssertEqual(LlamaCppEngine.notFound, Int32.min)
+    }
+
+    // MARK: - Engine status mapping
+
+    func testEveryEngineStatusMapsToItsOwnCase() {
+        let expected: [Int32: LlamaEngineError] = [
+            1: .invalidArgument, 2: .modelLoadFailed, 3: .contextCreateFailed,
+            4: .samplerCreateFailed, 5: .tokenizeFailed, 6: .contextExhausted,
+            7: .decodeFailed, 8: .noChatTemplate, 9: .templateFailed,
+            10: .cancelled, 11: .allocationFailed,
+        ]
+        for (status, error) in expected {
+            XCTAssertEqual(LlamaEngineError(status: status), error)
+        }
+        XCTAssertEqual(LlamaEngineError(status: 99), .unknown(99))
+    }
+}


### PR DESCRIPTION
## Summary

Third PR of Plan DZ: `LlamaCppLocalInferenceBackend`, an actor over PR2's wrapper, implementing the plan's load and generation flows. Still flag-gated (`ggufModelsEnabled` off ⇒ the backend refuses every load without touching anything native), and there is still no way to *install* a GGUF model — that's PR4.

Structure keeps policy out of transcription: `LlamaCppEngine` is the only file that calls `og_llama_*`; metadata validation and KV-derived context clamping, the load-time chat-template probe, and the UTF-8 accumulator each live in their own testable type behind a `Sendable` engine protocol (opaque handles, no pointers crossing into Swift).

Things the plan insisted on and this does:

- **No filename heuristics** — architecture, chat format and overrides come from GGUF metadata or the bundled descriptor.
- **Template probed at load**: a model whose embedded template can't render a minimal system/user/assistant exchange is refused (`unsupportedChatTemplate`) and unloaded, not guessed at. Where the probe shows the template drops the system role, system turns merge into the first user turn — without role labels.
- **Context clamps** to min(model capability, descriptor policy, KV-derived memory bound); when the file doesn't describe its shape the memory clamp is `nil` rather than an invented number.
- **KV and penalties cleared per request** — a second turn carries exactly one copy of each prior message, asserted on the assembled prompt (where a duplicate would actually appear).
- **Over-long prompts refuse before any native decode**, with counts and never prompt text in diagnostics.
- **Byte accumulator** so a split multi-byte sequence never becomes a replacement character; stop sequences match across token boundaries.
- **Reverse-order teardown** with an accelerator sync before every destruction and on every cancellation path.

Judgement calls worth review: the **decode loop runs off the actor** deliberately — holding the actor for a 30-second generation would leave `cancelGeneration()` unable to run until the generation it cancels had finished; only `setCancelled` (an atomic in the wrapper) is called concurrently, and nothing is freed until the loop is awaited and synchronized. Sampling rebuilds the chain only when options differ, new-before-free. The manifest re-check validates presence/containment/size rather than rehashing gigabytes the installer already hashed.

## Verification

- Full suite: **4340 tests, 0 failures** (4 env-gated skips) — **67 new** across `LlamaCppRuntimeTests` (35) and `LlamaCppBackendTests` (32, fake engine)
- Release build (generic iOS): green
- **Headless-verified exit criteria**: over-context refusal before decode; cancellation stops delivery and releases the coordinator lease
- **Partially verified** (structure proved, hardware pending): one-copy-per-turn, multi-chunk decode above `nBatch`, free-before-load across GGUF→MLX→GGUF
- **Device-pending entirely**: a real curated GGUF loading, answering and unloading — nothing here has opened a real GGUF file, and no curated entry exists to open until PR4. Metal execution remains unproven, as PR2 stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)