### PR TITLE
Acquire GGUF models through one validated pipeline (DZ P2/PR4)

### DIFF
--- a/OpenGlasses/Sources/Resources/LocalModelCatalog.json
+++ b/OpenGlasses/Sources/Resources/LocalModelCatalog.json
@@ -1,0 +1,98 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "id": "HuggingFaceTB/SmolLM2-360M-Instruct-GGUF#smollm2-360m-instruct-q8_0.gguf",
+      "displayName": "SmolLM2 360M",
+      "repositoryID": "HuggingFaceTB/SmolLM2-360M-Instruct-GGUF",
+      "revision": "593b5a2e04c8f3e4ee880263f93e0bd2901ad47f",
+      "quantization": "Q8_0",
+      "capabilities": ["text"],
+      "contextLength": 4096,
+      "estimatedWeightsBytes": 386404992,
+      "estimatedWorkingBytes": 805306368,
+      "minimumHeadroomBytes": 268435456,
+      "files": [
+        {
+          "relativePath": "smollm2-360m-instruct-q8_0.gguf",
+          "byteCount": 386404992,
+          "sha256": "48ab3034d0dd401fbc721eb1df3217902fee7dab9078992d66431f09b7750201",
+          "role": "weights"
+        }
+      ],
+      "license": {
+        "displayName": "Apache License 2.0",
+        "summary": "Permissive: use, modify and redistribute, keeping the notices and stating changes. Includes a patent grant.",
+        "requiresAcceptance": false,
+        "revision": "593b5a2e04c8f3e4ee880263f93e0bd2901ad47f"
+      },
+      "notes": "Smallest curated on-device model. Fast and light; short answers, limited reasoning.",
+      "minimumRAMGB": 4,
+      "architecture": "llama",
+      "trainedContextTokens": 8192,
+      "evidence": "fileMetadataOnly"
+    },
+    {
+      "id": "Qwen/Qwen2.5-0.5B-Instruct-GGUF#qwen2.5-0.5b-instruct-q4_k_m.gguf",
+      "displayName": "Qwen 2.5 0.5B",
+      "repositoryID": "Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+      "revision": "9217f5db79a29953eb74d5343926648285ec7e67",
+      "quantization": "Q4_K_M",
+      "capabilities": ["text"],
+      "contextLength": 4096,
+      "estimatedWeightsBytes": 491400032,
+      "estimatedWorkingBytes": 805306368,
+      "minimumHeadroomBytes": 268435456,
+      "files": [
+        {
+          "relativePath": "qwen2.5-0.5b-instruct-q4_k_m.gguf",
+          "byteCount": 491400032,
+          "sha256": "74a4da8c9fdbcd15bd1f6d01d621410d31c6fc00986f5eb687824e7b93d7a9db",
+          "role": "weights"
+        }
+      ],
+      "license": {
+        "displayName": "Apache License 2.0",
+        "summary": "Permissive: use, modify and redistribute, keeping the notices and stating changes. Includes a patent grant.",
+        "requiresAcceptance": false,
+        "revision": "9217f5db79a29953eb74d5343926648285ec7e67"
+      },
+      "notes": "Ultra-light multilingual model. Good for short questions and quick summaries.",
+      "minimumRAMGB": 4,
+      "architecture": "qwen2",
+      "trainedContextTokens": 32768,
+      "evidence": "fileMetadataOnly"
+    },
+    {
+      "id": "Qwen/Qwen2.5-1.5B-Instruct-GGUF#qwen2.5-1.5b-instruct-q4_k_m.gguf",
+      "displayName": "Qwen 2.5 1.5B",
+      "repositoryID": "Qwen/Qwen2.5-1.5B-Instruct-GGUF",
+      "revision": "91cad51170dc346986eccefdc2dd33a9da36ead9",
+      "quantization": "Q4_K_M",
+      "capabilities": ["text"],
+      "contextLength": 4096,
+      "estimatedWeightsBytes": 1117320736,
+      "estimatedWorkingBytes": 805306368,
+      "minimumHeadroomBytes": 268435456,
+      "files": [
+        {
+          "relativePath": "qwen2.5-1.5b-instruct-q4_k_m.gguf",
+          "byteCount": 1117320736,
+          "sha256": "6a1a2eb6d15622bf3c96857206351ba97e1af16c30d7a74ee38970e434e9407e",
+          "role": "weights"
+        }
+      ],
+      "license": {
+        "displayName": "Apache License 2.0",
+        "summary": "Permissive: use, modify and redistribute, keeping the notices and stating changes. Includes a patent grant.",
+        "requiresAcceptance": false,
+        "revision": "91cad51170dc346986eccefdc2dd33a9da36ead9"
+      },
+      "notes": "Stronger multilingual answers than the 0.5B, at roughly twice the download and memory.",
+      "minimumRAMGB": 6,
+      "architecture": "qwen2",
+      "trainedContextTokens": 32768,
+      "evidence": "fileMetadataOnly"
+    }
+  ]
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelDownloadManager.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelDownloadManager.swift
@@ -1,0 +1,609 @@
+import CryptoKit
+import Foundation
+
+/// The one acquisition pipeline, used by curated catalog entries and custom repository imports
+/// alike (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "Download state machine").
+///
+/// What it guarantees, and why each guarantee is where it is:
+///
+///  - **One plan at a time, files sequentially.** Two multi-gigabyte downloads at once is a disk
+///    and memory event on a phone, so a second plan is refused with a typed error rather than
+///    queued behind a silent wait.
+///  - **Nothing is trusted because the transport said so.** Status, final host, HTTPS, destination
+///    containment, byte count and SHA-256 are all re-checked here, against a transport that a test
+///    can make claim anything.
+///  - **The marker is written last.** Files are validated in staging, the manifest is written
+///    beside them, the whole directory is moved into place, and only then does `.complete` appear.
+///    A power loss at any earlier step leaves the previous installation intact and a plan on disk
+///    that says exactly where it stopped.
+///  - **Progress is a persisted fact.** Every transition rewrites `download-plan.json`, so a
+///    relaunch reads bytes rather than starting a progress bar from zero.
+///
+/// Everything except the live background session is injectable, so the exit criteria are exercised
+/// against a temp directory and a fake transport with no network anywhere in the suite.
+actor LocalModelDownloadManager {
+
+    /// Failures that belong to the manager rather than to a plan.
+    enum ManagerError: Error, Equatable {
+        /// Another plan is still running. Acquisition is deliberately one-at-a-time.
+        case anotherPlanActive(UUID)
+        case planNotFound(UUID)
+        /// The descriptor cannot be installed from — unpinned revision, missing digest, escaping path.
+        case descriptorNotInstallable
+        /// The fit report said no. The blockers travel with it so the caller can say which.
+        case fitRefused([LocalModelFitReport.Blocker])
+        /// The licence needs acceptance and none was supplied.
+        case consentRequired
+        case installationNotFound(LocalModelID)
+        /// A path resolved outside the directory it must stay in. Never recovered from.
+        case containmentRefused
+        case storageUnavailable
+    }
+
+    /// Quarantine bounds. A failure record is a diagnostic, not an archive.
+    static let quarantineRecordLimit = 10
+    static let quarantineMaximumAge: TimeInterval = 7 * 24 * 3600
+
+    private let repository: LocalModelRepository
+    private let fileManager: FileManager
+    private let transfer: any LocalModelFileTransferring
+    private let now: @Sendable () -> Date
+    /// Release a resident model before its files are removed. Injected as a closure so the manager
+    /// never has to know about the coordinator (and so the suite never touches a `.shared` service).
+    private let unloadIfResident: @Sendable (LocalModelID) async -> Void
+
+    init(repository: LocalModelRepository,
+         transfer: any LocalModelFileTransferring,
+         fileManager: FileManager = .default,
+         now: @escaping @Sendable () -> Date = Date.init,
+         unloadIfResident: @escaping @Sendable (LocalModelID) async -> Void = { _ in }) {
+        self.repository = repository
+        self.transfer = transfer
+        self.fileManager = fileManager
+        self.now = now
+        self.unloadIfResident = unloadIfResident
+    }
+
+    // MARK: - Locations
+
+    func planDirectory(_ planID: UUID) -> URL {
+        repository.stagingRoot.appendingPathComponent(planID.uuidString, isDirectory: true)
+    }
+
+    func filesDirectory(_ planID: UUID) -> URL {
+        planDirectory(planID).appendingPathComponent(LocalModelDownloadPlan.filesDirectoryName,
+                                                     isDirectory: true)
+    }
+
+    private func planFile(_ planID: UUID) -> URL {
+        planDirectory(planID).appendingPathComponent(LocalModelDownloadPlan.fileName)
+    }
+
+    // MARK: - Reading plans
+
+    /// Every plan on disk, oldest first. Unreadable plan files are skipped rather than guessed at.
+    func plans() -> [LocalModelDownloadPlan] {
+        guard let entries = try? fileManager.contentsOfDirectory(at: repository.stagingRoot,
+                                                                 includingPropertiesForKeys: nil) else {
+            return []
+        }
+        return entries
+            .compactMap { entry -> LocalModelDownloadPlan? in
+                guard let planID = UUID(uuidString: entry.lastPathComponent) else { return nil }
+                return readPlan(planID)
+            }
+            .sorted { $0.createdAt < $1.createdAt }
+    }
+
+    func plan(_ planID: UUID) -> LocalModelDownloadPlan? { readPlan(planID) }
+
+    /// The plan currently occupying the pipeline, if any.
+    func activePlan() -> LocalModelDownloadPlan? {
+        plans().first { !$0.state.isTerminal }
+    }
+
+    private func readPlan(_ planID: UUID) -> LocalModelDownloadPlan? {
+        guard let data = try? Data(contentsOf: planFile(planID)),
+              var plan = try? Self.decoder.decode(LocalModelDownloadPlan.self, from: data) else {
+            return nil
+        }
+        // A plan from a newer build is not resumed: its fields may mean something else, and a
+        // half-understood resume is worse than starting the download again.
+        guard plan.planVersion <= LocalModelDownloadPlan.currentPlanVersion else {
+            plan.state = .failed(.terminal(.planUnreadable))
+            return plan
+        }
+        return plan
+    }
+
+    @discardableResult
+    private func persist(_ plan: LocalModelDownloadPlan) throws -> LocalModelDownloadPlan {
+        let directory = planDirectory(plan.id)
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            excludeFromBackup(directory)
+            let data = try Self.encoder.encode(plan)
+            try data.write(to: planFile(plan.id), options: .atomic)
+        } catch {
+            throw ManagerError.storageUnavailable
+        }
+        return plan
+    }
+
+    // MARK: - Creating a plan
+
+    /// Create a plan for a descriptor whose fit has already been judged.
+    ///
+    /// The fit report is required rather than recomputed: free space and process headroom are
+    /// readings taken on the main actor next to the surface that showed them, and a plan created
+    /// from a *different* reading than the one the user consented to is not the plan they agreed
+    /// to.
+    func createPlan(descriptor: LocalModelDescriptor,
+                    origin: LocalModelDownloadPlan.Origin,
+                    fit: LocalModelFitReport) throws -> LocalModelDownloadPlan {
+        if let active = activePlan() { throw ManagerError.anotherPlanActive(active.id) }
+        guard fit.canInstall else { throw ManagerError.fitRefused(fit.blockers) }
+        guard var plan = LocalModelDownloadPlan(descriptor: descriptor, origin: origin, now: now()) else {
+            throw ManagerError.descriptorNotInstallable
+        }
+        try plan.advance(to: .awaitingConsent, now: now())
+        let stored = try persist(plan)
+        log(.downloadPlanned, plan: stored)
+        return stored
+    }
+
+    /// Record consent and queue the plan. A licence that requires acceptance and did not get it
+    /// leaves the plan exactly where it was.
+    func grantConsent(planID: UUID,
+                      acceptedLicenseRevision: String? = nil) throws -> LocalModelDownloadPlan {
+        guard var plan = readPlan(planID) else { throw ManagerError.planNotFound(planID) }
+        if plan.descriptor.license.requiresAcceptance {
+            guard let accepted = acceptedLicenseRevision,
+                  plan.descriptor.license.revision == nil || accepted == plan.descriptor.license.revision
+            else { throw ManagerError.consentRequired }
+        }
+        plan.acceptedLicenseRevision = acceptedLicenseRevision
+        try plan.advance(to: .queued, now: now())
+        return try persist(plan)
+    }
+
+    // MARK: - Running
+
+    /// Run a queued (or resumable) plan to completion. Returns the plan in its final state; a
+    /// failure is a state, not a thrown error, because a failed plan is still a thing the user can
+    /// see and retry.
+    @discardableResult
+    func run(planID: UUID) async -> LocalModelDownloadPlan? {
+        guard var plan = readPlan(planID) else { return nil }
+        if case .failed(let failure) = plan.state, failure.isRetryable {
+            guard (try? plan.advance(to: .queued, now: now())) != nil else { return plan }
+            plan = (try? persist(plan)) ?? plan
+        }
+        guard !plan.state.isTerminal else { return plan }
+        // Consent is a state, not a parameter: a plan that never reached `queued` has not been
+        // agreed to, and running it would be starting a download nobody approved.
+        switch plan.state {
+        case .queued, .downloading, .validating, .installing: break
+        default: return fail(plan, reason: .consentMissing)
+        }
+
+        log(.downloadStarted, plan: plan)
+        while let index = plan.nextFileIndex {
+            do {
+                plan = try await fetchAndValidate(plan, fileIndex: index)
+            } catch let reason as LocalModelDownloadPlan.FailureReason {
+                return fail(plan, reason: reason)
+            } catch is CancellationError {
+                return cancelPlan(plan)
+            } catch ManagerError.storageUnavailable {
+                return fail(plan, reason: .storageUnavailable)
+            } catch is LocalModelDownloadPlan.TransitionError {
+                // The plan asked for a move its own table forbids, which means the record on disk
+                // no longer describes a run that can continue.
+                return fail(plan, reason: .planUnreadable)
+            } catch {
+                return fail(plan, reason: .transport)
+            }
+            if case .cancelled = plan.state { return plan }
+        }
+        return finishInstall(plan)
+    }
+
+    /// One file: fetch, then re-check everything the outcome claims, then stage it.
+    private func fetchAndValidate(_ plan: LocalModelDownloadPlan,
+                                  fileIndex: Int) async throws -> LocalModelDownloadPlan {
+        var plan = plan
+        guard plan.files.indices.contains(fileIndex) else {
+            throw LocalModelDownloadPlan.FailureReason.planUnreadable
+        }
+        let file = plan.files[fileIndex]
+
+        // Containment first, and before the fetch: a path that will not stay inside the plan's own
+        // files directory must never reach the network at all, whatever else is wrong with it.
+        guard let destination = LocalModelPath.resolve(file.relativePath,
+                                                       under: filesDirectory(plan.id)) else {
+            throw LocalModelDownloadPlan.FailureReason.containmentRefused
+        }
+        // Then the URL, from validated pieces. A reference that will not parse, or a revision that
+        // is not an exact commit, cannot produce one — and that is a refusal, not a retry.
+        guard case .success(let reference) =
+                LocalModelRepositoryReference.parse(plan.descriptor.repositoryID),
+              let url = reference.fileURL(revision: plan.descriptor.revision,
+                                          relativePath: file.relativePath) else {
+            throw LocalModelDownloadPlan.FailureReason.revisionMismatch
+        }
+
+        try plan.advance(to: .downloading(fileIndex: fileIndex), now: now())
+        plan = try persist(plan)
+
+        let outcome: LocalModelFileTransferOutcome
+        do {
+            outcome = try await transfer.transfer(.init(
+                identifier: LocalModelTransferIdentifier(planID: plan.id, fileIndex: fileIndex),
+                url: url,
+                expectedBytes: file.byteCount))
+        } catch LocalModelFileTransferError.cancelled {
+            throw CancellationError()
+        } catch LocalModelFileTransferError.redirectRefused {
+            throw LocalModelDownloadPlan.FailureReason.redirectHostRejected
+        } catch {
+            throw LocalModelDownloadPlan.FailureReason.transport
+        }
+        defer { try? fileManager.removeItem(at: outcome.fileURL) }
+
+        // A cancellation can land while a fetch is in flight — the actor lets `cancel` interleave
+        // at exactly these suspension points. Continuing here would resurrect a plan the user
+        // stopped, and would rewrite the directory cancellation just removed.
+        guard let current = readPlan(plan.id), !isCancelled(current) else { throw CancellationError() }
+
+        try plan.advance(to: .validating(fileIndex: fileIndex), now: now())
+        plan = try persist(plan)
+
+        guard (200..<300).contains(outcome.statusCode) else {
+            throw LocalModelDownloadPlan.FailureReason.httpStatus
+        }
+        // Re-validated per response, not per request: this is the check a redirect is trying to
+        // get past.
+        let finalURL = outcome.finalURL
+        guard (finalURL?.scheme ?? "").lowercased() == "https" else {
+            throw LocalModelDownloadPlan.FailureReason.insecureRedirect
+        }
+        guard LocalModelRepositoryReference.isAllowedDownloadURL(finalURL) else {
+            throw LocalModelDownloadPlan.FailureReason.redirectHostRejected
+        }
+        let stagedBytes = fileSize(outcome.fileURL)
+        guard stagedBytes == file.byteCount, outcome.byteCount == file.byteCount else {
+            throw LocalModelDownloadPlan.FailureReason.sizeMismatch
+        }
+        guard let digest = try? LocalModelDigest.sha256(ofFileAt: outcome.fileURL),
+              digest == file.sha256.lowercased() else {
+            throw LocalModelDownloadPlan.FailureReason.digestMismatch
+        }
+
+        do {
+            try fileManager.createDirectory(at: destination.deletingLastPathComponent(),
+                                            withIntermediateDirectories: true)
+            try? fileManager.removeItem(at: destination)
+            try fileManager.moveItem(at: outcome.fileURL, to: destination)
+        } catch {
+            throw LocalModelDownloadPlan.FailureReason.storageUnavailable
+        }
+
+        plan.markValidated(fileIndex: fileIndex, byteCount: file.byteCount, now: now())
+        if let next = plan.nextFileIndex {
+            try plan.advance(to: .downloading(fileIndex: next), now: now())
+        }
+        return try persist(plan)
+    }
+
+    /// Manifest → move → marker. The order is the crash-consistency argument, and it lives in the
+    /// repository so "installed" has exactly one definition.
+    private func finishInstall(_ plan: LocalModelDownloadPlan) -> LocalModelDownloadPlan {
+        var plan = plan
+        guard plan.files.allSatisfy(\.isValidated) else { return fail(plan, reason: .installFailed) }
+
+        if case .installing = plan.state {} else {
+            guard (try? plan.advance(to: .installing, now: now())) != nil else {
+                return fail(plan, reason: .installFailed)
+            }
+            plan = (try? persist(plan)) ?? plan
+        }
+
+        let installation = InstalledLocalModel(
+            descriptor: plan.descriptor,
+            storage: .managed(directoryName: plan.descriptor.id.storageComponent),
+            installedAt: now(),
+            validatedFiles: plan.files.map(\.modelFile),
+            acceptedLicenseRevision: plan.acceptedLicenseRevision)
+
+        do {
+            try repository.install(installation, movingContentsOf: filesDirectory(plan.id))
+        } catch {
+            return fail(plan, reason: .installFailed)
+        }
+
+        guard (try? plan.advance(to: .installed, now: now())) != nil else {
+            return fail(plan, reason: .installFailed)
+        }
+        plan = (try? persist(plan)) ?? plan
+        log(.installCompleted, plan: plan)
+        // The plan has done its job; its directory goes now that nothing depends on it.
+        removePlanDirectory(plan.id)
+        return plan
+    }
+
+    private func fail(_ plan: LocalModelDownloadPlan,
+                      reason: LocalModelDownloadPlan.FailureReason) -> LocalModelDownloadPlan {
+        // The persisted plan is further along than the caller's copy — it was rewritten at each
+        // transition — so the failure is recorded against the step that actually failed.
+        var plan = readPlan(plan.id) ?? plan
+        let failure = LocalModelDownloadPlan.Failure.classify(reason)
+        try? plan.advance(to: .failed(failure), now: now())
+        let stored = (try? persist(plan)) ?? plan
+        log(.downloadFailed, plan: stored, detail: reason.rawValue)
+        if !failure.isRetryable {
+            quarantine(stored, reason: reason)
+            removeStagedFiles(stored.id)
+        }
+        return stored
+    }
+
+    // MARK: - Cancellation
+
+    /// Cancel one plan: its tasks, then its state, then its staged bytes. Only this plan's
+    /// directory is touched, and only after the path is proved to be beneath the staging root.
+    @discardableResult
+    func cancel(planID: UUID) async -> LocalModelDownloadPlan? {
+        await transfer.cancelTasks(forPlan: planID)
+        guard let plan = readPlan(planID) else { return nil }
+        return cancelPlan(plan)
+    }
+
+    private func cancelPlan(_ plan: LocalModelDownloadPlan) -> LocalModelDownloadPlan {
+        var plan = readPlan(plan.id) ?? plan
+        try? plan.advance(to: .cancelled, now: now())
+        // Already cleared by an earlier cancellation: reporting it again is fine, rewriting its
+        // directory is not.
+        guard readPlan(plan.id) != nil else { return plan }
+        let stored = (try? persist(plan)) ?? plan
+        log(.downloadCancelled, plan: stored)
+        removePlanDirectory(stored.id)
+        return stored
+    }
+
+    // MARK: - Recovery
+
+    /// Rebuild state after a relaunch: re-derive per-file progress from what is actually on disk,
+    /// discard finished plans, and report what each remaining plan wants to do next.
+    ///
+    /// Nothing here resumes anything on its own. A multi-gigabyte download is not something to
+    /// restart because an app launched — invariant 12 is explicit that acquisition is user-driven.
+    @discardableResult
+    func restore() async -> [(plan: LocalModelDownloadPlan, recovery: LocalModelDownloadPlan.Recovery)] {
+        let live = Set(await transfer.liveIdentifiers().map(\.planID))
+        var result: [(LocalModelDownloadPlan, LocalModelDownloadPlan.Recovery)] = []
+
+        for var plan in plans() {
+            // The one interruption that leaves no staged files and no marker: the directory was
+            // already moved into place and the process died before `.complete`. Recomputing
+            // progress here would find nothing on disk and conclude the download must start again,
+            // over a perfectly good installation.
+            if case .installing = plan.state,
+               !fileManager.fileExists(atPath: filesDirectory(plan.id).path),
+               fileManager.fileExists(atPath: repository.directory(for: plan.descriptor.id)
+                   .appendingPathComponent(LocalModelRepository.manifestFileName).path) {
+                let finished = finishInstall(plan)
+                result.append((finished, finished.recovery))
+                continue
+            }
+
+            // Progress from bytes on disk, not from a callback that no longer exists. A file whose
+            // staged size no longer matches is un-validated: the digest was computed over bytes
+            // that are gone.
+            for index in plan.files.indices {
+                guard let staged = LocalModelPath.resolve(plan.files[index].relativePath,
+                                                          under: filesDirectory(plan.id)) else {
+                    plan.files[index].completedBytes = 0
+                    plan.files[index].isValidated = false
+                    continue
+                }
+                let size = fileSize(staged)
+                plan.files[index].completedBytes = min(size, plan.files[index].byteCount)
+                if size != plan.files[index].byteCount { plan.files[index].isValidated = false }
+            }
+
+            let recovery = plan.recovery
+            switch recovery {
+            case .discard:
+                removePlanDirectory(plan.id)
+                continue
+            case .finishInstall where plan.files.allSatisfy(\.isValidated):
+                plan = finishInstall(plan)
+                result.append((plan, plan.recovery))
+                continue
+            default:
+                break
+            }
+            try? persist(plan)
+            log(.downloadRecovered, plan: plan,
+                detail: live.contains(plan.id) ? "taskLive" : "taskAbsent")
+            result.append((plan, recovery))
+        }
+        return result
+    }
+
+    // MARK: - Deletion
+
+    /// Delete an installed model: stop anything fetching it, release it if it is resident, then
+    /// remove exactly its directory after proving that directory is beneath the model root.
+    func deleteInstallation(_ id: LocalModelID) async throws {
+        for plan in plans() where plan.descriptor.id == id && !plan.state.isTerminal {
+            _ = await cancel(planID: plan.id)
+        }
+        guard let installation = repository.installation(for: id) else {
+            throw ManagerError.installationNotFound(id)
+        }
+        await unloadIfResident(id)
+        do {
+            try repository.remove(installation)
+        } catch LocalModelRepository.RecordError.notWritable {
+            throw ManagerError.containmentRefused
+        }
+        log(.deleted, id: id, origin: .curatedCatalog)
+    }
+
+    // MARK: - Quarantine
+
+    /// Record why a plan failed terminally. Counts, sizes and a case name — never a path, a URL or
+    /// a repository name, because an imported repository id is text a user typed.
+    private func quarantine(_ plan: LocalModelDownloadPlan,
+                            reason: LocalModelDownloadPlan.FailureReason) {
+        struct Record: Codable {
+            let planID: String
+            let origin: String
+            let reason: String
+            let failedFileIndex: Int?
+            let expectedBytes: Int64
+            let stagedBytes: Int64
+            let recordedAt: Date
+        }
+        let index = plan.state.fileIndex.flatMap { plan.files.indices.contains($0) ? $0 : nil }
+        let record = Record(planID: plan.id.uuidString,
+                            origin: plan.origin.rawValue,
+                            reason: reason.rawValue,
+                            failedFileIndex: index,
+                            expectedBytes: index.map { plan.files[$0].byteCount } ?? 0,
+                            stagedBytes: plan.completedBytes,
+                            recordedAt: now())
+        let directory = repository.quarantineRoot.appendingPathComponent(plan.id.uuidString,
+                                                                         isDirectory: true)
+        guard (try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)) != nil,
+              let data = try? Self.encoder.encode(record) else { return }
+        try? data.write(to: directory.appendingPathComponent("validation-failure.json"), options: .atomic)
+        excludeFromBackup(directory)
+        pruneQuarantine()
+    }
+
+    /// Bounded by count and age, so a repeatedly failing import cannot grow a diagnostic archive.
+    private func pruneQuarantine() {
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: repository.quarantineRoot,
+            includingPropertiesForKeys: [.creationDateKey]) else { return }
+        let dated = entries.map { url -> (URL, Date) in
+            let created = (try? url.resourceValues(forKeys: [.creationDateKey]).creationDate)
+                ?? Date(timeIntervalSince1970: 0)
+            return (url, created)
+        }.sorted { $0.1 > $1.1 }
+
+        let cutoff = now().addingTimeInterval(-Self.quarantineMaximumAge)
+        for (offset, entry) in dated.enumerated() {
+            if offset >= Self.quarantineRecordLimit || entry.1 < cutoff {
+                try? fileManager.removeItem(at: entry.0)
+            }
+        }
+    }
+
+    // MARK: - Filesystem helpers
+
+    /// Remove a plan's whole directory, after proving it is beneath the staging root. The
+    /// containment check is not ceremony: this is the one place the pipeline deletes a directory
+    /// derived from a value that has been round-tripped through disk.
+    private func removePlanDirectory(_ planID: UUID) {
+        let directory = planDirectory(planID)
+        guard Self.isContained(directory, within: repository.stagingRoot) else { return }
+        try? fileManager.removeItem(at: directory)
+    }
+
+    private func removeStagedFiles(_ planID: UUID) {
+        let directory = filesDirectory(planID)
+        guard Self.isContained(directory, within: repository.stagingRoot) else { return }
+        try? fileManager.removeItem(at: directory)
+    }
+
+    private func isCancelled(_ plan: LocalModelDownloadPlan) -> Bool {
+        if case .cancelled = plan.state { return true }
+        return false
+    }
+
+    private func fileSize(_ url: URL) -> Int64 {
+        let attributes = try? fileManager.attributesOfItem(atPath: url.path)
+        return (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+    }
+
+    private func excludeFromBackup(_ url: URL) {
+        var mutable = url
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try? mutable.setResourceValues(values)
+    }
+
+    static func isContained(_ url: URL, within root: URL) -> Bool {
+        let rootPath = root.standardizedFileURL.path
+        let path = url.standardizedFileURL.path
+        return path.hasPrefix(rootPath + "/")
+    }
+
+    // MARK: - Diagnostics
+
+    /// Log a plan event.
+    ///
+    /// A curated model id is a public catalog token and is logged; an *imported* repository id is
+    /// text the user typed and is not. Both cases carry the origin, so a log reader can still tell
+    /// which pipeline a line came from without the line naming anything private.
+    private func log(_ event: PrivacyLog.LocalModelEvent,
+                     plan: LocalModelDownloadPlan,
+                     detail: String? = nil) {
+        log(event, id: plan.descriptor.id, origin: plan.origin, detail: detail,
+            percent: Int(plan.fractionCompleted * 100))
+    }
+
+    private func log(_ event: PrivacyLog.LocalModelEvent,
+                     id: LocalModelID,
+                     origin: LocalModelDownloadPlan.Origin,
+                     detail: String? = nil,
+                     percent: Int? = nil) {
+        let isPublicToken = origin == .curatedCatalog
+            && LocalModelCatalog.catalogedModelIDs.contains(id.rawValue)
+        PrivacyLog.localModel(event,
+                              model: isPublicToken ? PrivacyToken(id.rawValue) : nil,
+                              detail: PrivacyToken(detail ?? origin.rawValue),
+                              percent: percent)
+    }
+
+    // MARK: - Coding
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}
+
+/// Streaming SHA-256 over a file.
+///
+/// Chunked rather than `Data(contentsOf:)` for the reason the plan states plainly: model files are
+/// gigabytes, and buffering one to hash it would undo the whole point of streaming it to disk.
+enum LocalModelDigest {
+    /// Bytes read per update. Large enough to keep the hash fed, small enough to be invisible in a
+    /// memory graph.
+    static let chunkBytes = 1 << 20
+
+    static func sha256(ofFileAt url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while true {
+            let chunk = try handle.read(upToCount: chunkBytes) ?? Data()
+            if chunk.isEmpty { break }
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelDownloadPlan.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelDownloadPlan.swift
@@ -1,0 +1,424 @@
+import Foundation
+
+/// The persisted record of one model acquisition, and the state machine it may move through
+/// (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "Download state machine").
+///
+/// ```text
+/// planned → awaitingConsent → queued → downloading → validating → installing → installed
+///                           ↘ cancelled
+/// downloading/validating/installing → failed(retryable | terminal)
+/// ```
+///
+/// The plan is the durable half of the pipeline: it lives at
+/// `staging/<plan id>/download-plan.json`, is rewritten after every transition, and carries the
+/// per-file byte counts that make progress survive a relaunch. Nothing here touches the network or
+/// the filesystem — the transition table, the identifiers and the recovery decision are all pure,
+/// which is what lets "the app recovers cleanly from termination during each transition" be a test
+/// rather than a hope.
+struct LocalModelDownloadPlan: Codable, Equatable, Sendable, Identifiable {
+
+    /// Bumped when the plan's *meaning* changes. A plan written by a newer build and found by an
+    /// older one is discarded rather than half-understood: a resumed download is not worth the
+    /// risk of misreading which files were already validated.
+    static let currentPlanVersion = 1
+    static let fileName = "download-plan.json"
+    /// Subdirectory of the plan directory holding the partial and completed files. Separate from
+    /// the plan file itself so the install step can move the *files* into place and leave the plan
+    /// behind to record that it did.
+    static let filesDirectoryName = "files"
+
+    /// Where the plan came from. Curated ids are public catalog tokens; an imported repository id
+    /// is text the user typed, and the two are logged differently for exactly that reason.
+    enum Origin: String, Codable, Sendable {
+        case curatedCatalog
+        case repositoryImport
+    }
+
+    /// One file to fetch, with everything needed to prove it arrived intact.
+    struct PlannedFile: Codable, Equatable, Sendable {
+        let relativePath: String
+        let byteCount: Int64
+        /// Lowercase hex SHA-256, always present: a plan cannot be built around a file without one.
+        let sha256: String
+        let role: LocalModelFile.Role
+        /// Bytes on disk for this file, as last persisted. This — not an in-memory callback — is
+        /// what progress is computed from after a relaunch.
+        var completedBytes: Int64
+        /// Size and digest both verified against the staged bytes.
+        var isValidated: Bool
+
+        init(relativePath: String,
+             byteCount: Int64,
+             sha256: String,
+             role: LocalModelFile.Role,
+             completedBytes: Int64 = 0,
+             isValidated: Bool = false) {
+            self.relativePath = relativePath
+            self.byteCount = byteCount
+            self.sha256 = sha256
+            self.role = role
+            self.completedBytes = completedBytes
+            self.isValidated = isValidated
+        }
+
+        var modelFile: LocalModelFile {
+            LocalModelFile(relativePath: relativePath, byteCount: byteCount, sha256: sha256, role: role)
+        }
+    }
+
+    /// Why a plan failed, in a closed vocabulary. Every case is a case name and nothing else, so a
+    /// failure can be logged without any of the text that produced it.
+    enum FailureReason: String, Codable, Equatable, Sendable, Error {
+        case transport
+        case httpStatus
+        case sizeMismatch
+        case digestMismatch
+        case redirectHostRejected
+        case insecureRedirect
+        case containmentRefused
+        case revisionMismatch
+        case storageUnavailable
+        case installFailed
+        case planUnreadable
+        case consentMissing
+        case fitRefused
+    }
+
+    /// Retryable means "the same plan may run again"; terminal means the plan is finished and a
+    /// new one must be created. Digest and containment failures are terminal on purpose — fetching
+    /// the same bytes again is not a fix, and retrying a refusal is how a refusal becomes a loop.
+    enum Failure: Equatable, Sendable {
+        case retryable(FailureReason)
+        case terminal(FailureReason)
+
+        var reason: FailureReason {
+            switch self {
+            case .retryable(let reason), .terminal(let reason): return reason
+            }
+        }
+
+        var isRetryable: Bool {
+            if case .retryable = self { return true }
+            return false
+        }
+
+        /// The classification, in one place. Anything that could plausibly succeed on the next
+        /// attempt is retryable; anything that says the remote bytes or the plan itself are wrong
+        /// is not.
+        static func classify(_ reason: FailureReason) -> Failure {
+            switch reason {
+            case .transport, .httpStatus, .storageUnavailable, .installFailed:
+                return .retryable(reason)
+            case .sizeMismatch, .digestMismatch, .redirectHostRejected, .insecureRedirect,
+                 .containmentRefused, .revisionMismatch, .planUnreadable, .consentMissing,
+                 .fitRefused:
+                return .terminal(reason)
+            }
+        }
+    }
+
+    enum State: Equatable, Sendable {
+        case planned
+        case awaitingConsent
+        case queued
+        case downloading(fileIndex: Int)
+        case validating(fileIndex: Int)
+        case installing
+        case installed
+        case cancelled
+        case failed(Failure)
+
+        /// No further work happens on a plan in a terminal state.
+        var isTerminal: Bool {
+            switch self {
+            case .installed, .cancelled: return true
+            case .failed(let failure): return !failure.isRetryable
+            default: return false
+            }
+        }
+
+        /// The file this state is working on, when it is working on one.
+        var fileIndex: Int? {
+            switch self {
+            case .downloading(let index), .validating(let index): return index
+            default: return nil
+            }
+        }
+    }
+
+    var planVersion: Int
+    let id: UUID
+    let descriptor: LocalModelDescriptor
+    let origin: Origin
+    var files: [PlannedFile]
+    var state: State
+    let createdAt: Date
+    var updatedAt: Date
+    /// Licence revision the user accepted, recorded before the download is allowed to start.
+    var acceptedLicenseRevision: String?
+
+    // MARK: - Construction
+
+    /// Build a plan from a descriptor. Returns nil when the descriptor is not installable — an
+    /// unpinned revision, a missing digest, a path that escapes the model root. That refusal is the
+    /// same `installationFaults()` gate the catalog uses, applied one more time at the point where
+    /// files would actually be fetched.
+    init?(descriptor: LocalModelDescriptor,
+          origin: Origin,
+          id: UUID = UUID(),
+          now: Date = Date()) {
+        guard descriptor.installationFaults().isEmpty else { return nil }
+        guard !descriptor.files.isEmpty else { return nil }
+        self.planVersion = Self.currentPlanVersion
+        self.id = id
+        self.descriptor = descriptor
+        self.origin = origin
+        self.files = descriptor.files.map {
+            PlannedFile(relativePath: $0.relativePath,
+                        byteCount: $0.byteCount,
+                        sha256: $0.sha256.lowercased(),
+                        role: $0.role)
+        }
+        self.state = .planned
+        self.createdAt = now
+        self.updatedAt = now
+        self.acceptedLicenseRevision = nil
+    }
+
+    // MARK: - Progress
+
+    var totalBytes: Int64 { files.reduce(0) { $0 + $1.byteCount } }
+    /// Progress from persisted bytes. Deliberately not from a callback: after a relaunch there is
+    /// no callback, and a progress bar that resets to zero reads as lost work.
+    var completedBytes: Int64 { files.reduce(0) { $0 + min($1.completedBytes, $1.byteCount) } }
+
+    var fractionCompleted: Double {
+        guard totalBytes > 0 else { return 0 }
+        return min(1, max(0, Double(completedBytes) / Double(totalBytes)))
+    }
+
+    /// Index of the first file still to fetch, or nil when every file has validated.
+    var nextFileIndex: Int? { files.firstIndex { !$0.isValidated } }
+
+    // MARK: - Transitions
+
+    /// Whether `next` may follow the current state. The single table; both the manager and the
+    /// recovery path consult it rather than each having an opinion.
+    func canTransition(to next: State) -> Bool {
+        switch (state, next) {
+        case (_, .cancelled):
+            return !state.isTerminal || isCancellableTerminal
+        case (_, .failed):
+            // A terminal state does not fail again; anything still in flight may.
+            return !state.isTerminal
+        case (.planned, .awaitingConsent), (.planned, .queued):
+            return true
+        case (.awaitingConsent, .queued):
+            return true
+        case (.queued, .downloading(let index)):
+            return index == (nextFileIndex ?? 0)
+        case (.downloading(let current), .validating(let index)):
+            return current == index
+        case (.validating(let current), .downloading(let index)):
+            return index > current && files.indices.contains(index)
+        case (.validating, .installing):
+            return files.allSatisfy(\.isValidated)
+        case (.installing, .installed):
+            return files.allSatisfy(\.isValidated)
+        case (.failed(let failure), .queued):
+            return failure.isRetryable
+        // A resumed plan re-enters the file it was working on rather than starting over.
+        case (.downloading(let current), .downloading(let index)),
+             (.validating(let current), .validating(let index)):
+            return current == index
+        default:
+            return false
+        }
+    }
+
+    /// Cancelling an already-cancelled plan is a no-op rather than an error; cancelling an
+    /// installed one is not, because the files are in use and deletion is a different operation
+    /// with different consequences.
+    private var isCancellableTerminal: Bool {
+        switch state {
+        case .cancelled: return true
+        case .failed(let failure): return !failure.isRetryable
+        default: return false
+        }
+    }
+
+    enum TransitionError: Error, Equatable {
+        case notAllowed
+    }
+
+    mutating func advance(to next: State, now: Date = Date()) throws {
+        guard canTransition(to: next) else { throw TransitionError.notAllowed }
+        state = next
+        updatedAt = now
+    }
+
+    /// Record a validated file. Separate from the transition so "validated" is a fact about the
+    /// file, not a side effect of moving state.
+    mutating func markValidated(fileIndex: Int, byteCount: Int64, now: Date = Date()) {
+        guard files.indices.contains(fileIndex) else { return }
+        files[fileIndex].completedBytes = byteCount
+        files[fileIndex].isValidated = true
+        updatedAt = now
+    }
+
+    mutating func recordProgress(fileIndex: Int, completedBytes: Int64, now: Date = Date()) {
+        guard files.indices.contains(fileIndex) else { return }
+        files[fileIndex].completedBytes = max(0, min(completedBytes, files[fileIndex].byteCount))
+        updatedAt = now
+    }
+
+    // MARK: - Recovery
+
+    /// What a plan found on disk after a relaunch should do next.
+    enum Recovery: Equatable, Sendable {
+        /// Waiting for the user; nothing to resume.
+        case awaitUser
+        /// Resume fetching, starting at this file. Any partially fetched file is refetched — a
+        /// resumed byte range cannot be verified against the digest without the bytes already on
+        /// disk being trustworthy, and they are exactly what a crash makes untrustworthy.
+        case resumeDownload(fileIndex: Int)
+        /// Every file validated but the install did not finish. Finish it.
+        case finishInstall
+        /// Nothing left to do; the plan directory can be removed.
+        case discard
+        /// A retryable failure the user may retry.
+        case offerRetry(FailureReason)
+    }
+
+    var recovery: Recovery {
+        switch state {
+        case .planned, .awaitingConsent:
+            return .awaitUser
+        case .queued:
+            return nextFileIndex.map { .resumeDownload(fileIndex: $0) } ?? .finishInstall
+        case .downloading(let index), .validating(let index):
+            let resume = nextFileIndex ?? index
+            return files.allSatisfy(\.isValidated) ? .finishInstall : .resumeDownload(fileIndex: resume)
+        case .installing:
+            // Only an install whose files all still validate can be finished; anything else goes
+            // back to fetching, because "installing" is not evidence that the bytes are there.
+            return files.allSatisfy(\.isValidated)
+                ? .finishInstall
+                : .resumeDownload(fileIndex: nextFileIndex ?? 0)
+        case .installed, .cancelled:
+            return .discard
+        case .failed(let failure):
+            return failure.isRetryable ? .offerRetry(failure.reason) : .discard
+        }
+    }
+
+    // MARK: - Codable
+    //
+    // Hand-written so the state is stored as a readable tagged object
+    // (`{"name":"downloading","fileIndex":1}`) rather than Swift's synthesized enum shape. A plan
+    // file is something a person may have to read while diagnosing a stuck download.
+
+    private enum CodingKeys: String, CodingKey {
+        case planVersion, id, descriptor, origin, files, state, createdAt, updatedAt
+        case acceptedLicenseRevision
+    }
+
+    private struct StoredState: Codable, Equatable {
+        var name: String
+        var fileIndex: Int?
+        var failureReason: FailureReason?
+        var isRetryable: Bool?
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        planVersion = (try? container.decode(Int.self, forKey: .planVersion)) ?? 1
+        id = try container.decode(UUID.self, forKey: .id)
+        descriptor = try container.decode(LocalModelDescriptor.self, forKey: .descriptor)
+        origin = (try? container.decode(Origin.self, forKey: .origin)) ?? .curatedCatalog
+        files = try container.decode([PlannedFile].self, forKey: .files)
+        createdAt = (try? container.decode(Date.self, forKey: .createdAt)) ?? Date(timeIntervalSince1970: 0)
+        updatedAt = (try? container.decode(Date.self, forKey: .updatedAt)) ?? createdAt
+        acceptedLicenseRevision = try? container.decode(String.self, forKey: .acceptedLicenseRevision)
+
+        let stored = try container.decode(StoredState.self, forKey: .state)
+        state = Self.state(from: stored)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(planVersion, forKey: .planVersion)
+        try container.encode(id, forKey: .id)
+        try container.encode(descriptor, forKey: .descriptor)
+        try container.encode(origin, forKey: .origin)
+        try container.encode(files, forKey: .files)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(acceptedLicenseRevision, forKey: .acceptedLicenseRevision)
+        try container.encode(Self.stored(from: state), forKey: .state)
+    }
+
+    private static func stored(from state: State) -> StoredState {
+        switch state {
+        case .planned: return StoredState(name: "planned")
+        case .awaitingConsent: return StoredState(name: "awaitingConsent")
+        case .queued: return StoredState(name: "queued")
+        case .downloading(let index): return StoredState(name: "downloading", fileIndex: index)
+        case .validating(let index): return StoredState(name: "validating", fileIndex: index)
+        case .installing: return StoredState(name: "installing")
+        case .installed: return StoredState(name: "installed")
+        case .cancelled: return StoredState(name: "cancelled")
+        case .failed(let failure):
+            return StoredState(name: "failed",
+                               failureReason: failure.reason,
+                               isRetryable: failure.isRetryable)
+        }
+    }
+
+    /// An unreadable or unknown stored state becomes a terminal `planUnreadable` failure rather
+    /// than a guess. A plan whose state cannot be established must not be resumed.
+    private static func state(from stored: StoredState) -> State {
+        switch stored.name {
+        case "planned": return .planned
+        case "awaitingConsent": return .awaitingConsent
+        case "queued": return .queued
+        case "downloading": return stored.fileIndex.map { .downloading(fileIndex: $0) } ?? .queued
+        case "validating": return stored.fileIndex.map { .validating(fileIndex: $0) } ?? .queued
+        case "installing": return .installing
+        case "installed": return .installed
+        case "cancelled": return .cancelled
+        case "failed":
+            let reason = stored.failureReason ?? .planUnreadable
+            return .failed(stored.isRetryable == true ? .retryable(reason) : .terminal(reason))
+        default:
+            return .failed(.terminal(.planUnreadable))
+        }
+    }
+}
+
+/// The stable identifier that ties a background transfer task to a plan and a file.
+///
+/// It is written into the task's `taskDescription`, which the system preserves across app
+/// termination — so after a relaunch the mapping is rebuilt by *reading the tasks*, not by
+/// remembering anything.
+struct LocalModelTransferIdentifier: Equatable, Hashable, Sendable, CustomStringConvertible {
+    let planID: UUID
+    let fileIndex: Int
+
+    var description: String { "\(planID.uuidString)#\(fileIndex)" }
+
+    init(planID: UUID, fileIndex: Int) {
+        self.planID = planID
+        self.fileIndex = fileIndex
+    }
+
+    init?(_ raw: String?) {
+        guard let raw else { return nil }
+        let parts = raw.split(separator: "#", omittingEmptySubsequences: false)
+        guard parts.count == 2,
+              let planID = UUID(uuidString: String(parts[0])),
+              let index = Int(parts[1]), index >= 0 else { return nil }
+        self.planID = planID
+        self.fileIndex = index
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelFileTransfer.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelFileTransfer.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+/// One file fetch, as the download manager sees it. The seam exists so the whole acquisition
+/// pipeline — redirect refusal included — runs headlessly against a fake, and so the background
+/// session's delegate machinery has exactly one job.
+struct LocalModelFileTransferRequest: Sendable {
+    /// Stable across relaunch; becomes the task's `taskDescription`.
+    let identifier: LocalModelTransferIdentifier
+    let url: URL
+    let expectedBytes: Int64
+}
+
+/// What a completed fetch delivered. Every field is something the manager re-checks: a transport
+/// that already validated them would be a transport the tests cannot make lie.
+struct LocalModelFileTransferOutcome: Sendable {
+    let statusCode: Int
+    /// The URL the response finally came from, after redirects. Checked against the download host
+    /// policy for *every* response, not only the request we built.
+    let finalURL: URL?
+    /// A temporary file the manager takes ownership of. Never a `Data` — weights are gigabytes.
+    let fileURL: URL
+    let byteCount: Int64
+}
+
+/// Why a transfer never produced a file. Transport-level only; policy refusals are the manager's.
+enum LocalModelFileTransferError: Error, Equatable, Sendable {
+    case cancelled
+    case redirectRefused
+    case transport
+    case noFileProduced
+}
+
+protocol LocalModelFileTransferring: Sendable {
+    /// Fetch one file. The returned temporary file belongs to the caller.
+    func transfer(_ request: LocalModelFileTransferRequest) async throws -> LocalModelFileTransferOutcome
+    /// Cancel every in-flight task belonging to a plan. Cancelling a plan that has none is a no-op.
+    func cancelTasks(forPlan planID: UUID) async
+    /// Identifiers of tasks the system is still holding for this app. After a relaunch this is how
+    /// the plan-to-task mapping is rebuilt — by reading the tasks, not by remembering them.
+    func liveIdentifiers() async -> [LocalModelTransferIdentifier]
+}
+
+/// The production transfer: a background `URLSession` whose tasks survive app termination.
+///
+/// Three things make this different from a plain `URLSession.download`:
+///
+///  1. **Background configuration with a fixed identifier**, so the system keeps fetching while the
+///     app is suspended and hands the results back on relaunch.
+///  2. **A stable `taskDescription`** on every task, which is the only piece of state that has to
+///     survive termination — the plan file on disk holds everything else.
+///  3. **Redirects are refused in the delegate**, before the request is reissued. Checking the host
+///     after the bytes have arrived would be checking after the request already went somewhere.
+///
+/// None of this is exercised by the headless suite: a background session needs a real app. What is
+/// tested is everything either side of it — the identifier encoding, the host policy the delegate
+/// calls, and the manager's re-validation of whatever an outcome claims.
+final class LocalModelBackgroundTransfer: NSObject, LocalModelFileTransferring, @unchecked Sendable {
+
+    /// One session per app, named so the system can hand its tasks back after a relaunch.
+    static let sessionIdentifier = "com.openglasses.localmodels.download"
+
+    private let lock = NSLock()
+    private var continuations: [LocalModelTransferIdentifier: CheckedContinuation<LocalModelFileTransferOutcome, Error>] = [:]
+    private var refusedRedirects: Set<LocalModelTransferIdentifier> = []
+    /// Called when the system finishes delivering background events, so the app delegate's stored
+    /// completion handler can be invoked.
+    private var backgroundEventsHandler: (@Sendable () -> Void)?
+
+    private lazy var session: URLSession = {
+        let configuration = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
+        configuration.isDiscretionary = false
+        configuration.sessionSendsLaunchEvents = true
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.httpShouldSetCookies = false
+        // Anonymous public repositories only: nothing here may attach a stored credential.
+        configuration.urlCredentialStorage = nil
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+    }()
+
+    /// Register the handler iOS gives the app delegate when it wakes it for this session.
+    func setBackgroundEventsHandler(_ handler: (@Sendable () -> Void)?) {
+        lock.lock()
+        backgroundEventsHandler = handler
+        lock.unlock()
+    }
+
+    func transfer(_ request: LocalModelFileTransferRequest) async throws -> LocalModelFileTransferOutcome {
+        guard LocalModelRepositoryReference.isAllowedDownloadURL(request.url) else {
+            throw LocalModelFileTransferError.redirectRefused
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            continuations[request.identifier] = continuation
+            refusedRedirects.remove(request.identifier)
+            lock.unlock()
+
+            var urlRequest = URLRequest(url: request.url)
+            urlRequest.httpMethod = "GET"
+            urlRequest.httpShouldHandleCookies = false
+            let task = session.downloadTask(with: urlRequest)
+            task.taskDescription = request.identifier.description
+            task.resume()
+        }
+    }
+
+    func cancelTasks(forPlan planID: UUID) async {
+        let tasks = await session.allTasks
+        for task in tasks {
+            guard let identifier = LocalModelTransferIdentifier(task.taskDescription),
+                  identifier.planID == planID else { continue }
+            task.cancel()
+        }
+    }
+
+    func liveIdentifiers() async -> [LocalModelTransferIdentifier] {
+        await session.allTasks.compactMap { LocalModelTransferIdentifier($0.taskDescription) }
+    }
+
+    // MARK: - Delegate plumbing
+
+    private func finish(_ identifier: LocalModelTransferIdentifier,
+                        with result: Result<LocalModelFileTransferOutcome, Error>) {
+        lock.lock()
+        let continuation = continuations.removeValue(forKey: identifier)
+        lock.unlock()
+        continuation?.resume(with: result)
+    }
+}
+
+extension LocalModelBackgroundTransfer: URLSessionDownloadDelegate {
+
+    func urlSession(_ session: URLSession,
+                    downloadTask: URLSessionDownloadTask,
+                    didFinishDownloadingTo location: URL) {
+        guard let identifier = LocalModelTransferIdentifier(downloadTask.taskDescription) else { return }
+        let response = downloadTask.response as? HTTPURLResponse
+
+        // The delegate's file is deleted the moment this method returns, so it is moved before
+        // anything else — including before deciding whether the response was acceptable, which the
+        // manager does with the file in hand.
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("localmodel-\(UUID().uuidString).part")
+        do {
+            try FileManager.default.moveItem(at: location, to: destination)
+        } catch {
+            finish(identifier, with: .failure(LocalModelFileTransferError.noFileProduced))
+            return
+        }
+        let size = (try? FileManager.default.attributesOfItem(atPath: destination.path)[.size] as? NSNumber)
+            .flatMap { $0?.int64Value } ?? 0
+        finish(identifier, with: .success(LocalModelFileTransferOutcome(
+            statusCode: response?.statusCode ?? 0,
+            finalURL: response?.url ?? downloadTask.originalRequest?.url,
+            fileURL: destination,
+            byteCount: size)))
+    }
+
+    func urlSession(_ session: URLSession,
+                    task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse,
+                    newRequest request: URLRequest,
+                    completionHandler: @escaping (URLRequest?) -> Void) {
+        guard LocalModelRepositoryReference.isAllowedDownloadURL(request.url) else {
+            if let identifier = LocalModelTransferIdentifier(task.taskDescription) {
+                lock.lock()
+                refusedRedirects.insert(identifier)
+                lock.unlock()
+            }
+            // Refusing the redirect completes the task with the redirect response instead of
+            // following it. The manager still re-checks the host it ended on.
+            completionHandler(nil)
+            return
+        }
+        completionHandler(request)
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let identifier = LocalModelTransferIdentifier(task.taskDescription) else { return }
+        lock.lock()
+        let wasRefused = refusedRedirects.remove(identifier) != nil
+        let isPending = continuations[identifier] != nil
+        lock.unlock()
+        guard isPending else { return }   // success already delivered by didFinishDownloadingTo
+
+        if wasRefused {
+            finish(identifier, with: .failure(LocalModelFileTransferError.redirectRefused))
+        } else if let error, (error as NSError).code == NSURLErrorCancelled {
+            finish(identifier, with: .failure(LocalModelFileTransferError.cancelled))
+        } else if error != nil {
+            finish(identifier, with: .failure(LocalModelFileTransferError.transport))
+        } else {
+            finish(identifier, with: .failure(LocalModelFileTransferError.noFileProduced))
+        }
+    }
+
+    func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        lock.lock()
+        let handler = backgroundEventsHandler
+        backgroundEventsHandler = nil
+        lock.unlock()
+        handler?()
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelFitReport.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelFitReport.swift
@@ -1,0 +1,232 @@
+import Foundation
+
+/// What the user is told before a model download starts, and what may stop it
+/// (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "Fit and consent").
+///
+/// The report is a value, not a screen: the model manager renders it, and every rule in it —
+/// including the awkward ones — is decided here where a test can drive the whole truth table.
+///
+/// The two rules that are easiest to get wrong, and are therefore the reason this type exists:
+///
+///  - **Unknown size, missing digest or unresolved revision blocks installation.** They are not
+///    warnings. Without them there is nothing to verify a download against, and an unverifiable
+///    install is precisely what the integrity invariant forbids.
+///  - **An unreadable free-space reading is an inability to check, not permission to proceed.**
+///    `nil` free space blocks; it does not fall through to "probably fine".
+struct LocalModelFitReport: Equatable, Sendable {
+
+    /// Space the download needs beyond the model itself — staging holds the bytes before they are
+    /// moved into place, and finishing an install by filling the phone is not an install.
+    static let storageMarginBytes: Int64 = OfflineModelOffer.storageMarginBytes
+
+    /// Something that makes installation impossible right now. Every case is checkable before a
+    /// byte moves.
+    enum Blocker: Equatable, Sendable {
+        /// A file with no declared byte count. Nothing could confirm the download finished.
+        case unknownFileSize(relativePath: String)
+        /// A file with no recorded digest. Nothing could confirm the bytes are the right bytes.
+        case missingDigest(relativePath: String)
+        /// No exact revision, so "the same model" means nothing tomorrow.
+        case unresolvedRevision
+        /// The descriptor declares no files at all.
+        case noFiles
+        /// Free space could not be read. Visible inability to check.
+        case freeSpaceUnreadable
+        /// It fits nowhere: download plus margin exceeds what is free.
+        case insufficientStorage(neededBytes: Int64, freeBytes: Int64)
+        /// The licence requires acceptance and none has been recorded.
+        case licenseNotAccepted
+    }
+
+    /// Something the user should know but which does not, on its own, stop an install.
+    enum Warning: Equatable, Sendable {
+        /// The honest one the plan requires: files can install perfectly and still never load,
+        /// because the architecture or the chat template inside them is not supported.
+        case mayInstallButNotLoad
+        /// The memory gate says this model cannot be loaded on this device as things stand. The
+        /// files may still be installed — freeing memory or closing other work can change the
+        /// verdict, and refusing the download would be refusing on a reading taken minutes early.
+        case unlikelyToLoad(neededBytes: Int64, availableBytes: Int64)
+        /// It loads, but with little to spare.
+        case tightMemoryHeadroom(spareBytes: Int64)
+        /// The requested context will be clamped at load time.
+        case contextWillBeClamped(toTokens: Int)
+        /// The licence has not been summarized in the app; the user should read it upstream.
+        case licenseNotSummarized
+        /// Free space is above the bar but not by much.
+        case storageAfterInstallIsTight(remainingBytes: Int64)
+    }
+
+    // Facts the consent surface shows.
+    let displayName: String
+    let runtime: LocalModelRuntime
+    let quantization: String?
+    let capabilities: Set<LocalModelCapability>
+    /// Exact bytes to be downloaded — the sum of the declared file sizes, never an estimate.
+    let downloadBytes: Int64
+    /// Free space, or `nil` when it could not be read.
+    let availableStorageBytes: Int64?
+    /// Weights plus the runtime's working reserve: the conservative figure the load verdict uses.
+    let estimatedResidentBytes: Int64
+    let loadVerdict: LocalModelBudget.Admission
+    let license: LocalModelLicenseSummary
+    let requiresLicenseAcceptance: Bool
+
+    let blockers: [Blocker]
+    let warnings: [Warning]
+
+    /// Installation may begin. The one gate the download manager consults.
+    var canInstall: Bool { blockers.isEmpty }
+
+    /// Everything the verdict looks at. Supplied rather than measured, so the unreadable-free-space
+    /// case is a value a test can pass rather than a device state it has to arrange.
+    struct Inputs: Equatable, Sendable {
+        let descriptor: LocalModelDescriptor
+        /// `nil` = could not be read. Not "unlimited".
+        let availableStorageBytes: Int64?
+        /// What this process may still allocate. `0` = no per-process budget known (simulator, Mac).
+        let availableProcessBytes: Int64
+        /// Licence revision the user has accepted for this model, if any.
+        let acceptedLicenseRevision: String?
+
+        init(descriptor: LocalModelDescriptor,
+             availableStorageBytes: Int64?,
+             availableProcessBytes: Int64,
+             acceptedLicenseRevision: String? = nil) {
+            self.descriptor = descriptor
+            self.availableStorageBytes = availableStorageBytes
+            self.availableProcessBytes = availableProcessBytes
+            self.acceptedLicenseRevision = acceptedLicenseRevision
+        }
+    }
+
+    static func make(_ inputs: Inputs) -> LocalModelFitReport {
+        let descriptor = inputs.descriptor
+        var blockers: [Blocker] = []
+        var warnings: [Warning] = []
+
+        if descriptor.files.isEmpty { blockers.append(.noFiles) }
+        if !descriptor.isRevisionPinned { blockers.append(.unresolvedRevision) }
+        for file in descriptor.files {
+            if file.byteCount <= 0 { blockers.append(.unknownFileSize(relativePath: file.relativePath)) }
+            if !file.hasVerifiedDigest { blockers.append(.missingDigest(relativePath: file.relativePath)) }
+        }
+
+        let downloadBytes = descriptor.files.reduce(Int64(0)) { $0 + max(0, $1.byteCount) }
+        let needed = downloadBytes + storageMarginBytes
+        switch inputs.availableStorageBytes {
+        case .none:
+            blockers.append(.freeSpaceUnreadable)
+        case .some(let free) where free < needed:
+            blockers.append(.insufficientStorage(neededBytes: needed, freeBytes: free))
+        case .some(let free):
+            let remaining = free - needed
+            if remaining < storageMarginBytes {
+                warnings.append(.storageAfterInstallIsTight(remainingBytes: free - downloadBytes))
+            }
+        }
+
+        if descriptor.license.requiresAcceptance,
+           inputs.acceptedLicenseRevision == nil
+               || (descriptor.license.revision != nil
+                       && inputs.acceptedLicenseRevision != descriptor.license.revision) {
+            blockers.append(.licenseNotAccepted)
+        }
+        if descriptor.license.revision == nil { warnings.append(.licenseNotSummarized) }
+
+        // The conservative load verdict: declared weights, the runtime's working reserve, and the
+        // descriptor's own extra reserve — through the one admission rule the load path uses.
+        //
+        // The extra reserve is added only for `llamaCpp`, because that is the only runtime whose
+        // load path passes `minimumHeadroomBytes` to `admit` as `safetyReserveBytes`. The MLX
+        // entries compute the same field as "weights + working set", so adding it there would
+        // double-count and make this verdict refuse loads the MLX path performs happily. The field
+        // meaning two things by runtime is a wrinkle worth removing; silently disagreeing with the
+        // gate that actually runs would be worse.
+        let extraReserve = descriptor.runtime == .llamaCpp ? max(0, descriptor.minimumHeadroomBytes) : 0
+        let residentBytes = descriptor.estimatedWeightsBytes
+            + LocalModelBudget.workingSetBytes(for: descriptor.runtime)
+            + extraReserve
+        let admission = LocalModelBudget.admit(.init(
+            runtime: descriptor.runtime,
+            declaredWeightsBytes: descriptor.estimatedWeightsBytes,
+            configuredContextTokens: descriptor.contextLength,
+            policyContextTokens: descriptor.contextLength,
+            availableProcessBytes: inputs.availableProcessBytes,
+            safetyReserveBytes: extraReserve))
+        switch admission {
+        case .allow:
+            break
+        case .allowConstrained(.tightHeadroom(let spare)):
+            warnings.append(.tightMemoryHeadroom(spareBytes: spare))
+        case .allowConstrained(.contextClamped(let tokens)):
+            warnings.append(.contextWillBeClamped(toTokens: tokens))
+        case .refuse(.insufficientHeadroom(let neededBytes, let availableBytes)):
+            warnings.append(.unlikelyToLoad(neededBytes: neededBytes, availableBytes: availableBytes))
+        }
+
+        // Always stated for the second runtime, never inferred away by a successful-looking plan:
+        // the GGUF backend refuses an unsupported architecture or chat template at load time, and
+        // that refusal happens after the files are already on disk.
+        if descriptor.runtime == .llamaCpp { warnings.append(.mayInstallButNotLoad) }
+
+        return LocalModelFitReport(
+            displayName: descriptor.displayName,
+            runtime: descriptor.runtime,
+            quantization: descriptor.quantization,
+            capabilities: descriptor.capabilities,
+            downloadBytes: downloadBytes,
+            availableStorageBytes: inputs.availableStorageBytes,
+            estimatedResidentBytes: residentBytes,
+            loadVerdict: admission,
+            license: descriptor.license,
+            requiresLicenseAcceptance: descriptor.license.requiresAcceptance,
+            blockers: blockers,
+            warnings: warnings)
+    }
+}
+
+extension LocalModelFitReport.Blocker {
+    /// User-facing copy. Says what is missing and, where there is one, what the user can do; it
+    /// never suggests proceeding anyway, because none of these are advisory.
+    var localizedMessage: String {
+        switch self {
+        case .unknownFileSize:
+            return "This model doesn't state how large its files are, so the download can't be checked."
+        case .missingDigest:
+            return "This model doesn't publish a checksum, so a download can't be verified."
+        case .unresolvedRevision:
+            return "This model isn't pinned to an exact version, so it can't be installed safely."
+        case .noFiles:
+            return "This model lists no files to download."
+        case .freeSpaceUnreadable:
+            return "Available storage couldn't be checked, so the download hasn't been started."
+        case .insufficientStorage:
+            return "There isn't enough free storage for this model."
+        case .licenseNotAccepted:
+            return "Accept this model's licence to continue."
+        }
+    }
+}
+
+extension LocalModelFitReport.Warning {
+    var localizedMessage: String {
+        switch self {
+        case .mayInstallButNotLoad:
+            return "This model may install and still not run: on-device models must use a supported "
+                + "architecture and chat template, which is only known once it loads."
+        case .unlikelyToLoad:
+            return "This device probably can't hold this model in memory right now. The files will "
+                + "install, but loading may fail until more memory is free."
+        case .tightMemoryHeadroom:
+            return "This model fits, but with little memory to spare. Expect slower answers and warmth."
+        case .contextWillBeClamped(let tokens):
+            return "Conversation length will be limited to about \(tokens) tokens on this device."
+        case .licenseNotSummarized:
+            return "This model's licence hasn't been summarized in the app. Read it on the "
+                + "repository page before installing."
+        case .storageAfterInstallIsTight:
+            return "Storage will be nearly full after this download."
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelGGUFCatalog.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelGGUFCatalog.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+/// The bundled GGUF catalog that PR1 deferred, and the validation that decides what it is allowed
+/// to claim (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "Catalog policy").
+///
+/// ### Why this one is JSON when the MLX catalog is Swift
+/// A JSON entry earns its format by carrying the size/digest/revision triple. The MLX entries have
+/// none — they are hub snapshots fetched whole — so PR1 kept them in Swift and said so. Every
+/// entry here has an exact revision, exact files, exact byte counts and real SHA-256 digests, which
+/// is precisely the data a hand-authored Swift literal is a bad home for.
+///
+/// ### What an entry is allowed to claim
+/// Loading refuses an entry that:
+///
+///  - fails `installationFaults()` — unpinned revision, missing digest, non-positive size, a path
+///    that escapes the model root, no `.text` capability;
+///  - declares a runtime other than `llamaCpp`; or
+///  - claims `.vision` or `.toolFriendly` without device evidence.
+///
+/// That last rule is the plan's, made structural: "Do not add a model based only on a successful
+/// load; it must complete the conversation, long-prompt, cancellation, tool-call, and
+/// device-memory fixtures relevant to its capability badges." An entry whose evidence is
+/// `fileMetadataOnly` can therefore be shipped honestly — it is a text model with verified bytes —
+/// but it cannot wear a badge nobody demonstrated.
+///
+/// ### `minimumHeadroomBytes` in this catalog
+/// It is an **additional** reserve on top of the weights and the runtime working set, because that
+/// is how the GGUF load path consumes it (`LlamaCppLocalInferenceBackend` passes it to
+/// `LocalModelBudget.admit` as `safetyReserveBytes`). It is not "weights + working set" the way the
+/// MLX entries compute it; writing that here would double-count and refuse loads that fit.
+struct LocalModelCatalogDocument: Equatable, Sendable {
+
+    /// Bumped when the document's *shape* changes.
+    static let currentVersion = 1
+    static let resourceName = "LocalModelCatalog"
+
+    let version: Int
+    let entries: [LocalModelCatalog.GGUFEntry]
+
+    /// Decode and validate. A malformed or over-claiming entry is dropped, not fatal: one bad row
+    /// must not cost the user the rest of the catalog. `loadStrict` reports what was dropped, which
+    /// is what the bundled-catalog test asserts is empty.
+    static func load(from data: Data) throws -> LocalModelCatalogDocument {
+        try loadStrict(from: data).document
+    }
+
+    static func loadStrict(from data: Data) throws -> (document: LocalModelCatalogDocument,
+                                                       rejected: [String]) {
+        let raw = try JSONDecoder().decode(RawDocument.self, from: data)
+        var entries: [LocalModelCatalog.GGUFEntry] = []
+        var rejected: [String] = []
+        var seen = Set<String>()
+
+        for candidate in raw.models {
+            let entry = candidate.entry
+            if let reason = LocalModelCatalog.validationError(for: entry) {
+                rejected.append("\(entry.descriptor.id.rawValue): \(reason)")
+            } else if !seen.insert(entry.descriptor.id.rawValue).inserted {
+                rejected.append("\(entry.descriptor.id.rawValue): duplicate id")
+            } else {
+                entries.append(entry)
+            }
+        }
+        return (LocalModelCatalogDocument(version: raw.version, entries: entries), rejected)
+    }
+
+    /// Tolerates one malformed element rather than failing the whole decode — the same shape the
+    /// bundled MCP catalogue already uses.
+    private struct RawDocument: Decodable {
+        let version: Int
+        let models: [LocalModelCatalog.RawGGUFEntry]
+
+        enum CodingKeys: String, CodingKey { case version, models }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            version = try container.decodeIfPresent(Int.self, forKey: .version) ?? 1
+            var list = try container.nestedUnkeyedContainer(forKey: .models)
+            var parsed: [LocalModelCatalog.RawGGUFEntry] = []
+            while !list.isAtEnd {
+                let element = try list.decode(FailableDecodable<LocalModelCatalog.RawGGUFEntry>.self)
+                if let value = element.value { parsed.append(value) }
+            }
+            models = parsed
+        }
+    }
+}
+
+extension LocalModelCatalog {
+
+    /// Evidence behind an entry's claims.
+    enum Evidence: String, Codable, Sendable, Equatable {
+        /// The entry's fixtures have been run on a physical device: it loads, holds a conversation,
+        /// survives a long prompt, cancels cleanly, and — where badged — produces tool calls.
+        case deviceVerified
+        /// The bytes are pinned and verified, and the file's own GGUF metadata was read at that
+        /// revision, but nothing has run it on hardware. Such an entry ships as a text model with
+        /// no capability badges beyond `.text`.
+        case fileMetadataOnly
+    }
+
+    /// A curated GGUF model.
+    struct GGUFEntry: Equatable, Sendable, Identifiable {
+        let descriptor: LocalModelDescriptor
+        /// Picker copy.
+        let notes: String
+        /// Minimum device RAM (GB) to offer this model. 0 = no restriction.
+        let minimumRAMGB: Double
+        /// `general.architecture` as read from the file at the pinned revision. A fact about the
+        /// bytes, not a guess from the name — and never a substitute for what the runtime reads at
+        /// load time.
+        let architecture: String?
+        /// `<arch>.context_length` from the same read. Recorded so the difference between what the
+        /// model was trained for and what this app is willing to allocate is visible.
+        let trainedContextTokens: Int?
+        let evidence: Evidence
+
+        var id: LocalModelID { descriptor.id }
+    }
+
+    /// Why an entry may not ship. Nil means it may.
+    static func validationError(for entry: GGUFEntry) -> String? {
+        let descriptor = entry.descriptor
+        guard descriptor.runtime == .llamaCpp else { return "runtime is not llamaCpp" }
+        let faults = descriptor.installationFaults()
+        guard faults.isEmpty else {
+            return "not installable: " + faults.map { String(describing: $0) }.joined(separator: ", ")
+        }
+        guard descriptor.contextLength > 0 else { return "context length must be positive" }
+        guard descriptor.estimatedWeightsBytes > 0 else { return "weights size must be positive" }
+        if entry.evidence != .deviceVerified {
+            // The plan's rule, enforced by construction rather than by review discipline.
+            let badged = descriptor.capabilities.subtracting([.text])
+            guard badged.isEmpty else {
+                return "claims \(badged.map(\.rawValue).sorted().joined(separator: ", "))"
+                    + " without device evidence"
+            }
+        }
+        if descriptor.license.requiresAcceptance && descriptor.license.revision == nil {
+            return "licence requires acceptance but names no revision to accept"
+        }
+        return nil
+    }
+
+    /// The catalog shipped in the app bundle. Empty when the resource is absent or unreadable —
+    /// callers fall back to the import path, exactly as the MCP catalogue does.
+    static func bundledGGUFDocument(_ bundle: Bundle = .main) -> LocalModelCatalogDocument? {
+        guard let url = bundle.url(forResource: LocalModelCatalogDocument.resourceName,
+                                   withExtension: "json"),
+              let data = try? Data(contentsOf: url) else { return nil }
+        return try? LocalModelCatalogDocument.load(from: data)
+    }
+
+    static func bundledGGUFEntries(_ bundle: Bundle = .main) -> [GGUFEntry] {
+        bundledGGUFDocument(bundle)?.entries ?? []
+    }
+
+    /// JSON shape, kept separate from the domain type so the file format can gain a field without
+    /// the runtime type gaining an optional.
+    struct RawGGUFEntry: Decodable {
+        let id: String
+        let displayName: String
+        let repositoryID: String
+        let revision: String
+        let quantization: String?
+        let capabilities: [String]?
+        let contextLength: Int
+        let estimatedWeightsBytes: Int64?
+        let estimatedWorkingBytes: Int64?
+        let minimumHeadroomBytes: Int64?
+        let files: [RawFile]
+        let license: RawLicense?
+        let notes: String?
+        let minimumRAMGB: Double?
+        let architecture: String?
+        let trainedContextTokens: Int?
+        let evidence: String?
+
+        struct RawFile: Decodable {
+            let relativePath: String
+            let byteCount: Int64
+            let sha256: String
+            let role: String?
+        }
+
+        struct RawLicense: Decodable {
+            let displayName: String
+            let summary: String
+            let requiresAcceptance: Bool?
+            let revision: String?
+        }
+
+        var entry: GGUFEntry {
+            let files = self.files.map {
+                LocalModelFile(relativePath: $0.relativePath,
+                               byteCount: $0.byteCount,
+                               sha256: $0.sha256.lowercased(),
+                               role: LocalModelFile.Role(rawValue: $0.role ?? "weights") ?? .weights)
+            }
+            // Unknown capability strings are dropped rather than kept: a badge this build cannot
+            // honour must not survive into a descriptor.
+            let declared = Set((capabilities ?? ["text"]).compactMap(LocalModelCapability.init(rawValue:)))
+            let weights = estimatedWeightsBytes ?? files.filter { $0.role == .weights }
+                .reduce(Int64(0)) { $0 + $1.byteCount }
+            let license = self.license.map {
+                LocalModelLicenseSummary(displayName: $0.displayName,
+                                         summary: $0.summary,
+                                         requiresAcceptance: $0.requiresAcceptance ?? false,
+                                         revision: $0.revision)
+            } ?? .unverified
+            let descriptor = LocalModelDescriptor(
+                id: LocalModelID(id),
+                displayName: displayName,
+                runtime: .llamaCpp,
+                repositoryID: repositoryID,
+                revision: revision,
+                files: files,
+                quantization: quantization,
+                capabilities: declared.isEmpty ? [.text] : declared,
+                contextLength: contextLength,
+                estimatedWeightsBytes: weights,
+                estimatedWorkingBytes: estimatedWorkingBytes
+                    ?? LocalModelBudget.workingSetBytes(for: .llamaCpp),
+                minimumHeadroomBytes: minimumHeadroomBytes ?? 0,
+                license: license)
+            return GGUFEntry(descriptor: descriptor,
+                             notes: notes ?? "",
+                             minimumRAMGB: minimumRAMGB ?? 0,
+                             architecture: architecture,
+                             trainedContextTokens: trainedContextTokens,
+                             evidence: Evidence(rawValue: evidence ?? "") ?? .fileMetadataOnly)
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelImportPlanner.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelImportPlanner.swift
@@ -1,0 +1,410 @@
+import Foundation
+
+/// Turning a parsed repository reference into an exact, verifiable set of files
+/// (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "Import parsing").
+///
+/// Three rules shape everything here:
+///
+///  1. **Resolve to an exact revision before a plan exists.** A branch name is not installable
+///     metadata, so the planner asks the repository what `main` currently *is* and pins the answer.
+///  2. **Structured metadata only.** The two network seams return JSON from the repository's own
+///     API. Nothing scrapes HTML, follows a model card link, or executes a repository script —
+///     Plan DZ's non-goal list is explicit about that.
+///  3. **A quantization label is display text.** It comes from the filename, so it is a caption,
+///     never evidence about what the file contains. Nothing in this file infers a capability, a
+///     context length or an architecture from a name.
+
+// MARK: - Remote metadata shapes
+
+/// What the repository says about itself at one moment. `revision` is the whole reason to ask.
+struct LocalModelRepositoryMetadata: Equatable, Sendable {
+    /// Exact immutable revision the default branch points at right now.
+    let revision: String
+    /// SPDX-ish licence identifier from the model card, when it declares one.
+    let licenseIdentifier: String?
+    /// Whether the repository requires accepting terms or credentials to download. The first
+    /// importer is public-only, so a gated repository is refused rather than half-supported.
+    let isGated: Bool
+    let isPrivate: Bool
+}
+
+/// One file in the repository at that revision.
+struct LocalModelRemoteFile: Equatable, Sendable {
+    let path: String
+    let byteCount: Int64
+    /// SHA-256 as recorded by the repository's large-file store. `nil` for a file it does not
+    /// track that way — such a file can be listed but can never be installed, because there is
+    /// nothing to verify the download against.
+    let sha256: String?
+}
+
+/// The two network seams, injected so every enumeration, grouping and refusal rule is exercised
+/// headlessly against fixtures.
+protocol LocalModelRepositoryMetadataFetching: Sendable {
+    func metadata(for reference: LocalModelRepositoryReference) async throws -> LocalModelRepositoryMetadata
+    func files(for reference: LocalModelRepositoryReference,
+               revision: String) async throws -> [LocalModelRemoteFile]
+}
+
+// MARK: - Faults
+
+/// Why an import cannot proceed past enumeration. Separate from `LocalModelImportRejection`, which
+/// is about the string; these are about what the repository turned out to contain.
+enum LocalModelImportFault: Error, Equatable, Sendable {
+    /// The repository did not name an exact revision, or named one that is not a full commit hash.
+    case revisionNotResolved
+    /// Gated or private. The first importer supports anonymous public repositories only.
+    case repositoryNotPublic
+    /// No `.gguf` file at that revision.
+    case noEligibleFiles
+    /// Every eligible file is missing the size or digest that installation requires.
+    case noVerifiableFiles
+    /// A listed path is not contained beneath the model root once normalized.
+    case pathOutsideModelRoot
+    /// The chosen candidate is not one this offer enumerated.
+    case unknownSelection
+}
+
+// MARK: - Candidates
+
+/// One installable choice: a single `.gguf` file, or the complete set of shards of one.
+///
+/// Shards are grouped because offering one shard of three would install a model that can never
+/// load — and because the *grouping* rule is the only part of a filename this file is willing to
+/// act on, since it decides completeness rather than capability.
+struct LocalModelImportCandidate: Equatable, Sendable, Identifiable {
+    /// Stable within an offer: the group's base name, which is also the file name for a single
+    /// unsharded file.
+    let id: String
+    /// Files that must all be installed together, in listing order.
+    let files: [LocalModelRemoteFile]
+    /// Display-only quantization caption parsed from the file name, e.g. `Q4_K_M`. Never trust
+    /// evidence: a repack under a different name must not change what the app believes.
+    let quantizationLabel: String?
+    let role: LocalModelFile.Role
+
+    var byteCount: Int64 { files.reduce(0) { $0 + $1.byteCount } }
+
+    /// Whether this candidate can be installed at all. Missing size or digest is not a warning:
+    /// there would be nothing to verify the bytes against, and an unverifiable install is exactly
+    /// what the integrity rules exist to prevent.
+    var isInstallable: Bool {
+        !files.isEmpty && files.allSatisfy { $0.byteCount > 0 && ($0.sha256?.isEmpty == false) }
+    }
+
+    /// Model files, in the descriptor's shape. Empty when the candidate is not installable, so an
+    /// unverifiable candidate cannot leak into a descriptor by a caller forgetting to check.
+    func modelFiles() -> [LocalModelFile] {
+        guard isInstallable else { return [] }
+        return files.compactMap { file in
+            guard case .contained(let normalized) = LocalModelPath.normalize(file.path),
+                  let digest = file.sha256 else { return nil }
+            return LocalModelFile(relativePath: normalized,
+                                  byteCount: file.byteCount,
+                                  sha256: digest.lowercased(),
+                                  role: role)
+        }
+    }
+}
+
+/// Everything a consent screen needs about an import, before any bytes move.
+struct LocalModelImportOffer: Equatable, Sendable {
+    let reference: LocalModelRepositoryReference
+    /// The exact revision every candidate was enumerated at.
+    let revision: String
+    let license: LocalModelLicenseSummary
+    /// Weights candidates, largest last so the cheapest option reads first.
+    let weights: [LocalModelImportCandidate]
+    /// Multimodal projectors found alongside the weights. Listed so the user can see they exist;
+    /// the text-only runtime does not install them, and their presence claims nothing about
+    /// whether this build could use them.
+    let projectors: [LocalModelImportCandidate]
+    /// A curated default, present only when the exact preferred file exists. `nil` means the user
+    /// must choose — the plan forbids picking "something close" on their behalf.
+    let defaultSelection: LocalModelImportCandidate?
+
+    var requiresSelection: Bool { defaultSelection == nil }
+}
+
+// MARK: - Planner
+
+/// Resolves a reference to a revision, enumerates its files, and builds descriptors from a choice.
+struct LocalModelImportPlanner: Sendable {
+
+    /// The one quantization the app will pick unaided. Chosen because it is the quality/size
+    /// balance a phone can actually hold; anything else is a decision the user makes.
+    static let preferredQuantizationLabel = "Q4_K_M"
+
+    /// Context window a freshly imported model is given until something better is known.
+    ///
+    /// It is the conservative default the budget already applies to unknown ids, *not* the file's
+    /// trained context: the runtime reads the real value out of the GGUF at load time and clamps
+    /// from there. Writing a name-derived window into a descriptor would be the guess the plan
+    /// forbids.
+    static let importedContextTokens = LocalModelBudget.defaultContextWindow
+
+    let fetcher: any LocalModelRepositoryMetadataFetching
+
+    init(fetcher: any LocalModelRepositoryMetadataFetching) {
+        self.fetcher = fetcher
+    }
+
+    /// Resolve and enumerate. Throws `LocalModelImportFault` on anything that makes an install
+    /// impossible; a repository with unverifiable extras but at least one verifiable weights file
+    /// succeeds, with the unverifiable candidates listed and marked.
+    func offer(for reference: LocalModelRepositoryReference) async throws -> LocalModelImportOffer {
+        let metadata = try await fetcher.metadata(for: reference)
+        guard !metadata.isGated, !metadata.isPrivate else {
+            throw LocalModelImportFault.repositoryNotPublic
+        }
+        guard LocalModelRepositoryReference.isValidRevision(metadata.revision) else {
+            throw LocalModelImportFault.revisionNotResolved
+        }
+
+        let listing = try await fetcher.files(for: reference, revision: metadata.revision)
+        return try Self.makeOffer(reference: reference, metadata: metadata, files: listing)
+    }
+
+    /// The pure half: grouping, classification and default selection over an already-fetched
+    /// listing. Everything the exit criteria care about is testable through this entry point.
+    static func makeOffer(reference: LocalModelRepositoryReference,
+                          metadata: LocalModelRepositoryMetadata,
+                          files: [LocalModelRemoteFile]) throws -> LocalModelImportOffer {
+        let eligible = files.filter { file in
+            file.path.lowercased().hasSuffix(".gguf")
+        }
+        guard !eligible.isEmpty else { throw LocalModelImportFault.noEligibleFiles }
+
+        // A path that does not normalize into the model root is refused for the whole offer, not
+        // silently dropped: a listing containing a traversal is a listing to walk away from.
+        for file in eligible {
+            guard case .contained = LocalModelPath.normalize(file.path) else {
+                throw LocalModelImportFault.pathOutsideModelRoot
+            }
+        }
+
+        let projectorFiles = eligible.filter { GGUFFileName.isProjector($0.path) }
+        let weightsFiles = eligible.filter { !GGUFFileName.isProjector($0.path) }
+
+        let weights = candidates(from: weightsFiles, role: .weights)
+        let projectors = candidates(from: projectorFiles, role: .projector)
+        guard weights.contains(where: \.isInstallable) else {
+            throw LocalModelImportFault.noVerifiableFiles
+        }
+
+        // "Prefer a curated default only when the exact file is present" — one installable
+        // candidate carrying exactly the preferred label, or nobody chooses but the user.
+        let preferred = weights.filter {
+            $0.isInstallable && $0.quantizationLabel == preferredQuantizationLabel
+        }
+        let defaultSelection = preferred.count == 1 ? preferred.first : nil
+
+        return LocalModelImportOffer(
+            reference: reference,
+            revision: metadata.revision,
+            license: LocalModelLicenseSummary.imported(identifier: metadata.licenseIdentifier,
+                                                       revision: metadata.revision),
+            weights: weights,
+            projectors: projectors,
+            defaultSelection: defaultSelection)
+    }
+
+    /// Group shards, caption quantizations, and sort smallest-first.
+    private static func candidates(from files: [LocalModelRemoteFile],
+                                   role: LocalModelFile.Role) -> [LocalModelImportCandidate] {
+        var groups: [String: [LocalModelRemoteFile]] = [:]
+        var order: [String] = []
+        for file in files {
+            let key = GGUFFileName.groupKey(for: file.path)
+            if groups[key] == nil { order.append(key) }
+            groups[key, default: []].append(file)
+        }
+        return order.map { key in
+            let members = (groups[key] ?? []).sorted { $0.path < $1.path }
+            return LocalModelImportCandidate(
+                id: key,
+                files: members,
+                quantizationLabel: GGUFFileName.quantizationLabel(for: members.first?.path ?? key),
+                role: role)
+        }
+        .sorted { ($0.byteCount, $0.id) < ($1.byteCount, $1.id) }
+    }
+
+    /// Build the descriptor an install plan is made from.
+    ///
+    /// Capabilities are `.text` and nothing else. A GGUF that loads is a text model as far as this
+    /// build is concerned; `.vision` needs the multimodal phase and `.toolFriendly` needs the
+    /// tool-call conformance fixture the plan requires before a badge is granted.
+    static func descriptor(for candidate: LocalModelImportCandidate,
+                           in offer: LocalModelImportOffer,
+                           displayName: String? = nil) throws -> LocalModelDescriptor {
+        guard offer.weights.contains(candidate) || offer.projectors.contains(candidate) else {
+            throw LocalModelImportFault.unknownSelection
+        }
+        guard candidate.isInstallable else { throw LocalModelImportFault.noVerifiableFiles }
+        let files = candidate.modelFiles()
+        guard files.count == candidate.files.count else { throw LocalModelImportFault.pathOutsideModelRoot }
+
+        let weightsBytes = candidate.byteCount
+        return LocalModelDescriptor(
+            id: LocalModelID.gguf(repositoryID: offer.reference.repositoryID, fileGroup: candidate.id),
+            displayName: displayName ?? "\(offer.reference.repository) · \(candidate.quantizationLabel ?? candidate.id)",
+            runtime: .llamaCpp,
+            repositoryID: offer.reference.repositoryID,
+            revision: offer.revision,
+            files: files,
+            quantization: candidate.quantizationLabel,
+            capabilities: [.text],
+            contextLength: importedContextTokens,
+            estimatedWeightsBytes: weightsBytes,
+            estimatedWorkingBytes: LocalModelBudget.workingSetBytes(for: .llamaCpp),
+            minimumHeadroomBytes: weightsBytes + LocalModelBudget.workingSetBytes(for: .llamaCpp),
+            license: offer.license)
+    }
+}
+
+// MARK: - Identity
+
+extension LocalModelID {
+    /// A GGUF model's id: the repository plus the file group inside it, because one repository
+    /// publishes a dozen quantizations of the same weights and each is a separate installation.
+    ///
+    /// `#` cannot appear in a repository name, so the join is unambiguous, and `storageComponent`
+    /// percent-encodes it before it reaches a directory name.
+    static func gguf(repositoryID: String, fileGroup: String) -> LocalModelID {
+        LocalModelID("\(repositoryID)#\(fileGroup)")
+    }
+}
+
+// MARK: - Licence
+
+extension LocalModelLicenseSummary {
+    /// Licences the app can describe from an identifier alone.
+    ///
+    /// Everything outside this table stays `.unverified` and says so. Summarizing a licence the
+    /// app has not read would be the same category of claim as inventing a digest.
+    static let describedIdentifiers: [String: (name: String, summary: String, requiresAcceptance: Bool)] = [
+        "apache-2.0": ("Apache License 2.0",
+                       "Permissive: use, modify and redistribute, keeping the notices and stating "
+                           + "changes. Includes a patent grant.",
+                       false),
+        "mit": ("MIT License",
+                "Permissive: use, modify and redistribute, keeping the copyright notice.",
+                false),
+        "bsd-3-clause": ("BSD 3-Clause License",
+                         "Permissive: redistribute with the notice, without using the authors' "
+                             + "names to endorse derived work.",
+                         false),
+        "cc-by-4.0": ("Creative Commons Attribution 4.0",
+                      "Permissive with attribution: credit the author and note any changes.",
+                      false),
+        "cc-by-sa-4.0": ("Creative Commons Attribution-ShareAlike 4.0",
+                         "Attribution plus share-alike: derived work carries the same licence.",
+                         false),
+    ]
+
+    /// Summary for an imported repository. Unknown or absent identifiers are `.unverified` with
+    /// acceptance required, which is the honest reading of "nobody here has read these terms".
+    static func imported(identifier: String?, revision: String) -> LocalModelLicenseSummary {
+        guard let identifier = identifier?.lowercased(),
+              let described = describedIdentifiers[identifier] else {
+            return LocalModelLicenseSummary(
+                displayName: identifier.map { $0.uppercased() } ?? "Unknown licence",
+                summary: "This model's terms have not been reviewed in the app. Read them on the "
+                    + "repository page before installing.",
+                requiresAcceptance: true,
+                revision: nil)
+        }
+        return LocalModelLicenseSummary(displayName: described.name,
+                                        summary: described.summary,
+                                        requiresAcceptance: described.requiresAcceptance,
+                                        revision: revision)
+    }
+}
+
+// MARK: - File names
+
+/// The only place a GGUF *file name* is read, and only for two decisions: which files belong
+/// together, and what caption to show.
+///
+/// Neither decision is a claim about the file's contents. Architecture, context length, chat
+/// template and capabilities all come from the file's own metadata at load time
+/// (`GGUFMetadataValidator`), never from here.
+enum GGUFFileName {
+
+    /// Quantization captions, longest first so `Q4_K_M` wins over `Q4_K` and `IQ4_XS` over `Q4`.
+    static let knownLabels: [String] = [
+        "IQ1_S", "IQ1_M", "IQ2_XXS", "IQ2_XS", "IQ2_S", "IQ2_M", "IQ3_XXS", "IQ3_XS", "IQ3_S",
+        "IQ3_M", "IQ4_XS", "IQ4_NL",
+        "Q2_K_L", "Q2_K_S", "Q2_K",
+        "Q3_K_L", "Q3_K_M", "Q3_K_S", "Q3_K",
+        "Q4_K_M", "Q4_K_S", "Q4_K", "Q4_0", "Q4_1",
+        "Q5_K_M", "Q5_K_S", "Q5_K", "Q5_0", "Q5_1",
+        "Q6_K_L", "Q6_K",
+        "Q8_0", "Q8_K",
+        "BF16", "FP16", "F16", "FP32", "F32",
+    ]
+
+    /// A projector file by the `mmproj` naming convention.
+    ///
+    /// Used for exactly one thing: keeping a projector out of the weights list, so a text-only
+    /// install cannot pick one by accident. It never grants `.vision` and never claims the
+    /// projector matches anything — that is the multimodal phase's evidence to produce.
+    static func isProjector(_ path: String) -> Bool {
+        fileName(path).lowercased().contains("mmproj")
+    }
+
+    /// Key that groups a sharded model's parts (`…-00001-of-00003.gguf`) under one candidate. An
+    /// unsharded file is its own group.
+    static func groupKey(for path: String) -> String {
+        let name = fileName(path)
+        guard let range = shardSuffixRange(in: name) else { return name }
+        return String(name[name.startIndex..<range.lowerBound]) + ".gguf"
+    }
+
+    /// The `-NNNNN-of-NNNNN.gguf` tail, when present.
+    private static func shardSuffixRange(in name: String) -> Range<String.Index>? {
+        guard name.lowercased().hasSuffix(".gguf") else { return nil }
+        let stem = String(name.dropLast(5))
+        // `-00001-of-00003`: two fixed-width numbers joined by `-of-`.
+        let parts = stem.split(separator: "-", omittingEmptySubsequences: false)
+        guard parts.count >= 3,
+              parts[parts.count - 2] == "of",
+              parts[parts.count - 1].count == 5, parts[parts.count - 1].allSatisfy(\.isNumber),
+              parts[parts.count - 3].count == 5, parts[parts.count - 3].allSatisfy(\.isNumber)
+        else { return nil }
+        let tailLength = parts[parts.count - 3].count + 1 + 2 + 1 + parts[parts.count - 1].count + 1
+        guard stem.count >= tailLength else { return nil }
+        let start = name.index(name.startIndex, offsetBy: stem.count - tailLength)
+        return start..<name.endIndex
+    }
+
+    /// Display caption, or nil when the name carries no recognised quantization token.
+    static func quantizationLabel(for path: String) -> String? {
+        let upper = fileName(path).uppercased()
+        for label in knownLabels where containsToken(label, in: upper) { return label }
+        return nil
+    }
+
+    /// Token match on `-`, `.` or `_` boundaries, so `Q4_0` in `MODELQ4_0X` is not a caption.
+    private static func containsToken(_ token: String, in name: String) -> Bool {
+        var searchRange = name.startIndex..<name.endIndex
+        while let found = name.range(of: token, range: searchRange) {
+            let beforeOK = found.lowerBound == name.startIndex
+                || isBoundary(name[name.index(before: found.lowerBound)])
+            let afterOK = found.upperBound == name.endIndex || isBoundary(name[found.upperBound])
+            if beforeOK && afterOK { return true }
+            guard found.upperBound < name.endIndex else { return false }
+            searchRange = found.upperBound..<name.endIndex
+        }
+        return false
+    }
+
+    private static func isBoundary(_ character: Character) -> Bool {
+        character == "-" || character == "." || character == "_"
+    }
+
+    private static func fileName(_ path: String) -> String {
+        String(path.split(separator: "/").last ?? Substring(path))
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelRepository.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelRepository.swift
@@ -231,6 +231,118 @@ final class LocalModelRepository {
         try? mutable.setResourceValues(values)
     }
 
+    // MARK: - Installing validated files
+
+    /// Publish a staged, fully validated directory as an installation.
+    ///
+    /// The order is the whole crash-consistency argument, and it lives here so "installed" keeps
+    /// exactly one definition:
+    ///
+    ///  1. write `installation.json` **inside the staging directory** and read it back;
+    ///  2. move (or atomically replace) that directory into `installed/<storage component>/`;
+    ///  3. write `.complete` last.
+    ///
+    /// A power loss before 2 leaves the previous installation untouched and the staging directory
+    /// recoverable. A power loss between 2 and 3 leaves a directory `installedModels()` refuses to
+    /// report — fail-closed — which the download plan's `installing` state is able to finish.
+    func install(_ installation: InstalledLocalModel, movingContentsOf stagedDirectory: URL) throws {
+        guard case .managed(let directoryName) = installation.storage,
+              directoryName == installation.id.storageComponent else {
+            throw RecordError.notWritable
+        }
+        let destination = directory(for: installation.id)
+        guard Self.isContained(destination, within: installedRoot),
+              Self.isContained(stagedDirectory, within: root) else {
+            throw RecordError.notWritable
+        }
+
+        // Resuming an install that was interrupted *after* the move: the staging directory is gone
+        // because it became the installed directory, and all that is missing is the marker. Without
+        // this the recovery path would try to move a directory that no longer exists and report a
+        // failed install over a perfectly good one.
+        if !fileManager.fileExists(atPath: stagedDirectory.path) {
+            guard let data = try? Data(contentsOf: destination.appendingPathComponent(Self.manifestFileName)),
+                  let decoded = try? Self.decoder.decode(InstalledLocalModel.self, from: data),
+                  decoded.id == installation.id else {
+                throw RecordError.notWritable
+            }
+            do {
+                try Data().write(to: destination.appendingPathComponent(Self.completionMarkerName),
+                                 options: .atomic)
+            } catch {
+                throw Self.classify(error)
+            }
+            excludeFromBackup(destination)
+            return
+        }
+
+        let manifest = stagedDirectory.appendingPathComponent(Self.manifestFileName)
+        do {
+            let data = try Self.encoder.encode(installation)
+            try data.write(to: manifest, options: .atomic)
+        } catch {
+            throw Self.classify(error)
+        }
+        guard let readBack = try? Data(contentsOf: manifest),
+              let decoded = try? Self.decoder.decode(InstalledLocalModel.self, from: readBack),
+              Self.matches(written: installation, readBack: decoded) else {
+            throw RecordError.readBackMismatch(installation.id)
+        }
+
+        do {
+            try fileManager.createDirectory(at: installedRoot, withIntermediateDirectories: true)
+            if fileManager.fileExists(atPath: destination.path) {
+                // Replacing rather than deleting-then-moving: a reinstall must never pass through
+                // a moment where neither copy exists.
+                _ = try fileManager.replaceItemAt(destination, withItemAt: stagedDirectory)
+            } else {
+                try fileManager.moveItem(at: stagedDirectory, to: destination)
+            }
+        } catch {
+            throw Self.classify(error)
+        }
+
+        do {
+            try Data().write(to: destination.appendingPathComponent(Self.completionMarkerName),
+                             options: .atomic)
+        } catch {
+            throw Self.classify(error)
+        }
+        excludeFromBackup(destination)
+    }
+
+    /// Remove an installation's files and record, after proving the directory is beneath the model
+    /// root. Removal is by *the record*, never by a caller-supplied path, so there is nothing for a
+    /// caller to get wrong.
+    func remove(_ installation: InstalledLocalModel) throws {
+        let directory = directory(for: installation)
+        guard Self.isContained(directory, within: root) else { throw RecordError.notWritable }
+        do {
+            try fileManager.removeItem(at: directory)
+        } catch {
+            // An already-absent directory is the state the caller asked for.
+            let nsError = error as NSError
+            guard nsError.domain == NSCocoaErrorDomain,
+                  CocoaError.Code(rawValue: nsError.code) == .fileNoSuchFile else {
+                throw Self.classify(error)
+            }
+        }
+        // A managed installation keeps its record in the same directory; a legacy discovery keeps
+        // it separately under `installed/`, so that record goes too.
+        if installation.storage.isLegacy {
+            let record = self.directory(for: installation.id)
+            if Self.isContained(record, within: installedRoot) {
+                try? fileManager.removeItem(at: record)
+            }
+        }
+    }
+
+    /// Path containment: `url` must be strictly beneath `root` once standardized.
+    static func isContained(_ url: URL, within root: URL) -> Bool {
+        let rootPath = root.standardizedFileURL.path
+        return url.standardizedFileURL.path.hasPrefix(rootPath + "/")
+    }
+
     // MARK: - Migration
 
     /// True while legacy MLX installs still have no record at the current version.

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelRepositoryClient.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelRepositoryClient.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// The production `LocalModelRepositoryMetadataFetching`: two JSON endpoints, no HTML, no scripts.
+///
+/// Splitting decode from transport is deliberate — `parseMetadata` and `parseFileListing` are pure
+/// and carry every field rule, so the whole contract is pinned by fixtures and the suite never
+/// touches the network.
+struct LocalModelRepositoryClient: LocalModelRepositoryMetadataFetching {
+
+    /// Faults that belong to the transport rather than to the repository's contents.
+    enum ClientError: Error, Equatable {
+        case requestNotBuildable
+        case badStatus(Int)
+        case malformedResponse
+        /// A response arrived from somewhere other than the allowlisted domain family. Checked on
+        /// the response, not only on the request, so a redirect cannot move the conversation.
+        case responseHostRejected
+    }
+
+    /// Metadata responses are small; a model repository listing with thousands of files is not.
+    /// The cap makes a hostile response a bounded read rather than a memory event.
+    static let maximumResponseBytes = 4 * 1024 * 1024
+
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func metadata(for reference: LocalModelRepositoryReference) async throws -> LocalModelRepositoryMetadata {
+        let data = try await get(path: "/api/models/\(reference.owner)/\(reference.repository)",
+                                 host: reference.host)
+        return try Self.parseMetadata(data)
+    }
+
+    func files(for reference: LocalModelRepositoryReference,
+               revision: String) async throws -> [LocalModelRemoteFile] {
+        guard LocalModelRepositoryReference.isValidRevision(revision) else {
+            throw LocalModelImportFault.revisionNotResolved
+        }
+        let data = try await get(
+            path: "/api/models/\(reference.owner)/\(reference.repository)/tree/\(revision)",
+            host: reference.host,
+            query: [URLQueryItem(name: "recursive", value: "1")])
+        return try Self.parseFileListing(data)
+    }
+
+    // MARK: - Transport
+
+    private func get(path: String, host: String, query: [URLQueryItem] = []) async throws -> Data {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.path = path
+        if !query.isEmpty { components.queryItems = query }
+        guard let endpoint = components.url,
+              LocalModelRepositoryReference.isAllowedDownloadURL(endpoint) else {
+            throw ClientError.requestNotBuildable
+        }
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        // No credentials are sent and none are stored: the first importer is anonymous-public only.
+        request.httpShouldHandleCookies = false
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw ClientError.malformedResponse }
+        guard LocalModelRepositoryReference.isAllowedDownloadURL(http.url ?? endpoint) else {
+            throw ClientError.responseHostRejected
+        }
+        guard (200..<300).contains(http.statusCode) else { throw ClientError.badStatus(http.statusCode) }
+        guard data.count <= Self.maximumResponseBytes else { throw ClientError.malformedResponse }
+        return data
+    }
+
+    // MARK: - Decoding
+
+    /// `{ "sha": …, "private": Bool, "gated": false | "auto" | "manual", "cardData": { "license": … } }`
+    static func parseMetadata(_ data: Data) throws -> LocalModelRepositoryMetadata {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ClientError.malformedResponse
+        }
+        guard let sha = object["sha"] as? String else { throw LocalModelImportFault.revisionNotResolved }
+
+        // `gated` is a bool when open and a string naming the gate when not, so anything that is
+        // not literally `false` counts as gated. Defaulting the unknown shape to "gated" is the
+        // fail-closed reading.
+        let isGated: Bool
+        switch object["gated"] {
+        case let flag as Bool: isGated = flag
+        case is NSNull, nil: isGated = false
+        default: isGated = true
+        }
+
+        let card = object["cardData"] as? [String: Any]
+        // A repository may declare one licence or several; several is not something the app can
+        // summarize, so only the single-string form is read.
+        let license = (card?["license"] as? String) ?? (object["license"] as? String)
+
+        return LocalModelRepositoryMetadata(revision: sha,
+                                            licenseIdentifier: license,
+                                            isGated: isGated,
+                                            isPrivate: (object["private"] as? Bool) ?? false)
+    }
+
+    /// `[{ "type": "file", "path": …, "size": …, "lfs": { "oid": <sha256>, "size": … } }]`
+    ///
+    /// The digest comes from the large-file record. A file the repository does not track that way
+    /// has no recorded digest, and the candidate carrying it is marked uninstallable rather than
+    /// installed on trust.
+    static func parseFileListing(_ data: Data) throws -> [LocalModelRemoteFile] {
+        guard let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            throw ClientError.malformedResponse
+        }
+        return rows.compactMap { row in
+            guard (row["type"] as? String) == "file", let path = row["path"] as? String else { return nil }
+            let lfs = row["lfs"] as? [String: Any]
+            let size = (lfs?["size"] as? NSNumber)?.int64Value
+                ?? (row["size"] as? NSNumber)?.int64Value
+                ?? 0
+            let digest = (lfs?["oid"] as? String).flatMap { isSHA256($0) ? $0.lowercased() : nil }
+            return LocalModelRemoteFile(path: path, byteCount: size, sha256: digest)
+        }
+    }
+
+    /// 64 lowercase hex characters. A digest of any other shape is treated as no digest at all —
+    /// a store that one day records a different hash must not have it silently compared as SHA-256.
+    static func isSHA256(_ value: String) -> Bool {
+        value.count == 64 && value.allSatisfy { $0.isHexDigit && !$0.isUppercase }
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelRepositoryReference.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelRepositoryReference.swift
@@ -1,0 +1,267 @@
+import Foundation
+
+/// Parsing and refusing the text a user types when importing a model from a public repository
+/// (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "Import parsing").
+///
+/// The whole file is pure and structural: it decides what a string is allowed to *mean* before any
+/// network call exists to be pointed somewhere. That ordering is the point — a host allowlist that
+/// runs after the first request has already leaked the request.
+///
+/// **The parsed value is user content.** `owner` and `repository` are whatever someone typed, so
+/// they may be shown back to that person and sent to the allowlisted host, and they may never be
+/// written to a log line. Every diagnostic in the acquisition path logs a rejection's *case name*
+/// via `PrivacyToken.caseName(of:)`, never its payload.
+
+/// A public model repository, already proved to be well-formed and on an allowlisted host.
+///
+/// Deliberately carries no revision: a reference names a repository, and a *pinned* revision is
+/// something only the resolver can produce. Nothing downstream can accidentally treat "the
+/// repository the user typed" as "the exact bytes we agreed to fetch".
+struct LocalModelRepositoryReference: Equatable, Hashable, Sendable {
+    /// Canonical host — always `huggingface.co`, even when the user pasted the `hf.co` short form.
+    let host: String
+    let owner: String
+    let repository: String
+
+    /// `owner/repository`, the form the metadata API and the descriptor both use.
+    var repositoryID: String { "\(owner)/\(repository)" }
+
+    /// The repository's public page. Built from validated components rather than kept from the
+    /// input, so nothing the user typed survives into a request unexamined.
+    var webURL: URL? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        components.path = "/\(owner)/\(repository)"
+        return components.url
+    }
+
+    /// The download URL for one file at one exact revision.
+    ///
+    /// `revision` must be an exact immutable revision; a branch name here would produce a URL that
+    /// resolves to different bytes tomorrow, which is the thing decision 9 forbids. The planner is
+    /// what guarantees that, and `LocalModelDownloadPlan` refuses to be built without it.
+    func fileURL(revision: String, relativePath: String) -> URL? {
+        guard case .contained(let normalized) = LocalModelPath.normalize(relativePath),
+              LocalModelRepositoryReference.isValidRevision(revision) else { return nil }
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = host
+        // Percent-encoded per component: a path segment is data, and letting `?` or `#` from a
+        // filename become URL syntax is exactly how a path turns into a query.
+        let segments = ["", owner, repository, "resolve", revision]
+            + normalized.split(separator: "/").map(String.init)
+        components.percentEncodedPath = segments
+            .map { $0.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? $0 }
+            .joined(separator: "/")
+        return components.url
+    }
+
+    /// An exact revision is a full 40-character hex commit. Short hashes and branch names are both
+    /// refused: a short hash is ambiguous and a branch moves.
+    static func isValidRevision(_ revision: String) -> Bool {
+        revision.count == 40 && revision.allSatisfy { $0.isHexDigit && ($0.isNumber || $0.isLowercase) }
+    }
+}
+
+/// Why an import string was refused. One case per rule, so the UI can say which rule and the log
+/// can record the case name with none of the text that triggered it.
+enum LocalModelImportRejection: Error, Equatable, Sendable {
+    /// Nothing but whitespace.
+    case empty
+    /// Not parseable as a URL at all.
+    case notAURL
+    /// A host-looking string with no scheme (`huggingface.co/owner/repo`). Refused rather than
+    /// upgraded to HTTPS: silently choosing the scheme for someone is how a downgrade goes unseen.
+    case missingScheme
+    /// Any scheme other than HTTPS, `http` included.
+    case disallowedScheme(String)
+    /// `https://user:password@host/…`.
+    case embeddedCredentials
+    /// A query string. Repository URLs need none, and a query is where token material travels.
+    case queryNotAllowed
+    /// A fragment. Same reasoning, plus it is a second place to hide a path.
+    case fragmentNotAllowed
+    /// A host that is not on the allowlist.
+    case disallowedHost(String)
+    /// A private, loopback, link-local or otherwise reserved host.
+    case privateOrReservedHost(String)
+    /// The path is not exactly `/owner/repository` — a file, branch, or app route.
+    case pathOutsideRepositoryForm
+    /// The owner segment is not a legal repository-owner name.
+    case malformedOwner
+    /// The repository segment is not a legal repository name.
+    case malformedRepository
+
+    /// User-facing copy. Deliberately says which rule failed and what to do instead; it never
+    /// echoes the input, because a rejection message is also the most convenient place to leak it.
+    var localizedMessage: String {
+        switch self {
+        case .empty:
+            return "Enter a model repository, for example owner/repository."
+        case .notAURL:
+            return "That isn't a repository name or a web address."
+        case .missingScheme:
+            return "Paste the full address, starting with https://."
+        case .disallowedScheme:
+            return "Only https:// addresses can be imported."
+        case .embeddedCredentials:
+            return "Addresses with a username or password can't be imported."
+        case .queryNotAllowed:
+            return "Remove everything after the ? — a repository address needs no query."
+        case .fragmentNotAllowed:
+            return "Remove everything after the # — a repository address needs no fragment."
+        case .disallowedHost:
+            return "Models can only be imported from a supported public model host."
+        case .privateOrReservedHost:
+            return "That address points at a private or reserved network."
+        case .pathOutsideRepositoryForm:
+            return "Use the repository address itself, without a file or branch path."
+        case .malformedOwner:
+            return "That owner name isn't valid."
+        case .malformedRepository:
+            return "That repository name isn't valid."
+        }
+    }
+}
+
+extension LocalModelRepositoryReference {
+
+    // MARK: - Host policy
+
+    /// Hosts a repository may be named by. One entry today; the set exists so adding a second host
+    /// is a data change with a test, not an `if` somewhere in the parser.
+    ///
+    /// `hf.co` is the same service's short form and canonicalizes to `huggingface.co`, so a
+    /// reference has one spelling regardless of what was pasted.
+    static let allowedRepositoryHosts: [String: String] = [
+        "huggingface.co": "huggingface.co",
+        "www.huggingface.co": "huggingface.co",
+        "hf.co": "huggingface.co",
+        "www.hf.co": "huggingface.co",
+    ]
+
+    /// Registrable domains a *download* response may finally land on.
+    ///
+    /// This is intentionally broader than the repository host: weights are served by CDN hosts
+    /// under the same domains (`us.aws.cdn.hf.co`, `cdn-lfs.huggingface.co`,
+    /// `transfer.xethub.hf.co`), so pinning the download to the exact repository host would refuse
+    /// every real download. The rule is "same domain family, HTTPS, no credentials" and it is
+    /// re-checked on every response, not only on the request we built.
+    static let allowedDownloadDomains: [String] = ["huggingface.co", "hf.co"]
+
+    /// Whether a response's final host may serve model bytes.
+    static func isAllowedDownloadHost(_ rawHost: String?) -> Bool {
+        guard let rawHost, !rawHost.isEmpty else { return false }
+        let host = rawHost.lowercased()
+        guard !URLFetchGuard.isBlockedHost(host) else { return false }
+        return allowedDownloadDomains.contains { domain in
+            host == domain || host.hasSuffix("." + domain)
+        }
+    }
+
+    /// Whether a redirect target is acceptable: HTTPS, no credentials, allowlisted domain family.
+    static func isAllowedDownloadURL(_ url: URL?) -> Bool {
+        guard let url else { return false }
+        guard (url.scheme ?? "").lowercased() == "https" else { return false }
+        guard url.user == nil, url.password == nil else { return false }
+        return isAllowedDownloadHost(url.host)
+    }
+
+    // MARK: - Parsing
+
+    /// Parse `owner/repository` or a full HTTPS repository URL.
+    ///
+    /// Refuses in the order the rules are cheapest to check, so the reason a user sees is the
+    /// first thing actually wrong rather than whichever check happened to run last.
+    static func parse(_ raw: String) -> Result<LocalModelRepositoryReference, LocalModelImportRejection> {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .failure(.empty) }
+        // A control character or whitespace inside the string is never part of a legal reference,
+        // and is the cheapest way to smuggle a second line into a request.
+        guard !trimmed.contains(where: { $0.isWhitespace || $0.unicodeScalars.contains(where: { $0.value < 0x20 }) })
+        else { return .failure(.notAURL) }
+
+        if trimmed.contains("://") || trimmed.hasPrefix("//") {
+            return parseURLForm(trimmed)
+        }
+        return parseShorthand(trimmed)
+    }
+
+    /// `owner/repository`, with no scheme and no host.
+    private static func parseShorthand(
+        _ input: String) -> Result<LocalModelRepositoryReference, LocalModelImportRejection> {
+        let components = input.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        // A leading host with no scheme is a specific, common mistake: name it rather than letting
+        // it fail as a malformed owner, and never repair it by inventing `https://`.
+        if let first = components.first?.lowercased(), allowedRepositoryHosts[first] != nil {
+            return .failure(.missingScheme)
+        }
+        guard components.count == 2 else {
+            return components.count > 2 ? .failure(.pathOutsideRepositoryForm) : .failure(.notAURL)
+        }
+        return assemble(host: "huggingface.co", owner: components[0], repository: components[1])
+    }
+
+    private static func parseURLForm(
+        _ input: String) -> Result<LocalModelRepositoryReference, LocalModelImportRejection> {
+        guard let components = URLComponents(string: input) else { return .failure(.notAURL) }
+
+        let scheme = (components.scheme ?? "").lowercased()
+        guard !scheme.isEmpty else { return .failure(.missingScheme) }
+        guard scheme == "https" else { return .failure(.disallowedScheme(scheme)) }
+
+        guard components.user == nil, components.password == nil else {
+            return .failure(.embeddedCredentials)
+        }
+        guard components.query == nil, components.percentEncodedQuery == nil else {
+            return .failure(.queryNotAllowed)
+        }
+        guard components.fragment == nil, components.percentEncodedFragment == nil else {
+            return .failure(.fragmentNotAllowed)
+        }
+
+        guard let rawHost = components.host, !rawHost.isEmpty else { return .failure(.notAURL) }
+        let host = rawHost.lowercased()
+        // Checked before the allowlist so a private address is reported as what it is. No
+        // allowlisted host can be private today; the ordering is what keeps that true if one day a
+        // host resolves differently.
+        guard !URLFetchGuard.isBlockedHost(host) else { return .failure(.privateOrReservedHost(host)) }
+        guard let canonical = allowedRepositoryHosts[host] else { return .failure(.disallowedHost(host)) }
+
+        // Decoded path segments: `%2e%2e` must be a traversal here, not a literal name.
+        let decodedPath = components.path.removingPercentEncoding ?? components.path
+        let segments = decodedPath
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+        guard segments.count == 2 else { return .failure(.pathOutsideRepositoryForm) }
+        return assemble(host: canonical, owner: segments[0], repository: segments[1])
+    }
+
+    private static func assemble(
+        host: String, owner: String,
+        repository: String) -> Result<LocalModelRepositoryReference, LocalModelImportRejection> {
+        guard isValidName(owner) else { return .failure(.malformedOwner) }
+        // `git clone` copy/paste is the one repair worth making: it changes no host, no path, and
+        // no meaning.
+        let repositoryName = repository.hasSuffix(".git") ? String(repository.dropLast(4)) : repository
+        guard isValidName(repositoryName) else { return .failure(.malformedRepository) }
+        return .success(LocalModelRepositoryReference(host: host, owner: owner, repository: repositoryName))
+    }
+
+    /// A legal owner or repository segment.
+    ///
+    /// Starts alphanumeric, then alphanumerics plus `.`, `_`, `-`; never contains `..`; bounded in
+    /// length. The charset is what keeps a segment from being a path, a traversal, or URL syntax
+    /// once it is pasted back into a request.
+    static func isValidName(_ name: String) -> Bool {
+        guard !name.isEmpty, name.count <= 96 else { return false }
+        guard !name.contains("..") else { return false }
+        guard let first = name.first, first.isASCII, first.isLetter || first.isNumber else { return false }
+        return name.allSatisfy { character in
+            guard character.isASCII else { return false }
+            return character.isLetter || character.isNumber
+                || character == "." || character == "_" || character == "-"
+        }
+    }
+}

--- a/OpenGlasses/Sources/Utils/PrivacyLog.swift
+++ b/OpenGlasses/Sources/Utils/PrivacyLog.swift
@@ -1417,6 +1417,11 @@ enum PrivacyLog {
         /// descriptor's id is whatever the user typed into the model field, which makes it
         /// user-authored text rather than a public catalog token.
         case recordsMigrated, recordsMigrationDeferred, recordsMigrationFailed
+        /// Acquisition pipeline. A *curated* plan names its catalog id, which is a public token; an
+        /// **imported** plan names nothing — the repository the user typed is user content, and the
+        /// `detail` field carries the plan's origin instead, so a log reader can still tell the two
+        /// pipelines apart without the line naming anyone's repository.
+        case downloadPlanned, downloadStarted, downloadRecovered, downloadFailed, installCompleted
     }
 
     /// `shape` is the prompt tensor's dimensions rendered as `1x842` — the diagnostic that

--- a/OpenGlassesTests/LocalModelDownloadManagerTests.swift
+++ b/OpenGlassesTests/LocalModelDownloadManagerTests.swift
@@ -1,0 +1,669 @@
+import CryptoKit
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DZ P2 — the acquisition pipeline end to end, against a temp directory and a fake transport.
+///
+/// The five exit criteria drive the file:
+///  - curated and custom imports use the same state machine;
+///  - pause/relaunch/resume preserves progress, from persisted bytes rather than a callback;
+///  - size, digest, redirect, traversal and revision mismatches cannot produce `.complete`;
+///  - cancellation and deletion affect only the selected plan; and
+///  - the app recovers cleanly from termination during each transition.
+///
+/// No test touches the network, and none exercises a `.shared` service.
+final class LocalModelDownloadManagerTests: XCTestCase {
+
+    private var root: URL!
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    /// Extra roots created mid-test, so nothing is left in the temp directory afterwards.
+    private var scratchRoots: [URL] = []
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dz-download-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        suiteName = "dz.download.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        for scratch in scratchRoots { try? FileManager.default.removeItem(at: scratch) }
+        try? FileManager.default.removeItem(at: root)
+        defaults.removePersistentDomain(forName: suiteName)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Exit criterion 1: one state machine for both origins
+
+    func testCuratedAndImportedModelsInstallThroughTheSamePipeline() async throws {
+        for origin in [LocalModelDownloadPlan.Origin.curatedCatalog, .repositoryImport] {
+            let body = Data("weights-\(origin.rawValue)".utf8)
+            let repository = makeRepository()
+            let transfer = FakeFileTransfer(body: body)
+            let manager = makeManager(repository: repository, transfer: transfer)
+            let descriptor = descriptor(for: body, id: "owner/repo#\(origin.rawValue).gguf")
+
+            let plan = try await manager.createPlan(descriptor: descriptor, origin: origin,
+                                                    fit: fit(descriptor))
+            _ = try await manager.grantConsent(planID: plan.id)
+            let outcome = await manager.run(planID: plan.id)
+            let finished = try XCTUnwrap(outcome)
+
+            XCTAssertEqual(finished.state, .installed, origin.rawValue)
+            let installation = try XCTUnwrap(repository.installation(for: descriptor.id))
+            XCTAssertEqual(installation.validatedFiles.count, 1)
+            XCTAssertEqual(installation.descriptor.revision, descriptor.revision)
+            // The weights are where the backend will look for them, byte-identical.
+            let installed = repository.directory(for: installation)
+                .appendingPathComponent("model.gguf")
+            XCTAssertEqual(try Data(contentsOf: installed), body)
+            // And the plan directory is gone once nothing depends on it.
+            XCTAssertFalse(FileManager.default.fileExists(
+                atPath: repository.stagingRoot.appendingPathComponent(plan.id.uuidString).path))
+        }
+    }
+
+    func testOnlyOnePlanMayBeActiveAtATime() async throws {
+        let repository = makeRepository()
+        let manager = makeManager(repository: repository, transfer: FakeFileTransfer(body: Data("a".utf8)))
+        let first = try await manager.createPlan(descriptor: descriptor(for: Data("a".utf8)),
+                                                 origin: .curatedCatalog,
+                                                 fit: fit(descriptor(for: Data("a".utf8))))
+        let second = descriptor(for: Data("b".utf8), id: "owner/repo#second.gguf")
+        do {
+            _ = try await manager.createPlan(descriptor: second, origin: .repositoryImport,
+                                             fit: fit(second))
+            XCTFail("a second concurrent plan must be refused")
+        } catch let error as LocalModelDownloadManager.ManagerError {
+            XCTAssertEqual(error, .anotherPlanActive(first.id))
+        }
+    }
+
+    func testAPlanIsRefusedWhenTheFitReportSaysNo() async throws {
+        let repository = makeRepository()
+        let manager = makeManager(repository: repository, transfer: FakeFileTransfer(body: Data()))
+        let descriptor = descriptor(for: Data("a".utf8))
+        // The unreadable-free-space case: the fit is not installable, so no plan exists at all.
+        let refusedFit = LocalModelFitReport.make(.init(descriptor: descriptor,
+                                                        availableStorageBytes: nil,
+                                                        availableProcessBytes: 8_000_000_000))
+        do {
+            _ = try await manager.createPlan(descriptor: descriptor, origin: .repositoryImport,
+                                             fit: refusedFit)
+            XCTFail("an uninstallable fit must not produce a plan")
+        } catch let error as LocalModelDownloadManager.ManagerError {
+            XCTAssertEqual(error, .fitRefused([.freeSpaceUnreadable]))
+        }
+        let plans = await manager.plans()
+        XCTAssertTrue(plans.isEmpty)
+    }
+
+    func testConsentIsRequiredBeforeAnyByteMoves() async throws {
+        let body = Data("weights".utf8)
+        let repository = makeRepository()
+        let transfer = FakeFileTransfer(body: body)
+        let manager = makeManager(repository: repository, transfer: transfer)
+        let descriptor = descriptor(for: body, license: LocalModelLicenseSummary(
+            displayName: "Custom", summary: "…", requiresAcceptance: true, revision: "rev-1"))
+
+        let plan = try await manager.createPlan(
+            descriptor: descriptor, origin: .repositoryImport,
+            fit: fit(descriptor, acceptedLicenseRevision: "rev-1"))
+
+        // Consent for the wrong revision, and no consent at all, both leave the plan where it was.
+        await XCTAssertThrowsErrorAsync(try await manager.grantConsent(planID: plan.id))
+        await XCTAssertThrowsErrorAsync(
+            try await manager.grantConsent(planID: plan.id, acceptedLicenseRevision: "rev-0"))
+        let unconsentedOutcome = await manager.run(planID: plan.id)
+        let unconsented = try XCTUnwrap(unconsentedOutcome)
+        XCTAssertEqual(unconsented.state, .failed(.terminal(.consentMissing)))
+        let requests = await transfer.requestedIdentifiers
+        XCTAssertTrue(requests.isEmpty, "nothing may be fetched before consent")
+
+        XCTAssertNil(repository.installation(for: descriptor.id))
+    }
+
+    // MARK: - Exit criterion 3: mismatches cannot produce `.complete`
+
+    func testSizeMismatchCannotProduceAnInstallation() async throws {
+        let (repository, plan) = try await runPlan(body: Data("weights".utf8)) { transfer in
+            await transfer.setResponse(.init(body: Data("weights-but-longer".utf8)))
+        }
+        XCTAssertEqual(plan.state, .failed(.terminal(.sizeMismatch)))
+        assertNothingInstalled(repository)
+    }
+
+    func testDigestMismatchCannotProduceAnInstallation() async throws {
+        // Same length, different bytes: only the digest can catch this one.
+        let (repository, plan) = try await runPlan(body: Data("weights".utf8)) { transfer in
+            await transfer.setResponse(.init(body: Data("WEIGHTS".utf8)))
+        }
+        XCTAssertEqual(plan.state, .failed(.terminal(.digestMismatch)))
+        assertNothingInstalled(repository)
+    }
+
+    func testARedirectToAnotherHostCannotProduceAnInstallation() async throws {
+        let body = Data("weights".utf8)
+        let (repository, plan) = try await runPlan(body: body) { transfer in
+            await transfer.setResponse(.init(body: body,
+                                             finalURL: URL(string: "https://evil.example/model.gguf")))
+        }
+        XCTAssertEqual(plan.state, .failed(.terminal(.redirectHostRejected)))
+        assertNothingInstalled(repository)
+    }
+
+    func testAnInsecureFinalURLCannotProduceAnInstallation() async throws {
+        let body = Data("weights".utf8)
+        let (repository, plan) = try await runPlan(body: body) { transfer in
+            await transfer.setResponse(.init(body: body,
+                                             finalURL: URL(string: "http://huggingface.co/model.gguf")))
+        }
+        XCTAssertEqual(plan.state, .failed(.terminal(.insecureRedirect)))
+        assertNothingInstalled(repository)
+    }
+
+    func testAnErrorStatusFailsRetryablyAndInstallsNothing() async throws {
+        let body = Data("weights".utf8)
+        let (repository, plan) = try await runPlan(body: body) { transfer in
+            await transfer.setResponse(.init(body: body, statusCode: 503))
+        }
+        XCTAssertEqual(plan.state, .failed(.retryable(.httpStatus)))
+        assertNothingInstalled(repository)
+    }
+
+    func testAnUnpinnedRevisionCannotProduceAnInstallationAndNeverReachesTheNetwork() async throws {
+        let body = Data("weights".utf8)
+        let repository = makeRepository()
+        let transfer = FakeFileTransfer(body: body)
+        let manager = makeManager(repository: repository, transfer: transfer)
+        // A branch name passes the descriptor's own fault check (it is "pinned" in the sense of not
+        // being the legacy sentinel) but can never resolve to an exact file URL.
+        let descriptor = descriptor(for: body, revision: "main")
+
+        let plan = try await manager.createPlan(descriptor: descriptor, origin: .repositoryImport,
+                                                fit: fit(descriptor))
+        _ = try await manager.grantConsent(planID: plan.id)
+        let outcome = await manager.run(planID: plan.id)
+        let finished = try XCTUnwrap(outcome)
+
+        XCTAssertEqual(finished.state, .failed(.terminal(.revisionMismatch)))
+        let requests = await transfer.requestedIdentifiers
+        XCTAssertTrue(requests.isEmpty)
+        assertNothingInstalled(repository)
+    }
+
+    func testATraversalPathInAStoredPlanIsRefusedBeforeAnyRequest() async throws {
+        let repository = makeRepository()
+        let transfer = FakeFileTransfer(body: Data("weights".utf8))
+        let manager = makeManager(repository: repository, transfer: transfer)
+
+        // A plan whose file escapes its own staging directory cannot be built through the public
+        // API, so it is written straight to disk — the shape a tampered or corrupted plan has.
+        let planID = UUID()
+        try writeRawPlan(planID: planID, in: repository, state: ["name": "queued"]) { stored in
+            var json = stored
+            var files = (json["files"] as? [[String: Any]]) ?? []
+            files[0]["relativePath"] = "../../escape.gguf"
+            json["files"] = files
+            return json
+        }
+
+        let outcome = await manager.run(planID: planID)
+        let finished = try XCTUnwrap(outcome)
+        XCTAssertEqual(finished.state, .failed(.terminal(.containmentRefused)))
+        let requests = await transfer.requestedIdentifiers
+        XCTAssertTrue(requests.isEmpty, "containment is checked before the fetch, not after")
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("escape.gguf").path))
+    }
+
+    // MARK: - Exit criterion 4: cancellation and deletion are scoped
+
+    func testCancellationTouchesOnlyTheSelectedPlan() async throws {
+        let repository = makeRepository()
+        let transfer = FakeFileTransfer(body: Data("weights".utf8))
+        let manager = makeManager(repository: repository, transfer: transfer)
+
+        let cancelled = UUID()
+        let bystander = UUID()
+        try writeRawPlan(planID: cancelled, in: repository, state: ["name": "queued"])
+        try writeRawPlan(planID: bystander, in: repository, state: ["name": "awaitingConsent"])
+
+        let cancelOutcome = await manager.cancel(planID: cancelled)
+        let result = try XCTUnwrap(cancelOutcome)
+        XCTAssertEqual(result.state, .cancelled)
+        let cancelledPlans = await transfer.cancelledPlans
+        XCTAssertEqual(cancelledPlans, [cancelled], "only the selected plan's tasks are cancelled")
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: repository.stagingRoot.appendingPathComponent(cancelled.uuidString).path))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: repository.stagingRoot.appendingPathComponent(bystander.uuidString).path))
+    }
+
+    func testDeletionRemovesOnlyTheSelectedModelAndUnloadsItFirst() async throws {
+        let repository = makeRepository()
+        let unloaded = UnloadRecorder()
+        let manager = makeManager(repository: repository,
+                                  transfer: FakeFileTransfer(body: Data("a".utf8)),
+                                  unloadIfResident: { id in await unloaded.record(id) })
+
+        let keptID = try await install(body: Data("kept".utf8), id: "owner/repo#kept.gguf",
+                                       repository: repository)
+        let doomedID = try await install(body: Data("doomed".utf8), id: "owner/repo#doomed.gguf",
+                                          repository: repository)
+
+        try await manager.deleteInstallation(doomedID)
+
+        XCTAssertNil(repository.installation(for: doomedID))
+        XCTAssertNotNil(repository.installation(for: keptID))
+        let recorded = await unloaded.ids
+        XCTAssertEqual(recorded, [doomedID], "the model is released before its files go")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: repository.directory(for: doomedID).path))
+
+        // Deleting something that is not installed is a typed error, not a silent success.
+        await XCTAssertThrowsErrorAsync(
+            try await manager.deleteInstallation(LocalModelID("owner/repo#never.gguf"))) {
+            XCTAssertEqual($0 as? LocalModelDownloadManager.ManagerError,
+                           .installationNotFound(LocalModelID("owner/repo#never.gguf")))
+        }
+    }
+
+    // MARK: - Exit criterion 2: pause, relaunch, resume
+
+    func testProgressSurvivesRelaunchAndOnlyTheUnfinishedFileIsRefetched() async throws {
+        let repository = makeRepository()
+        let first = Data("first-file".utf8)
+        let second = Data("second-file".utf8)
+        let descriptor = descriptor(files: [(name: "a.gguf", body: first), (name: "b.gguf", body: second)])
+
+        // The state a termination mid-download leaves: one file staged and validated, the plan
+        // recorded as working on the second.
+        let planID = UUID()
+        var plan = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor,
+                                                        origin: .curatedCatalog, id: planID))
+        plan.markValidated(fileIndex: 0, byteCount: Int64(first.count))
+        plan.state = .downloading(fileIndex: 1)
+        try writePlan(plan, in: repository)
+        let filesDirectory = repository.stagingRoot.appendingPathComponent(planID.uuidString)
+            .appendingPathComponent(LocalModelDownloadPlan.filesDirectoryName)
+        try FileManager.default.createDirectory(at: filesDirectory, withIntermediateDirectories: true)
+        try first.write(to: filesDirectory.appendingPathComponent("a.gguf"))
+
+        // A fresh manager, as after a relaunch: no in-memory callbacks survive, only the plan file.
+        let transfer = FakeFileTransfer(body: second)
+        let manager = makeManager(repository: repository, transfer: transfer)
+        let restored = await manager.restore()
+        XCTAssertEqual(restored.count, 1)
+        XCTAssertEqual(restored[0].recovery, .resumeDownload(fileIndex: 1))
+        XCTAssertEqual(restored[0].plan.completedBytes, Int64(first.count),
+                       "progress comes from the bytes on disk, not from a callback")
+        XCTAssertGreaterThan(restored[0].plan.fractionCompleted, 0)
+
+        let outcome = await manager.run(planID: planID)
+        let finished = try XCTUnwrap(outcome)
+        XCTAssertEqual(finished.state, .installed)
+        let requested = await transfer.requestedIdentifiers
+        XCTAssertEqual(requested, [LocalModelTransferIdentifier(planID: planID, fileIndex: 1)],
+                       "a validated file is not fetched again")
+    }
+
+    func testAStagedFileThatNoLongerMatchesIsNotTrustedAfterRelaunch() async throws {
+        let repository = makeRepository()
+        let body = Data("weights".utf8)
+        let planID = UUID()
+        var plan = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor(for: body),
+                                                        origin: .curatedCatalog, id: planID))
+        plan.markValidated(fileIndex: 0, byteCount: Int64(body.count))
+        plan.state = .installing
+        try writePlan(plan, in: repository)
+        // The staged file is truncated — the bytes the digest was computed over are gone.
+        let filesDirectory = repository.stagingRoot.appendingPathComponent(planID.uuidString)
+            .appendingPathComponent(LocalModelDownloadPlan.filesDirectoryName)
+        try FileManager.default.createDirectory(at: filesDirectory, withIntermediateDirectories: true)
+        try Data("wei".utf8).write(to: filesDirectory.appendingPathComponent("model.gguf"))
+
+        let manager = makeManager(repository: repository, transfer: FakeFileTransfer(body: body))
+        let restored = await manager.restore()
+        XCTAssertEqual(restored.first?.recovery, .resumeDownload(fileIndex: 0))
+        assertNothingInstalled(repository)
+    }
+
+    // MARK: - Exit criterion 5: recovery from termination at every transition
+
+    func testRecoveryFromTerminationAtEveryTransition() async throws {
+        let states: [(name: String, extra: [String: Any], expected: LocalModelDownloadPlan.Recovery)] = [
+            ("planned", [:], .awaitUser),
+            ("awaitingConsent", [:], .awaitUser),
+            ("queued", [:], .resumeDownload(fileIndex: 0)),
+            ("downloading", ["fileIndex": 0], .resumeDownload(fileIndex: 0)),
+            ("validating", ["fileIndex": 0], .resumeDownload(fileIndex: 0)),
+            ("installing", [:], .resumeDownload(fileIndex: 0)),
+            ("installed", [:], .discard),
+            ("cancelled", [:], .discard),
+            ("failed", ["failureReason": "transport", "isRetryable": true], .offerRetry(.transport)),
+            ("failed", ["failureReason": "digestMismatch", "isRetryable": false], .discard),
+        ]
+
+        for testCase in states {
+            // A fresh root per row: plans from earlier rows would otherwise still be on disk and
+            // the "nothing left" assertions would be about the wrong plan.
+            scratchRoots.append(root)
+            root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("dz-download-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let repository = makeRepository()
+            let manager = makeManager(repository: repository,
+                                      transfer: FakeFileTransfer(body: Data("weights".utf8)))
+            let planID = UUID()
+            var state: [String: Any] = ["name": testCase.name]
+            state.merge(testCase.extra) { _, new in new }
+            try writeRawPlan(planID: planID, in: repository, state: state)
+
+            let restored = await manager.restore()
+            let mine = restored.first { $0.plan.id == planID }
+            switch testCase.expected {
+            case .discard:
+                XCTAssertNil(mine, "\(testCase.name) should be discarded")
+                XCTAssertFalse(FileManager.default.fileExists(
+                    atPath: repository.stagingRoot.appendingPathComponent(planID.uuidString).path))
+            default:
+                XCTAssertEqual(mine?.recovery, testCase.expected, testCase.name)
+            }
+            // Whatever the state, nothing was published as installed by recovering.
+            assertNothingInstalled(repository)
+        }
+    }
+
+    func testAnInstallInterruptedAfterTheMoveIsFinishedByRecovery() async throws {
+        // The one interruption that leaves files in place without a marker: the directory moved,
+        // the process died before `.complete`. Recovery must finish it, not fail it.
+        let repository = makeRepository()
+        let body = Data("weights".utf8)
+        let descriptor = descriptor(for: body)
+        let planID = UUID()
+        var plan = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor,
+                                                        origin: .curatedCatalog, id: planID))
+        plan.markValidated(fileIndex: 0, byteCount: Int64(body.count))
+        plan.state = .installing
+        try writePlan(plan, in: repository)
+
+        // Files and manifest already in the installed directory; marker absent.
+        let installed = repository.directory(for: descriptor.id)
+        try FileManager.default.createDirectory(at: installed, withIntermediateDirectories: true)
+        try body.write(to: installed.appendingPathComponent("model.gguf"))
+        let installation = InstalledLocalModel(
+            descriptor: descriptor,
+            storage: .managed(directoryName: descriptor.id.storageComponent),
+            installedAt: Date(timeIntervalSince1970: 1_000),
+            validatedFiles: plan.files.map(\.modelFile))
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        try encoder.encode(installation)
+            .write(to: installed.appendingPathComponent(LocalModelRepository.manifestFileName))
+
+        XCTAssertNil(repository.installation(for: descriptor.id),
+                     "without the marker the model is not installed — the marker is written last")
+
+        let manager = makeManager(repository: repository, transfer: FakeFileTransfer(body: body))
+        _ = await manager.restore()
+        XCTAssertNotNil(repository.installation(for: descriptor.id))
+    }
+
+    func testTheMarkerIsTheLastThingWrittenSoAHalfInstallIsNeverPresented() throws {
+        let repository = makeRepository()
+        let body = Data("weights".utf8)
+        let descriptor = descriptor(for: body)
+        let staging = repository.stagingRoot.appendingPathComponent("staged", isDirectory: true)
+        try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+        try body.write(to: staging.appendingPathComponent("model.gguf"))
+
+        let installation = InstalledLocalModel(
+            descriptor: descriptor,
+            storage: .managed(directoryName: descriptor.id.storageComponent),
+            installedAt: Date(timeIntervalSince1970: 1_000),
+            validatedFiles: descriptor.files)
+        try repository.install(installation, movingContentsOf: staging)
+
+        let directory = repository.directory(for: descriptor.id)
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent(LocalModelRepository.completionMarkerName).path))
+        XCTAssertNotNil(repository.installation(for: descriptor.id))
+
+        // Remove the marker and the installation disappears from view, files and manifest intact.
+        try FileManager.default.removeItem(
+            at: directory.appendingPathComponent(LocalModelRepository.completionMarkerName))
+        XCTAssertNil(repository.installation(for: descriptor.id))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent("model.gguf").path))
+    }
+
+    func testReinstallingReplacesTheDirectoryWithoutEverLosingBothCopies() throws {
+        let repository = makeRepository()
+        let descriptor = descriptor(for: Data("v1".utf8))
+        for body in [Data("v1".utf8), Data("v2-longer".utf8)] {
+            let staging = repository.stagingRoot
+                .appendingPathComponent("staged-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+            try body.write(to: staging.appendingPathComponent("model.gguf"))
+            try repository.install(InstalledLocalModel(
+                descriptor: descriptor,
+                storage: .managed(directoryName: descriptor.id.storageComponent),
+                installedAt: Date(timeIntervalSince1970: 1_000),
+                validatedFiles: descriptor.files), movingContentsOf: staging)
+            XCTAssertNotNil(repository.installation(for: descriptor.id))
+        }
+        let installed = repository.directory(for: descriptor.id).appendingPathComponent("model.gguf")
+        XCTAssertEqual(try Data(contentsOf: installed), Data("v2-longer".utf8))
+    }
+
+    // MARK: - Digest
+
+    func testDigestIsStreamedAndAgreesWithTheOneShotHash() throws {
+        // Bigger than the read chunk, so the incremental path is the one under test.
+        var body = Data()
+        for index in 0..<(LocalModelDigest.chunkBytes / 8 + 1_000) {
+            withUnsafeBytes(of: UInt64(index)) { body.append(contentsOf: $0) }
+        }
+        let url = root.appendingPathComponent("big.bin")
+        try body.write(to: url)
+        let expected = SHA256.hash(data: body).map { String(format: "%02x", $0) }.joined()
+        XCTAssertEqual(try LocalModelDigest.sha256(ofFileAt: url), expected)
+    }
+
+    // MARK: - Helpers
+
+    private func makeRepository() -> LocalModelRepository {
+        LocalModelRepository(root: root, defaults: defaults, legacyModelIDs: { [] },
+                             now: { Date(timeIntervalSince1970: 2_000) })
+    }
+
+    private func makeManager(repository: LocalModelRepository,
+                             transfer: FakeFileTransfer,
+                             unloadIfResident: @escaping @Sendable (LocalModelID) async -> Void = { _ in })
+        -> LocalModelDownloadManager {
+        LocalModelDownloadManager(repository: repository,
+                                  transfer: transfer,
+                                  now: { Date(timeIntervalSince1970: 2_000) },
+                                  unloadIfResident: unloadIfResident)
+    }
+
+    /// Run a single-file plan whose transport is configured by `configure`, returning the outcome.
+    private func runPlan(body: Data,
+                         configure: (FakeFileTransfer) async -> Void)
+        async throws -> (LocalModelRepository, LocalModelDownloadPlan) {
+        let repository = makeRepository()
+        let transfer = FakeFileTransfer(body: body)
+        await configure(transfer)
+        let manager = makeManager(repository: repository, transfer: transfer)
+        let descriptor = descriptor(for: body)
+        let plan = try await manager.createPlan(descriptor: descriptor, origin: .repositoryImport,
+                                                fit: fit(descriptor))
+        _ = try await manager.grantConsent(planID: plan.id)
+        let outcome = await manager.run(planID: plan.id)
+        return (repository, try XCTUnwrap(outcome))
+    }
+
+    /// Install a model through the real pipeline, returning its id.
+    private func install(body: Data, id: String,
+                         repository: LocalModelRepository) async throws -> LocalModelID {
+        let manager = makeManager(repository: repository, transfer: FakeFileTransfer(body: body))
+        let descriptor = descriptor(for: body, id: id)
+        let plan = try await manager.createPlan(descriptor: descriptor, origin: .curatedCatalog,
+                                                fit: fit(descriptor))
+        _ = try await manager.grantConsent(planID: plan.id)
+        let outcome = await manager.run(planID: plan.id)
+        let finished = try XCTUnwrap(outcome)
+        XCTAssertEqual(finished.state, .installed)
+        return descriptor.id
+    }
+
+    private func assertNothingInstalled(_ repository: LocalModelRepository,
+                                        file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertTrue(repository.installedModels().isEmpty,
+                      "no failure path may publish an installation", file: file, line: line)
+        let markers = (try? FileManager.default.subpathsOfDirectory(atPath: root.path))?
+            .filter { $0.hasSuffix(LocalModelRepository.completionMarkerName) } ?? []
+        XCTAssertTrue(markers.isEmpty, "a `.complete` marker exists where it must not",
+                      file: file, line: line)
+    }
+
+    private func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func descriptor(for body: Data,
+                            id: String = "owner/repo#model.gguf",
+                            revision: String = String(repeating: "b", count: 40),
+                            license: LocalModelLicenseSummary = .unverified) -> LocalModelDescriptor {
+        LocalModelDescriptor(
+            id: LocalModelID(id),
+            displayName: "Test model",
+            runtime: .llamaCpp,
+            repositoryID: "owner/repo",
+            revision: revision,
+            files: [LocalModelFile(relativePath: "model.gguf",
+                                   byteCount: Int64(body.count),
+                                   sha256: sha256(body),
+                                   role: .weights)],
+            quantization: "Q4_K_M",
+            capabilities: [.text],
+            contextLength: 4096,
+            estimatedWeightsBytes: Int64(body.count),
+            estimatedWorkingBytes: 1,
+            minimumHeadroomBytes: 0,
+            license: license)
+    }
+
+    private func descriptor(files: [(name: String, body: Data)]) -> LocalModelDescriptor {
+        LocalModelDescriptor(
+            id: LocalModelID("owner/repo#multi.gguf"),
+            displayName: "Multi-file model",
+            runtime: .llamaCpp,
+            repositoryID: "owner/repo",
+            revision: String(repeating: "b", count: 40),
+            files: files.map {
+                LocalModelFile(relativePath: $0.name, byteCount: Int64($0.body.count),
+                               sha256: sha256($0.body), role: .weights)
+            },
+            quantization: "Q4_K_M",
+            capabilities: [.text],
+            contextLength: 4096,
+            estimatedWeightsBytes: Int64(files.reduce(0) { $0 + $1.body.count }),
+            estimatedWorkingBytes: 1,
+            minimumHeadroomBytes: 0)
+    }
+
+    private func fit(_ descriptor: LocalModelDescriptor,
+                     acceptedLicenseRevision: String? = nil) -> LocalModelFitReport {
+        LocalModelFitReport.make(.init(descriptor: descriptor,
+                                       availableStorageBytes: 64_000_000_000,
+                                       availableProcessBytes: 8_000_000_000,
+                                       acceptedLicenseRevision: acceptedLicenseRevision))
+    }
+
+    private func writePlan(_ plan: LocalModelDownloadPlan,
+                           in repository: LocalModelRepository) throws {
+        let directory = repository.stagingRoot.appendingPathComponent(plan.id.uuidString,
+                                                                      isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(plan).write(to: directory.appendingPathComponent(LocalModelDownloadPlan.fileName))
+    }
+
+    /// Write a plan straight to disk, optionally mangling the JSON — the shape a tampered or
+    /// half-written plan file has, which the public API deliberately cannot produce.
+    private func writeRawPlan(planID: UUID,
+                              in repository: LocalModelRepository,
+                              state: [String: Any],
+                              transform: ([String: Any]) -> [String: Any] = { $0 }) throws {
+        var plan = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor(for: Data("weights".utf8)),
+                                                        origin: .curatedCatalog, id: planID))
+        plan.state = .queued
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        var json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoder.encode(plan))
+                                    as? [String: Any])
+        json["state"] = state
+        json = transform(json)
+
+        let directory = repository.stagingRoot.appendingPathComponent(planID.uuidString,
+                                                                      isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+            .write(to: directory.appendingPathComponent(LocalModelDownloadPlan.fileName))
+    }
+}
+
+/// Records the ids handed to the unload hook, so "deletion releases the model first" is observable.
+actor UnloadRecorder {
+    private(set) var ids: [LocalModelID] = []
+    func record(_ id: LocalModelID) { ids.append(id) }
+}
+
+/// A transport that answers from memory. Every field an outcome carries is settable, because the
+/// manager's job is to re-check all of them.
+actor FakeFileTransfer: LocalModelFileTransferring {
+
+    struct Response {
+        var body: Data
+        var statusCode: Int = 200
+        var finalURL: URL?
+        /// Byte count the transport *claims*, when it should differ from what it wrote.
+        var reportedBytes: Int64?
+        var error: LocalModelFileTransferError?
+    }
+
+    private var response: Response
+    private(set) var requestedIdentifiers: [LocalModelTransferIdentifier] = []
+    private(set) var cancelledPlans: [UUID] = []
+    private var live: [LocalModelTransferIdentifier] = []
+
+    init(body: Data) {
+        self.response = Response(body: body)
+    }
+
+    func setResponse(_ response: Response) { self.response = response }
+    func setLiveIdentifiers(_ identifiers: [LocalModelTransferIdentifier]) { live = identifiers }
+
+    func transfer(_ request: LocalModelFileTransferRequest) async throws -> LocalModelFileTransferOutcome {
+        requestedIdentifiers.append(request.identifier)
+        if let error = response.error { throw error }
+        let temporary = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fake-\(UUID().uuidString).part")
+        try response.body.write(to: temporary)
+        return LocalModelFileTransferOutcome(
+            statusCode: response.statusCode,
+            finalURL: response.finalURL ?? request.url,
+            fileURL: temporary,
+            byteCount: response.reportedBytes ?? Int64(response.body.count))
+    }
+
+    func cancelTasks(forPlan planID: UUID) async { cancelledPlans.append(planID) }
+
+    func liveIdentifiers() async -> [LocalModelTransferIdentifier] { live }
+}

--- a/OpenGlassesTests/LocalModelDownloadPlanTests.swift
+++ b/OpenGlassesTests/LocalModelDownloadPlanTests.swift
@@ -1,0 +1,227 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DZ P2 — the download state machine as a value.
+///
+/// The transition table, the persisted shape and the recovery decision are pure, so "the app
+/// recovers cleanly from termination during each transition" is decided here and merely *observed*
+/// in the manager tests.
+final class LocalModelDownloadPlanTests: XCTestCase {
+
+    // MARK: - Construction
+
+    func testAPlanCannotBeBuiltFromADescriptorThatCannotBeVerified() {
+        // Unpinned revision, missing digest, zero size, escaping path, no files: each is enough on
+        // its own, and each is the reason a download must not start.
+        let unverifiable: [LocalModelDescriptor] = [
+            descriptor(revision: LocalModelDescriptor.floatingRevision),
+            descriptor(files: [LocalModelFile(relativePath: "m.gguf", byteCount: 10, sha256: "", role: .weights)]),
+            descriptor(files: [LocalModelFile(relativePath: "m.gguf", byteCount: 0, sha256: digest, role: .weights)]),
+            descriptor(files: [LocalModelFile(relativePath: "../m.gguf", byteCount: 10, sha256: digest, role: .weights)]),
+            descriptor(files: []),
+        ]
+        for candidate in unverifiable {
+            XCTAssertNil(LocalModelDownloadPlan(descriptor: candidate, origin: .repositoryImport),
+                         candidate.files.first?.relativePath ?? "no files")
+        }
+        XCTAssertNotNil(LocalModelDownloadPlan(descriptor: descriptor(), origin: .curatedCatalog))
+    }
+
+    // MARK: - Transitions
+
+    func testTheAllowedPathIsTheDiagrammedOne() throws {
+        var plan = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor(fileCount: 2),
+                                                        origin: .curatedCatalog))
+        try plan.advance(to: .awaitingConsent)
+        try plan.advance(to: .queued)
+        try plan.advance(to: .downloading(fileIndex: 0))
+        try plan.advance(to: .validating(fileIndex: 0))
+        plan.markValidated(fileIndex: 0, byteCount: 10)
+        try plan.advance(to: .downloading(fileIndex: 1))
+        try plan.advance(to: .validating(fileIndex: 1))
+        plan.markValidated(fileIndex: 1, byteCount: 10)
+        try plan.advance(to: .installing)
+        try plan.advance(to: .installed)
+        XCTAssertEqual(plan.state, .installed)
+        XCTAssertEqual(plan.fractionCompleted, 1)
+    }
+
+    func testForbiddenTransitions() throws {
+        var plan = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor(fileCount: 2),
+                                                        origin: .curatedCatalog))
+        // Consent cannot be skipped, and a file cannot be skipped.
+        XCTAssertThrowsError(try plan.advance(to: .downloading(fileIndex: 0)))
+        try plan.advance(to: .awaitingConsent)
+        try plan.advance(to: .queued)
+        XCTAssertThrowsError(try plan.advance(to: .downloading(fileIndex: 1)),
+                             "files are fetched in order")
+        XCTAssertThrowsError(try plan.advance(to: .installing),
+                             "nothing installs before every file validates")
+
+        // A terminal state is terminal.
+        var installed = plan
+        try installed.advance(to: .downloading(fileIndex: 0))
+        try installed.advance(to: .validating(fileIndex: 0))
+        installed.markValidated(fileIndex: 0, byteCount: 10)
+        try installed.advance(to: .downloading(fileIndex: 1))
+        try installed.advance(to: .validating(fileIndex: 1))
+        installed.markValidated(fileIndex: 1, byteCount: 10)
+        try installed.advance(to: .installing)
+        try installed.advance(to: .installed)
+        XCTAssertThrowsError(try installed.advance(to: .queued))
+        XCTAssertThrowsError(try installed.advance(to: .cancelled),
+                             "an installed model is deleted, not cancelled")
+        XCTAssertThrowsError(try installed.advance(to: .failed(.retryable(.transport))))
+    }
+
+    func testRetryableFailuresMayRequeueAndTerminalOnesMayNot() throws {
+        var retryable = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor(),
+                                                             origin: .curatedCatalog))
+        try retryable.advance(to: .failed(.retryable(.transport)))
+        XCTAssertNoThrow(try retryable.advance(to: .queued))
+
+        var terminal = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor(),
+                                                            origin: .curatedCatalog))
+        try terminal.advance(to: .failed(.terminal(.digestMismatch)))
+        XCTAssertThrowsError(try terminal.advance(to: .queued))
+        XCTAssertNoThrow(try terminal.advance(to: .cancelled), "a dead plan can still be cleared")
+    }
+
+    func testFailureClassificationIsFixedAndDeliberate() {
+        for reason in [LocalModelDownloadPlan.FailureReason.transport, .httpStatus,
+                       .storageUnavailable, .installFailed] {
+            XCTAssertTrue(LocalModelDownloadPlan.Failure.classify(reason).isRetryable, reason.rawValue)
+        }
+        for reason in [LocalModelDownloadPlan.FailureReason.sizeMismatch, .digestMismatch,
+                       .redirectHostRejected, .insecureRedirect, .containmentRefused,
+                       .revisionMismatch, .planUnreadable, .consentMissing, .fitRefused] {
+            XCTAssertFalse(LocalModelDownloadPlan.Failure.classify(reason).isRetryable,
+                           "\(reason.rawValue): refetching the same bytes is not a fix")
+        }
+    }
+
+    // MARK: - Progress and recovery
+
+    func testProgressComesFromPersistedBytes() throws {
+        var plan = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor(fileCount: 2),
+                                                        origin: .curatedCatalog))
+        XCTAssertEqual(plan.fractionCompleted, 0)
+        plan.recordProgress(fileIndex: 0, completedBytes: 5)
+        XCTAssertEqual(plan.fractionCompleted, 0.25, accuracy: 0.0001)
+        plan.markValidated(fileIndex: 0, byteCount: 10)
+        XCTAssertEqual(plan.fractionCompleted, 0.5, accuracy: 0.0001)
+        // A count beyond the file's size cannot inflate the bar.
+        plan.recordProgress(fileIndex: 1, completedBytes: 999)
+        XCTAssertEqual(plan.fractionCompleted, 1, accuracy: 0.0001)
+    }
+
+    func testRecoveryForEveryState() throws {
+        let base = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor(fileCount: 2),
+                                                        origin: .curatedCatalog))
+        func recovery(_ state: LocalModelDownloadPlan.State,
+                      validatedFiles: Int = 0) -> LocalModelDownloadPlan.Recovery {
+            var plan = base
+            for index in 0..<validatedFiles { plan.markValidated(fileIndex: index, byteCount: 10) }
+            plan.state = state
+            return plan.recovery
+        }
+
+        XCTAssertEqual(recovery(.planned), .awaitUser)
+        XCTAssertEqual(recovery(.awaitingConsent), .awaitUser)
+        XCTAssertEqual(recovery(.queued), .resumeDownload(fileIndex: 0))
+        XCTAssertEqual(recovery(.downloading(fileIndex: 0)), .resumeDownload(fileIndex: 0))
+        XCTAssertEqual(recovery(.validating(fileIndex: 0)), .resumeDownload(fileIndex: 0))
+        XCTAssertEqual(recovery(.downloading(fileIndex: 1), validatedFiles: 1),
+                       .resumeDownload(fileIndex: 1))
+        XCTAssertEqual(recovery(.validating(fileIndex: 1), validatedFiles: 2), .finishInstall)
+        XCTAssertEqual(recovery(.installing, validatedFiles: 2), .finishInstall)
+        XCTAssertEqual(recovery(.installing), .resumeDownload(fileIndex: 0),
+                       "\"installing\" is not evidence that the bytes are still there")
+        XCTAssertEqual(recovery(.installed), .discard)
+        XCTAssertEqual(recovery(.cancelled), .discard)
+        XCTAssertEqual(recovery(.failed(.retryable(.transport))), .offerRetry(.transport))
+        XCTAssertEqual(recovery(.failed(.terminal(.digestMismatch))), .discard)
+    }
+
+    // MARK: - Persistence shape
+
+    func testPlanRoundTripsThroughItsStoredForm() throws {
+        var plan = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor(fileCount: 2),
+                                                        origin: .repositoryImport))
+        plan.markValidated(fileIndex: 0, byteCount: 10)
+        plan.acceptedLicenseRevision = "rev"
+        plan.state = .validating(fileIndex: 1)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(LocalModelDownloadPlan.self, from: encoder.encode(plan))
+
+        XCTAssertEqual(decoded.state, .validating(fileIndex: 1))
+        XCTAssertEqual(decoded.files, plan.files)
+        XCTAssertEqual(decoded.origin, .repositoryImport)
+        XCTAssertEqual(decoded.acceptedLicenseRevision, "rev")
+
+        // The stored form is readable, not a synthesized enum blob.
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoder.encode(plan))
+                                    as? [String: Any])
+        let state = try XCTUnwrap(json["state"] as? [String: Any])
+        XCTAssertEqual(state["name"] as? String, "validating")
+        XCTAssertEqual(state["fileIndex"] as? Int, 1)
+    }
+
+    func testAnUnreadableStoredStateBecomesATerminalFailureRatherThanAGuess() throws {
+        var plan = try XCTUnwrap(LocalModelDownloadPlan(descriptor: descriptor(),
+                                                        origin: .curatedCatalog))
+        plan.state = .queued
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        var json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoder.encode(plan))
+                                    as? [String: Any])
+        json["state"] = ["name": "somethingFromTheFuture"]
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(
+            LocalModelDownloadPlan.self,
+            from: JSONSerialization.data(withJSONObject: json))
+        XCTAssertEqual(decoded.state, .failed(.terminal(.planUnreadable)))
+    }
+
+    // MARK: - Transfer identifiers
+
+    func testTransferIdentifiersRoundTripAndRejectRubbish() {
+        let identifier = LocalModelTransferIdentifier(planID: UUID(), fileIndex: 3)
+        XCTAssertEqual(LocalModelTransferIdentifier(identifier.description), identifier)
+        for bad in [nil, "", "not-a-uuid#0", identifier.planID.uuidString,
+                    "\(identifier.planID.uuidString)#x", "\(identifier.planID.uuidString)#-1"] {
+            XCTAssertNil(LocalModelTransferIdentifier(bad), bad ?? "nil")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private let digest = String(repeating: "a", count: 64)
+
+    private func descriptor(revision: String = String(repeating: "b", count: 40),
+                            fileCount: Int = 1,
+                            files: [LocalModelFile]? = nil) -> LocalModelDescriptor {
+        let resolved = files ?? (0..<fileCount).map {
+            LocalModelFile(relativePath: "file\($0).gguf", byteCount: 10, sha256: digest, role: .weights)
+        }
+        return LocalModelDescriptor(
+            id: LocalModelID("owner/repo#file.gguf"),
+            displayName: "Test",
+            runtime: .llamaCpp,
+            repositoryID: "owner/repo",
+            revision: revision,
+            files: resolved,
+            quantization: "Q4_K_M",
+            capabilities: [.text],
+            contextLength: 4096,
+            estimatedWeightsBytes: Int64(10 * max(resolved.count, 1)),
+            estimatedWorkingBytes: 1,
+            minimumHeadroomBytes: 0)
+    }
+}

--- a/OpenGlassesTests/LocalModelFitReportTests.swift
+++ b/OpenGlassesTests/LocalModelFitReportTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DZ P2 — the pre-download fit and consent verdict.
+///
+/// The awkward rows are the reason this is a truth table rather than a couple of happy-path checks:
+/// an unknown size, a missing digest and an *unreadable* free-space reading must each stop an
+/// install, and none of them may be softened into a warning.
+final class LocalModelFitReportTests: XCTestCase {
+
+    private let gigabyte: Int64 = 1_073_741_824
+
+    // MARK: - The facts shown
+
+    func testReportStatesExactSizeRuntimeQuantizationAndCapabilities() {
+        let report = LocalModelFitReport.make(.init(descriptor: descriptor(weightsBytes: 500_000_000),
+                                                    availableStorageBytes: 20 * gigabyte,
+                                                    availableProcessBytes: 4 * gigabyte))
+        XCTAssertEqual(report.downloadBytes, 500_000_000, "the exact sum of declared files, not an estimate")
+        XCTAssertEqual(report.runtime, .llamaCpp)
+        XCTAssertEqual(report.quantization, "Q4_K_M")
+        XCTAssertEqual(report.capabilities, [.text])
+        XCTAssertEqual(report.availableStorageBytes, 20 * gigabyte)
+        XCTAssertTrue(report.canInstall)
+    }
+
+    // MARK: - Blockers
+
+    func testUnknownSizeMissingDigestAndUnpinnedRevisionEachBlockInstallation() {
+        let unknownSize = LocalModelFitReport.make(.init(
+            descriptor: descriptor(files: [file(bytes: 0)]),
+            availableStorageBytes: 20 * gigabyte, availableProcessBytes: 4 * gigabyte))
+        XCTAssertFalse(unknownSize.canInstall)
+        XCTAssertTrue(unknownSize.blockers.contains(.unknownFileSize(relativePath: "m.gguf")))
+
+        let noDigest = LocalModelFitReport.make(.init(
+            descriptor: descriptor(files: [file(sha256: "")]),
+            availableStorageBytes: 20 * gigabyte, availableProcessBytes: 4 * gigabyte))
+        XCTAssertFalse(noDigest.canInstall)
+        XCTAssertTrue(noDigest.blockers.contains(.missingDigest(relativePath: "m.gguf")))
+
+        let unpinned = LocalModelFitReport.make(.init(
+            descriptor: descriptor(revision: LocalModelDescriptor.floatingRevision),
+            availableStorageBytes: 20 * gigabyte, availableProcessBytes: 4 * gigabyte))
+        XCTAssertFalse(unpinned.canInstall)
+        XCTAssertTrue(unpinned.blockers.contains(.unresolvedRevision))
+
+        let noFiles = LocalModelFitReport.make(.init(
+            descriptor: descriptor(files: []),
+            availableStorageBytes: 20 * gigabyte, availableProcessBytes: 4 * gigabyte))
+        XCTAssertTrue(noFiles.blockers.contains(.noFiles))
+    }
+
+    func testUnreadableFreeSpaceIsAnInabilityToCheckNotPermissionToProceed() {
+        let report = LocalModelFitReport.make(.init(descriptor: descriptor(),
+                                                    availableStorageBytes: nil,
+                                                    availableProcessBytes: 8 * gigabyte))
+        XCTAssertFalse(report.canInstall, "a reading nobody could take is not a reading that passed")
+        XCTAssertEqual(report.blockers, [.freeSpaceUnreadable])
+    }
+
+    func testStorageMustCoverTheDownloadPlusAMargin() {
+        let weights: Int64 = 2 * gigabyte
+        // Enough for the file but not for the margin.
+        let tooTight = LocalModelFitReport.make(.init(
+            descriptor: descriptor(weightsBytes: weights, files: [file(bytes: weights)]),
+            availableStorageBytes: weights + 100,
+            availableProcessBytes: 8 * gigabyte))
+        XCTAssertFalse(tooTight.canInstall)
+        XCTAssertEqual(tooTight.blockers,
+                       [.insufficientStorage(neededBytes: weights + LocalModelFitReport.storageMarginBytes,
+                                             freeBytes: weights + 100)])
+
+        // Just over the bar: allowed, but the user is told it will be tight.
+        let tight = LocalModelFitReport.make(.init(
+            descriptor: descriptor(weightsBytes: weights, files: [file(bytes: weights)]),
+            availableStorageBytes: weights + LocalModelFitReport.storageMarginBytes + 1,
+            availableProcessBytes: 8 * gigabyte))
+        XCTAssertTrue(tight.canInstall)
+        XCTAssertTrue(tight.warnings.contains { if case .storageAfterInstallIsTight = $0 { return true }
+                                                return false })
+    }
+
+    func testLicenceAcceptanceGatesInstallationWhenItIsRequired() {
+        let licensed = descriptor(license: LocalModelLicenseSummary(
+            displayName: "Custom terms", summary: "…", requiresAcceptance: true, revision: "rev-1"))
+
+        let unaccepted = LocalModelFitReport.make(.init(descriptor: licensed,
+                                                        availableStorageBytes: 20 * gigabyte,
+                                                        availableProcessBytes: 8 * gigabyte))
+        XCTAssertEqual(unaccepted.blockers, [.licenseNotAccepted])
+        XCTAssertTrue(unaccepted.requiresLicenseAcceptance)
+
+        // Accepting a *different* revision is not accepting this one.
+        let wrongRevision = LocalModelFitReport.make(.init(descriptor: licensed,
+                                                           availableStorageBytes: 20 * gigabyte,
+                                                           availableProcessBytes: 8 * gigabyte,
+                                                           acceptedLicenseRevision: "rev-0"))
+        XCTAssertEqual(wrongRevision.blockers, [.licenseNotAccepted])
+
+        let accepted = LocalModelFitReport.make(.init(descriptor: licensed,
+                                                       availableStorageBytes: 20 * gigabyte,
+                                                       availableProcessBytes: 8 * gigabyte,
+                                                       acceptedLicenseRevision: "rev-1"))
+        XCTAssertTrue(accepted.canInstall)
+    }
+
+    // MARK: - Warnings
+
+    func testAGGUFImportAlwaysWarnsThatItMayInstallAndStillNotLoad() {
+        let report = LocalModelFitReport.make(.init(descriptor: descriptor(),
+                                                    availableStorageBytes: 20 * gigabyte,
+                                                    availableProcessBytes: 8 * gigabyte))
+        XCTAssertTrue(report.warnings.contains(.mayInstallButNotLoad))
+
+        // The MLX path has no unsupported-template failure mode to warn about.
+        let mlx = LocalModelFitReport.make(.init(descriptor: descriptor(runtime: .mlx),
+                                                  availableStorageBytes: 20 * gigabyte,
+                                                  availableProcessBytes: 8 * gigabyte))
+        XCTAssertFalse(mlx.warnings.contains(.mayInstallButNotLoad))
+    }
+
+    func testMemoryVerdictWarnsButDoesNotBlock() {
+        // Weights far beyond what the process may allocate: the files can still be installed,
+        // because memory a minute from now is not memory now.
+        let report = LocalModelFitReport.make(.init(
+            descriptor: descriptor(weightsBytes: 6 * gigabyte, files: [file(bytes: 6 * gigabyte)]),
+            availableStorageBytes: 64 * gigabyte,
+            availableProcessBytes: gigabyte))
+        XCTAssertTrue(report.canInstall)
+        XCTAssertTrue(report.warnings.contains { if case .unlikelyToLoad = $0 { return true }
+                                                 return false })
+        if case .refuse = report.loadVerdict {} else { XCTFail("the load verdict itself must refuse") }
+    }
+
+    func testTightHeadroomIsReportedSeparatelyFromRefusal() {
+        // Fits, but inside the comfort margin.
+        let weights: Int64 = gigabyte
+        let available = weights + LocalModelBudget.workingSetBytes(for: .llamaCpp)
+            + LocalModelBudget.admissionComfortMarginBytes / 2
+        let report = LocalModelFitReport.make(.init(
+            descriptor: descriptor(weightsBytes: weights, minimumHeadroomBytes: 0,
+                                   files: [file(bytes: weights)]),
+            availableStorageBytes: 64 * gigabyte,
+            availableProcessBytes: available))
+        XCTAssertTrue(report.canInstall)
+        XCTAssertTrue(report.warnings.contains { if case .tightMemoryHeadroom = $0 { return true }
+                                                 return false })
+    }
+
+    func testTheVerdictUsesTheSameReserveTheGGUFLoadPathWillUse() {
+        // `minimumHeadroomBytes` is an *additional* reserve for the GGUF runtime, and the load gate
+        // adds it. A pre-download verdict that ignored it would promise a load the backend refuses.
+        let weights: Int64 = gigabyte
+        let reserve: Int64 = 512 * 1024 * 1024
+        let available = weights + LocalModelBudget.workingSetBytes(for: .llamaCpp) + reserve - 1
+        let report = LocalModelFitReport.make(.init(
+            descriptor: descriptor(weightsBytes: weights, minimumHeadroomBytes: reserve,
+                                   files: [file(bytes: weights)]),
+            availableStorageBytes: 64 * gigabyte,
+            availableProcessBytes: available))
+        if case .refuse = report.loadVerdict {} else {
+            XCTFail("the extra reserve must count against the verdict, as it does at load time")
+        }
+        XCTAssertEqual(report.estimatedResidentBytes,
+                       weights + LocalModelBudget.workingSetBytes(for: .llamaCpp) + reserve)
+    }
+
+    func testEveryBlockerAndWarningHasCopy() {
+        let blockers: [LocalModelFitReport.Blocker] = [
+            .unknownFileSize(relativePath: "m.gguf"), .missingDigest(relativePath: "m.gguf"),
+            .unresolvedRevision, .noFiles, .freeSpaceUnreadable,
+            .insufficientStorage(neededBytes: 1, freeBytes: 0), .licenseNotAccepted,
+        ]
+        for blocker in blockers { XCTAssertFalse(blocker.localizedMessage.isEmpty) }
+
+        let warnings: [LocalModelFitReport.Warning] = [
+            .mayInstallButNotLoad, .unlikelyToLoad(neededBytes: 1, availableBytes: 0),
+            .tightMemoryHeadroom(spareBytes: 1), .contextWillBeClamped(toTokens: 2048),
+            .licenseNotSummarized, .storageAfterInstallIsTight(remainingBytes: 1),
+        ]
+        for warning in warnings { XCTAssertFalse(warning.localizedMessage.isEmpty) }
+    }
+
+    // MARK: - Helpers
+
+    private func file(bytes: Int64 = 500_000_000,
+                      sha256: String = String(repeating: "a", count: 64)) -> LocalModelFile {
+        LocalModelFile(relativePath: "m.gguf", byteCount: bytes, sha256: sha256, role: .weights)
+    }
+
+    private func descriptor(runtime: LocalModelRuntime = .llamaCpp,
+                            revision: String = String(repeating: "b", count: 40),
+                            weightsBytes: Int64 = 500_000_000,
+                            minimumHeadroomBytes: Int64 = 0,
+                            files: [LocalModelFile]? = nil,
+                            license: LocalModelLicenseSummary = .unverified) -> LocalModelDescriptor {
+        LocalModelDescriptor(
+            id: LocalModelID("owner/repo#m.gguf"),
+            displayName: "Test model",
+            runtime: runtime,
+            repositoryID: "owner/repo",
+            revision: revision,
+            files: files ?? [file(bytes: weightsBytes)],
+            quantization: "Q4_K_M",
+            capabilities: [.text],
+            contextLength: 4096,
+            estimatedWeightsBytes: weightsBytes,
+            estimatedWorkingBytes: LocalModelBudget.workingSetBytes(for: runtime),
+            minimumHeadroomBytes: minimumHeadroomBytes,
+            license: license)
+    }
+}

--- a/OpenGlassesTests/LocalModelGGUFCatalogTests.swift
+++ b/OpenGlassesTests/LocalModelGGUFCatalogTests.swift
@@ -1,0 +1,194 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DZ P2 — the bundled GGUF catalog and the rules about what an entry may claim.
+///
+/// The catalog is data, so these tests are mostly about the *claims*: every entry is pinned to an
+/// exact revision, every file carries a real digest and an exact size, and no entry wears a
+/// capability badge nobody has demonstrated on a device.
+final class LocalModelGGUFCatalogTests: XCTestCase {
+
+    /// The app bundle, located through a class that lives in the app target.
+    private var appBundle: Bundle { Bundle(for: LocalModelRepository.self) }
+
+    // MARK: - The shipped catalog
+
+    func testBundledCatalogLoadsWithNothingRejected() throws {
+        let url = try XCTUnwrap(appBundle.url(forResource: LocalModelCatalogDocument.resourceName,
+                                              withExtension: "json"),
+                                "LocalModelCatalog.json should be bundled with the app target")
+        let (document, rejected) = try LocalModelCatalogDocument.loadStrict(from: Data(contentsOf: url))
+        XCTAssertEqual(rejected, [], "a shipped entry that the loader refuses is a shipping mistake")
+        XCTAssertEqual(document.version, LocalModelCatalogDocument.currentVersion)
+        XCTAssertFalse(document.entries.isEmpty)
+    }
+
+    func testEveryEntryIsPinnedDigestedAndInstallable() throws {
+        for entry in LocalModelCatalog.bundledGGUFEntries(appBundle) {
+            let descriptor = entry.descriptor
+            let label = descriptor.id.rawValue
+
+            XCTAssertEqual(descriptor.runtime, .llamaCpp, label)
+            XCTAssertTrue(LocalModelRepositoryReference.isValidRevision(descriptor.revision),
+                          "\(label): revision must be an exact 40-character commit")
+            XCTAssertFalse(descriptor.files.isEmpty, label)
+            for file in descriptor.files {
+                XCTAssertGreaterThan(file.byteCount, 0, "\(label): \(file.relativePath)")
+                XCTAssertTrue(LocalModelRepositoryClient.isSHA256(file.sha256),
+                              "\(label): \(file.relativePath) must carry a real SHA-256")
+                XCTAssertEqual(LocalModelPath.normalize(file.relativePath),
+                               .contained(file.relativePath), label)
+            }
+            XCTAssertTrue(descriptor.installationFaults().isEmpty, label)
+            // The gate the downloader itself applies: a catalog entry must be able to become a plan.
+            XCTAssertNotNil(LocalModelDownloadPlan(descriptor: descriptor, origin: .curatedCatalog),
+                            "\(label): a curated entry must be plannable")
+
+            // The repository half of the id is a reference this build would accept as an import.
+            let repositoryID = String(descriptor.id.rawValue.split(separator: "#").first ?? "")
+            XCTAssertEqual(repositoryID, descriptor.repositoryID, label)
+            guard case .success = LocalModelRepositoryReference.parse(descriptor.repositoryID) else {
+                return XCTFail("\(label): repository id is not a reference this app would accept")
+            }
+            // And the id survives the round trip through a directory name.
+            XCTAssertEqual(LocalModelID(storageComponent: descriptor.id.storageComponent),
+                           descriptor.id, label)
+        }
+    }
+
+    func testNoEntryWearsACapabilityBadgeWithoutDeviceEvidence() {
+        for entry in LocalModelCatalog.bundledGGUFEntries(appBundle) {
+            if entry.evidence != .deviceVerified {
+                XCTAssertEqual(entry.descriptor.capabilities, [.text],
+                               "\(entry.descriptor.id.rawValue): badges need fixtures, not a hunch")
+            }
+        }
+    }
+
+    func testShippedContextPolicyStaysWithinWhatTheFileWasTrainedFor() {
+        for entry in LocalModelCatalog.bundledGGUFEntries(appBundle) {
+            guard let trained = entry.trainedContextTokens else { continue }
+            XCTAssertLessThanOrEqual(entry.descriptor.contextLength, trained,
+                                     entry.descriptor.id.rawValue)
+            XCTAssertGreaterThan(entry.descriptor.contextLength, 0)
+        }
+    }
+
+    func testEveryEntryDeclaresALicenceItCanName() {
+        for entry in LocalModelCatalog.bundledGGUFEntries(appBundle) {
+            let license = entry.descriptor.license
+            XCTAssertFalse(license.displayName.isEmpty, entry.descriptor.id.rawValue)
+            XCTAssertFalse(license.summary.isEmpty, entry.descriptor.id.rawValue)
+            if license.requiresAcceptance {
+                XCTAssertNotNil(license.revision,
+                                "\(entry.descriptor.id.rawValue): acceptance needs a revision to accept")
+            }
+        }
+    }
+
+    func testCuratedEntriesAreFitCheckedLikeAnyOtherModel() throws {
+        let entry = try XCTUnwrap(LocalModelCatalog.bundledGGUFEntries(appBundle).first)
+        let generous = LocalModelFitReport.make(.init(descriptor: entry.descriptor,
+                                                      availableStorageBytes: 64_000_000_000,
+                                                      availableProcessBytes: 8_000_000_000))
+        XCTAssertTrue(generous.canInstall)
+        XCTAssertEqual(generous.downloadBytes, entry.descriptor.files.reduce(0) { $0 + $1.byteCount })
+
+        // A curated entry is not exempt from the storage check.
+        let cramped = LocalModelFitReport.make(.init(descriptor: entry.descriptor,
+                                                      availableStorageBytes: 1_000,
+                                                      availableProcessBytes: 8_000_000_000))
+        XCTAssertFalse(cramped.canInstall)
+    }
+
+    // MARK: - What the loader refuses
+
+    func testLoaderRefusesEntriesThatOverclaimOrCannotBeVerified() throws {
+        let cases: [(name: String, mutate: (inout [String: Any]) -> Void)] = [
+            ("tool badge without device evidence", { $0["capabilities"] = ["text", "toolFriendly"] }),
+            ("vision badge without device evidence", { $0["capabilities"] = ["text", "vision"] }),
+            ("missing digest", { json in
+                var files = json["files"] as! [[String: Any]]
+                files[0]["sha256"] = ""
+                json["files"] = files
+            }),
+            ("zero size", { json in
+                var files = json["files"] as! [[String: Any]]
+                files[0]["byteCount"] = 0
+                json["files"] = files
+            }),
+            ("unpinned revision", { $0["revision"] = LocalModelDescriptor.floatingRevision }),
+            ("escaping path", { json in
+                var files = json["files"] as! [[String: Any]]
+                files[0]["relativePath"] = "../escape.gguf"
+                json["files"] = files
+            }),
+            ("acceptance with no licence revision", { json in
+                json["license"] = ["displayName": "Custom", "summary": "…",
+                                   "requiresAcceptance": true]
+            }),
+        ]
+
+        for testCase in cases {
+            var entry = validEntryJSON
+            testCase.mutate(&entry)
+            let data = try JSONSerialization.data(withJSONObject: ["version": 1, "models": [entry]])
+            let (document, rejected) = try LocalModelCatalogDocument.loadStrict(from: data)
+            XCTAssertTrue(document.entries.isEmpty, testCase.name)
+            XCTAssertEqual(rejected.count, 1, testCase.name)
+        }
+    }
+
+    func testADeviceVerifiedEntryMayCarryItsBadges() throws {
+        var entry = validEntryJSON
+        entry["capabilities"] = ["text", "toolFriendly"]
+        entry["evidence"] = "deviceVerified"
+        let data = try JSONSerialization.data(withJSONObject: ["version": 1, "models": [entry]])
+        let (document, rejected) = try LocalModelCatalogDocument.loadStrict(from: data)
+        XCTAssertEqual(rejected, [])
+        XCTAssertEqual(document.entries.first?.descriptor.capabilities, [.text, .toolFriendly])
+    }
+
+    func testDuplicateIDsAndMalformedRowsAreDroppedNotFatal() throws {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "version": 1,
+            "models": [validEntryJSON, validEntryJSON, ["id": "broken"]],
+        ])
+        let (document, rejected) = try LocalModelCatalogDocument.loadStrict(from: data)
+        XCTAssertEqual(document.entries.count, 1)
+        XCTAssertEqual(rejected.count, 1, "the malformed row fails to decode and never reaches validation")
+        XCTAssertTrue(rejected[0].contains("duplicate id"))
+    }
+
+    func testAMissingResourceIsAnEmptyCatalogNotACrash() {
+        XCTAssertNil(LocalModelCatalog.bundledGGUFDocument(Bundle(for: XCTestCase.self)))
+        XCTAssertTrue(LocalModelCatalog.bundledGGUFEntries(Bundle(for: XCTestCase.self)).isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private var validEntryJSON: [String: Any] {
+        [
+            "id": "owner/repo#model-q4_k_m.gguf",
+            "displayName": "Test model",
+            "repositoryID": "owner/repo",
+            "revision": String(repeating: "b", count: 40),
+            "quantization": "Q4_K_M",
+            "capabilities": ["text"],
+            "contextLength": 4096,
+            "estimatedWeightsBytes": 1_000,
+            "estimatedWorkingBytes": 2_000,
+            "minimumHeadroomBytes": 0,
+            "files": [["relativePath": "model-q4_k_m.gguf",
+                       "byteCount": 1_000,
+                       "sha256": String(repeating: "a", count: 64),
+                       "role": "weights"]],
+            "license": ["displayName": "Apache License 2.0", "summary": "Permissive.",
+                        "requiresAcceptance": false,
+                        "revision": String(repeating: "b", count: 40)],
+            "notes": "Test",
+            "minimumRAMGB": 4,
+            "evidence": "fileMetadataOnly",
+        ]
+    }
+}

--- a/OpenGlassesTests/LocalModelImportParsingTests.swift
+++ b/OpenGlassesTests/LocalModelImportParsingTests.swift
@@ -1,0 +1,409 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DZ P2 — the repository importer's parsing half.
+///
+/// The rejection table is the point: every rule in the plan's "Import parsing" section gets its own
+/// case, because a host allowlist with one untested hole is a host allowlist that does not exist.
+/// Nothing here touches the network — the two fetches are behind a protocol and the enumeration
+/// rules are exercised against fixtures.
+final class LocalModelImportParsingTests: XCTestCase {
+
+    // MARK: - Accepted forms
+
+    func testShorthandAndURLFormsResolveToTheSameReference() {
+        let expected = LocalModelRepositoryReference(host: "huggingface.co",
+                                                     owner: "Qwen",
+                                                     repository: "Qwen2.5-0.5B-Instruct-GGUF")
+        for input in ["Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+                      "  Qwen/Qwen2.5-0.5B-Instruct-GGUF  ",
+                      "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+                      "https://www.huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+                      "https://hf.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+                      "https://HuggingFace.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF",
+                      "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF.git"] {
+            switch LocalModelRepositoryReference.parse(input) {
+            case .success(let reference):
+                XCTAssertEqual(reference, expected, "input: \(input)")
+            case .failure(let rejection):
+                XCTFail("\(input) should parse, got \(rejection)")
+            }
+        }
+    }
+
+    // MARK: - The rejection table
+
+    func testRejectionTable() {
+        let cases: [(input: String, expected: LocalModelImportRejection)] = [
+            ("", .empty),
+            ("   ", .empty),
+            ("owner repo", .notAURL),
+            ("owner", .notAURL),
+            ("huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF", .missingScheme),
+            ("hf.co/owner/repo", .missingScheme),
+            ("owner/repo/tree/main", .pathOutsideRepositoryForm),
+            ("http://huggingface.co/owner/repo", .disallowedScheme("http")),
+            ("ftp://huggingface.co/owner/repo", .disallowedScheme("ftp")),
+            ("file:///etc/passwd", .disallowedScheme("file")),
+            ("javascript://huggingface.co/owner/repo", .disallowedScheme("javascript")),
+            ("https://user:secret@huggingface.co/owner/repo", .embeddedCredentials),
+            ("https://huggingface.co/owner/repo?token=abc", .queryNotAllowed),
+            ("https://huggingface.co/owner/repo#anchor", .fragmentNotAllowed),
+            ("https://evil.example.com/owner/repo", .disallowedHost("evil.example.com")),
+            // A lookalike subdomain is not the allowlisted host.
+            ("https://huggingface.co.evil.example/owner/repo", .disallowedHost("huggingface.co.evil.example")),
+            ("https://cdn-lfs.huggingface.co/owner/repo", .disallowedHost("cdn-lfs.huggingface.co")),
+            ("https://127.0.0.1/owner/repo", .privateOrReservedHost("127.0.0.1")),
+            ("https://192.168.1.1/owner/repo", .privateOrReservedHost("192.168.1.1")),
+            ("https://169.254.169.254/owner/repo", .privateOrReservedHost("169.254.169.254")),
+            ("https://localhost/owner/repo", .privateOrReservedHost("localhost")),
+            ("https://huggingface.co/owner", .pathOutsideRepositoryForm),
+            ("https://huggingface.co/owner/repo/tree/main", .pathOutsideRepositoryForm),
+            ("https://huggingface.co/owner/repo/resolve/main/model.gguf", .pathOutsideRepositoryForm),
+            // Traversal, plain and percent-encoded: both leave the repository form.
+            ("https://huggingface.co/owner/../../etc/passwd", .pathOutsideRepositoryForm),
+            ("https://huggingface.co/%2e%2e/%2e%2e/etc", .pathOutsideRepositoryForm),
+            ("../owner/repo", .pathOutsideRepositoryForm),
+            ("..%2Frepo", .notAURL),
+            ("-owner/repo", .malformedOwner),
+            ("ow ner/repo", .notAURL),
+            ("owner/re;po", .malformedRepository),
+            ("owner/re..po", .malformedRepository),
+            ("owner/", .malformedRepository),
+            ("/repo", .malformedOwner),
+        ]
+
+        for testCase in cases {
+            switch LocalModelRepositoryReference.parse(testCase.input) {
+            case .success(let reference):
+                XCTFail("\(testCase.input) should be refused, parsed as \(reference.repositoryID)")
+            case .failure(let rejection):
+                XCTAssertEqual(rejection, testCase.expected, "input: \(testCase.input)")
+            }
+        }
+    }
+
+    /// A site route that *happens* to have two path segments parses as a reference, and that is
+    /// deliberate: structure cannot tell `owner/repo` from an app route, and a denylist of the
+    /// host's own pages would be a list to maintain forever. Resolution is what settles it — the
+    /// first thing the planner does is ask the metadata API, which has no such repository.
+    func testARouteShapedLikeARepositoryIsLeftForResolutionToRefuse() {
+        guard case .success(let reference) =
+                LocalModelRepositoryReference.parse("https://huggingface.co/settings/tokens") else {
+            return XCTFail("a two-segment path is structurally a repository reference")
+        }
+        XCTAssertEqual(reference.repositoryID, "settings/tokens")
+    }
+
+    func testEveryRejectionHasUserFacingCopyThatDoesNotEchoTheInput() {
+        let rejections: [LocalModelImportRejection] = [
+            .empty, .notAURL, .missingScheme, .disallowedScheme("gopher"), .embeddedCredentials,
+            .queryNotAllowed, .fragmentNotAllowed, .disallowedHost("evil.example"),
+            .privateOrReservedHost("10.0.0.1"), .pathOutsideRepositoryForm,
+            .malformedOwner, .malformedRepository,
+        ]
+        for rejection in rejections {
+            let message = rejection.localizedMessage
+            XCTAssertFalse(message.isEmpty)
+            XCTAssertFalse(message.contains("evil.example"))
+            XCTAssertFalse(message.contains("10.0.0.1"))
+            XCTAssertFalse(message.contains("gopher"))
+        }
+    }
+
+    // MARK: - Download host policy
+
+    func testDownloadHostPolicyAllowsTheCDNFamilyAndNothingElse() {
+        // Real weights are served from CDN hosts under the same domains — a policy pinned to the
+        // repository host alone would refuse every actual download.
+        for allowed in ["https://huggingface.co/x", "https://cdn-lfs.huggingface.co/x",
+                        "https://us.aws.cdn.hf.co/x", "https://transfer.xethub.hf.co/x",
+                        "https://hf.co/x"] {
+            XCTAssertTrue(LocalModelRepositoryReference.isAllowedDownloadURL(URL(string: allowed)!),
+                          allowed)
+        }
+        for refused in ["http://huggingface.co/x",                  // not HTTPS
+                        "https://user:pw@huggingface.co/x",         // credentials
+                        "https://huggingface.co.evil.example/x",    // suffix lookalike
+                        "https://evil.example/huggingface.co/x",
+                        "https://s3.amazonaws.com/x",
+                        "https://127.0.0.1/x"] {
+            XCTAssertFalse(LocalModelRepositoryReference.isAllowedDownloadURL(URL(string: refused)!),
+                           refused)
+        }
+        XCTAssertFalse(LocalModelRepositoryReference.isAllowedDownloadURL(nil))
+    }
+
+    // MARK: - File URLs
+
+    func testFileURLRequiresAnExactRevisionAndAContainedPath() {
+        let reference = LocalModelRepositoryReference(host: "huggingface.co",
+                                                      owner: "Qwen",
+                                                      repository: "Qwen2.5-0.5B-Instruct-GGUF")
+        let revision = String(repeating: "a", count: 40)
+        XCTAssertEqual(
+            reference.fileURL(revision: revision, relativePath: "model.gguf")?.absoluteString,
+            "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/\(revision)/model.gguf")
+
+        // A branch, a short hash and an empty revision are all refused — a floating pointer is not
+        // installable metadata.
+        for badRevision in ["main", "abc1234", "", String(repeating: "z", count: 40)] {
+            XCTAssertNil(reference.fileURL(revision: badRevision, relativePath: "model.gguf"),
+                         badRevision)
+        }
+        // Traversal never produces a URL.
+        for badPath in ["../../etc/passwd", "/etc/passwd", "%2e%2e/x.gguf", ""] {
+            XCTAssertNil(reference.fileURL(revision: revision, relativePath: badPath), badPath)
+        }
+    }
+
+    // MARK: - Quantization labels and shard grouping
+
+    func testQuantizationLabelsAreParsedAsDisplayTextOnly() {
+        XCTAssertEqual(GGUFFileName.quantizationLabel(for: "qwen2.5-0.5b-instruct-q4_k_m.gguf"), "Q4_K_M")
+        XCTAssertEqual(GGUFFileName.quantizationLabel(for: "Model-IQ4_XS.gguf"), "IQ4_XS")
+        XCTAssertEqual(GGUFFileName.quantizationLabel(for: "smollm2-360m-instruct-q8_0.gguf"), "Q8_0")
+        XCTAssertEqual(GGUFFileName.quantizationLabel(for: "model.F16.gguf"), "F16")
+        XCTAssertNil(GGUFFileName.quantizationLabel(for: "model.gguf"))
+        // Not a boundary-delimited token: a caption is never pulled out of the middle of a word.
+        XCTAssertNil(GGUFFileName.quantizationLabel(for: "modelq4_k_mx.gguf"))
+    }
+
+    func testShardedFilesGroupIntoOneCandidate() throws {
+        let files = [
+            LocalModelRemoteFile(path: "big-00001-of-00002.gguf", byteCount: 10, sha256: digest("a")),
+            LocalModelRemoteFile(path: "big-00002-of-00002.gguf", byteCount: 20, sha256: digest("b")),
+            LocalModelRemoteFile(path: "small-q4_k_m.gguf", byteCount: 5, sha256: digest("c")),
+        ]
+        let offer = try XCTUnwrap(try? LocalModelImportPlanner.makeOffer(reference: reference,
+                                                                         metadata: metadata(),
+                                                                         files: files))
+        XCTAssertEqual(offer.weights.count, 2)
+        let sharded = offer.weights.first { $0.id == "big.gguf" }
+        XCTAssertEqual(sharded?.files.count, 2, "a shard group is one candidate, never one shard")
+        XCTAssertEqual(sharded?.byteCount, 30)
+    }
+
+    func testProjectorsAreListedSeparatelyAndGrantNoCapability() throws {
+        let files = [
+            LocalModelRemoteFile(path: "model-q4_k_m.gguf", byteCount: 10, sha256: digest("a")),
+            LocalModelRemoteFile(path: "mmproj-model-f16.gguf", byteCount: 3, sha256: digest("b")),
+        ]
+        let offer = try LocalModelImportPlanner.makeOffer(reference: reference,
+                                                          metadata: metadata(),
+                                                          files: files)
+        XCTAssertEqual(offer.weights.map(\.id), ["model-q4_k_m.gguf"])
+        XCTAssertEqual(offer.projectors.map(\.id), ["mmproj-model-f16.gguf"])
+
+        let descriptor = try LocalModelImportPlanner.descriptor(for: XCTUnwrap(offer.defaultSelection),
+                                                                in: offer)
+        XCTAssertEqual(descriptor.capabilities, [.text],
+                       "a projector in the repository must not make the import vision-capable")
+    }
+
+    // MARK: - Default selection
+
+    func testCuratedDefaultOnlyWhenTheExactPreferredFileIsPresent() throws {
+        let withPreferred = try LocalModelImportPlanner.makeOffer(
+            reference: reference, metadata: metadata(),
+            files: [LocalModelRemoteFile(path: "m-q4_k_m.gguf", byteCount: 10, sha256: digest("a")),
+                    LocalModelRemoteFile(path: "m-q8_0.gguf", byteCount: 20, sha256: digest("b"))])
+        XCTAssertEqual(withPreferred.defaultSelection?.id, "m-q4_k_m.gguf")
+        XCTAssertFalse(withPreferred.requiresSelection)
+
+        let withoutPreferred = try LocalModelImportPlanner.makeOffer(
+            reference: reference, metadata: metadata(),
+            files: [LocalModelRemoteFile(path: "m-q5_k_m.gguf", byteCount: 10, sha256: digest("a")),
+                    LocalModelRemoteFile(path: "m-q8_0.gguf", byteCount: 20, sha256: digest("b"))])
+        XCTAssertNil(withoutPreferred.defaultSelection)
+        XCTAssertTrue(withoutPreferred.requiresSelection, "the user chooses when nothing matches exactly")
+    }
+
+    func testCandidateWithoutDigestOrSizeIsNotInstallable() throws {
+        let offer = try LocalModelImportPlanner.makeOffer(
+            reference: reference, metadata: metadata(),
+            files: [LocalModelRemoteFile(path: "good-q4_k_m.gguf", byteCount: 10, sha256: digest("a")),
+                    LocalModelRemoteFile(path: "nodigest-q8_0.gguf", byteCount: 10, sha256: nil),
+                    LocalModelRemoteFile(path: "nosize-q6_k.gguf", byteCount: 0, sha256: digest("c"))])
+        let unverifiable = offer.weights.filter { !$0.isInstallable }.map(\.id)
+        XCTAssertEqual(Set(unverifiable), ["nodigest-q8_0.gguf", "nosize-q6_k.gguf"])
+
+        for candidate in offer.weights where !candidate.isInstallable {
+            XCTAssertThrowsError(try LocalModelImportPlanner.descriptor(for: candidate, in: offer)) {
+                XCTAssertEqual($0 as? LocalModelImportFault, .noVerifiableFiles)
+            }
+        }
+    }
+
+    // MARK: - Offer-level refusals
+
+    func testOfferRefusals() {
+        // No GGUF at all.
+        XCTAssertThrowsError(try LocalModelImportPlanner.makeOffer(
+            reference: reference, metadata: metadata(),
+            files: [LocalModelRemoteFile(path: "README.md", byteCount: 10, sha256: nil)])) {
+            XCTAssertEqual($0 as? LocalModelImportFault, .noEligibleFiles)
+        }
+        // Nothing verifiable.
+        XCTAssertThrowsError(try LocalModelImportPlanner.makeOffer(
+            reference: reference, metadata: metadata(),
+            files: [LocalModelRemoteFile(path: "m.gguf", byteCount: 10, sha256: nil)])) {
+            XCTAssertEqual($0 as? LocalModelImportFault, .noVerifiableFiles)
+        }
+        // A traversal anywhere in the listing sinks the whole offer.
+        XCTAssertThrowsError(try LocalModelImportPlanner.makeOffer(
+            reference: reference, metadata: metadata(),
+            files: [LocalModelRemoteFile(path: "ok-q4_k_m.gguf", byteCount: 10, sha256: digest("a")),
+                    LocalModelRemoteFile(path: "../escape.gguf", byteCount: 10, sha256: digest("b"))])) {
+            XCTAssertEqual($0 as? LocalModelImportFault, .pathOutsideModelRoot)
+        }
+    }
+
+    func testGatedOrUnresolvedRepositoriesAreRefusedBeforeAnyPlanExists() async {
+        let listing = [LocalModelRemoteFile(path: "m-q4_k_m.gguf", byteCount: 10, sha256: digest("a"))]
+
+        let gated = LocalModelImportPlanner(fetcher: FakeMetadataFetcher(
+            metadata: LocalModelRepositoryMetadata(revision: String(repeating: "a", count: 40),
+                                                   licenseIdentifier: "apache-2.0",
+                                                   isGated: true, isPrivate: false),
+            files: listing))
+        await XCTAssertThrowsErrorAsync(try await gated.offer(for: reference)) {
+            XCTAssertEqual($0 as? LocalModelImportFault, .repositoryNotPublic)
+        }
+
+        let floating = LocalModelImportPlanner(fetcher: FakeMetadataFetcher(
+            metadata: LocalModelRepositoryMetadata(revision: "main",
+                                                   licenseIdentifier: nil,
+                                                   isGated: false, isPrivate: false),
+            files: listing))
+        await XCTAssertThrowsErrorAsync(try await floating.offer(for: reference)) {
+            XCTAssertEqual($0 as? LocalModelImportFault, .revisionNotResolved)
+        }
+    }
+
+    // MARK: - Descriptor construction
+
+    func testImportedDescriptorIsPinnedInstallableAndTextOnly() throws {
+        let revision = String(repeating: "b", count: 40)
+        let offer = try LocalModelImportPlanner.makeOffer(
+            reference: reference,
+            metadata: LocalModelRepositoryMetadata(revision: revision,
+                                                   licenseIdentifier: "apache-2.0",
+                                                   isGated: false, isPrivate: false),
+            files: [LocalModelRemoteFile(path: "m-q4_k_m.gguf", byteCount: 1_024, sha256: digest("a"))])
+        let descriptor = try LocalModelImportPlanner.descriptor(
+            for: try XCTUnwrap(offer.defaultSelection), in: offer)
+
+        XCTAssertEqual(descriptor.runtime, .llamaCpp)
+        XCTAssertEqual(descriptor.revision, revision)
+        XCTAssertEqual(descriptor.quantization, "Q4_K_M")
+        XCTAssertEqual(descriptor.capabilities, [.text])
+        XCTAssertEqual(descriptor.contextLength, LocalModelImportPlanner.importedContextTokens)
+        XCTAssertTrue(descriptor.installationFaults().isEmpty,
+                      "an offer's descriptor must pass the very gate the downloader applies")
+        XCTAssertEqual(descriptor.license.displayName, "Apache License 2.0")
+        XCTAssertFalse(descriptor.license.requiresAcceptance)
+    }
+
+    func testUnknownLicenceRequiresAcceptanceAndClaimsNoSummary() {
+        let summary = LocalModelLicenseSummary.imported(identifier: "some-custom-terms",
+                                                        revision: String(repeating: "c", count: 40))
+        XCTAssertTrue(summary.requiresAcceptance)
+        XCTAssertNil(summary.revision, "an unread licence names no revision it could claim to summarize")
+    }
+
+    func testCandidateFromAnotherOfferIsRefused() throws {
+        let offerA = try LocalModelImportPlanner.makeOffer(
+            reference: reference, metadata: metadata(),
+            files: [LocalModelRemoteFile(path: "a-q4_k_m.gguf", byteCount: 10, sha256: digest("a"))])
+        let offerB = try LocalModelImportPlanner.makeOffer(
+            reference: reference, metadata: metadata(),
+            files: [LocalModelRemoteFile(path: "b-q4_k_m.gguf", byteCount: 10, sha256: digest("b"))])
+        XCTAssertThrowsError(try LocalModelImportPlanner.descriptor(
+            for: try XCTUnwrap(offerA.defaultSelection), in: offerB)) {
+            XCTAssertEqual($0 as? LocalModelImportFault, .unknownSelection)
+        }
+    }
+
+    // MARK: - Response decoding (fixtures, never the network)
+
+    func testMetadataDecodingTreatsAnythingButFalseAsGated() throws {
+        let open = try LocalModelRepositoryClient.parseMetadata(Data("""
+        {"sha":"\(String(repeating: "a", count: 40))","private":false,"gated":false,
+         "cardData":{"license":"apache-2.0"}}
+        """.utf8))
+        XCTAssertFalse(open.isGated)
+        XCTAssertEqual(open.licenseIdentifier, "apache-2.0")
+
+        for gatedValue in ["\"auto\"", "\"manual\"", "true", "{}"] {
+            let parsed = try LocalModelRepositoryClient.parseMetadata(Data("""
+            {"sha":"\(String(repeating: "a", count: 40))","gated":\(gatedValue)}
+            """.utf8))
+            XCTAssertTrue(parsed.isGated, "gated: \(gatedValue)")
+        }
+
+        XCTAssertThrowsError(try LocalModelRepositoryClient.parseMetadata(Data("{}".utf8)))
+    }
+
+    func testFileListingTakesDigestsOnlyFromTheLargeFileRecord() throws {
+        let sha = digest("a")
+        let files = try LocalModelRepositoryClient.parseFileListing(Data("""
+        [{"type":"directory","path":"sub"},
+         {"type":"file","path":"m.gguf","size":123,"lfs":{"oid":"\(sha)","size":456}},
+         {"type":"file","path":"README.md","size":10},
+         {"type":"file","path":"weird.gguf","size":7,"lfs":{"oid":"not-a-sha"}}]
+        """.utf8))
+        XCTAssertEqual(files.count, 3)
+        XCTAssertEqual(files[0], LocalModelRemoteFile(path: "m.gguf", byteCount: 456, sha256: sha),
+                       "the large-file record's size wins: it is the size of the real object")
+        XCTAssertNil(files[1].sha256)
+        XCTAssertNil(files[2].sha256, "a digest that is not SHA-256-shaped is no digest at all")
+    }
+
+    // MARK: - Helpers
+
+    private let reference = LocalModelRepositoryReference(host: "huggingface.co",
+                                                          owner: "owner",
+                                                          repository: "repo")
+
+    private func metadata() -> LocalModelRepositoryMetadata {
+        LocalModelRepositoryMetadata(revision: String(repeating: "a", count: 40),
+                                     licenseIdentifier: "apache-2.0",
+                                     isGated: false,
+                                     isPrivate: false)
+    }
+
+    /// A 64-character lowercase hex string. Digest *shape* is what these fixtures need; the real
+    /// hashing is exercised against real bytes in the download-manager tests.
+    private func digest(_ seed: String) -> String {
+        String(repeating: seed.lowercased(), count: 64)
+    }
+}
+
+/// A fetcher that answers from fixtures. The suite has no other kind.
+struct FakeMetadataFetcher: LocalModelRepositoryMetadataFetching {
+    let metadata: LocalModelRepositoryMetadata
+    let files: [LocalModelRemoteFile]
+
+    func metadata(for reference: LocalModelRepositoryReference) async throws -> LocalModelRepositoryMetadata {
+        metadata
+    }
+
+    func files(for reference: LocalModelRepositoryReference,
+               revision: String) async throws -> [LocalModelRemoteFile] {
+        files
+    }
+}
+
+/// `XCTAssertThrowsError` has no async form; this is the smallest thing that does the job.
+func XCTAssertThrowsErrorAsync<T>(_ expression: @autoclosure () async throws -> T,
+                                  file: StaticString = #filePath,
+                                  line: UInt = #line,
+                                  _ handler: (Error) -> Void = { _ in }) async {
+    do {
+        _ = try await expression()
+        XCTFail("expected an error", file: file, line: line)
+    } catch {
+        handler(error)
+    }
+}


### PR DESCRIPTION
## Summary

Fourth PR of Plan DZ: one acquisition pipeline serving both curated catalog entries and public-repository imports — parse, resolve to an exact immutable revision, plan, consent, download, validate, install. Still behind `ggufModelsEnabled`; the manager UI that calls it is PR5.

**Import parsing** refuses a dozen typed cases with its own message each — no scheme (never silently upgraded), wrong scheme, embedded credentials, query or fragment material, lookalike hosts (`huggingface.co.evil.example`), private/reserved addresses, paths outside the repository form (including `%2e%2e` traversal), malformed owner or name — and **never echoes the input back**. Download responses deliberately use a *wider* host policy than repository references, because real weights redirect to CDN hosts (`us.aws.cdn.hf.co`, `cdn-lfs.*`, `transfer.xethub.hf.co`); that redirect chain was verified live rather than assumed.

**Fit and consent** is a value, not a screen (PR5 renders it): name, runtime, quantization, size, storage, a conservative load verdict, licence summary, and the honest warning that a model may install and still not run. Unknown size, missing digest, unresolved revision, unreadable free space, insufficient storage and unaccepted licence all **block**; a memory-headroom concern warns.

**The state machine persists per plan** — plan file beside a files directory, so install can move the payload and leave the plan recording `installing`, which is exactly what makes a crash between move and marker recoverable. Task identity lives in `taskDescription`, so the mapping is rebuilt by reading tasks rather than remembering them; progress is recomputed from bytes on disk. Manifest written → read back → compared → payload moved → **`.complete` last**. Size, digest, redirect host, insecure final URL, traversal and unresolved revision each provably cannot produce a completed install; traversal and unpinned revisions never reach the transport at all. Digest and containment failures are terminal, transport and storage retryable — refetching the same bytes doesn't fix a bad digest.

**The catalog PR1 deferred** ships three text-only entries — SmolLM2-360M-Instruct Q8_0, Qwen2.5-0.5B and 1.5B Instruct Q4_K_M, all Apache-2.0 — with **real SHA-256 digests**, each cross-checked against the repository's large-file record, and one verified by downloading the 386 MB file and hashing it. Architecture and trained-context values were read from GGUF metadata at the pinned revision. **No entry carries a tool or vision badge**, and the loader structurally refuses any that claims one without device evidence: those fixtures can't run headlessly, and a chat template containing tool scaffolding is not evidence.

Flagged for follow-up: `minimumHeadroomBytes` means "additive reserve" to the llama backend but "weights + working set" to the MLX catalog. The fit report adds it only for llama.cpp so the pre-download verdict matches the gate that actually runs — but the field should mean one thing.

## Verification

- Full suite: **4408 tests, 0 failures** (4 env-gated skips) — **68 new** across 5 classes
- Release build (generic iOS): green; privacy-log gate: zero findings
- **Device-pending**: the background `URLSession` itself (the suite drives the transfer seam, not the live session), any real download, and every capability badge
- New user-facing strings are plain `String` in error properties, so extraction didn't see them — listed for the next catalog sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)