### PR TITLE
Release a waiter that arrives after its run was parked

### DIFF
--- a/OpenGlasses/Sources/Services/OpenClaw/ChatRunTracker.swift
+++ b/OpenGlasses/Sources/Services/OpenClaw/ChatRunTracker.swift
@@ -123,7 +123,14 @@ final class ChatRunTracker {
 
     /// Suspend until the run reaches a terminal state or `park(runId:)` is called.
     func wait(runId: String) async -> Outcome {
-        if let terminal = runs[runId]?.terminal { return Self.outcome(for: terminal) }
+        if let run = runs[runId] {
+            if let terminal = run.terminal { return Self.outcome(for: terminal) }
+            // Already given up on before this waiter arrived. Suspending here would wait on a
+            // transition that has already happened: `park` resumes the continuation it finds,
+            // and a run parked with none is never resumed again. Its answer is not lost — it
+            // still surfaces as `.lateAnswer` — but no one may block for it.
+            if run.parked { return .timedOut }
+        }
         register(runId: runId)
         return await withCheckedContinuation { continuation in
             runs[runId]?.continuation = continuation

--- a/OpenGlassesTests/ChatRunTrackerTests.swift
+++ b/OpenGlassesTests/ChatRunTrackerTests.swift
@@ -136,8 +136,7 @@ final class ChatRunTrackerTests: XCTestCase {
     func testTerminalRunsArePrunedButAwaitedOnesKept() async {
         let tracker = ChatRunTracker()
         tracker.register(runId: "keep")
-        async let _ = tracker.wait(runId: "keep")
-        await Task.yield()
+        let waiter = Task { await tracker.wait(runId: "keep") }
         for i in 0..<80 {
             tracker.register(runId: "run-\(i)")
             _ = tracker.handle(payload: final("run-\(i)", seq: 1, text: "x"))
@@ -145,5 +144,20 @@ final class ChatRunTrackerTests: XCTestCase {
         XCTAssertTrue(tracker.trackedRunIds.contains("keep"))
         XCTAssertLessThanOrEqual(tracker.trackedRunIds.count, 65)
         tracker.park(runId: "keep")
+
+        // Released whichever way the two raced: the park resumes a waiter that got there first,
+        // and a waiter that arrives afterwards is told the run was given up on. This test used
+        // to depend on one `Task.yield()` being enough for the waiter to arrive first, and hung
+        // for ever on a machine slow enough to lose that race.
+        let outcome = await waiter.value
+        XCTAssertEqual(outcome, .timedOut)
+    }
+
+    func testParkBeforeAnyoneWaitsDoesNotStrandTheNextWaiter() async {
+        let tracker = ChatRunTracker()
+        tracker.register(runId: "r")
+        tracker.park(runId: "r")
+        let outcome = await tracker.wait(runId: "r")
+        XCTAssertEqual(outcome, .timedOut, "no one may block on a run already given up on")
     }
 }


### PR DESCRIPTION
This is the CI hang. `ChatRunTrackerTests.testTerminalRunsArePrunedButAwaitedOnesKept` has been stalling runs since #404 (`817418f`, Plan EH P1) — output stops mid-suite and the job burns to its 90-minute cap. #415's per-test timeout named it on its first run.

## The hang

The test starts a waiter, gives it one `Task.yield()` to reach the tracker, and parks the run at the end:

```swift
async let _ = tracker.wait(runId: "keep")
await Task.yield()
...
tracker.park(runId: "keep")
```

On a machine slow enough that one yield is not enough, `park` finds no continuation to resume. The waiter then installs one that nothing will ever resume — `park` has been and gone, and no terminal event is coming for that run. The test's implicit `await` on its `async let` child never returns, and nothing times it out.

That is why the stalls appeared at `ChatReadbackPolicyTests` and `BrainStoreTests`: the unbuffered `grep` in the workflow (fixed in #415) left the visible log a block behind the real stopping point, which was `ChatRunTrackerTests` both times.

## The fix

`wait` already declines to suspend on a run that is terminal. It now declines the same way on a run that was parked, because that transition is just as final *for a waiter*: `park` resumes the continuation it finds, and a run parked without one is never resumed again. The answer is not lost — it still surfaces as `.lateAnswer`, unchanged.

This is the same shape as #413: a wait whose completion depended on winning a scheduling race, invisible on a fast Mac.

## Tests

- `testTerminalRunsArePrunedButAwaitedOnesKept` no longer depends on winning the race — it asserts the waiter is released either way, and awaits it explicitly rather than through `async let` scope exit.
- `testParkBeforeAnyoneWaitsDoesNotStrandTheNextWaiter` pins the park-then-wait order directly, with no scheduling in it at all.

## Verification

- `ChatRunTrackerTests` — 13/13 pass, the previously hanging test in 0.003s.
- Full `OpenGlassesTests` suite — **4341 tests, 0 failures**, 4 skipped, 51.6s, run with `-test-timeouts-enabled YES -default-test-execution-time-allowance 120` so that any other test of this shape would have been named rather than hanging. None was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)