### PR TITLE
Give local models a manager, an importer, and a diagnostics card (DZ P2/PR5)

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -106,11 +106,25 @@ final class OpenGlassesAppDelegate: NSObject, UIApplicationDelegate {
     }
 
     /// Handle background URLSession events (model downloads completing while app is suspended).
-    /// The Hub library uses a background URLSession with identifier "{bundleId}.hub.hubclient.background".
+    ///
+    /// Two sessions can wake the app here, and they are handled differently because they are owned
+    /// differently. The GGUF download session is ours: its delegate knows when it has finished
+    /// delivering, so the system's handler is given to it and invoked exactly then. The Hub
+    /// library's session ("{bundleId}.hub.hubclient.background") is not ours and exposes no such
+    /// signal, so its handler keeps the timed release it has always had.
     func application(_ application: UIApplication,
                      handleEventsForBackgroundURLSession identifier: String,
                      completionHandler: @escaping () -> Void) {
         PrivacyLog.transfer(.backgroundDownload, .sessionResumed)
+        if LocalModelAcquisition.ownsBackgroundSession(identifier) {
+            Task { @MainActor in
+                LocalModelAcquisition.shared.adoptBackgroundEventsHandler {
+                    completionHandler()
+                    PrivacyLog.transfer(.backgroundDownload, .sessionCompleted)
+                }
+            }
+            return
+        }
         // The Hub library's background session delegate handles the actual download completion.
         // We just need to store the completion handler so the system knows we processed the event.
         BackgroundSessionCompletionStore.shared.completionHandler = completionHandler
@@ -196,6 +210,11 @@ struct OpenGlassesApp: App {
         // so no model is ever redownloaded — and the version stamp is written only once every
         // record has been read back, so an interrupted or unwritable run retries next launch.
         LocalModelRepository().migrateIfNeeded()
+        // Carry the on-device model *selection* forward from the legacy provider string to a stable
+        // id (Plan DZ P2). Forward-only, read-back-verified, and it writes nothing into the legacy
+        // field — that value is already what it is migrating from, so an interrupted run leaves the
+        // previous behaviour exactly intact.
+        LocalModelSelection.store().migrateIfNeeded()
         // Establish the settings-journey state before anything can change it, and in
         // particular before onboarding runs (Plan DE): "has this app been used before"
         // is only answerable at launch — once a first-time user finishes onboarding they

--- a/OpenGlasses/Sources/App/Views/LocalModelDiagnosticsCard.swift
+++ b/OpenGlasses/Sources/App/Views/LocalModelDiagnosticsCard.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// The diagnostics card in the local-model manager: what the engine is, what the last on-device run
+/// did, and how hot the phone got doing it.
+///
+/// Every number comes from `LocalRuntimeDiagnostics`, which the runtime writes at the same call
+/// sites it writes its log lines — so a bug report's log and this card describe the same run. The
+/// card itself computes nothing except the layout.
+struct LocalModelDiagnosticsCard: View {
+
+    /// Re-read on a timer rather than observed: samples are recorded from inside the decode loop,
+    /// which must not hop to the main actor to publish. Two seconds matches the memory readouts
+    /// above it on the same screen.
+    private static let refreshInterval: TimeInterval = 2
+
+    let diagnostics: LocalRuntimeDiagnostics
+
+    init(diagnostics: LocalRuntimeDiagnostics = .shared) {
+        self.diagnostics = diagnostics
+    }
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: Self.refreshInterval)) { _ in
+            let rows = LocalRuntimeDiagnosticsCard.rows(
+                sample: diagnostics.latest,
+                frameworkDescription: LlamaRuntimeAvailability.engineDescription)
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(rows) { row in
+                    LabeledContent(row.label) {
+                        Text(row.value)
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.trailing)
+                    }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(row.spokenLabel)
+                }
+            }
+        }
+    }
+}

--- a/OpenGlasses/Sources/App/Views/LocalModelImportSheet.swift
+++ b/OpenGlasses/Sources/App/Views/LocalModelImportSheet.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+/// Importing a model from a public repository: address, file, licence, and a last screen that says
+/// exactly what will happen before anything is fetched.
+///
+/// The sheet draws what `LocalModelImportController` decides. Two rules it must not blur:
+///
+///  - **Refusals are shown verbatim.** The parser and the planner write their own sentences, and
+///    those sentences deliberately never echo what was typed. Re-wording them here would lose both
+///    the rule they name and that property.
+///  - **Blockers disable; warnings permit.** The confirm button reads `canDownload`, which reads
+///    the fit report. Nothing on this screen can talk a blocker into being advice.
+struct LocalModelImportSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var controller: LocalModelImportController
+    @FocusState private var repositoryFieldFocused: Bool
+
+    init(acquisition: LocalModelAcquisition) {
+        _controller = StateObject(wrappedValue: LocalModelImportController(acquisition: acquisition))
+    }
+
+    /// Injection point for the suite and for previews.
+    init(controller: @autoclosure @escaping () -> LocalModelImportController) {
+        _controller = StateObject(wrappedValue: controller())
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                repositorySection
+                if case .failed(let message) = controller.stage {
+                    Section {
+                        OGStatusLabel(message, kind: .error, systemImage: "exclamationmark.triangle")
+                    }
+                }
+                if controller.offer != nil {
+                    fileSection
+                    if !controller.projectorCandidates.isEmpty { projectorSection }
+                }
+                if let presentation = controller.fitPresentation {
+                    licenceSection
+                    confirmationSection(presentation)
+                }
+            }
+            .ogFormStyle()
+            .navigationTitle("Import a model")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .onChange(of: controller.stage) { _, stage in
+                if case .started = stage { dismiss() }
+            }
+        }
+    }
+
+    // MARK: - Repository
+
+    private var repositorySection: some View {
+        Section {
+            HStack {
+                TextField("owner/repository", text: $controller.repositoryText)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .keyboardType(.URL)
+                    .focused($repositoryFieldFocused)
+                    .submitLabel(.search)
+                    .onSubmit { Task { await controller.resolve() } }
+                    .accessibilityLabel("Model repository")
+                    .accessibilityHint("Enter owner slash repository, or paste the repository's "
+                                           + "web address.")
+                if case .resolving = controller.stage {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Button("Look up") {
+                        repositoryFieldFocused = false
+                        Task { await controller.resolve() }
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(controller.repositoryText.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+        } header: {
+            Text("Repository")
+        } footer: {
+            Text("Public repositories only, over https. The exact version is pinned before "
+                     + "anything is downloaded, and every file is checked against its published "
+                     + "checksum.")
+        }
+    }
+
+    // MARK: - Files
+
+    private var fileSection: some View {
+        Section {
+            ForEach(controller.weightsCandidates) { candidate in
+                Button {
+                    controller.choose(candidate.id)
+                } label: {
+                    HStack(alignment: .firstTextBaseline) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(candidate.quantizationLabel ?? candidate.id)
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                            Text(LocalModelImportController.candidateSubtitle(candidate))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer(minLength: 8)
+                        OGSelectionCheck(controller.selectedCandidateID == candidate.id)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(!candidate.isInstallable)
+                .accessibilityLabel(LocalModelImportController.candidateSpokenLabel(candidate))
+                .accessibilityAddTraits(controller.selectedCandidateID == candidate.id
+                                            ? [.isButton, .isSelected] : .isButton)
+            }
+        } header: {
+            Text("Choose a file")
+        } footer: {
+            Text(controller.offer?.requiresSelection == true
+                     ? "Several quantizations are published. Smaller files use less memory and "
+                         + "answer faster; larger ones answer better."
+                     : "The recommended quantization is selected. Tap another to change it.")
+        }
+    }
+
+    private var projectorSection: some View {
+        Section {
+            ForEach(controller.projectorCandidates) { candidate in
+                LabeledContent(candidate.id,
+                               value: LocalModelPresentation.formatBytes(candidate.byteCount))
+                    .foregroundStyle(.secondary)
+            }
+        } header: {
+            Text("Vision files in this repository")
+        } footer: {
+            Text("This repository also publishes vision projector files. This version of the app "
+                     + "runs on-device models as text only, so they aren't installed.")
+        }
+    }
+
+    // MARK: - Licence
+
+    private var licenceSection: some View {
+        Section {
+            if let licence = controller.offer?.license {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(licence.displayName).font(.subheadline.weight(.semibold))
+                    Text(licence.summary).font(.caption).foregroundStyle(.secondary)
+                }
+                if let url = controller.offer?.reference.webURL {
+                    Link("Open the repository page", destination: url)
+                        .font(.caption)
+                }
+            }
+            if controller.requiresLicenceAcceptance {
+                Toggle(isOn: $controller.licenceAccepted) {
+                    Text("I accept this model's licence")
+                }
+                .onChange(of: controller.licenceAccepted) { _, _ in
+                    controller.licenceAcceptanceChanged()
+                }
+                .accessibilityHint("Required before this model can be downloaded.")
+            }
+        } header: {
+            Text("Licence")
+        }
+    }
+
+    // MARK: - Confirmation
+
+    @ViewBuilder
+    private func confirmationSection(
+        _ presentation: LocalModelPresentation.FitPresentation) -> some View {
+        Section {
+            ForEach(presentation.facts) { fact in
+                LabeledContent(fact.label, value: fact.value)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("\(fact.label): \(fact.value)")
+            }
+            ForEach(Array(presentation.warningMessages.enumerated()), id: \.offset) { _, message in
+                OGStatusLabel(message, kind: .warn)
+            }
+            ForEach(Array(presentation.blockerMessages.enumerated()), id: \.offset) { _, message in
+                OGStatusLabel(message, kind: .error)
+            }
+
+            Button {
+                Task { await controller.confirm() }
+            } label: {
+                Text("Download \(LocalModelPresentation.formatBytes(controller.fit?.downloadBytes ?? 0))")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.ogProminent)
+            .disabled(!controller.canDownload)
+            // The disabled reason is on the button, not only in the list above it: a person who
+            // reaches the action first must hear why it will not move.
+            .accessibilityHint(controller.canDownload
+                                   ? "Starts the download. It continues in the background."
+                                   : (presentation.blockerMessages.first
+                                        ?? "This model can't be downloaded."))
+        } header: {
+            Text("Before downloading")
+        } footer: {
+            Text("Installing a model doesn't guarantee it will run: on-device models must use a "
+                     + "supported architecture and chat template, and that's only known once it "
+                     + "loads.")
+        }
+    }
+}

--- a/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
+++ b/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
@@ -1,208 +1,70 @@
 import SwiftUI
 
 /// Download, manage, and select local LLM models for on-device inference.
+///
+/// The screen covers two runtimes now (MLX and GGUF) and two acquisition paths, so the parts that
+/// used to be inline `if`s are values: `LocalModelRowState` decides what a row is about,
+/// `LocalModelPresentation` writes what it says, `LocalModelAcquisition` owns the download
+/// pipeline, and `LocalRuntimeDiagnostics` holds what the last on-device run measured. What is left
+/// here is layout and the actions.
+///
+/// The two acquisition paths are deliberately **not** merged. MLX models are hub snapshots with no
+/// pinned revision and no published digests — the verified pipeline refuses them by construction,
+/// and it is right to. They keep the fetch they have always had; GGUF models, whose bytes are
+/// pinned and checksummed, go through the download manager.
 struct LocalModelManagerView: View {
     @EnvironmentObject var appState: AppState
-    @State private var downloadedIds: [String] = []
+    @ObservedObject private var acquisition = LocalModelAcquisition.shared
+
+    @State private var legacyDownloadedIds: [String] = []
     @State private var selectedModelId: String = ""
-    @State private var textModelId: String = Config.localTextModelId
-    @State private var visionModelId: String = Config.localVisionModelId
     @State private var customModelId = ""
     @State private var downloadingModelId: String?
     @State private var downloadError: String?
-    @State private var loadingModelId: String?
-    @State private var loadedLocalModelId: String?   // mirrors the in-memory loaded model for the UI
+
+    @State private var loadingModelId: LocalModelID?
+    @State private var residentModelId: LocalModelID?
     @State private var loadError: String?
-    @State private var failedLoadModelId: String?    // enables Try again after e.g. a headroom refusal
+    @State private var failedLoadModelId: LocalModelID?
+    /// Reasons recorded by a failed load this session. In memory: a model that was refused because
+    /// its runtime was switched off must get a fresh chance the moment it is switched back on.
+    @State private var incompatibilities: [LocalModelID: LocalModelIncompatibility] = [:]
+
+    @State private var runtimeFilter: LocalModelPresentation.RuntimeFilter = .all
+    @State private var capabilityFilter: LocalModelPresentation.CapabilityFilter = .all
+
+    @State private var pendingRemoval: PendingRemoval?
+    @State private var reasonOnScreen: LocalModelIncompatibility?
+    @State private var showImportSheet = false
+
     @ScaledMetric(relativeTo: .body) private var loadTapTarget: CGFloat = 44
+
+    /// How often the staged rows re-read the pipeline while the screen is up. Fast enough for a
+    /// progress bar, slow enough that a plan read is not a per-frame disk hit.
+    private static let progressRefreshInterval: Duration = .milliseconds(1200)
+
+    private struct PendingRemoval: Identifiable {
+        let id: LocalModelID
+        let displayName: String
+        let message: String
+    }
 
     private var localService: LocalLLMService? {
         appState.llmService.localLLMService
     }
 
+    private var ggufEnabled: Bool { Config.ggufModelsEnabled }
 
     var body: some View {
         List {
-            // MARK: Device Info
-            Section {
-                let totalRAM = ProcessInfo.processInfo.physicalMemory
-                let ramGB = Double(totalRAM) / 1_073_741_824
-                LabeledContent("Device RAM", value: String(format: "%.1f GB", ramGB))
-                if ramGB < 4 {
-                    OGStatusLabel("Limited RAM — use models under 1 GB", kind: .warn)
-                }
-                // Live memory readout: refreshes while visible so the user can watch a
-                // model load/unload. Sandboxing limits this to the app's own numbers —
-                // other apps' memory isn't visible from inside an iOS app.
-                TimelineView(.periodic(from: .now, by: 2)) { _ in
-                    LabeledContent("App memory", value: formatBytes(MemoryHeadroom.appFootprintBytes()))
-                }
-                TimelineView(.periodic(from: .now, by: 2)) { _ in
-                    let available = MemoryHeadroom.availableBytes()
-                    LabeledContent("Headroom", value: available > 0 ? formatBytes(available) : "—")
-                }
-            } header: {
-                Text("Device")
-            } footer: {
-                Text("Headroom is how much more memory the app can use before iOS terminates it. A model won't load unless it fits in the current headroom with room to generate.")
-            }
-
-            // MARK: Downloaded Models
-            Section {
-                if downloadedIds.isEmpty {
-                    Text("No models downloaded yet. Pick one below to get started.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(downloadedIds, id: \.self) { modelId in
-                        HStack(spacing: 10) {
-                            Button {
-                                selectModel(modelId)
-                            } label: {
-                                HStack {
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(modelDisplayName(modelId))
-                                            .foregroundStyle(.primary)
-                                            .lineLimit(1)
-                                        Text(formatBytes(localService?.modelSizeOnDisk(modelId) ?? 0))
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                    OGSelectionCheck(selectedModelId == modelId)
-                                }
-                                .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
-
-                            Spacer(minLength: 0)
-
-                            loadControl(for: modelId)
-                        }
-                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                            Button(role: .destructive) {
-                                deleteModel(modelId)
-                            } label: {
-                                Label("Delete", systemImage: "trash")
-                            }
-                        }
-                    }
-                }
-                if let loadError {
-                    VStack(alignment: .leading, spacing: 8) {
-                        OGStatusLabel(loadError, kind: .error, systemImage: "exclamationmark.triangle")
-                        if let failedLoadModelId {
-                            // Retry seam for the headroom gate: the user swipes other apps
-                            // away, watches headroom recover, and retries without leaving
-                            // the screen.
-                            HStack(spacing: 12) {
-                                Button("Try again") { loadLocalModel(failedLoadModelId) }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.small)
-                                    .disabled(loadingModelId != nil)
-                                TimelineView(.periodic(from: .now, by: 2)) { _ in
-                                    let available = MemoryHeadroom.availableBytes()
-                                    if available > 0 {
-                                        Text("Headroom now: \(formatBytes(available))")
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            } header: {
-                Text("Downloaded Models")
-            } footer: {
-                Text("Tap a model to select it. Tap Load to bring it into memory now (so the first reply is instant) — or Unload to free memory. Swipe left to delete.")
-            }
-
-            // MARK: Recommended Models
-            Section {
-                ForEach(LocalLLMService.recommendedModels) { model in
-                    VStack(alignment: .leading, spacing: 6) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(model.name)
-                                    .lineLimit(1)
-                                HStack(spacing: 8) {
-                                    Text(model.estimatedSize)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                    if model.hasVision {
-                                        Label("Vision", systemImage: "eye")
-                                            .font(.caption2)
-                                            .foregroundStyle(Color(.label))
-                                    }
-                                    if model.hasToolCalling {
-                                        Label("Tools", systemImage: "wrench")
-                                            .font(.caption2)
-                                            .foregroundStyle(OGTheme.okLabel)
-                                    }
-                                }
-                            }
-                            Spacer()
-
-                            if downloadedIds.contains(model.id) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundStyle(OGTheme.okLabel)
-                            } else if downloadingModelId == model.id, let service = localService {
-                                // Own subview so the service's @Published progress actually
-                                // re-renders it — read through the computed optional above,
-                                // nothing observed the service and the bar never moved.
-                                DownloadProgressRow(service: service) {
-                                    service.cancelDownload()
-                                    downloadingModelId = nil
-                                }
-                            } else if !model.isCompatibleWithDevice {
-                                // The model's OWN requirement — this badge was hardcoded
-                                // "Needs 8 GB" and misreported every other tier.
-                                Label("Needs \(Int(model.minimumRAMGB)) GB", systemImage: "memorychip")
-                                    .font(.caption)
-                                    .foregroundStyle(OGTheme.warnLabel)
-                            } else {
-                                Button("Download") {
-                                    downloadModel(model.id)
-                                }
-                                .buttonStyle(.bordered)
-                                .controlSize(.small)
-                                .tint(.primary)
-                            }
-                        }
-
-                        Text(model.notes)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    .padding(.vertical, 4)
-                }
-            } header: {
-                Text("Recommended")
-            } footer: {
-                Text("These models are tested on iPhone and optimized for size. Larger models need more RAM. Keep the app open while downloading — the screen stays awake automatically.")
-            }
-
-            // MARK: Custom Model
-            Section {
-                HStack {
-                    TextField("HuggingFace model ID", text: $customModelId)
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
-                    Button("Download") {
-                        let id = customModelId.trimmingCharacters(in: .whitespaces)
-                        guard !id.isEmpty else { return }
-                        downloadModel(id)
-                    }
-                    .disabled(customModelId.trimmingCharacters(in: .whitespaces).isEmpty)
-                }
-            } header: {
-                Text("Custom Model")
-            } footer: {
-                Text("Paste any HuggingFace MLX model ID, e.g. \"mlx-community/phi-3-mini-4k-instruct-4bit\"")
-            }
-
-            // MARK: Error
-            if let error = downloadError {
+            deviceSection
+            filterSection
+            installedSection
+            recommendedSection
+            if ggufEnabled { ggufCatalogSection }
+            customSection
+            diagnosticsSection
+            if let error = downloadError ?? acquisition.errorMessage {
                 Section {
                     OGStatusLabel(error, kind: .error, systemImage: "exclamationmark.triangle")
                 }
@@ -210,36 +72,615 @@ struct LocalModelManagerView: View {
         }
         .navigationTitle("Local Models")
         .ogFormStyle()
-        .onAppear {
-            refreshDownloaded()
-            // Set initial selection from active model config
-            if let activeModel = Config.activeModel, activeModel.llmProvider == .local {
-                selectedModelId = activeModel.model
+        .task { await refreshEverything() }
+        .task(id: acquisition.staging.isEmpty) {
+            // Only polls while something is staged; an idle screen does no disk work.
+            guard !acquisition.staging.isEmpty else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(for: Self.progressRefreshInterval)
+                if Task.isCancelled { return }
+                await acquisition.refreshPlans()
+            }
+        }
+        .onDisappear(perform: announceBackgroundContinuation)
+        .sheet(isPresented: $showImportSheet) {
+            LocalModelImportSheet(acquisition: acquisition)
+        }
+        .confirmationDialog("Remove model",
+                            isPresented: Binding(get: { pendingRemoval != nil },
+                                                 set: { if !$0 { pendingRemoval = nil } }),
+                            titleVisibility: .visible,
+                            presenting: pendingRemoval) { removal in
+            Button("Remove", role: .destructive) {
+                pendingRemoval = nil
+                Task { await remove(removal.id) }
+            }
+            Button("Keep", role: .cancel) { pendingRemoval = nil }
+        } message: { removal in
+            Text(removal.message)
+        }
+        .alert("Why this model can't run",
+               isPresented: Binding(get: { reasonOnScreen != nil },
+                                    set: { if !$0 { reasonOnScreen = nil } }),
+               presenting: reasonOnScreen) { _ in
+            Button("OK", role: .cancel) { reasonOnScreen = nil }
+        } message: { reason in
+            Text(reason.explanation)
+        }
+    }
+
+    // MARK: - Device
+
+    private var deviceSection: some View {
+        Section {
+            let totalRAM = ProcessInfo.processInfo.physicalMemory
+            let ramGB = Double(totalRAM) / 1_073_741_824
+            LabeledContent("Device RAM", value: String(format: "%.1f GB", ramGB))
+            if ramGB < 4 {
+                OGStatusLabel("Limited RAM — use models under 1 GB", kind: .warn)
+            }
+            // Live memory readout: refreshes while visible so the user can watch a
+            // model load/unload. Sandboxing limits this to the app's own numbers —
+            // other apps' memory isn't visible from inside an iOS app.
+            TimelineView(.periodic(from: .now, by: 2)) { _ in
+                LabeledContent("App memory",
+                               value: LocalModelPresentation.formatBytes(
+                                   MemoryHeadroom.appFootprintBytes()))
+            }
+            TimelineView(.periodic(from: .now, by: 2)) { _ in
+                let available = MemoryHeadroom.availableBytes()
+                LabeledContent("Headroom",
+                               value: available > 0
+                                   ? LocalModelPresentation.formatBytes(available) : "—")
+            }
+        } header: {
+            Text("Device")
+        } footer: {
+            Text("Headroom is how much more memory the app can use before iOS terminates it. A model won't load unless it fits in the current headroom with room to generate.")
+        }
+    }
+
+    // MARK: - Filters
+
+    private var filterSection: some View {
+        Section {
+            Picker("Runtime", selection: $runtimeFilter) {
+                ForEach(LocalModelPresentation.RuntimeFilter.allCases, id: \.self) { filter in
+                    Text(filter.title)
+                        .accessibilityLabel(filter.spokenLabel)
+                        .tag(filter)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityLabel("Filter by runtime")
+
+            Picker("Capability", selection: $capabilityFilter) {
+                ForEach(LocalModelPresentation.CapabilityFilter.allCases, id: \.self) { filter in
+                    Text(filter.title)
+                        .accessibilityLabel(filter.spokenLabel)
+                        .tag(filter)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityLabel("Filter by capability")
+        } header: {
+            Text("Show")
+        }
+    }
+
+    // MARK: - Installed
+
+    private var installedSection: some View {
+        Section {
+            let rows = filtered(installedRows)
+            if rows.isEmpty {
+                Text(installedRows.isEmpty
+                         ? "No models downloaded yet. Pick one below to get started."
+                         : "No downloaded models match this filter.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(rows) { row in
+                    installedRow(row)
+                }
+            }
+            if let loadError {
+                loadFailureNotice(loadError)
+            }
+            if let notice = acquisition.backgroundContinuationNotice() {
+                // The plan requires this said explicitly, and it has to be *visible* as well as
+                // spoken: the announcement on leaving reaches VoiceOver only, and a sighted person
+                // backing out of a half-finished download deserves the same reassurance.
+                OGStatusLabel(notice, kind: .ok, systemImage: "arrow.down.circle")
+            }
+        } header: {
+            Text("On this iPhone")
+        } footer: {
+            Text("Tap a model to select it. Load brings it into memory now, so the first reply is instant; Unload frees that memory. Swipe left to remove it.")
+        }
+    }
+
+    @ViewBuilder
+    private func installedRow(_ row: ManagedModel) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                Button {
+                    select(row.id)
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(row.descriptor.displayName)
+                                .foregroundStyle(.primary)
+                                .lineLimit(2)
+                            badgeStrip(row)
+                        }
+                        OGSelectionCheck(selectedModelId == row.id.rawValue)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(row.isIncompatible)
+
+                Spacer(minLength: 0)
+
+                loadControl(for: row)
+            }
+
+            sizeFactsStrip(row)
+
+            if case .staged(let staging) = row.state {
+                stagingControls(row, staging: staging)
+            }
+            if case .incompatible(let reason) = row.state {
+                Button("Why can't this run?") { reasonOnScreen = reason }
+                    .font(.caption)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityHint(reason.spokenLabel)
+            }
+        }
+        .padding(.vertical, 2)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                confirmRemoval(row)
+            } label: {
+                Label("Remove", systemImage: "trash")
             }
         }
     }
 
-    private func selectModel(_ modelId: String) {
-        selectedModelId = modelId
-        // Update the active model config if one exists for local provider
-        var models = Config.savedModels
-        if let idx = models.firstIndex(where: { $0.llmProvider == .local }) {
-            models[idx].model = modelId
-            Config.setSavedModels(models)
-            appState.llmService.refreshActiveModel()
+    /// Badges never carry meaning in colour alone: each one supplies its own spoken sentence, and
+    /// the row groups them into a single element so VoiceOver reads them as one description rather
+    /// than as six stops.
+    private func badgeStrip(_ row: ManagedModel) -> some View {
+        let badges = LocalModelPresentation.rowBadges(state: row.state, descriptor: row.descriptor)
+        return HStack(spacing: 6) {
+            ForEach(badges) { badge in
+                Label {
+                    Text(badge.text)
+                } icon: {
+                    if let glyph = badge.systemImage { Image(systemName: glyph) }
+                }
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(tint(for: badge.emphasis))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color(.quaternarySystemFill),
+                            in: RoundedRectangle(cornerRadius: 5, style: .continuous))
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(badges.map(\.spokenLabel).joined(separator: ". "))
+    }
+
+    private func tint(for emphasis: LocalModelBadge.Emphasis) -> Color {
+        switch emphasis {
+        case .neutral: return .secondary
+        case .positive: return OGTheme.okLabel
+        case .caution: return OGTheme.warnLabel
+        case .critical: return OGTheme.errorLabel
         }
     }
 
-    private func downloadModel(_ modelId: String) {
+    private func sizeFactsStrip(_ row: ManagedModel) -> some View {
+        let facts = LocalModelPresentation.sizeFacts(descriptor: row.descriptor,
+                                                     onDiskBytes: row.onDiskBytes)
+        return Text(facts.map { "\($0.label) \($0.value)" }.joined(separator: " · "))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .accessibilityLabel(facts.map { "\($0.label) \($0.value)" }.joined(separator: ", "))
+    }
+
+    @ViewBuilder
+    private func stagingControls(_ row: ManagedModel, staging: LocalModelStagingSummary) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if staging.isRetryable {
+                if case .retryable(let reason) = staging.phase {
+                    OGStatusLabel(LocalModelRowState.retryExplanation(reason), kind: .warn)
+                }
+                Button("Try again") { Task { await acquisition.retry(row.id) } }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            } else {
+                ProgressView(value: staging.fractionCompleted)
+                    .accessibilityLabel(row.state.spokenLabel)
+                    .accessibilityValue("\(Int(staging.fractionCompleted * 100)) percent")
+                HStack {
+                    Text(fileProgressCaption(staging))
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Cancel") { Task { await acquisition.cancel(row.id) } }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .accessibilityLabel("Cancel the download of \(row.descriptor.displayName)")
+                }
+            }
+        }
+    }
+
+    private func fileProgressCaption(_ staging: LocalModelStagingSummary) -> String {
+        let sizes = "\(LocalModelPresentation.formatBytes(staging.completedBytes))"
+            + " of \(LocalModelPresentation.formatBytes(staging.totalBytes))"
+        guard let number = staging.fileNumber, staging.fileCount > 1 else { return sizes }
+        return "File \(number) of \(staging.fileCount) · \(sizes)"
+    }
+
+    @ViewBuilder
+    private func loadFailureNotice(_ message: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            OGStatusLabel(message, kind: .error, systemImage: "exclamationmark.triangle")
+            if let failedLoadModelId {
+                // Retry seam for the headroom gate: the user swipes other apps
+                // away, watches headroom recover, and retries without leaving
+                // the screen.
+                HStack(spacing: 12) {
+                    Button("Try again") { load(failedLoadModelId) }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(loadingModelId != nil)
+                    TimelineView(.periodic(from: .now, by: 2)) { _ in
+                        let available = MemoryHeadroom.availableBytes()
+                        if available > 0 {
+                            Text("Headroom now: \(LocalModelPresentation.formatBytes(available))")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Recommended (MLX)
+
+    private var recommendedSection: some View {
+        Section {
+            let entries = LocalModelCatalog.entries.filter {
+                isVisible($0.descriptor) && !isInstalled($0.descriptor.id)
+            }
+            if entries.isEmpty {
+                Text("No MLX models match this filter.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(entries, id: \.descriptor.id) { entry in
+                catalogRow(entry: entry)
+            }
+        } header: {
+            Text("Recommended")
+        } footer: {
+            Text("These models are tested on iPhone and optimized for size. Larger models need more RAM. Keep the app open while downloading — the screen stays awake automatically.")
+        }
+    }
+
+    @ViewBuilder
+    private func catalogRow(entry: LocalModelCatalog.Entry) -> some View {
+        let compatible = ProcessInfo.processInfo.physicalMemory
+            >= UInt64(entry.minimumRAMGB * 1_073_741_824)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(entry.descriptor.displayName).lineLimit(1)
+                    HStack(spacing: 8) {
+                        Text(entry.estimatedSize)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        ForEach(LocalModelPresentation
+                            .capabilityBadges(entry.descriptor.capabilities)) { badge in
+                            Label(badge.text, systemImage: badge.systemImage ?? "circle")
+                                .font(.caption2)
+                                .foregroundStyle(OGTheme.okLabel)
+                                .accessibilityLabel(badge.spokenLabel)
+                        }
+                    }
+                }
+                Spacer()
+
+                if downloadingModelId == entry.descriptor.id.rawValue, let service = localService {
+                    DownloadProgressRow(service: service) {
+                        service.cancelDownload()
+                        downloadingModelId = nil
+                    }
+                } else if !compatible {
+                    // The model's OWN requirement — this badge was hardcoded
+                    // "Needs 8 GB" and misreported every other tier.
+                    Label("Needs \(Int(entry.minimumRAMGB)) GB", systemImage: "memorychip")
+                        .font(.caption)
+                        .foregroundStyle(OGTheme.warnLabel)
+                } else {
+                    Button("Download") { downloadMLXModel(entry.descriptor.id.rawValue) }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .tint(.primary)
+                        .accessibilityLabel("Download \(entry.descriptor.displayName), "
+                                                + "\(entry.estimatedSize)")
+                }
+            }
+            Text(entry.notes)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Curated GGUF
+
+    private var ggufCatalogSection: some View {
+        Section {
+            let entries = LocalModelCatalog.bundledGGUFEntries().filter {
+                isVisible($0.descriptor) && !isInstalled($0.id) && acquisition.staging[$0.id] == nil
+            }
+            if entries.isEmpty {
+                Text("No GGUF models match this filter.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(entries, id: \.id) { entry in
+                ggufCatalogRow(entry)
+            }
+        } header: {
+            Text("GGUF models")
+        } footer: {
+            Text("Each of these is pinned to an exact version and checked against its published checksum before it's installed.")
+        }
+    }
+
+    @ViewBuilder
+    private func ggufCatalogRow(_ entry: LocalModelCatalog.GGUFEntry) -> some View {
+        let fit = acquisition.fitReport(for: entry.descriptor)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(entry.descriptor.displayName).lineLimit(2)
+                    HStack(spacing: 6) {
+                        ForEach([LocalModelPresentation.runtimeBadge(entry.descriptor.runtime)]
+                            + (LocalModelPresentation
+                                .quantizationBadge(entry.descriptor.quantization)
+                                .map { [$0] } ?? [])) { badge in
+                            Text(badge.text)
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                                .accessibilityLabel(badge.spokenLabel)
+                        }
+                        Text(LocalModelPresentation.formatBytes(fit.downloadBytes))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+                Button("Download") {
+                    Task {
+                        await acquisition.startDownload(descriptor: entry.descriptor,
+                                                        origin: .curatedCatalog)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .tint(.primary)
+                .disabled(!fit.canInstall || acquisition.isWorking)
+                .accessibilityLabel("Download \(entry.descriptor.displayName), "
+                                        + LocalModelPresentation.formatBytes(fit.downloadBytes))
+                .accessibilityHint(fit.canInstall
+                                       ? LocalModelPresentation.verdictText(fit.loadVerdict)
+                                       : (fit.blockers.first?.localizedMessage ?? ""))
+            }
+            if !entry.notes.isEmpty {
+                Text(entry.notes).font(.caption).foregroundStyle(.secondary)
+            }
+            if let blocker = fit.blockers.first {
+                OGStatusLabel(blocker.localizedMessage, kind: .error)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Custom
+
+    private var customSection: some View {
+        Section {
+            if ggufEnabled {
+                Button {
+                    showImportSheet = true
+                } label: {
+                    Label("Import from a repository", systemImage: "square.and.arrow.down.on.square")
+                }
+                .accessibilityHint("Choose a GGUF model from a public model repository.")
+            }
+            HStack {
+                TextField("MLX model ID", text: $customModelId)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .accessibilityLabel("Custom MLX model ID")
+                Button("Download") {
+                    let id = customModelId.trimmingCharacters(in: .whitespaces)
+                    guard !id.isEmpty else { return }
+                    downloadMLXModel(id)
+                }
+                .disabled(customModelId.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        } header: {
+            Text("Add a model")
+        } footer: {
+            Text(ggufEnabled
+                     ? "Repository imports are pinned to an exact version and verified against a published checksum. An MLX model ID is fetched whole from the hub, as it always has been."
+                     : "Paste any MLX model ID, e.g. \"mlx-community/phi-3-mini-4k-instruct-4bit\". GGUF models are turned off — turn them on to import from a repository.")
+        }
+    }
+
+    // MARK: - Diagnostics
+
+    private var diagnosticsSection: some View {
+        Section {
+            LocalModelDiagnosticsCard()
+        } header: {
+            Text("Diagnostics")
+        } footer: {
+            Text("What the last on-device run measured. Speed and first-token time depend on the model, the context length and how warm the phone is.")
+        }
+    }
+
+    // MARK: - Row assembly
+
+    /// One row's worth of facts, whatever the model's provenance.
+    private struct ManagedModel: Identifiable {
+        let id: LocalModelID
+        let descriptor: LocalModelDescriptor
+        let installation: InstalledLocalModel?
+        let state: LocalModelRowState
+        let onDiskBytes: Int64?
+
+        var isIncompatible: Bool {
+            if case .incompatible = state { return true }
+            return false
+        }
+    }
+
+    /// Everything on this iPhone: installation records, anything still staging, and any MLX
+    /// snapshot on disk that has no record yet.
+    ///
+    /// The last of those matters more than it looks: the installed-records migration is allowed to
+    /// defer or fail, and a screen that listed only records would tell a user their models were
+    /// gone when they are sitting on disk exactly where they were.
+    private var installedRows: [ManagedModel] {
+        var rows: [LocalModelID: ManagedModel] = [:]
+
+        for installation in acquisition.installed {
+            rows[installation.id] = makeRow(descriptor: installation.descriptor,
+                                            installation: installation)
+        }
+        for rawID in legacyDownloadedIds {
+            let id = LocalModelID(rawID)
+            guard rows[id] == nil else { continue }
+            let descriptor = LocalModelCatalog.resolveDescriptor(forLegacyMLXModelID: rawID)
+            rows[id] = makeRow(descriptor: descriptor,
+                               installation: LocalModelSelection.installation(for: id,
+                                                                              repository: acquisition.repository))
+        }
+        for (id, descriptor) in acquisition.stagedDescriptors where rows[id] == nil {
+            rows[id] = makeRow(descriptor: descriptor, installation: nil)
+        }
+        return rows.values.sorted { $0.descriptor.displayName < $1.descriptor.displayName }
+    }
+
+    private func makeRow(descriptor: LocalModelDescriptor,
+                         installation: InstalledLocalModel?) -> ManagedModel {
+        // The offered descriptor is the catalog's when there is one, so an installed model at an
+        // older revision can be seen to be behind.
+        let offered = LocalModelCatalog.bundledGGUFEntries()
+            .first { $0.id == descriptor.id }?.descriptor
+            ?? LocalModelCatalog.descriptor(for: descriptor.id)
+            ?? descriptor
+        let state = LocalModelRowState.derive(.init(
+            descriptor: offered,
+            installation: installation,
+            plan: nil,
+            isResident: residentModelId == descriptor.id,
+            recordedIncompatibility: incompatibilities[descriptor.id],
+            runtimeAvailability: availability(for: descriptor.runtime)))
+        // Staging is applied on top rather than passed in: the acquisition object has already
+        // folded the live byte reading into the summary, and rebuilding a plan here to re-derive
+        // it would be a second answer to the same question.
+        let resolved = acquisition.staging[descriptor.id].map { LocalModelRowState.staged($0) } ?? state
+        return ManagedModel(id: descriptor.id,
+                            descriptor: descriptor,
+                            installation: installation,
+                            state: resolved,
+                            onDiskBytes: installation.flatMap { _ in
+                                localService?.modelSizeOnDisk(descriptor.id.rawValue)
+                            })
+    }
+
+    private func availability(for runtime: LocalModelRuntime) -> LocalModelRuntimeAvailability {
+        switch runtime {
+        case .mlx: return .available
+        case .llamaCpp: return ggufEnabled ? .available : .disabled
+        }
+    }
+
+    private func isInstalled(_ id: LocalModelID) -> Bool {
+        acquisition.repository.isInstalled(id) || legacyDownloadedIds.contains(id.rawValue)
+    }
+
+    private func isVisible(_ descriptor: LocalModelDescriptor) -> Bool {
+        runtimeFilter.accepts(descriptor.runtime)
+            && capabilityFilter.accepts(descriptor.capabilities)
+    }
+
+    private func filtered(_ rows: [ManagedModel]) -> [ManagedModel] {
+        rows.filter { isVisible($0.descriptor) }
+    }
+
+    // MARK: - Actions
+
+    private func refreshEverything() async {
+        legacyDownloadedIds = localService?.downloadedModelIds() ?? []
+        acquisition.releaseResident = { [weak appState] id in
+            guard let coordinator = appState?.llmService.localInferenceCoordinator() else { return }
+            if await coordinator.loadedModel?.id == id { await coordinator.unload() }
+        }
+        await acquisition.restore()
+        await refreshResident()
+        if let activeModel = Config.activeModel, activeModel.llmProvider == .local {
+            selectedModelId = LocalModelSelection.store(repository: acquisition.repository)
+                .selectedID()?.rawValue ?? activeModel.model
+        }
+    }
+
+    private func refreshResident() async {
+        if let coordinator = appState.llmService.localInferenceCoordinator(),
+           let loaded = await coordinator.loadedModel {
+            residentModelId = loaded.id
+            return
+        }
+        // The direct MLX route is still the shipping path with the coordinator flag off, and it is
+        // the same service either way — so what it reports is the truth about residency.
+        residentModelId = (localService?.isModelLoaded == true)
+            ? localService?.loadedModelId.map { LocalModelID($0) }
+            : nil
+    }
+
+    /// Record the selection as a stable id, and keep the legacy string field in step.
+    private func select(_ id: LocalModelID) {
+        selectedModelId = id.rawValue
+        LocalModelSelection.store(repository: acquisition.repository).select(id)
+        appState.llmService.refreshActiveModel()
+    }
+
+    /// The MLX fetch, unchanged. It cannot go through the verified pipeline: an MLX entry has no
+    /// pinned revision and no per-file digests, which `installationFaults()` refuses on purpose.
+    private func downloadMLXModel(_ modelId: String) {
         downloadingModelId = modelId
         downloadError = nil
         Task {
             do {
                 try await localService?.downloadModel(modelId)
-                refreshDownloaded()
+                legacyDownloadedIds = localService?.downloadedModelIds() ?? []
+                await acquisition.refresh()
                 downloadingModelId = nil
+                LocalModelAcquisition.post("\(modelId) downloaded.")
             } catch is CancellationError {
-                downloadingModelId = nil   // BK P5: user cancelled — not an error to surface
+                downloadingModelId = nil   // user cancelled — not an error to surface
             } catch {
                 downloadError = error.localizedDescription
                 downloadingModelId = nil
@@ -247,29 +688,51 @@ struct LocalModelManagerView: View {
         }
     }
 
-    private func deleteModel(_ modelId: String) {
-        try? localService?.deleteModel(modelId)
-        refreshDownloaded()
+    private func confirmRemoval(_ row: ManagedModel) {
+        pendingRemoval = PendingRemoval(
+            id: row.id,
+            displayName: row.descriptor.displayName,
+            message: acquisition.removalConfirmation(for: row.id,
+                                                     displayName: row.descriptor.displayName))
     }
 
-    private func refreshDownloaded() {
-        downloadedIds = localService?.downloadedModelIds() ?? []
-        loadedLocalModelId = (localService?.isModelLoaded == true) ? localService?.loadedModelId : nil
+    private func remove(_ id: LocalModelID) async {
+        if acquisition.repository.isInstalled(id) {
+            await acquisition.delete(id)
+        } else {
+            await acquisition.cancel(id)
+        }
+        // A legacy hub snapshot has a record pointing at it but its bytes live in the MLX cache;
+        // removing the record alone would leave the weights on disk.
+        if legacyDownloadedIds.contains(id.rawValue) {
+            try? localService?.deleteModel(id.rawValue)
+        }
+        if residentModelId == id { residentModelId = nil }
+        incompatibilities[id] = nil
+        if selectedModelId == id.rawValue {
+            LocalModelSelection.store(repository: acquisition.repository).clearSelection()
+            selectedModelId = ""
+        }
+        legacyDownloadedIds = localService?.downloadedModelIds() ?? []
+        await acquisition.refresh()
+        await refreshResident()
     }
 
-    // MARK: - Manual load / unload
+    // MARK: - Load / unload
 
-    /// Load/Unload control for a downloaded model — lets the user choose when the
-    /// (heavy) model is brought into memory, instead of it loading lazily on first use.
     @ViewBuilder
-    private func loadControl(for modelId: String) -> some View {
-        if loadingModelId == modelId {
+    private func loadControl(for row: ManagedModel) -> some View {
+        if case .staged = row.state {
+            EmptyView()
+        } else if row.isIncompatible {
+            EmptyView()
+        } else if loadingModelId == row.id {
             HStack(spacing: 6) {
                 ProgressView().controlSize(.small)
                 Text("Loading…").font(.caption).foregroundStyle(.secondary)
             }
-        } else if loadedLocalModelId == modelId {
-            Button { unloadLocalModel() } label: {
+        } else if residentModelId == row.id {
+            Button { unload() } label: {
                 Label("Loaded", systemImage: "checkmark.circle.fill")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(OGTheme.okLabel)
@@ -277,9 +740,9 @@ struct LocalModelManagerView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.borderless)
-            .accessibilityLabel("Model loaded — tap to unload")
-        } else {
-            Button { loadLocalModel(modelId) } label: {
+            .accessibilityLabel("\(row.descriptor.displayName) is loaded — tap to unload")
+        } else if row.installation != nil {
+            Button { load(row.id) } label: {
                 Text("Load")
                     .font(.caption.weight(.semibold))
                     .padding(.horizontal, 12)
@@ -290,43 +753,71 @@ struct LocalModelManagerView: View {
             }
             .buttonStyle(.borderless)
             .disabled(loadingModelId != nil)
+            .accessibilityLabel("Load \(row.descriptor.displayName) into memory")
         }
     }
 
-    private func loadLocalModel(_ modelId: String) {
-        loadingModelId = modelId
+    /// Load through the coordinator whenever one exists, whatever the runtime.
+    ///
+    /// That is the point of the coordinator: it is the single owner of residency, so loading a GGUF
+    /// model here evicts a resident MLX one rather than the two of them competing for the same
+    /// memory. With no coordinator available the MLX service is used directly, exactly as before.
+    private func load(_ id: LocalModelID) {
+        loadingModelId = id
         loadError = nil
         failedLoadModelId = nil
         Task {
+            let installation = LocalModelSelection.installation(for: id,
+                                                                repository: acquisition.repository)
             do {
-                try await localService?.loadModel(modelId)
-                loadedLocalModelId = modelId
+                if let coordinator = appState.llmService.localInferenceCoordinator() {
+                    _ = try await coordinator.load(
+                        installation,
+                        configuration: LocalLoadConfiguration(
+                            contextLength: installation.descriptor.contextLength > 0
+                                ? installation.descriptor.contextLength
+                                : LocalModelBudget.contextWindow(for: id.rawValue)))
+                } else {
+                    try await localService?.loadModel(id.rawValue)
+                }
+                incompatibilities[id] = nil
+                LocalModelAcquisition.post("\(installation.descriptor.displayName) loaded.")
             } catch {
-                loadError = error.localizedDescription
-                failedLoadModelId = modelId
+                // A typed refusal about the *model* is recorded as an incompatibility, which
+                // changes the row and unlocks the reason action. Anything else stays a retryable
+                // load error with its Try again button.
+                if let incompatibility = LocalModelIncompatibility.from(error) {
+                    incompatibilities[id] = incompatibility
+                    loadError = nil
+                    LocalModelAcquisition.post(incompatibility.spokenLabel)
+                } else {
+                    loadError = error.localizedDescription
+                    failedLoadModelId = id
+                }
             }
             loadingModelId = nil
+            await refreshResident()
         }
     }
 
-    private func unloadLocalModel() {
-        localService?.unloadModel()
-        loadedLocalModelId = nil
-    }
-
-    private func modelDisplayName(_ modelId: String) -> String {
-        // "mlx-community/gemma-2-2b-it-4bit" → "gemma-2-2b-it-4bit"
-        if let name = modelId.split(separator: "/").last {
-            return String(name)
+    private func unload() {
+        Task {
+            if let coordinator = appState.llmService.localInferenceCoordinator() {
+                await coordinator.unload()
+            }
+            localService?.unloadModel()
+            await refreshResident()
+            LocalModelAcquisition.post("Model unloaded.")
         }
-        return modelId
     }
 
-    private func formatBytes(_ bytes: Int64) -> String {
-        if bytes < 1024 { return "\(bytes) B" }
-        if bytes < 1024 * 1024 { return String(format: "%.0f KB", Double(bytes) / 1024) }
-        if bytes < 1024 * 1024 * 1024 { return String(format: "%.1f MB", Double(bytes) / (1024 * 1024)) }
-        return String(format: "%.1f GB", Double(bytes) / (1024 * 1024 * 1024))
+    // MARK: - Leaving mid-download
+
+    /// The plan's rule, said out loud: leaving the screen during a background download explicitly
+    /// says the download continues.
+    private func announceBackgroundContinuation() {
+        guard let notice = acquisition.backgroundContinuationNotice() else { return }
+        LocalModelAcquisition.post(notice)
     }
 }
 

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -194,6 +194,18 @@ class LLMService: ObservableObject {
         return created
     }
 
+    /// The coordinator, for surfaces that manage residency directly rather than through a turn —
+    /// the model manager's Load/Unload and the deletion path.
+    ///
+    /// Returns nil only when there is no on-device service at all. Handing the manager the same
+    /// coordinator the turn path uses is what keeps "at most one resident model" true across the
+    /// two runtimes: a GGUF load from the manager evicts a resident MLX model instead of the two
+    /// of them competing for the same memory.
+    func localInferenceCoordinator() -> LocalInferenceCoordinator? {
+        guard let localLLMService else { return nil }
+        return coordinator(for: localLLMService)
+    }
+
     /// Session the SSE streaming helpers use. Injectable purely so tests can stub `URLProtocol`
     /// and exercise the stream parsing/error paths headlessly (BM P9); production uses `.shared`.
     var streamingSession: URLSession = .shared
@@ -2735,12 +2747,12 @@ class LLMService: ObservableObject {
     /// a retired entry, or one the user typed — resolves to a compatibility descriptor so no
     /// configuration can be made unusable by this seam. Storage is `.legacyHubSnapshot`, which is
     /// where MLX files actually live and where PR1 leaves them.
+    /// The compatibility installation for a model with no record — a hub snapshot discovered on
+    /// disk, or an id someone typed. One definition, shared with the selection resolver, so the
+    /// turn path and the model manager cannot synthesize two different installations for the same
+    /// id.
     nonisolated static func mlxInstallation(forModelID modelID: String) -> InstalledLocalModel {
-        InstalledLocalModel(
-            descriptor: LocalModelCatalog.resolveDescriptor(forLegacyMLXModelID: modelID),
-            storage: .legacyHubSnapshot(
-                directoryName: LocalModelRepository.legacyDirectoryName(forModelID: modelID)),
-            installedAt: Date(timeIntervalSince1970: 0))
+        LocalModelSelection.compatibilityInstallation(for: LocalModelID(modelID))
     }
 
     // Unlike the cloud providers, the on-device path is deliberately NOT on the shared `runToolLoop`
@@ -2756,12 +2768,26 @@ class LLMService: ObservableObject {
         // Load the configured model (no auto-swap — user picks one model). With the DZ seam on,
         // the same load goes through the coordinator, which owns residency across runtimes; with
         // it off this is the call it has always been.
-        let useCoordinator = Config.localRuntimeCoordinatorEnabled
+        // The selected model is a stable id whose runtime comes from its installation record; the
+        // legacy `config.model` string is the fallback for a device whose selection migration has
+        // not run. For every MLX model the two are the same string by construction, so this path is
+        // unchanged for everyone who has one selected.
+        let selection = LocalModelSelection.store()
+        let selectedID = selection.selectedID() ?? LocalModelID(config.model)
+        let installation = LocalModelSelection.installation(for: selectedID)
+        let isGGUF = installation.runtime == .llamaCpp
+
+        // A GGUF model has no direct route: `LocalLLMService` is the MLX runtime. The coordinator
+        // is therefore required for it, whatever the seam flag says — that flag is about which
+        // route *MLX* takes, not about whether a second runtime exists.
+        let useCoordinator = Config.localRuntimeCoordinatorEnabled || isGGUF
         if useCoordinator {
             try await coordinator(for: localService).load(
-                Self.mlxInstallation(forModelID: config.model),
+                installation,
                 configuration: LocalLoadConfiguration(
-                    contextLength: LocalModelBudget.contextWindow(for: config.model)))
+                    contextLength: installation.descriptor.contextLength > 0
+                        ? installation.descriptor.contextLength
+                        : LocalModelBudget.contextWindow(for: selectedID.rawValue)))
         } else if !localService.isModelLoaded || localService.loadedModelId != config.model {
             try await localService.loadModel(config.model)
         }
@@ -2800,11 +2826,11 @@ class LLMService: ObservableObject {
                                                        history: history,
                                                        userMessage: text),
                     images: imageData.map { [LocalImageInput(data: $0)] } ?? [],
-                    maxOutputTokens: LocalModelBudget.generationReserve(for: config.model),
+                    maxOutputTokens: LocalModelBudget.generationReserve(for: selectedID.rawValue),
                     previewSink: onToken)
                 do {
                     let stream = try await coordinator(for: localService)
-                        .generate(request, expecting: LocalModelID(config.model))
+                        .generate(request, expecting: selectedID)
                     var assembled = ""
                     for try await chunk in stream { assembled += chunk }
                     response = assembled
@@ -2813,7 +2839,7 @@ class LLMService: ObservableObject {
                     // refuses it inside `generate`. Same outcome, and deliberately the same words —
                     // answering blind about a photo the model never saw is the failure both nets
                     // exist to prevent.
-                    PrivacyLog.localModel(.imageRefused, model: PrivacyToken(config.model))
+                    PrivacyLog.localModel(.imageRefused, model: PrivacyToken(selectedID.rawValue))
                     response = LocalLLMService.visionWeightsUnavailableMessage
                 }
             } else {

--- a/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaCppLocalInferenceBackend.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LlamaCpp/LlamaCppLocalInferenceBackend.swift
@@ -101,6 +101,10 @@ actor LlamaCppLocalInferenceBackend: LocalInferenceBackend {
     private let monotonicNanoseconds: @Sendable () -> UInt64
     /// Whether GGUF is switched on. Injected so a test does not mutate a global default.
     private let isRuntimeEnabled: @Sendable () -> Bool
+    /// Where the diagnostics card's numbers go. It is a *second sink on the existing measurement*,
+    /// not a second measurement: the two call sites below hand it the same values they hand
+    /// `PrivacyLog`, so the card and the log can never disagree about a run.
+    private let recordDiagnostics: @Sendable (LocalRuntimeDiagnosticsSample) -> Void
 
     // MARK: - Resident state
 
@@ -143,7 +147,9 @@ actor LlamaCppLocalInferenceBackend: LocalInferenceBackend {
             = { ProcessInfo.processInfo.thermalState },
          monotonicNanoseconds: @escaping @Sendable () -> UInt64
             = { DispatchTime.now().uptimeNanoseconds },
-         isRuntimeEnabled: @escaping @Sendable () -> Bool = { Config.ggufModelsEnabled }) {
+         isRuntimeEnabled: @escaping @Sendable () -> Bool = { Config.ggufModelsEnabled },
+         recordDiagnostics: @escaping @Sendable (LocalRuntimeDiagnosticsSample) -> Void
+            = { LocalRuntimeDiagnostics.shared.record($0) }) {
         self.engine = engine
         self.directoryForInstallation = directoryForInstallation ?? { installation in
             LocalModelRepository.defaultDirectory(for: installation)
@@ -154,6 +160,7 @@ actor LlamaCppLocalInferenceBackend: LocalInferenceBackend {
         self.thermalState = thermalState
         self.monotonicNanoseconds = monotonicNanoseconds
         self.isRuntimeEnabled = isRuntimeEnabled
+        self.recordDiagnostics = recordDiagnostics
     }
 
     var loadedModel: LocalLoadedModel? { resources?.loaded }
@@ -277,6 +284,7 @@ actor LlamaCppLocalInferenceBackend: LocalInferenceBackend {
                                   loaded: loaded,
                                   headroomAfterLoadBytes: availableProcessBytes())
 
+            let loadMilliseconds = milliseconds(since: startedAt)
             PrivacyLog.localModel(.loaded,
                                   model: PrivacyToken(installation.id.rawValue),
                                   vision: false,
@@ -284,8 +292,24 @@ actor LlamaCppLocalInferenceBackend: LocalInferenceBackend {
                                   footprintMegabytes: megabytes(appFootprintBytes()),
                                   headroomMegabytes: megabytes(availableProcessBytes()),
                                   detail: PrivacyToken("gguf-\(plan.binding.rawValue)"),
-                                  milliseconds: milliseconds(since: startedAt),
+                                  milliseconds: loadMilliseconds,
                                   state: thermalToken())
+            // Same numbers, second sink: the card can say what the context came out at before the
+            // wearer has asked the model anything.
+            recordDiagnostics(LocalRuntimeDiagnosticsSample(
+                kind: .load,
+                modelID: installation.id,
+                runtime: .llamaCpp,
+                modelRevision: installation.descriptor.revision,
+                contextTokens: actualContext,
+                promptTokens: 0,
+                generatedTokens: 0,
+                firstTokenMilliseconds: nil,
+                totalMilliseconds: loadMilliseconds,
+                headroomDeltaBytes: 0,
+                footprintBytes: appFootprintBytes(),
+                thermalState: .init(thermalState()),
+                recordedAt: Date()))
             return loaded
         } catch {
             // 7. Reverse-order teardown of whatever was created, then a typed error. A raw engine
@@ -447,6 +471,7 @@ actor LlamaCppLocalInferenceBackend: LocalInferenceBackend {
                               state: thermalToken())
 
         let plan = GenerationPlan(installationID: resources.installation.id,
+                                  modelRevision: resources.installation.descriptor.revision,
                                   model: resources.model,
                                   context: resources.context,
                                   sampler: sampler,
@@ -476,6 +501,9 @@ actor LlamaCppLocalInferenceBackend: LocalInferenceBackend {
     /// Everything the decode loop needs, captured so the loop can run off the actor.
     private struct GenerationPlan: Sendable {
         let installationID: LocalModelID
+        /// Carried rather than looked up: the completion record runs off the actor, and reaching
+        /// back for the installation there would be a hop for a value that cannot change mid-turn.
+        let modelRevision: String
         let model: LlamaModelHandle
         let context: LlamaContextHandle
         let sampler: LlamaSamplerHandle
@@ -604,6 +632,10 @@ actor LlamaCppLocalInferenceBackend: LocalInferenceBackend {
                                               position: Int) {
         let headroomNow = availableProcessBytes()
         let usage = plan.contextTokens > 0 ? (position * 100) / plan.contextTokens : 0
+        let totalMilliseconds = milliseconds(since: plan.promptStartedAt)
+        let firstTokenMilliseconds = firstTokenAt.map {
+            Int(($0 &- plan.promptStartedAt) / 1_000_000)
+        }
         PrivacyLog.localModel(.generationCompleted,
                               model: PrivacyToken(plan.installationID.rawValue),
                               count: generated,
@@ -612,12 +644,26 @@ actor LlamaCppLocalInferenceBackend: LocalInferenceBackend {
                               footprintMegabytes: megabytes(appFootprintBytes()),
                               headroomMegabytes: megabytes(headroomNow - plan.headroomAfterLoadBytes),
                               detail: PrivacyToken("gguf"),
-                              milliseconds: milliseconds(since: plan.promptStartedAt),
-                              firstTokenMilliseconds: firstTokenAt.map {
-                                  Int(($0 &- plan.promptStartedAt) / 1_000_000)
-                              },
+                              milliseconds: totalMilliseconds,
+                              firstTokenMilliseconds: firstTokenMilliseconds,
                               percent: usage,
                               state: thermalToken())
+        // The diagnostics card reads exactly what the line above recorded — same counts, same
+        // clock, same headroom reading — so there is one measurement with two readers.
+        recordDiagnostics(LocalRuntimeDiagnosticsSample(
+            kind: .generation,
+            modelID: plan.installationID,
+            runtime: .llamaCpp,
+            modelRevision: plan.modelRevision,
+            contextTokens: plan.contextTokens,
+            promptTokens: plan.promptTokens.count,
+            generatedTokens: generated,
+            firstTokenMilliseconds: firstTokenMilliseconds,
+            totalMilliseconds: totalMilliseconds,
+            headroomDeltaBytes: headroomNow - plan.headroomAfterLoadBytes,
+            footprintBytes: appFootprintBytes(),
+            thermalState: .init(thermalState()),
+            recordedAt: Date()))
     }
 
     // MARK: - Cancellation

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelAcquisition.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelAcquisition.swift
@@ -1,0 +1,314 @@
+import Foundation
+import UIKit
+
+/// The screen-facing half of the acquisition pipeline: one object that owns the repository, the
+/// background transfer and the download manager, and publishes what a row needs to draw
+/// (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "Local model manager and diagnostics").
+///
+/// It exists so three things have exactly one owner:
+///
+///  - **The background `URLSession`.** iOS hands its completion handler to the app delegate, which
+///    needs to reach the same transfer object the screen is driving. A view cannot be that owner —
+///    it is gone by the time the system wakes the app.
+///  - **The plan-to-row mapping.** Rows are keyed by `LocalModelID`; plans are keyed by UUID. One
+///    place derives one from the other, so cancel and retry cannot act on a different plan than the
+///    row was drawn from.
+///  - **Announcements.** Progress is announced at bounded intervals and completion immediately, and
+///    the announcer's state has to outlive a redraw.
+///
+/// Everything decision-shaped lives in the pure types this drives (`LocalModelFitReport`,
+/// `LocalModelRowState`, `LocalModelProgressAnnouncer`); what is here is wiring and lifecycle.
+@MainActor
+final class LocalModelAcquisition: ObservableObject {
+
+    /// The app's instance. The app delegate reaches it to deliver background events; the model
+    /// manager observes it.
+    static let shared = LocalModelAcquisition()
+
+    let repository: LocalModelRepository
+    private let transfer: LocalModelBackgroundTransfer
+    /// Lazy so its `unloadIfResident` hook can route back through this object: the closure has to
+    /// capture `self`, and a stored property cannot during initialization.
+    private lazy var manager = LocalModelDownloadManager(
+        repository: repository,
+        transfer: transfer,
+        unloadIfResident: { [weak self] id in await self?.callReleaseResident(id) })
+
+    /// Release a resident model before its files go. Set by whoever owns residency (the model
+    /// manager wires it to the inference coordinator); nil means nothing can be resident.
+    var releaseResident: ((LocalModelID) async -> Void)?
+
+    // MARK: - Published state
+
+    @Published private(set) var installed: [InstalledLocalModel] = []
+    /// Acquisitions in flight, by the model they install.
+    @Published private(set) var staging: [LocalModelID: LocalModelStagingSummary] = [:]
+    /// The descriptor of anything staged but not yet installed, so an import can be shown as a row
+    /// before it exists on disk.
+    @Published private(set) var stagedDescriptors: [LocalModelID: LocalModelDescriptor] = [:]
+    /// The last failure worth showing, already user-ready.
+    @Published var errorMessage: String?
+    /// True while a plan is being created or run from this screen.
+    @Published private(set) var isWorking = false
+
+    private var planIDs: [LocalModelID: UUID] = [:]
+    private var announcers: [LocalModelID: LocalModelProgressAnnouncer] = [:]
+    private var runTask: Task<Void, Never>?
+
+    init(repository: LocalModelRepository = LocalModelRepository()) {
+        self.repository = repository
+        self.transfer = LocalModelBackgroundTransfer()
+    }
+
+    private func callReleaseResident(_ id: LocalModelID) async {
+        await releaseResident?(id)
+    }
+
+    // MARK: - Background session
+
+    /// Whether an identifier belongs to the model-download session. The app delegate serves more
+    /// than one background session, and answering "not mine" correctly is what keeps the other
+    /// one's completion handler from being swallowed here.
+    nonisolated static func ownsBackgroundSession(_ identifier: String) -> Bool {
+        identifier == LocalModelBackgroundTransfer.sessionIdentifier
+    }
+
+    /// Take the system's completion handler for a relaunch caused by a finished background
+    /// transfer. It is invoked once the session has delivered everything it held.
+    func adoptBackgroundEventsHandler(_ handler: @escaping @Sendable () -> Void) {
+        transfer.setBackgroundEventsHandler(handler)
+        // Delivery wakes the app with plans on disk and tasks the system still holds; restoring is
+        // what turns that into installed models.
+        Task { await self.restore() }
+    }
+
+    // MARK: - Refresh
+
+    func refresh() async {
+        installed = repository.installedModels()
+        await refreshPlans()
+    }
+
+    /// Re-derive the staging map. Called on a timer while the screen is visible, which is also what
+    /// drives the progress bar and the bounded announcements.
+    func refreshPlans() async {
+        let plans = await manager.plans()
+        var staging: [LocalModelID: LocalModelStagingSummary] = [:]
+        var descriptors: [LocalModelID: LocalModelDescriptor] = [:]
+        var ids: [LocalModelID: UUID] = [:]
+        for plan in plans {
+            let live = await manager.progress(plan.id)?.completedBytes
+            guard let summary = LocalModelStagingSummary(plan: plan, completedBytes: live) else {
+                continue
+            }
+            staging[plan.descriptor.id] = summary
+            descriptors[plan.descriptor.id] = plan.descriptor
+            ids[plan.descriptor.id] = plan.id
+        }
+        self.staging = staging
+        self.stagedDescriptors = descriptors
+        self.planIDs = ids
+        announceProgress(for: staging)
+    }
+
+    /// Restore after a relaunch and finish anything that was mid-install.
+    func restore() async {
+        _ = await manager.restore()
+        await refresh()
+    }
+
+    // MARK: - Fit
+
+    /// The fit report for a descriptor, taken against live readings of this device.
+    ///
+    /// Both readings are taken here, on the main actor, next to the surface that shows them — the
+    /// download manager requires the report rather than recomputing it precisely so the plan is
+    /// built from the numbers the user agreed to.
+    func fitReport(for descriptor: LocalModelDescriptor,
+                   acceptedLicenseRevision: String? = nil) -> LocalModelFitReport {
+        LocalModelFitReport.make(.init(
+            descriptor: descriptor,
+            availableStorageBytes: OfflineModelOffer.freeDiskBytes(),
+            availableProcessBytes: MemoryHeadroom.availableBytes(),
+            acceptedLicenseRevision: acceptedLicenseRevision))
+    }
+
+    // MARK: - Starting a download
+
+    /// Create, consent to, and run a plan. One call, because a plan that is created and not
+    /// consented to is a directory on disk that nothing will ever finish.
+    func startDownload(descriptor: LocalModelDescriptor,
+                       origin: LocalModelDownloadPlan.Origin,
+                       acceptedLicenseRevision: String? = nil) async {
+        guard !isWorking else { return }
+        isWorking = true
+        errorMessage = nil
+        defer { isWorking = false }
+
+        let fit = fitReport(for: descriptor, acceptedLicenseRevision: acceptedLicenseRevision)
+        guard fit.canInstall else {
+            errorMessage = fit.blockers.first?.localizedMessage
+                ?? "This model can't be downloaded."
+            return
+        }
+        do {
+            let plan = try await manager.createPlan(descriptor: descriptor, origin: origin, fit: fit)
+            _ = try await manager.grantConsent(planID: plan.id,
+                                               acceptedLicenseRevision: acceptedLicenseRevision)
+            announcers[descriptor.id] = LocalModelProgressAnnouncer(modelName: descriptor.displayName)
+            await refreshPlans()
+            run(planID: plan.id, modelID: descriptor.id)
+        } catch let error as LocalModelDownloadManager.ManagerError {
+            errorMessage = Self.message(for: error)
+        } catch {
+            errorMessage = "The download couldn't be started."
+        }
+    }
+
+    private func run(planID: UUID, modelID: LocalModelID) {
+        runTask?.cancel()
+        runTask = Task { [weak self] in
+            guard let self else { return }
+            let finished = await self.manager.run(planID: planID)
+            await self.finish(plan: finished, modelID: modelID)
+        }
+    }
+
+    private func finish(plan: LocalModelDownloadPlan?, modelID: LocalModelID) async {
+        await refresh()
+        guard let plan else { return }
+        switch plan.state {
+        case .installed:
+            announce(.completed, for: modelID)
+        case .cancelled:
+            announce(.cancelled, for: modelID)
+        case .failed(let failure):
+            let message = LocalModelRowState.retryExplanation(failure.reason)
+            errorMessage = message
+            announce(.failed(message), for: modelID)
+        default:
+            break
+        }
+    }
+
+    // MARK: - Cancel, retry, delete
+
+    func cancel(_ id: LocalModelID) async {
+        guard let planID = planIDs[id] else { return }
+        runTask?.cancel()
+        _ = await manager.cancel(planID: planID)
+        announce(.cancelled, for: id)
+        await refresh()
+    }
+
+    func retry(_ id: LocalModelID) async {
+        guard let planID = planIDs[id] else { return }
+        announcers[id]?.restart()
+        errorMessage = nil
+        await refreshPlans()
+        run(planID: planID, modelID: id)
+    }
+
+    /// Remove an installation. Cancels anything fetching it and releases it if resident first —
+    /// both inside the download manager, which is where that ordering is already proved.
+    func delete(_ id: LocalModelID) async {
+        errorMessage = nil
+        do {
+            try await manager.deleteInstallation(id)
+            announcers[id] = nil
+        } catch let error as LocalModelDownloadManager.ManagerError {
+            errorMessage = Self.message(for: error)
+        } catch {
+            errorMessage = "That model couldn't be removed."
+        }
+        await refresh()
+    }
+
+    /// What a removal will actually delete, named before it happens.
+    ///
+    /// The plan requires the confirmation to say whether staged *and* installed files go. Both can
+    /// exist at once — a re-download of an installed model stages a second copy — and a person
+    /// agreeing to "delete" deserves to know they are agreeing to both.
+    func removalConfirmation(for id: LocalModelID, displayName: String) -> String {
+        let hasInstall = repository.installation(for: id) != nil
+        let hasStaging = staging[id] != nil
+        switch (hasInstall, hasStaging) {
+        case (true, true):
+            return "Remove \(displayName)? Its installed files and the partly downloaded copy are "
+                + "both deleted. It can be downloaded again later."
+        case (true, false):
+            return "Remove \(displayName)? Its installed files are deleted from this iPhone. It can "
+                + "be downloaded again later."
+        case (false, true):
+            return "Stop and remove \(displayName)? The partly downloaded files are deleted. "
+                + "Nothing was installed."
+        case (false, false):
+            return "Remove \(displayName)?"
+        }
+    }
+
+    // MARK: - Announcements
+
+    private func announceProgress(for staging: [LocalModelID: LocalModelStagingSummary]) {
+        for (id, summary) in staging {
+            guard case .downloading = summary.phase else { continue }
+            announce(.progress(fraction: summary.fractionCompleted), for: id)
+        }
+    }
+
+    private func announce(_ event: LocalModelProgressAnnouncer.Event, for id: LocalModelID) {
+        let name = stagedDescriptors[id]?.displayName
+            ?? repository.installation(for: id)?.descriptor.displayName
+            ?? id.rawValue
+        var announcer = announcers[id] ?? LocalModelProgressAnnouncer(modelName: name)
+        let sentence = announcer.announcement(for: event, at: Date())
+        announcers[id] = announcer
+        guard let sentence else { return }
+        Self.post(sentence)
+    }
+
+    /// Say something to VoiceOver. Nothing happens when it is off, which is why the announcer's
+    /// interval logic lives in a pure type rather than being inferred from the absence of speech.
+    static func post(_ announcement: String) {
+        UIAccessibility.post(notification: .announcement, argument: announcement)
+    }
+
+    /// The sentence a person sees when they leave the screen mid-download.
+    func backgroundContinuationNotice() -> String? {
+        let running = staging.first { summary in
+            switch summary.value.phase {
+            case .queued, .downloading, .validating, .installing: return true
+            case .awaitingConsent, .retryable: return false
+            }
+        }
+        guard let running else { return nil }
+        let name = stagedDescriptors[running.key]?.displayName ?? running.key.rawValue
+        return LocalModelProgressAnnouncer.backgroundContinuationNotice(modelName: name)
+    }
+
+    // MARK: - Errors
+
+    /// Manager faults, said in words. A blocker list is collapsed to its first entry: the consent
+    /// screen shows them all, and this path is the one where a plan was refused *after* consent,
+    /// where the first reason is the one that changed.
+    static func message(for error: LocalModelDownloadManager.ManagerError) -> String {
+        switch error {
+        case .anotherPlanActive:
+            return "Another model is downloading. Wait for it to finish, or cancel it first."
+        case .planNotFound:
+            return "That download is no longer available."
+        case .descriptorNotInstallable:
+            return "This model isn't described precisely enough to install safely."
+        case .fitRefused(let blockers):
+            return blockers.first?.localizedMessage ?? "This model can't be downloaded."
+        case .consentRequired:
+            return "Accept this model's licence to continue."
+        case .installationNotFound:
+            return "That model isn't installed."
+        case .containmentRefused:
+            return "That model's files couldn't be removed safely, so nothing was deleted."
+        case .storageUnavailable:
+            return "There wasn't room to write to storage."
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelDownloadManager.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelDownloadManager.swift
@@ -52,6 +52,12 @@ actor LocalModelDownloadManager {
     /// never has to know about the coordinator (and so the suite never touches a `.shared` service).
     private let unloadIfResident: @Sendable (LocalModelID) async -> Void
 
+    /// Bytes written for the file currently being fetched, keyed by plan. In memory only, and only
+    /// for the progress bar: what survives a relaunch is the persisted plan, whose byte counts are
+    /// recomputed from the files actually staged on disk. Cleared as soon as a file validates,
+    /// because from that moment the persisted count is the better number.
+    private var liveFileBytes: [UUID: (fileIndex: Int, bytes: Int64)] = [:]
+
     init(repository: LocalModelRepository,
          transfer: any LocalModelFileTransferring,
          fileManager: FileManager = .default,
@@ -96,6 +102,25 @@ actor LocalModelDownloadManager {
     }
 
     func plan(_ planID: UUID) -> LocalModelDownloadPlan? { readPlan(planID) }
+
+    /// Progress for one plan: the bytes it has persisted, plus the live reading for the file in
+    /// flight. Returns nil when there is no such plan.
+    func progress(_ planID: UUID) -> (completedBytes: Int64, totalBytes: Int64)? {
+        guard let plan = readPlan(planID) else { return nil }
+        var completed = plan.completedBytes
+        if let live = liveFileBytes[planID],
+           plan.files.indices.contains(live.fileIndex),
+           !plan.files[live.fileIndex].isValidated {
+            // The persisted count already includes anything validated; the live figure belongs to
+            // the one file that has not been.
+            completed += min(live.bytes, plan.files[live.fileIndex].byteCount)
+        }
+        return (min(completed, plan.totalBytes), plan.totalBytes)
+    }
+
+    private func recordLiveBytes(planID: UUID, fileIndex: Int, bytes: Int64) {
+        liveFileBytes[planID] = (fileIndex, bytes)
+    }
 
     /// The plan currently occupying the pipeline, if any.
     func activePlan() -> LocalModelDownloadPlan? {
@@ -238,10 +263,18 @@ actor LocalModelDownloadManager {
 
         let outcome: LocalModelFileTransferOutcome
         do {
+            let planID = plan.id
             outcome = try await transfer.transfer(.init(
-                identifier: LocalModelTransferIdentifier(planID: plan.id, fileIndex: fileIndex),
+                identifier: LocalModelTransferIdentifier(planID: planID, fileIndex: fileIndex),
                 url: url,
-                expectedBytes: file.byteCount))
+                expectedBytes: file.byteCount,
+                onProgress: { [weak self] written in
+                    // Already throttled by the transport; one hop per megabyte is affordable and
+                    // is what keeps the actor's state the single owner of the reading.
+                    Task { await self?.recordLiveBytes(planID: planID,
+                                                       fileIndex: fileIndex,
+                                                       bytes: written) }
+                }))
         } catch LocalModelFileTransferError.cancelled {
             throw CancellationError()
         } catch LocalModelFileTransferError.redirectRefused {
@@ -290,6 +323,7 @@ actor LocalModelDownloadManager {
         }
 
         plan.markValidated(fileIndex: fileIndex, byteCount: file.byteCount, now: now())
+        liveFileBytes[plan.id] = nil
         if let next = plan.nextFileIndex {
             try plan.advance(to: .downloading(fileIndex: next), now: now())
         }
@@ -327,6 +361,7 @@ actor LocalModelDownloadManager {
         }
         plan = (try? persist(plan)) ?? plan
         log(.installCompleted, plan: plan)
+        liveFileBytes[plan.id] = nil
         // The plan has done its job; its directory goes now that nothing depends on it.
         removePlanDirectory(plan.id)
         return plan
@@ -366,6 +401,7 @@ actor LocalModelDownloadManager {
         // directory is not.
         guard readPlan(plan.id) != nil else { return plan }
         let stored = (try? persist(plan)) ?? plan
+        liveFileBytes[stored.id] = nil
         log(.downloadCancelled, plan: stored)
         removePlanDirectory(stored.id)
         return stored
@@ -424,7 +460,7 @@ actor LocalModelDownloadManager {
             default:
                 break
             }
-            try? persist(plan)
+            _ = try? persist(plan)
             log(.downloadRecovered, plan: plan,
                 detail: live.contains(plan.id) ? "taskLive" : "taskAbsent")
             result.append((plan, recovery))

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelFileTransfer.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelFileTransfer.swift
@@ -8,6 +8,23 @@ struct LocalModelFileTransferRequest: Sendable {
     let identifier: LocalModelTransferIdentifier
     let url: URL
     let expectedBytes: Int64
+    /// Bytes written so far for this file, reported while the fetch runs.
+    ///
+    /// UI only, and deliberately so: what survives a relaunch is still the persisted plan, which is
+    /// recomputed from bytes actually on disk. This is the live reading laid over it, so a
+    /// multi-gigabyte file does not sit at nought percent for ten minutes and then jump to whole.
+    /// Implementations throttle it — see `progressReportingStepBytes`.
+    let onProgress: (@Sendable (Int64) -> Void)?
+
+    init(identifier: LocalModelTransferIdentifier,
+         url: URL,
+         expectedBytes: Int64,
+         onProgress: (@Sendable (Int64) -> Void)? = nil) {
+        self.identifier = identifier
+        self.url = url
+        self.expectedBytes = expectedBytes
+        self.onProgress = onProgress
+    }
 }
 
 /// What a completed fetch delivered. Every field is something the manager re-checks: a transport
@@ -59,9 +76,16 @@ final class LocalModelBackgroundTransfer: NSObject, LocalModelFileTransferring, 
     /// One session per app, named so the system can hand its tasks back after a relaunch.
     static let sessionIdentifier = "com.openglasses.localmodels.download"
 
+    /// How much must arrive before progress is reported again. `URLSession` calls its delegate
+    /// every few kilobytes; forwarding each one would spend more time waking the actor than
+    /// fetching. A megabyte is invisible on a progress bar and rare enough to cost nothing.
+    static let progressReportingStepBytes: Int64 = 1 << 20
+
     private let lock = NSLock()
     private var continuations: [LocalModelTransferIdentifier: CheckedContinuation<LocalModelFileTransferOutcome, Error>] = [:]
     private var refusedRedirects: Set<LocalModelTransferIdentifier> = []
+    private var progressSinks: [LocalModelTransferIdentifier: @Sendable (Int64) -> Void] = [:]
+    private var lastReportedBytes: [LocalModelTransferIdentifier: Int64] = [:]
     /// Called when the system finishes delivering background events, so the app delegate's stored
     /// completion handler can be invoked.
     private var backgroundEventsHandler: (@Sendable () -> Void)?
@@ -92,6 +116,8 @@ final class LocalModelBackgroundTransfer: NSObject, LocalModelFileTransferring, 
             lock.lock()
             continuations[request.identifier] = continuation
             refusedRedirects.remove(request.identifier)
+            progressSinks[request.identifier] = request.onProgress
+            lastReportedBytes[request.identifier] = 0
             lock.unlock()
 
             var urlRequest = URLRequest(url: request.url)
@@ -122,8 +148,24 @@ final class LocalModelBackgroundTransfer: NSObject, LocalModelFileTransferring, 
                         with result: Result<LocalModelFileTransferOutcome, Error>) {
         lock.lock()
         let continuation = continuations.removeValue(forKey: identifier)
+        progressSinks.removeValue(forKey: identifier)
+        lastReportedBytes.removeValue(forKey: identifier)
         lock.unlock()
         continuation?.resume(with: result)
+    }
+
+    /// Forward a progress reading, at most once per `progressReportingStepBytes`.
+    private func reportProgress(_ identifier: LocalModelTransferIdentifier, written: Int64) {
+        lock.lock()
+        let last = lastReportedBytes[identifier] ?? 0
+        guard written - last >= Self.progressReportingStepBytes else {
+            lock.unlock()
+            return
+        }
+        lastReportedBytes[identifier] = written
+        let sink = progressSinks[identifier]
+        lock.unlock()
+        sink?(written)
     }
 }
 
@@ -153,6 +195,15 @@ extension LocalModelBackgroundTransfer: URLSessionDownloadDelegate {
             finalURL: response?.url ?? downloadTask.originalRequest?.url,
             fileURL: destination,
             byteCount: size)))
+    }
+
+    func urlSession(_ session: URLSession,
+                    downloadTask: URLSessionDownloadTask,
+                    didWriteData bytesWritten: Int64,
+                    totalBytesWritten: Int64,
+                    totalBytesExpectedToWrite: Int64) {
+        guard let identifier = LocalModelTransferIdentifier(downloadTask.taskDescription) else { return }
+        reportProgress(identifier, written: totalBytesWritten)
     }
 
     func urlSession(_ session: URLSession,

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelImportController.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelImportController.swift
@@ -1,0 +1,237 @@
+import Foundation
+
+/// The import sheet's state machine: repository text → parsed reference → resolved offer → chosen
+/// file → licence → fit verdict → confirmed download
+/// (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "a custom import sheet with repository
+/// parser, file/quant selection, license acceptance, and final download confirmation").
+///
+/// It is a separate object from the sheet for one reason: every refusal in this flow is a typed
+/// value with copy written for a person — `LocalModelImportRejection` for the string,
+/// `LocalModelImportFault` for what the repository turned out to contain — and a view that
+/// re-words them is a view that eventually softens one. Here the messages are passed through
+/// **verbatim**, and a test can prove it without a screenshot.
+///
+/// Every dependency is injected: the planner's fetcher, the fit report, and the download. The whole
+/// flow therefore runs headlessly against fixtures with no network anywhere.
+@MainActor
+final class LocalModelImportController: ObservableObject {
+
+    /// Where the sheet is. `failed` carries copy that is already user-ready.
+    enum Stage: Equatable {
+        /// Waiting for a repository.
+        case entry
+        /// Talking to the repository.
+        case resolving
+        /// The repository resolved; a file has to be chosen (or the curated default confirmed).
+        case choosing
+        /// Everything is chosen; the fit verdict and the licence are on screen.
+        case confirming
+        /// The download has been handed to the pipeline.
+        case started
+        case failed(String)
+    }
+
+    // MARK: - Inputs
+
+    @Published var repositoryText: String = ""
+    @Published var licenceAccepted: Bool = false
+    /// The chosen weights candidate's id, within the offer.
+    @Published var selectedCandidateID: String?
+
+    // MARK: - Derived state
+
+    @Published private(set) var stage: Stage = .entry
+    @Published private(set) var offer: LocalModelImportOffer?
+    @Published private(set) var descriptor: LocalModelDescriptor?
+    @Published private(set) var fit: LocalModelFitReport?
+
+    private let planner: LocalModelImportPlanner
+    private let makeFit: (LocalModelDescriptor, String?) -> LocalModelFitReport
+    private let startDownload: (LocalModelDescriptor, String?) async -> Void
+
+    init(planner: LocalModelImportPlanner,
+         makeFit: @escaping (LocalModelDescriptor, String?) -> LocalModelFitReport,
+         startDownload: @escaping (LocalModelDescriptor, String?) async -> Void) {
+        self.planner = planner
+        self.makeFit = makeFit
+        self.startDownload = startDownload
+    }
+
+    /// The production wiring: the live repository client, and the acquisition object's own fit
+    /// reading and download call.
+    convenience init(acquisition: LocalModelAcquisition) {
+        self.init(planner: LocalModelImportPlanner(fetcher: LocalModelRepositoryClient()),
+                  makeFit: { [weak acquisition] descriptor, accepted in
+                      acquisition?.fitReport(for: descriptor, acceptedLicenseRevision: accepted)
+                          ?? LocalModelFitReport.make(.init(descriptor: descriptor,
+                                                            availableStorageBytes: nil,
+                                                            availableProcessBytes: 0,
+                                                            acceptedLicenseRevision: accepted))
+                  },
+                  startDownload: { [weak acquisition] descriptor, accepted in
+                      await acquisition?.startDownload(descriptor: descriptor,
+                                                       origin: .repositoryImport,
+                                                       acceptedLicenseRevision: accepted)
+                  })
+    }
+
+    // MARK: - Step 1: parse and resolve
+
+    /// Parse the typed reference and, if it is well-formed, resolve the repository.
+    ///
+    /// The parse refusal is shown exactly as `LocalModelRepositoryReference` wrote it. Those
+    /// sentences deliberately never echo the input — a rejection message is the most convenient
+    /// place to leak whatever was pasted into it — so rewording them here would undo that as well
+    /// as losing the rule they name.
+    func resolve() async {
+        offer = nil
+        descriptor = nil
+        fit = nil
+        selectedCandidateID = nil
+        licenceAccepted = false
+
+        switch LocalModelRepositoryReference.parse(repositoryText) {
+        case .failure(let rejection):
+            stage = .failed(rejection.localizedMessage)
+            // The case name, never the payload: an import rejection's associated value is the
+            // host or scheme the user typed.
+            PrivacyLog.localModel(.downloadFailed,
+                                  detail: PrivacyToken.caseName(of: rejection))
+            return
+        case .success(let reference):
+            stage = .resolving
+            do {
+                let resolved = try await planner.offer(for: reference)
+                offer = resolved
+                selectedCandidateID = resolved.defaultSelection?.id
+                stage = .choosing
+                if resolved.defaultSelection != nil { prepareConfirmation() }
+            } catch let fault as LocalModelImportFault {
+                stage = .failed(fault.localizedMessage)
+            } catch {
+                // Transport and decoding faults collapse to one sentence: the specific HTTP status
+                // of a repository lookup is not something a person can act on.
+                stage = .failed("That repository couldn't be read. Check the address and your "
+                                    + "connection, then try again.")
+            }
+        }
+    }
+
+    // MARK: - Step 2: choose a file
+
+    var weightsCandidates: [LocalModelImportCandidate] { offer?.weights ?? [] }
+    var projectorCandidates: [LocalModelImportCandidate] { offer?.projectors ?? [] }
+
+    var selectedCandidate: LocalModelImportCandidate? {
+        guard let id = selectedCandidateID else { return nil }
+        return offer?.weights.first { $0.id == id }
+    }
+
+    func choose(_ candidateID: String) {
+        selectedCandidateID = candidateID
+        prepareConfirmation()
+    }
+
+    // MARK: - Step 3: confirmation
+
+    /// Build the descriptor and its fit report for the chosen candidate.
+    ///
+    /// Recomputed whenever the licence acceptance changes, because acceptance is one of the fit
+    /// report's *blockers* — a consent screen whose action stays disabled after the box is ticked
+    /// is a screen nobody can finish.
+    func prepareConfirmation() {
+        guard let offer, let candidate = selectedCandidate else {
+            descriptor = nil
+            fit = nil
+            return
+        }
+        guard candidate.isInstallable else {
+            stage = .failed(LocalModelImportFault.noVerifiableFiles.localizedMessage)
+            return
+        }
+        do {
+            let built = try LocalModelImportPlanner.descriptor(for: candidate, in: offer)
+            descriptor = built
+            fit = makeFit(built, acceptedLicenseRevision)
+            stage = .confirming
+        } catch let fault as LocalModelImportFault {
+            stage = .failed(fault.localizedMessage)
+        } catch {
+            stage = .failed("That file couldn't be prepared for download.")
+        }
+    }
+
+    /// The licence revision to record, or nil when nothing has been accepted. An offer's licence
+    /// revision is the repository revision it was read at, so accepting is accepting *those* terms.
+    var acceptedLicenseRevision: String? {
+        guard licenceAccepted else { return nil }
+        return offer?.license.revision ?? offer?.revision
+    }
+
+    var requiresLicenceAcceptance: Bool { offer?.license.requiresAcceptance ?? false }
+
+    /// Re-derive the fit after the licence toggle moves.
+    func licenceAcceptanceChanged() {
+        guard descriptor != nil else { return }
+        prepareConfirmation()
+    }
+
+    /// Whether the confirm action is enabled. **Blockers disable; warnings permit** — the rule is
+    /// the fit report's, and this reads it rather than reproducing it.
+    var canDownload: Bool {
+        guard case .confirming = stage else { return false }
+        return fit?.canInstall == true
+    }
+
+    /// The fit report, in the shape the sheet renders.
+    var fitPresentation: LocalModelPresentation.FitPresentation? {
+        fit.map(LocalModelPresentation.present)
+    }
+
+    // MARK: - Step 4: download
+
+    func confirm() async {
+        guard canDownload, let descriptor else { return }
+        stage = .started
+        await startDownload(descriptor, acceptedLicenseRevision)
+    }
+
+    /// Back out of the confirmation to the file list, without losing the resolved offer.
+    func backToChoosing() {
+        descriptor = nil
+        fit = nil
+        stage = .choosing
+    }
+
+    /// Start over from the text field.
+    func reset() {
+        offer = nil
+        descriptor = nil
+        fit = nil
+        selectedCandidateID = nil
+        licenceAccepted = false
+        stage = .entry
+    }
+
+    // MARK: - Copy
+
+    /// The candidate list's secondary line: what it is and whether it can be installed at all.
+    static func candidateSubtitle(_ candidate: LocalModelImportCandidate) -> String {
+        var parts: [String] = [LocalModelPresentation.formatBytes(candidate.byteCount)]
+        if candidate.files.count > 1 { parts.append("\(candidate.files.count) files") }
+        if !candidate.isInstallable { parts.append("no checksum — can't be verified") }
+        return parts.joined(separator: " · ")
+    }
+
+    static func candidateSpokenLabel(_ candidate: LocalModelImportCandidate) -> String {
+        var sentence = candidate.quantizationLabel
+            .map { "\(LocalModelPresentation.spellOut($0)) quantization" }
+            ?? candidate.id
+        sentence += ", \(LocalModelPresentation.formatBytes(candidate.byteCount))"
+        if candidate.files.count > 1 { sentence += ", \(candidate.files.count) files" }
+        if !candidate.isInstallable {
+            sentence += ". This file publishes no checksum, so it can't be downloaded."
+        }
+        return sentence
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelImportPlanner.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelImportPlanner.swift
@@ -63,6 +63,29 @@ enum LocalModelImportFault: Error, Equatable, Sendable {
     case pathOutsideModelRoot
     /// The chosen candidate is not one this offer enumerated.
     case unknownSelection
+
+    /// User-facing copy, in the same register as `LocalModelImportRejection.localizedMessage`: it
+    /// says which rule the repository failed and never echoes anything the user typed.
+    var localizedMessage: String {
+        switch self {
+        case .revisionNotResolved:
+            return "That repository doesn't name an exact version, so there's nothing to pin the "
+                + "download to."
+        case .repositoryNotPublic:
+            return "That repository needs an account or accepted terms to download from. Only "
+                + "public repositories can be imported."
+        case .noEligibleFiles:
+            return "That repository holds no GGUF model files."
+        case .noVerifiableFiles:
+            return "That repository's model files publish no checksum, so a download couldn't be "
+                + "verified."
+        case .pathOutsideModelRoot:
+            return "That repository lists a file path that wouldn't stay inside the model's own "
+                + "folder, so it hasn't been imported."
+        case .unknownSelection:
+            return "That file isn't one of the ones listed for this repository."
+        }
+    }
 }
 
 // MARK: - Candidates

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelPresentation.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelPresentation.swift
@@ -1,0 +1,300 @@
+import Foundation
+
+/// The copy the local-model manager draws, kept out of the view so the wording is a test rather
+/// than a screenshot (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "Local model manager
+/// and diagnostics").
+///
+/// The accessibility requirement that shapes the whole file: **badges have full VoiceOver labels
+/// rather than relying on colour**. A badge on screen is three characters in a tinted capsule; the
+/// same badge to VoiceOver is a sentence. Both come from here, so one cannot be changed without
+/// the other.
+
+/// One badge: what is drawn, what is spoken, and the glyph that keeps two badges of the same size
+/// from being distinguishable only by hue.
+struct LocalModelBadge: Equatable, Sendable, Identifiable {
+    /// How much attention the badge asks for. Never the *only* carrier of anything — it selects a
+    /// tint, and the text says the same thing.
+    enum Emphasis: Equatable, Sendable { case neutral, positive, caution, critical }
+
+    let id: String
+    let text: String
+    let spokenLabel: String
+    let systemImage: String?
+    let emphasis: Emphasis
+
+    init(id: String,
+         text: String,
+         spokenLabel: String,
+         systemImage: String? = nil,
+         emphasis: Emphasis = .neutral) {
+        self.id = id
+        self.text = text
+        self.spokenLabel = spokenLabel
+        self.systemImage = systemImage
+        self.emphasis = emphasis
+    }
+}
+
+enum LocalModelPresentation {
+
+    // MARK: - Runtime and quantization
+
+    /// Which engine runs this model. Drawn as the name people see in model repositories, spoken as
+    /// a sentence, because "MLX" read aloud is three letters with no context.
+    static func runtimeBadge(_ runtime: LocalModelRuntime) -> LocalModelBadge {
+        switch runtime {
+        case .mlx:
+            return LocalModelBadge(id: "runtime.mlx",
+                                   text: "MLX",
+                                   spokenLabel: "Runs on the MLX runtime",
+                                   systemImage: "cpu")
+        case .llamaCpp:
+            return LocalModelBadge(id: "runtime.gguf",
+                                   text: "GGUF",
+                                   spokenLabel: "Runs on the GGUF runtime",
+                                   systemImage: "cpu")
+        }
+    }
+
+    /// The quantization caption. It is display metadata parsed from a file name and nothing more —
+    /// the spoken form says "labelled", not "is", because a repack under a different name must not
+    /// make the app claim something about the bytes.
+    static func quantizationBadge(_ quantization: String?) -> LocalModelBadge? {
+        guard let quantization,
+              !quantization.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return LocalModelBadge(id: "quantization",
+                               text: quantization,
+                               spokenLabel: "Labelled \(spellOut(quantization)) quantization",
+                               systemImage: "square.stack.3d.down.right")
+    }
+
+    /// `Q4_K_M` spoken as letters and numbers rather than as a word. VoiceOver makes a mouthful of
+    /// the underscores otherwise.
+    static func spellOut(_ label: String) -> String {
+        label.replacingOccurrences(of: "_", with: " ")
+    }
+
+    /// What the model can factually do. `.text` is not badged: everything can, and a badge every
+    /// row wears carries no information.
+    static func capabilityBadges(_ capabilities: Set<LocalModelCapability>) -> [LocalModelBadge] {
+        var badges: [LocalModelBadge] = []
+        if capabilities.contains(.vision) {
+            badges.append(LocalModelBadge(id: "capability.vision",
+                                          text: "Vision",
+                                          spokenLabel: "Can look at photos",
+                                          systemImage: "eye",
+                                          emphasis: .positive))
+        }
+        if capabilities.contains(.toolFriendly) {
+            badges.append(LocalModelBadge(id: "capability.tools",
+                                          text: "Tools",
+                                          spokenLabel: "Can call the app's tools",
+                                          systemImage: "wrench.and.screwdriver",
+                                          emphasis: .positive))
+        }
+        return badges
+    }
+
+    /// The state badge for a row, from the derived state.
+    static func stateBadge(_ state: LocalModelRowState) -> LocalModelBadge {
+        let emphasis: LocalModelBadge.Emphasis
+        let glyph: String
+        switch state {
+        case .notInstalled: emphasis = .neutral; glyph = "arrow.down.circle"
+        case .staged(let staging): emphasis = staging.isRetryable ? .caution : .neutral
+            glyph = staging.isRetryable ? "exclamationmark.arrow.circlepath" : "arrow.down.circle"
+        case .incompatible: emphasis = .critical; glyph = "exclamationmark.triangle"
+        case .loaded: emphasis = .positive; glyph = "memorychip"
+        case .updateAvailable: emphasis = .caution; glyph = "arrow.triangle.2.circlepath"
+        case .installed: emphasis = .positive; glyph = "checkmark.circle"
+        }
+        return LocalModelBadge(id: "state",
+                               text: state.badgeText,
+                               spokenLabel: state.spokenLabel,
+                               systemImage: glyph,
+                               emphasis: emphasis)
+    }
+
+    /// Every badge a row wears, in drawing order: state first (it is what changed), then what the
+    /// model is.
+    static func rowBadges(state: LocalModelRowState,
+                          descriptor: LocalModelDescriptor) -> [LocalModelBadge] {
+        var badges = [stateBadge(state), runtimeBadge(descriptor.runtime)]
+        if let quantization = quantizationBadge(descriptor.quantization) { badges.append(quantization) }
+        badges.append(contentsOf: capabilityBadges(descriptor.capabilities))
+        return badges
+    }
+
+    // MARK: - Filters
+
+    /// The manager's filter axes. Two independent choices rather than one combined list, because
+    /// "the GGUF ones" and "the ones that can see" are different questions and combining them into
+    /// a single picker forces a person to ask both at once.
+    enum RuntimeFilter: String, CaseIterable, Equatable, Sendable {
+        case all, mlx, gguf
+
+        var title: String {
+            switch self {
+            case .all: return "All runtimes"
+            case .mlx: return "MLX"
+            case .gguf: return "GGUF"
+            }
+        }
+
+        /// Spoken separately: the drawn title is a segment in a row of segments, and "MLX" alone
+        /// does not say it is a filter.
+        var spokenLabel: String {
+            switch self {
+            case .all: return "Show models for every runtime"
+            case .mlx: return "Show only MLX models"
+            case .gguf: return "Show only GGUF models"
+            }
+        }
+
+        func accepts(_ runtime: LocalModelRuntime) -> Bool {
+            switch self {
+            case .all: return true
+            case .mlx: return runtime == .mlx
+            case .gguf: return runtime == .llamaCpp
+            }
+        }
+    }
+
+    enum CapabilityFilter: String, CaseIterable, Equatable, Sendable {
+        case all, text, vision
+
+        var title: String {
+            switch self {
+            case .all: return "All models"
+            case .text: return "Text only"
+            case .vision: return "Vision"
+            }
+        }
+
+        var spokenLabel: String {
+            switch self {
+            case .all: return "Show text and vision models"
+            case .text: return "Show only text models"
+            case .vision: return "Show only models that can look at photos"
+            }
+        }
+
+        /// `.text` means *text-only* — a vision model answers text as well, so a filter that let it
+        /// through would make the two options indistinguishable on a list of vision models.
+        func accepts(_ capabilities: Set<LocalModelCapability>) -> Bool {
+            switch self {
+            case .all: return true
+            case .text: return !capabilities.contains(.vision)
+            case .vision: return capabilities.contains(.vision)
+            }
+        }
+    }
+
+    // MARK: - Sizes
+
+    /// Byte counts as this screen has always drawn them. Binary units, because that is what a model
+    /// repository quotes and what the catalog's authored sizes were parsed from.
+    static func formatBytes(_ bytes: Int64) -> String {
+        if bytes < 1024 { return "\(bytes) B" }
+        if bytes < 1024 * 1024 { return String(format: "%.0f KB", Double(bytes) / 1024) }
+        if bytes < 1024 * 1024 * 1024 {
+            return String(format: "%.1f MB", Double(bytes) / (1024 * 1024))
+        }
+        return String(format: "%.1f GB", Double(bytes) / (1024 * 1024 * 1024))
+    }
+
+    /// The four size facts the plan requires on every row, as label/value pairs. `onDiskBytes` is
+    /// nil for a model that is not installed — there is no such fact yet, and printing a zero would
+    /// look like a measurement.
+    static func sizeFacts(descriptor: LocalModelDescriptor,
+                          onDiskBytes: Int64?) -> [(label: String, value: String)] {
+        var facts: [(String, String)] = []
+        let downloadBytes = descriptor.files.reduce(Int64(0)) { $0 + max(0, $1.byteCount) }
+        if downloadBytes > 0 {
+            facts.append(("Download", formatBytes(downloadBytes)))
+        }
+        if let onDiskBytes, onDiskBytes > 0 {
+            facts.append(("On disk", formatBytes(onDiskBytes)))
+        }
+        let working = estimatedResidentBytes(descriptor)
+        if working > 0 {
+            facts.append(("Working memory", "about \(formatBytes(working))"))
+        }
+        return facts
+    }
+
+    /// Weights plus the runtime's working reserve — the same conservative figure the fit report
+    /// judges the load verdict on, computed the same way so the row and the consent screen cannot
+    /// disagree about the number they both print.
+    static func estimatedResidentBytes(_ descriptor: LocalModelDescriptor) -> Int64 {
+        let extraReserve = descriptor.runtime == .llamaCpp ? max(0, descriptor.minimumHeadroomBytes) : 0
+        return descriptor.estimatedWeightsBytes
+            + LocalModelBudget.workingSetBytes(for: descriptor.runtime)
+            + extraReserve
+    }
+
+    // MARK: - Fit verdict
+
+    /// How a fit report reads on a consent surface: whether the action may proceed, and what the
+    /// person is told either way.
+    ///
+    /// The one rule worth stating out loud, because it is the plan's and it is easy to soften:
+    /// **blockers disable the action and say why; warnings inform and permit.** Nothing here can
+    /// turn a blocker into a warning — `canInstall` is the report's own, and this type reads it.
+    struct FitPresentation: Equatable, Sendable {
+        let canProceed: Bool
+        /// Short line under the action, e.g. "Can't download". Empty when it can proceed.
+        let refusalSummary: String?
+        let blockerMessages: [String]
+        let warningMessages: [String]
+        /// Facts a person checks before agreeing: size, free space, working memory, load verdict.
+        let facts: [Fact]
+
+        struct Fact: Equatable, Sendable, Identifiable {
+            let id: String
+            let label: String
+            let value: String
+        }
+    }
+
+    static func present(_ report: LocalModelFitReport) -> FitPresentation {
+        var facts: [FitPresentation.Fact] = [
+            .init(id: "runtime", label: "Runtime", value: runtimeBadge(report.runtime).text),
+        ]
+        if let quantization = report.quantization, !quantization.isEmpty {
+            facts.append(.init(id: "quantization", label: "Quantization", value: quantization))
+        }
+        facts.append(.init(id: "download", label: "Download",
+                           value: formatBytes(report.downloadBytes)))
+        facts.append(.init(id: "storage", label: "Free storage",
+                           value: report.availableStorageBytes.map(formatBytes) ?? "Couldn't be read"))
+        facts.append(.init(id: "memory", label: "Working memory",
+                           value: "about \(formatBytes(report.estimatedResidentBytes))"))
+        facts.append(.init(id: "verdict", label: "Fit on this iPhone",
+                           value: verdictText(report.loadVerdict)))
+        facts.append(.init(id: "licence", label: "Licence", value: report.license.displayName))
+
+        return FitPresentation(
+            canProceed: report.canInstall,
+            refusalSummary: report.canInstall ? nil : "This model can't be downloaded.",
+            blockerMessages: report.blockers.map(\.localizedMessage),
+            warningMessages: report.warnings.map(\.localizedMessage),
+            facts: facts)
+    }
+
+    /// The admission verdict in one phrase. `refuse` is deliberately not "won't fit": the fit
+    /// report files that as a *warning*, because a memory reading taken on a consent screen can
+    /// change by the time someone taps Load.
+    static func verdictText(_ admission: LocalModelBudget.Admission) -> String {
+        switch admission {
+        case .allow:
+            return "Fits"
+        case .allowConstrained(.tightHeadroom):
+            return "Fits, with little to spare"
+        case .allowConstrained(.contextClamped(let tokens)):
+            return "Fits, conversation limited to about \(tokens) tokens"
+        case .refuse(.insufficientHeadroom):
+            return "Probably won't fit right now"
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelProgressAnnouncer.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelProgressAnnouncer.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Deciding *when* a download says something out loud, and what it says
+/// (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "Accessibility requirements":
+/// "progress changes are announced at bounded intervals, plus completion/failure immediately").
+///
+/// A multi-gigabyte download emits progress dozens of times a second. Posting each one to
+/// VoiceOver makes the screen unusable — announcements queue, interrupt each other, and bury the
+/// one that mattered. Suppressing them entirely leaves a blind user with a spinner and no way to
+/// know whether anything is happening.
+///
+/// So the rule is a floor on both axes: a progress announcement needs **both** enough elapsed time
+/// and enough movement. Completion and failure ignore both floors, because they are the two events
+/// a person is actually waiting for and a delayed "finished" is worse than a noisy one.
+///
+/// Pure and time-injected, so the whole interval rule is a test rather than a stopwatch.
+struct LocalModelProgressAnnouncer: Equatable, Sendable {
+
+    /// Minimum movement between spoken progress updates. Ten points means at most ten progress
+    /// announcements for a whole download, which is what a person can follow without it becoming
+    /// the only thing they can hear.
+    static let minimumPercentStep = 10
+    /// Minimum wall-clock gap. A fast download can cross ten points in under a second, and two
+    /// announcements in one second interrupt each other rather than stack.
+    static let minimumInterval: TimeInterval = 4
+
+    /// What happened, in the vocabulary the announcer cares about.
+    enum Event: Equatable, Sendable {
+        /// Progress moved. `fraction` is 0…1.
+        case progress(fraction: Double)
+        /// The download finished and the model is installed.
+        case completed
+        /// The download stopped. The message is the already-user-ready sentence from the plan's
+        /// failure vocabulary — this type never composes one from an error.
+        case failed(String)
+        /// The user cancelled. Announced immediately, because a cancel that says nothing reads as
+        /// a button that did nothing.
+        case cancelled
+    }
+
+    /// The model this announcer is tracking, so the sentence names it. A curated display name; the
+    /// caller supplies it, and for an imported model it is the name the *user* chose to install.
+    let modelName: String
+
+    private var lastAnnouncedPercent: Int?
+    private var lastAnnouncedAt: Date?
+    private var isFinished = false
+
+    init(modelName: String) {
+        self.modelName = modelName
+    }
+
+    /// The announcement to post, or nil when this event is inside the floors.
+    ///
+    /// Mutating rather than pure-functional because the floors are state: the decision depends on
+    /// what was last said and when. Everything that decision reads is a parameter.
+    mutating func announcement(for event: Event, at now: Date) -> String? {
+        switch event {
+        case .completed:
+            guard !isFinished else { return nil }
+            isFinished = true
+            return "\(modelName) downloaded and installed."
+        case .failed(let message):
+            guard !isFinished else { return nil }
+            isFinished = true
+            return "\(modelName) download stopped. \(message)"
+        case .cancelled:
+            guard !isFinished else { return nil }
+            isFinished = true
+            return "\(modelName) download cancelled."
+        case .progress(let fraction):
+            guard !isFinished else { return nil }
+            let percent = Int((min(1, max(0, fraction)) * 100).rounded(.down))
+            // Zero is the state the screen already reads as "starting"; announcing it adds nothing.
+            guard percent > 0 else { return nil }
+            if let last = lastAnnouncedPercent, percent - last < Self.minimumPercentStep {
+                return nil
+            }
+            if let lastAt = lastAnnouncedAt, now.timeIntervalSince(lastAt) < Self.minimumInterval {
+                return nil
+            }
+            lastAnnouncedPercent = percent
+            lastAnnouncedAt = now
+            return "\(modelName), \(percent) percent downloaded."
+        }
+    }
+
+    /// Reset for a retry. A retried download starts its own announcement budget — otherwise the
+    /// second attempt inherits the first one's ceiling and says nothing until it passes it.
+    mutating func restart() {
+        lastAnnouncedPercent = nil
+        lastAnnouncedAt = nil
+        isFinished = false
+    }
+
+    /// What is said when the screen is left with a download still running. The plan requires this
+    /// explicitly, and it is the one sentence a person needs before they press Back: the transfer
+    /// is a background `URLSession`, so it genuinely does continue.
+    static func backgroundContinuationNotice(modelName: String) -> String {
+        "\(modelName) keeps downloading in the background. You can leave this screen; it will "
+            + "finish installing on its own, even if the app is closed."
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelRowState.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelRowState.swift
@@ -1,0 +1,432 @@
+import Foundation
+
+/// What one row of the local-model manager is *about*, derived from facts rather than from
+/// whichever branch the view happened to take first
+/// (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "Local model manager and diagnostics").
+///
+/// The screen has to show five states — installed, staged, incompatible, loaded, update-available —
+/// and a model can satisfy several at once: an installed model can be resident *and* have a newer
+/// catalog revision, and an installed model can be re-downloading while the old copy is still
+/// loaded. A view that answers that with nested `if`s answers it differently in each place it
+/// asks. So the precedence is a single pure function with a truth table behind it, and the row
+/// renders what it returns.
+///
+/// ### Precedence, and why it is this order
+///
+/// 1. **staged** — bytes are moving. It is the only state with a clock, a cancel and a retry, and
+///    it is the state a person came to the screen to watch.
+/// 2. **incompatible** — the files are there and the runtime will not take them. Saying "installed"
+///    to someone who is about to tap Load is a lie they act on.
+/// 3. **loaded** — residency is a fact about right now and it owns the unload action.
+/// 4. **updateAvailable** — the same model, at a revision the catalog has moved past.
+/// 5. **installed**, then **notInstalled**.
+///
+/// `incompatible` and `loaded` cannot both be true of an honest input: a model that loaded is a
+/// model the runtime accepted, and a successful load clears the recorded reason. The ordering says
+/// what happens if a caller passes a stale reason anyway, rather than leaving it to chance.
+enum LocalModelRowState: Equatable, Sendable {
+    /// No files on disk and nothing in flight.
+    case notInstalled
+    /// An acquisition plan exists for this model.
+    case staged(LocalModelStagingSummary)
+    /// Installed, and this build cannot load it. Carries what is missing.
+    case incompatible(LocalModelIncompatibility)
+    /// Resident in memory right now.
+    case loaded
+    /// Installed at an older revision than the one on offer.
+    case updateAvailable(installedRevision: String, availableRevision: String)
+    /// Installed, loadable, not resident.
+    case installed
+}
+
+/// How far an acquisition has got, in the shape a row renders.
+///
+/// Byte counts come from the plan, which reads them back from disk — so this survives a relaunch
+/// with the same numbers, which is the whole reason `LocalModelDownloadPlan` persists them.
+struct LocalModelStagingSummary: Equatable, Sendable {
+
+    /// The plan's state, collapsed to what the row says out loud. `awaitingConsent` is kept
+    /// separate from `queued` because one of them is waiting for a person and the other is waiting
+    /// for the network, and telling a person their download is "waiting" when it is waiting for
+    /// *them* is how a stuck download gets reported as a bug.
+    enum Phase: Equatable, Sendable {
+        case awaitingConsent
+        case queued
+        case downloading
+        case validating
+        case installing
+        /// Stopped, and the same plan may run again.
+        case retryable(LocalModelDownloadPlan.FailureReason)
+    }
+
+    let phase: Phase
+    /// 1-based index of the file being worked on, or nil when no file is.
+    let fileNumber: Int?
+    let fileCount: Int
+    let completedBytes: Int64
+    let totalBytes: Int64
+
+    var fractionCompleted: Double {
+        guard totalBytes > 0 else { return 0 }
+        return min(1, max(0, Double(completedBytes) / Double(totalBytes)))
+    }
+
+    /// Whether the row should offer Cancel. A failed plan has nothing to cancel — it offers Retry.
+    var isCancellable: Bool {
+        if case .retryable = phase { return false }
+        return true
+    }
+
+    var isRetryable: Bool {
+        if case .retryable = phase { return true }
+        return false
+    }
+
+    /// Build from a plan, or nil when the plan has finished and has nothing left to show.
+    ///
+    /// `completedBytes` overrides the plan's own persisted count with the live reading the download
+    /// manager keeps for the file in flight. The persisted count is still the fallback, and is what
+    /// a relaunched app shows.
+    init?(plan: LocalModelDownloadPlan, completedBytes: Int64? = nil) {
+        let phase: Phase
+        switch plan.state {
+        case .planned, .awaitingConsent: phase = .awaitingConsent
+        case .queued: phase = .queued
+        case .downloading: phase = .downloading
+        case .validating: phase = .validating
+        case .installing: phase = .installing
+        case .failed(let failure) where failure.isRetryable: phase = .retryable(failure.reason)
+        // Installed, cancelled and terminally failed plans are not staging: the row's state comes
+        // from the installation record (or its absence), not from a plan that is over.
+        case .installed, .cancelled, .failed: return nil
+        }
+        self.phase = phase
+        self.fileNumber = plan.state.fileIndex.map { $0 + 1 }
+        self.fileCount = plan.files.count
+        self.completedBytes = completedBytes ?? plan.completedBytes
+        self.totalBytes = plan.totalBytes
+    }
+}
+
+// MARK: - Runtime availability
+
+/// Whether the runtime a model needs can run it here at all. Separate from the model's own files:
+/// a perfectly good GGUF is unloadable on a build with the feature switched off, and that is a
+/// different sentence from "this file is broken".
+enum LocalModelRuntimeAvailability: Equatable, Sendable {
+    /// A backend is registered and switched on.
+    case available
+    /// The runtime exists in this build but the user has not turned it on.
+    case disabled
+    /// This build has no backend for that runtime at all.
+    case unavailable
+}
+
+// MARK: - Incompatibility
+
+/// Why an installed model cannot be loaded, in the vocabulary the runtime actually refused in.
+///
+/// Every case names *what is missing* rather than saying the load failed — that is the plan's
+/// accessibility requirement ("unsupported models explain what metadata or runtime capability is
+/// missing"), and it is the difference between a message a person can act on and one they can only
+/// report.
+///
+/// Transient failures are deliberately **not** here. Not enough memory, a transition already in
+/// flight, the app being backgrounded — those are retryable conditions the manager already surfaces
+/// with a Try again button, and filing them as incompatibility would tell someone their model is
+/// broken because they had a video call open.
+enum LocalModelIncompatibility: Equatable, Sendable {
+    /// The GGUF runtime is switched off.
+    case runtimeDisabled(LocalModelRuntime)
+    /// No backend for the runtime this model declares.
+    case runtimeUnavailable(LocalModelRuntime)
+    /// The file carries no `general.architecture`, so nothing can be configured from it.
+    case missingArchitectureMetadata
+    /// The embedded chat template cannot carry a conversation.
+    case unsupportedChatTemplate(LlamaChatTemplateFault)
+    /// Every ceiling together left a context too small to hold one exchange.
+    case contextTooSmall(tokens: Int)
+    /// The manifest names a weights file that is not on disk.
+    case weightsMissing
+    /// The manifest no longer describes what is on disk.
+    case installationIncomplete
+
+    /// Map a load failure to an incompatibility, or nil when the failure was transient.
+    ///
+    /// Driven by the backends' own typed errors (`LlamaBackendError` from PR3,
+    /// `LocalInferenceError` from PR1) so the screen cannot drift from what the runtime refused.
+    static func from(_ error: Error) -> LocalModelIncompatibility? {
+        if let backend = error as? LlamaBackendError {
+            switch backend {
+            case .runtimeDisabled: return .runtimeDisabled(.llamaCpp)
+            case .unsupportedArchitecture: return .missingArchitectureMetadata
+            case .unsupportedChatTemplate(let fault): return .unsupportedChatTemplate(fault)
+            case .contextTooSmall(let tokens): return .contextTooSmall(tokens: tokens)
+            case .weightsMissing: return .weightsMissing
+            case .installationIncomplete: return .installationIncomplete
+            // Memory, engine faults, tokenization and "already generating" are conditions of the
+            // moment, not of the model.
+            case .insufficientMemory, .notLoaded, .alreadyGenerating, .promptTooLong,
+                 .tokenizationFailed, .engine:
+                return nil
+            }
+        }
+        if let seam = error as? LocalInferenceError {
+            switch seam {
+            case .noBackend(let runtime): return .runtimeUnavailable(runtime)
+            case .installationInvalid: return .installationIncomplete
+            case .transitionInProgress, .notLoaded, .wrongModelResident, .backgrounded,
+                 .visionNotAvailable:
+                return nil
+            }
+        }
+        return nil
+    }
+
+    /// Whether re-running the same load could plausibly succeed without anything else changing.
+    /// Only the two switch-shaped cases can: the rest are properties of the file.
+    var isResolvableBySetting: Bool {
+        switch self {
+        case .runtimeDisabled: return true
+        case .runtimeUnavailable, .missingArchitectureMetadata, .unsupportedChatTemplate,
+             .contextTooSmall, .weightsMissing, .installationIncomplete:
+            return false
+        }
+    }
+
+    /// One line for the badge. Short enough for a row, and never colour alone — the badge is text.
+    var badgeText: String {
+        switch self {
+        case .runtimeDisabled: return "Turned off"
+        case .runtimeUnavailable: return "Unsupported"
+        case .missingArchitectureMetadata, .unsupportedChatTemplate: return "Can't run"
+        case .contextTooSmall: return "Too large"
+        case .weightsMissing, .installationIncomplete: return "Files missing"
+        }
+    }
+
+    /// The whole reason, in the words the "show incompatibility reason" action puts on screen. It
+    /// names the missing metadata or capability and, where one exists, the way out.
+    var explanation: String {
+        switch self {
+        case .runtimeDisabled:
+            return "GGUF models are switched off on this iPhone, so this model can't be loaded. "
+                + "Turn them on in Settings to use it. Its files stay where they are either way."
+        case .runtimeUnavailable(let runtime):
+            return "This build has no on-device runtime for \(Self.runtimeName(runtime)) models, "
+                + "so it can't load this one."
+        case .missingArchitectureMetadata:
+            return "This model file doesn't record which architecture it is, so nothing can be "
+                + "configured from it. On-device models are read from the file's own metadata — "
+                + "the architecture is the one field there is no safe default for. Its files stay "
+                + "installed; it can't be selected for conversation."
+        case .unsupportedChatTemplate(let fault):
+            return "This model doesn't carry a usable chat template, so there's no way to hand it "
+                + "a conversation. " + Self.templateDetail(fault)
+                + " Its files stay installed; it can't be selected for conversation."
+        case .contextTooSmall(let tokens):
+            return "There isn't enough memory on this iPhone to give this model a usable "
+                + "conversation window — it came out at \(tokens) tokens, below the minimum for a "
+                + "system prompt and one exchange. A smaller model, or a smaller quantization of "
+                + "this one, will fit."
+        case .weightsMissing:
+            return "The model file this installation names isn't on disk any more. Remove it and "
+                + "download it again."
+        case .installationIncomplete:
+            return "This installation's record no longer matches the files on disk, so it can't be "
+                + "trusted to load. Remove it and download it again."
+        }
+    }
+
+    /// Spoken form. Same words — the explanation is already a sentence rather than a colour or a
+    /// glyph — prefixed so a VoiceOver user hears what the sentence is *about* first.
+    var spokenLabel: String { "Can't be loaded. \(explanation)" }
+
+    private static func runtimeName(_ runtime: LocalModelRuntime) -> String {
+        switch runtime {
+        case .mlx: return "MLX"
+        case .llamaCpp: return "GGUF"
+        }
+    }
+
+    /// The template fault, said in terms of what the file failed to do rather than which probe
+    /// caught it.
+    private static func templateDetail(_ fault: LlamaChatTemplateFault) -> String {
+        switch fault {
+        case .absent: return "The file carries no chat template at all."
+        case .renderFailed: return "Its template couldn't render a basic exchange."
+        case .emptyRender: return "Its template rendered an exchange to nothing."
+        case .dropsUserContent: return "Its template drops what the user said."
+        case .dropsAssistantContent: return "Its template drops the model's own replies."
+        case .noAssistantHeader:
+            return "Its template has no way to signal that it's the model's turn to speak."
+        }
+    }
+}
+
+// MARK: - Derivation
+
+/// Everything the row state is derived from. A value rather than a view's `@State` so the truth
+/// table is a test rather than a screenshot.
+struct LocalModelRowInputs: Equatable, Sendable {
+    /// What is on offer: the catalog entry, the import descriptor, or the installed model's own.
+    let descriptor: LocalModelDescriptor
+    /// The installation record, when the files are on disk.
+    let installation: InstalledLocalModel?
+    /// An acquisition plan naming this model, when there is one.
+    let plan: LocalModelDownloadPlan?
+    /// Resident in memory right now.
+    let isResident: Bool
+    /// A reason recorded by a previous failed load, when one was recorded.
+    let recordedIncompatibility: LocalModelIncompatibility?
+    let runtimeAvailability: LocalModelRuntimeAvailability
+
+    init(descriptor: LocalModelDescriptor,
+         installation: InstalledLocalModel? = nil,
+         plan: LocalModelDownloadPlan? = nil,
+         isResident: Bool = false,
+         recordedIncompatibility: LocalModelIncompatibility? = nil,
+         runtimeAvailability: LocalModelRuntimeAvailability = .available) {
+        self.descriptor = descriptor
+        self.installation = installation
+        self.plan = plan
+        self.isResident = isResident
+        self.recordedIncompatibility = recordedIncompatibility
+        self.runtimeAvailability = runtimeAvailability
+    }
+}
+
+extension LocalModelRowState {
+
+    /// The truth table. Precedence is documented on the type; this is the only place it is applied.
+    static func derive(_ inputs: LocalModelRowInputs) -> LocalModelRowState {
+        if let plan = inputs.plan, let staging = LocalModelStagingSummary(plan: plan) {
+            return .staged(staging)
+        }
+        guard let installation = inputs.installation else { return .notInstalled }
+
+        if let incompatibility = incompatibility(for: installation, inputs: inputs) {
+            return .incompatible(incompatibility)
+        }
+        if inputs.isResident { return .loaded }
+        if let update = updateRevision(installed: installation, offered: inputs.descriptor) {
+            return .updateAvailable(installedRevision: installation.descriptor.revision,
+                                    availableRevision: update)
+        }
+        return .installed
+    }
+
+    /// A runtime that cannot run is an incompatibility of its own, and it outranks a recorded one:
+    /// "GGUF is switched off" is why the load would fail *now*, whatever failed last time.
+    private static func incompatibility(for installation: InstalledLocalModel,
+                                        inputs: LocalModelRowInputs) -> LocalModelIncompatibility? {
+        switch inputs.runtimeAvailability {
+        case .disabled: return .runtimeDisabled(installation.runtime)
+        case .unavailable: return .runtimeUnavailable(installation.runtime)
+        case .available: return inputs.recordedIncompatibility
+        }
+    }
+
+    /// An update is a *different pinned revision*. Two unpinned revisions are not comparable — the
+    /// legacy MLX entries all read `unpinned-legacy`, and calling that an update would put an
+    /// "Update" badge on every model a user already has.
+    private static func updateRevision(installed: InstalledLocalModel,
+                                       offered: LocalModelDescriptor) -> String? {
+        guard installed.descriptor.id == offered.id else { return nil }
+        guard installed.descriptor.isRevisionPinned, offered.isRevisionPinned else { return nil }
+        guard installed.descriptor.revision != offered.revision else { return nil }
+        return offered.revision
+    }
+}
+
+// MARK: - Row copy
+
+extension LocalModelRowState {
+
+    /// The short state caption drawn on the row.
+    var badgeText: String {
+        switch self {
+        case .notInstalled: return "Not installed"
+        case .staged(let staging): return LocalModelRowState.stagingBadge(staging)
+        case .incompatible(let reason): return reason.badgeText
+        case .loaded: return "Loaded"
+        case .updateAvailable: return "Update available"
+        case .installed: return "Installed"
+        }
+    }
+
+    /// The whole state, spoken. Every badge on this screen carries one of these, because the badges
+    /// differ in colour on screen and a colour is not a label.
+    var spokenLabel: String {
+        switch self {
+        case .notInstalled:
+            return "Not installed"
+        case .staged(let staging):
+            return LocalModelRowState.stagingSpokenLabel(staging)
+        case .incompatible(let reason):
+            return reason.spokenLabel
+        case .loaded:
+            return "Loaded into memory"
+        case .updateAvailable(let installed, let available):
+            return "Update available. Installed version \(shortRevision(installed)), "
+                + "version \(shortRevision(available)) is available."
+        case .installed:
+            return "Installed, not loaded"
+        }
+    }
+
+    /// A commit hash is unreadable aloud in full; twelve characters is what the diagnostics card
+    /// shows and what a person compares.
+    private func shortRevision(_ revision: String) -> String { String(revision.prefix(12)) }
+
+    private static func stagingBadge(_ staging: LocalModelStagingSummary) -> String {
+        switch staging.phase {
+        case .awaitingConsent: return "Waiting for you"
+        case .queued: return "Queued"
+        case .downloading: return "Downloading"
+        case .validating: return "Checking"
+        case .installing: return "Installing"
+        case .retryable: return "Stopped"
+        }
+    }
+
+    private static func stagingSpokenLabel(_ staging: LocalModelStagingSummary) -> String {
+        let percent = Int((staging.fractionCompleted * 100).rounded())
+        let fileClause: String
+        if let number = staging.fileNumber, staging.fileCount > 1 {
+            fileClause = ", file \(number) of \(staging.fileCount)"
+        } else {
+            fileClause = ""
+        }
+        switch staging.phase {
+        case .awaitingConsent:
+            return "Waiting for you to confirm the download"
+        case .queued:
+            return "Download queued\(fileClause)"
+        case .downloading:
+            return "Downloading, \(percent) percent\(fileClause)"
+        case .validating:
+            return "Checking the downloaded file\(fileClause)"
+        case .installing:
+            return "Installing"
+        case .retryable(let reason):
+            return "Download stopped at \(percent) percent. \(retryExplanation(reason))"
+        }
+    }
+
+    /// Why a stopped download stopped, in the closed vocabulary the plan records. Only retryable
+    /// reasons reach here — a terminal failure has already removed its plan.
+    static func retryExplanation(_ reason: LocalModelDownloadPlan.FailureReason) -> String {
+        switch reason {
+        case .transport: return "The connection dropped. You can try again."
+        case .httpStatus: return "The server refused the request. You can try again."
+        case .storageUnavailable: return "There wasn't room to write the file. Free up space and try again."
+        case .installFailed: return "The files downloaded but couldn't be installed. You can try again."
+        // Terminal reasons never carry a retry offer; if one is ever passed here, say so plainly
+        // rather than inviting a retry that will fail the same way.
+        case .sizeMismatch, .digestMismatch, .redirectHostRejected, .insecureRedirect,
+             .containmentRefused, .revisionMismatch, .planUnreadable, .consentMissing, .fitRefused:
+            return "The download was refused and can't be resumed. Start it again."
+        }
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelSelection.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelSelection.swift
@@ -1,0 +1,253 @@
+import Foundation
+
+/// The selected on-device model, as a stable identity rather than a runtime-specific string
+/// (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "The selected local model stored in app
+/// configuration becomes a stable `LocalModelID`; the runtime is resolved from the descriptor").
+///
+/// ### What changes, and what deliberately does not
+/// Before this, "the local model" was `ModelConfig.model` — a hub repository id that the MLX path
+/// read directly. That string cannot name a GGUF installation: one repository publishes a dozen
+/// quantizations and each is a separate install, which is why `LocalModelID.gguf` joins the
+/// repository to the file group. So the selection becomes a `LocalModelID` in its own versioned
+/// record, and the runtime comes from the *installation record's descriptor* — never from the
+/// shape of the string.
+///
+/// The legacy field stays, and stays synchronized, for one compatibility release. That is the
+/// plan's requirement and it has a concrete consequence worth stating: for every model that exists
+/// today the id **is** the hub repository id, so an MLX selection writes an identical value into
+/// both places and every existing reader of `ModelConfig.model` keeps working unchanged.
+///
+/// ### The one place the two fields diverge, and why
+/// A GGUF selection is not written into the legacy field. A build without this plan has no GGUF
+/// runtime; handing it `owner/repo#model-Q4_K_M.gguf` would give it an id it will try to fetch from
+/// the MLX hub and fail on, every launch, with no way for the user to tell why. Instead the legacy
+/// field keeps the last MLX selection — or is cleared when there has never been one, which leaves
+/// the older build in the "no on-device model chosen" state it already handles. That is the
+/// downgrade-safety property: **an MLX selection always survives a downgrade, and a GGUF selection
+/// never corrupts one.**
+
+/// The persisted selection. Versioned because the *meaning* of the field may change again when the
+/// legacy mirror is dropped, and a record whose version is newer than this build understands is
+/// ignored rather than half-read.
+struct LocalModelSelectionRecord: Codable, Equatable, Sendable {
+    static let currentVersion = 1
+
+    var version: Int
+    var id: LocalModelID
+    var updatedAt: Date
+
+    init(id: LocalModelID, updatedAt: Date, version: Int = LocalModelSelectionRecord.currentVersion) {
+        self.version = version
+        self.id = id
+        self.updatedAt = updatedAt
+    }
+}
+
+/// Reads and writes the selection, with every environment dependency injected so the migration and
+/// the synchronization rule are exercised headlessly against in-memory storage.
+struct LocalModelSelectionStore: Sendable {
+
+    static let recordKey = "localModelSelection"
+    /// Forward-only stamp, in the same shape as the installed-records migration.
+    static let migrationVersionKey = "localModelSelectionMigratedVersion"
+    static let migrationVersion = 1
+
+    enum MigrationOutcome: Equatable, Sendable {
+        /// The stamp is already at or past this version.
+        case alreadyMigrated
+        /// No legacy selection to carry forward. Stamped anyway: from here on `select` writes both
+        /// fields, so nothing can appear later that this migration would have been for.
+        case nothingToMigrate
+        case migrated(LocalModelID)
+        /// The record did not read back as written. Nothing is stamped; the next launch retries.
+        case readBackFailed
+    }
+
+    let defaults: UserDefaults
+    /// The legacy string field — `ModelConfig.model` for the on-device provider, in production.
+    let legacySelection: @Sendable () -> String
+    let setLegacySelection: @Sendable (String) -> Void
+    /// Which runtime an id belongs to, resolved from the installation record's descriptor. Falls
+    /// back to `.mlx` for an id nothing knows about, because MLX is the only runtime that could
+    /// have produced an installation before this plan.
+    let runtimeForID: @Sendable (LocalModelID) -> LocalModelRuntime
+    let now: @Sendable () -> Date
+
+    init(defaults: UserDefaults = .standard,
+         legacySelection: @escaping @Sendable () -> String,
+         setLegacySelection: @escaping @Sendable (String) -> Void,
+         runtimeForID: @escaping @Sendable (LocalModelID) -> LocalModelRuntime,
+         now: @escaping @Sendable () -> Date = Date.init) {
+        self.defaults = defaults
+        self.legacySelection = legacySelection
+        self.setLegacySelection = setLegacySelection
+        self.runtimeForID = runtimeForID
+        self.now = now
+    }
+
+    // MARK: - Reading
+
+    /// The stored record, or nil when there is none or it was written by a newer build.
+    func record() -> LocalModelSelectionRecord? {
+        guard let data = defaults.data(forKey: Self.recordKey),
+              let decoded = try? Self.decoder.decode(LocalModelSelectionRecord.self, from: data),
+              decoded.version <= LocalModelSelectionRecord.currentVersion,
+              !decoded.id.rawValue.isEmpty else { return nil }
+        return decoded
+    }
+
+    /// The selected id. Falls back to the legacy string, which is what makes a device that has not
+    /// run the migration yet — or one whose migration could not write — behave exactly as before.
+    func selectedID() -> LocalModelID? {
+        if let record = record() { return record.id }
+        let legacy = legacySelection().trimmingCharacters(in: .whitespacesAndNewlines)
+        return legacy.isEmpty ? nil : LocalModelID(legacy)
+    }
+
+    // MARK: - Writing
+
+    /// Record a selection and synchronize the legacy field per the rule documented on this file.
+    @discardableResult
+    func select(_ id: LocalModelID) -> Bool {
+        let record = LocalModelSelectionRecord(id: id, updatedAt: now())
+        guard let data = try? Self.encoder.encode(record) else { return false }
+        defaults.set(data, forKey: Self.recordKey)
+        synchronizeLegacyField(for: id)
+        // Read back, for the same reason the installed-records migration does: a preferences write
+        // that did not land must not be reported as a selection that did.
+        return self.record()?.id == id
+    }
+
+    /// Forget the selection — used when the selected model is removed, so nothing keeps pointing at
+    /// files that are gone.
+    func clearSelection() {
+        // Read before removing: the legacy field is cleared only when it named the model being
+        // forgotten, and after the record is gone there is nothing left to compare it against. An
+        // MLX id left there by an earlier selection is still a usable answer for an older build.
+        let forgotten = record()?.id
+        defaults.removeObject(forKey: Self.recordKey)
+        if let forgotten, legacySelection() == forgotten.rawValue {
+            setLegacySelection("")
+        }
+    }
+
+    /// The synchronization rule. Its whole content is the divergence documented above.
+    private func synchronizeLegacyField(for id: LocalModelID) {
+        switch runtimeForID(id) {
+        case .mlx:
+            setLegacySelection(id.rawValue)
+        case .llamaCpp:
+            // Leave a usable MLX id in place; clear anything else so an older build is never handed
+            // an id it cannot fetch.
+            let legacy = legacySelection().trimmingCharacters(in: .whitespacesAndNewlines)
+            if legacy.isEmpty { return }
+            if runtimeForID(LocalModelID(legacy)) != .mlx { setLegacySelection("") }
+        }
+    }
+
+    // MARK: - Migration
+
+    /// Carry the legacy string forward into a record. Forward-only, idempotent, and stamped only
+    /// after the written record reads back identical.
+    @discardableResult
+    func migrateIfNeeded() -> MigrationOutcome {
+        guard defaults.integer(forKey: Self.migrationVersionKey) < Self.migrationVersion else {
+            return .alreadyMigrated
+        }
+        // A record already present means a newer build wrote one before this migration ran. Stamp
+        // and leave it alone rather than overwriting a deliberate selection with a stale string.
+        if record() != nil {
+            defaults.set(Self.migrationVersion, forKey: Self.migrationVersionKey)
+            return .alreadyMigrated
+        }
+
+        let legacy = legacySelection().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !legacy.isEmpty else {
+            defaults.set(Self.migrationVersion, forKey: Self.migrationVersionKey)
+            return .nothingToMigrate
+        }
+
+        let id = LocalModelID(legacy)
+        let record = LocalModelSelectionRecord(id: id, updatedAt: now())
+        guard let data = try? Self.encoder.encode(record) else { return .readBackFailed }
+        defaults.set(data, forKey: Self.recordKey)
+        guard self.record()?.id == id else { return .readBackFailed }
+        // The legacy field is untouched by the migration: it already holds this value, and writing
+        // it back would be a Keychain write with nothing to change.
+        defaults.set(Self.migrationVersion, forKey: Self.migrationVersionKey)
+        PrivacyLog.localModel(.recordsMigrated, count: 1, detail: PrivacyToken("selection"))
+        return .migrated(id)
+    }
+
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}
+
+// MARK: - App wiring
+
+/// The production store and the lookups it needs. Separate from `LocalModelSelectionStore` so the
+/// store itself never has to know about the Keychain, the repository, or the catalog.
+enum LocalModelSelection {
+
+    /// The legacy field: the on-device provider's `model` string in the saved model configurations.
+    static func legacyModelString() -> String {
+        Config.savedModels.first { $0.llmProvider == .local }?.model ?? ""
+    }
+
+    static func setLegacyModelString(_ value: String) {
+        var models = Config.savedModels
+        guard let index = models.firstIndex(where: { $0.llmProvider == .local }) else { return }
+        guard models[index].model != value else { return }
+        models[index].model = value
+        Config.setSavedModels(models)
+    }
+
+    /// Runtime from the descriptor, in the order of increasing guesswork: the installation record
+    /// first (it is a fact about files on disk), then the bundled GGUF catalog (an entry that could
+    /// be installed), then MLX.
+    static func runtime(for id: LocalModelID,
+                        repository: LocalModelRepository = LocalModelRepository()) -> LocalModelRuntime {
+        if let installation = repository.installation(for: id) { return installation.runtime }
+        if LocalModelCatalog.bundledGGUFEntries().contains(where: { $0.id == id }) { return .llamaCpp }
+        return .mlx
+    }
+
+    static func store(repository: LocalModelRepository = LocalModelRepository()) -> LocalModelSelectionStore {
+        LocalModelSelectionStore(
+            legacySelection: { legacyModelString() },
+            setLegacySelection: { setLegacyModelString($0) },
+            runtimeForID: { runtime(for: $0, repository: repository) })
+    }
+
+    /// Resolve the installation a load should be given for an id.
+    ///
+    /// This is the "runtime is resolved from the descriptor" half of the migration: an installed
+    /// model answers with its own record — real runtime, real storage, real revision — and anything
+    /// else falls back to the MLX compatibility installation the seam has always synthesized, so a
+    /// model the repository has no record of behaves exactly as it did before.
+    static func installation(for id: LocalModelID,
+                             repository: LocalModelRepository = LocalModelRepository())
+        -> InstalledLocalModel {
+        if let installation = repository.installation(for: id) { return installation }
+        return compatibilityInstallation(for: id)
+    }
+
+    /// The MLX compatibility installation the seam has always synthesized for an id with no record.
+    static func compatibilityInstallation(for id: LocalModelID) -> InstalledLocalModel {
+        InstalledLocalModel(
+            descriptor: LocalModelCatalog.resolveDescriptor(forLegacyMLXModelID: id.rawValue),
+            storage: .legacyHubSnapshot(
+                directoryName: LocalModelRepository.legacyDirectoryName(forModelID: id.rawValue)),
+            installedAt: Date(timeIntervalSince1970: 0))
+    }
+}

--- a/OpenGlasses/Sources/Services/LocalInference/LocalRuntimeDiagnostics.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalRuntimeDiagnostics.swift
@@ -1,0 +1,269 @@
+import Foundation
+
+/// The numbers the diagnostics card shows, captured where the runtime already measures them
+/// (docs/plans/DZ-local-gguf-and-durable-agent-runtime.md, "a diagnostic card showing framework
+/// revision, model revision, context, first-token latency, tokens/second, memory delta, and
+/// thermal state").
+///
+/// ### Why this is not a second metrics path
+/// The GGUF backend already measures every one of these to write its `generationCompleted` and
+/// `loaded` log lines: prompt/generated token counts, first-token latency, total duration, the
+/// headroom delta against the reading taken at load, the app footprint, and the thermal state.
+/// A card that measured them again would be a second stopwatch disagreeing with the first. So this
+/// type is a *sink at the same call site*: the backend hands the identical values to the log and to
+/// this store, and the card renders what the log recorded.
+///
+/// Tokens per second is the one number that is derived rather than recorded, and it is derived
+/// here rather than in the backend for the reason PR3 gives for leaving it out of the log line —
+/// a stored ratio is one more thing that can disagree with its inputs. The card shows the inputs
+/// beside it.
+struct LocalRuntimeDiagnosticsSample: Equatable, Sendable {
+
+    /// Which measurement this is. A load and a generation report different fields, and a card that
+    /// pretended one was the other would show a first-token latency of zero for a model nobody has
+    /// spoken to yet.
+    enum Kind: Equatable, Sendable {
+        /// Recorded when a model finished loading.
+        case load
+        /// Recorded when a generation finished normally.
+        case generation
+    }
+
+    /// Thermal state, as its own case set. `ProcessInfo.ThermalState` is an imported enum; copying
+    /// it keeps this value trivially `Sendable` and keeps the spoken names in one place.
+    enum ThermalState: String, Equatable, Sendable {
+        case nominal, fair, serious, critical, unknown
+
+        init(_ state: ProcessInfo.ThermalState) {
+            switch state {
+            case .nominal: self = .nominal
+            case .fair: self = .fair
+            case .serious: self = .serious
+            case .critical: self = .critical
+            @unknown default: self = .unknown
+            }
+        }
+
+        /// Said in terms of what it means for the person holding the phone, not the enum name.
+        var displayName: String {
+            switch self {
+            case .nominal: return "Normal"
+            case .fair: return "Warm"
+            case .serious: return "Hot — the phone is slowing itself down"
+            case .critical: return "Very hot — on-device work will be throttled hard"
+            case .unknown: return "Unknown"
+            }
+        }
+    }
+
+    let kind: Kind
+    let modelID: LocalModelID
+    let runtime: LocalModelRuntime
+    /// The exact revision the installed files were pinned at, or the legacy sentinel.
+    let modelRevision: String
+    /// Context window the runtime actually created, after every clamp.
+    let contextTokens: Int
+    /// Prompt tokens submitted. Zero for a load sample.
+    let promptTokens: Int
+    /// Tokens produced. Zero for a load sample.
+    let generatedTokens: Int
+    /// Milliseconds from the start of the turn to the first produced token; nil when nothing was
+    /// produced, and always nil for a load sample.
+    let firstTokenMilliseconds: Int?
+    /// For a generation: the whole turn, prefill included. For a load: how long the load took.
+    let totalMilliseconds: Int
+    /// Headroom now minus headroom at the moment the load finished. Negative means the app has
+    /// taken more memory since; that is the number a jetsam investigation starts from.
+    let headroomDeltaBytes: Int64
+    let footprintBytes: Int64
+    let thermalState: ThermalState
+    let recordedAt: Date
+
+    /// Decode rate: tokens produced per second *after* the first one arrived. Prefill is excluded
+    /// deliberately — including it produces a figure that changes with prompt length and describes
+    /// neither the prefill nor the decode.
+    ///
+    /// `nil` when there is nothing to divide: no tokens, no first-token time, or a window so short
+    /// the ratio would be an artefact of the clock rather than a measurement.
+    var tokensPerSecond: Double? {
+        guard kind == .generation, generatedTokens > 1, let first = firstTokenMilliseconds else {
+            return nil
+        }
+        let decodeMilliseconds = totalMilliseconds - first
+        guard decodeMilliseconds >= 100 else { return nil }
+        // The first token is excluded from the numerator as well as the denominator: it is the one
+        // token that was produced *at* `first`, not during the window being measured.
+        return Double(generatedTokens - 1) / (Double(decodeMilliseconds) / 1000)
+    }
+}
+
+/// The last sample from each runtime, for the diagnostics card to read.
+///
+/// Deliberately not a `@Published` object: samples are recorded from a nonisolated context inside
+/// the decode loop, and hopping to the main actor to publish would put a UI concern inside the one
+/// path that must not wait for anything. The card reads it on a timer it already has.
+///
+/// It holds **one sample per runtime** and nothing else — no history, no aggregation. A ring buffer
+/// of inference timings is a performance archive, and this is a card that says what the last run
+/// did.
+final class LocalRuntimeDiagnostics: @unchecked Sendable {
+
+    /// The instance the app's backends record into. Tests construct their own.
+    static let shared = LocalRuntimeDiagnostics()
+
+    private let lock = NSLock()
+    private var samples: [LocalModelRuntime: LocalRuntimeDiagnosticsSample] = [:]
+
+    init() {}
+
+    func record(_ sample: LocalRuntimeDiagnosticsSample) {
+        lock.lock()
+        // A generation sample never replaces itself with a load sample: loading a model that is
+        // already resident is a no-op that would otherwise wipe the timings from the turn before.
+        if let existing = samples[sample.runtime],
+           existing.kind == .generation, sample.kind == .load,
+           existing.modelID == sample.modelID {
+            lock.unlock()
+            return
+        }
+        samples[sample.runtime] = sample
+        lock.unlock()
+    }
+
+    func latest(for runtime: LocalModelRuntime) -> LocalRuntimeDiagnosticsSample? {
+        lock.lock()
+        defer { lock.unlock() }
+        return samples[runtime]
+    }
+
+    /// The most recent sample from any runtime. What the card shows when the user has not chosen a
+    /// runtime to inspect.
+    var latest: LocalRuntimeDiagnosticsSample? {
+        lock.lock()
+        defer { lock.unlock() }
+        return samples.values.max { $0.recordedAt < $1.recordedAt }
+    }
+
+    func clear() {
+        lock.lock()
+        samples.removeAll()
+        lock.unlock()
+    }
+}
+
+// MARK: - Card copy
+
+/// The diagnostics card's rows, as label/value pairs with spoken forms.
+///
+/// Every field's source is named in a comment beside it, because "where did this number come from"
+/// is the first question anyone reading a diagnostics card asks, and the answer must not be
+/// "somewhere in the view".
+enum LocalRuntimeDiagnosticsCard {
+
+    struct Row: Equatable, Sendable, Identifiable {
+        let id: String
+        let label: String
+        let value: String
+        /// Spoken form, when the drawn value is an abbreviation or a hash.
+        let spokenValue: String?
+
+        init(id: String, label: String, value: String, spokenValue: String? = nil) {
+            self.id = id
+            self.label = label
+            self.value = value
+            self.spokenValue = spokenValue
+        }
+
+        var spokenLabel: String { "\(label): \(spokenValue ?? value)" }
+    }
+
+    /// Build the card. `frameworkDescription` is the engine's own report of the revision it was
+    /// built from (`LlamaRuntimeAvailability.engineDescription`), passed in so this stays pure.
+    static func rows(sample: LocalRuntimeDiagnosticsSample?,
+                     frameworkDescription: String) -> [Row] {
+        // 1. Framework revision — from the linked binary, not a constant typed into Swift.
+        var rows = [Row(id: "framework", label: "Runtime build", value: frameworkDescription,
+                        spokenValue: spokenRevisionPhrase(frameworkDescription))]
+
+        guard let sample else {
+            rows.append(Row(id: "empty", label: "Last run",
+                            value: "No on-device run recorded yet",
+                            spokenValue: "No on-device run has been recorded yet"))
+            return rows
+        }
+
+        // 2. Model revision — the descriptor's pinned revision, as installed.
+        rows.append(Row(id: "modelRevision", label: "Model version",
+                        value: revisionText(sample.modelRevision),
+                        spokenValue: spokenRevision(sample.modelRevision)))
+        // 3. Context — what the runtime actually created after every clamp, reported by the
+        //    context itself at load time.
+        rows.append(Row(id: "context", label: "Context",
+                        value: "\(sample.contextTokens) tokens"))
+
+        if sample.kind == .generation {
+            // 4. First-token latency — the backend's `firstTokenMilliseconds`, measured from the
+            //    start of the turn, prefill included.
+            rows.append(Row(id: "firstToken", label: "First token",
+                            value: sample.firstTokenMilliseconds.map { "\($0) ms" } ?? "—",
+                            spokenValue: sample.firstTokenMilliseconds
+                                .map { "\($0) milliseconds" } ?? "not measured"))
+            // 5. Tokens per second — derived from the recorded counts and durations beside it.
+            rows.append(Row(id: "rate", label: "Speed",
+                            value: sample.tokensPerSecond
+                                .map { String(format: "%.1f tokens/s", $0) } ?? "—",
+                            spokenValue: sample.tokensPerSecond
+                                .map { String(format: "%.1f tokens per second", $0) }
+                                ?? "not measured"))
+            rows.append(Row(id: "tokens", label: "Tokens",
+                            value: "\(sample.promptTokens) in, \(sample.generatedTokens) out",
+                            spokenValue: "\(sample.promptTokens) in, \(sample.generatedTokens) out"))
+        } else {
+            rows.append(Row(id: "loadTime", label: "Load time",
+                            value: "\(sample.totalMilliseconds) ms",
+                            spokenValue: "\(sample.totalMilliseconds) milliseconds"))
+        }
+
+        // 6. Memory delta — headroom now against the reading taken when the load finished.
+        rows.append(Row(id: "memory", label: "Memory since load",
+                        value: signedBytes(sample.headroomDeltaBytes),
+                        spokenValue: spokenMemoryDelta(sample.headroomDeltaBytes)))
+        // 7. Thermal state — `ProcessInfo.thermalState` as read at the same moment.
+        rows.append(Row(id: "thermal", label: "Thermal state",
+                        value: sample.thermalState.displayName))
+        return rows
+    }
+
+    private static func revisionText(_ revision: String) -> String {
+        guard revision != LocalModelDescriptor.floatingRevision, !revision.isEmpty else {
+            return "Not pinned"
+        }
+        return String(revision.prefix(12))
+    }
+
+    private static func spokenRevision(_ revision: String) -> String {
+        guard revision != LocalModelDescriptor.floatingRevision, !revision.isEmpty else {
+            return "not pinned to an exact version"
+        }
+        return "version \(String(revision.prefix(12)))"
+    }
+
+    /// A build identifier read aloud verbatim is a stream of letters; say what it is first.
+    private static func spokenRevisionPhrase(_ description: String) -> String {
+        "engine build \(description)"
+    }
+
+    private static func signedBytes(_ delta: Int64) -> String {
+        let magnitude = LocalModelPresentation.formatBytes(abs(delta))
+        if delta == 0 { return "unchanged" }
+        return delta > 0 ? "+\(magnitude) free" : "−\(magnitude) free"
+    }
+
+    private static func spokenMemoryDelta(_ delta: Int64) -> String {
+        let magnitude = LocalModelPresentation.formatBytes(abs(delta))
+        if delta == 0 { return "unchanged since the model loaded" }
+        return delta > 0
+            ? "\(magnitude) more free than when the model loaded"
+            : "\(magnitude) less free than when the model loaded"
+    }
+}

--- a/OpenGlassesTests/LocalModelImportFlowTests.swift
+++ b/OpenGlassesTests/LocalModelImportFlowTests.swift
@@ -1,0 +1,289 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DZ P2 — the import sheet's flow, and the announcements and diagnostics that go with the
+/// download it starts.
+///
+/// The controller is driven against fakes end to end: parse → resolve → choose → licence → fit →
+/// confirm. No network, no `.shared` service, no screen.
+@MainActor
+final class LocalModelImportFlowTests: XCTestCase {
+
+    private let gigabyte: Int64 = 1_073_741_824
+    private let revision = String(repeating: "c", count: 40)
+
+    // MARK: - Parse refusals reach the sheet verbatim
+
+    func testAParseRefusalIsShownInTheParsersOwnWords() async {
+        let controller = makeController()
+        for (input, expected): (String, LocalModelImportRejection) in [
+            ("", .empty),
+            ("http://huggingface.co/owner/repo", .disallowedScheme("http")),
+            ("https://huggingface.co/owner/repo?token=abc", .queryNotAllowed),
+            ("https://example.com/owner/repo", .disallowedHost("example.com")),
+            ("huggingface.co/owner/repo", .missingScheme),
+            ("https://huggingface.co/owner/repo/blob/main/f.gguf", .pathOutsideRepositoryForm),
+        ] {
+            controller.repositoryText = input
+            await controller.resolve()
+            guard case .failed(let message) = controller.stage else {
+                return XCTFail("\(input) was not refused")
+            }
+            XCTAssertEqual(message, expected.localizedMessage,
+                           "the refusal was reworded on its way to the sheet")
+        }
+    }
+
+    func testARefusalNeverEchoesWhatWasTyped() async {
+        let controller = makeController()
+        controller.repositoryText = "https://evil.example.com/secret-token-abc123/repo"
+        await controller.resolve()
+        guard case .failed(let message) = controller.stage else { return XCTFail("not refused") }
+        XCTAssertFalse(message.contains("secret-token-abc123"))
+        XCTAssertFalse(message.contains("evil.example.com"))
+    }
+
+    // MARK: - Repository faults
+
+    func testAGatedRepositoryIsRefusedWithTheFaultsOwnMessage() async {
+        let controller = makeController(metadata: metadata(isGated: true))
+        controller.repositoryText = "owner/repo"
+        await controller.resolve()
+        guard case .failed(let message) = controller.stage else { return XCTFail("not refused") }
+        XCTAssertEqual(message, LocalModelImportFault.repositoryNotPublic.localizedMessage)
+    }
+
+    func testARepositoryWithNoCheckSummedFilesCannotBeImported() async {
+        let controller = makeController(files: [
+            LocalModelRemoteFile(path: "model-Q4_K_M.gguf", byteCount: 500_000_000, sha256: nil),
+        ])
+        controller.repositoryText = "owner/repo"
+        await controller.resolve()
+        guard case .failed(let message) = controller.stage else { return XCTFail("not refused") }
+        XCTAssertEqual(message, LocalModelImportFault.noVerifiableFiles.localizedMessage)
+    }
+
+    // MARK: - Selection
+
+    func testTheCuratedDefaultIsPreselectedAndGoesStraightToConfirmation() async {
+        let controller = makeController()
+        controller.repositoryText = "owner/repo"
+        await controller.resolve()
+
+        XCTAssertEqual(controller.selectedCandidateID, "model-Q4_K_M.gguf")
+        XCTAssertEqual(controller.stage, .confirming)
+        XCTAssertNotNil(controller.fit)
+    }
+
+    func testWithoutTheExactPreferredFileTheUserMustChoose() async {
+        let controller = makeController(files: [
+            file("model-Q5_K_M.gguf", bytes: 700_000_000),
+            file("model-Q3_K_S.gguf", bytes: 300_000_000),
+        ])
+        controller.repositoryText = "owner/repo"
+        await controller.resolve()
+
+        XCTAssertEqual(controller.stage, .choosing)
+        XCTAssertNil(controller.selectedCandidateID, "nobody chooses for the user but the user")
+        XCTAssertEqual(controller.weightsCandidates.map(\.id),
+                       ["model-Q3_K_S.gguf", "model-Q5_K_M.gguf"],
+                       "smallest first, so the cheapest option reads first")
+
+        controller.choose("model-Q5_K_M.gguf")
+        XCTAssertEqual(controller.stage, .confirming)
+        XCTAssertEqual(controller.descriptor?.quantization, "Q5_K_M")
+    }
+
+    func testProjectorsAreListedButNeverSelectable() async {
+        let controller = makeController(files: [
+            file("model-Q4_K_M.gguf"),
+            file("mmproj-model-f16.gguf", bytes: 100_000_000),
+        ])
+        controller.repositoryText = "owner/repo"
+        await controller.resolve()
+
+        XCTAssertEqual(controller.projectorCandidates.count, 1)
+        XCTAssertFalse(controller.weightsCandidates.contains { $0.id.contains("mmproj") })
+    }
+
+    // MARK: - Licence acceptance and the fit gate
+
+    func testAnUnknownLicenceBlocksUntilItIsAcceptedAndThenPermits() async {
+        // An identifier the app has not summarized requires acceptance — the honest reading of
+        // "nobody here has read these terms".
+        let controller = makeController(metadata: metadata(license: "some-bespoke-licence"))
+        controller.repositoryText = "owner/repo"
+        await controller.resolve()
+
+        XCTAssertTrue(controller.requiresLicenceAcceptance)
+        XCTAssertFalse(controller.canDownload)
+        XCTAssertEqual(controller.fitPresentation?.blockerMessages,
+                       [LocalModelFitReport.Blocker.licenseNotAccepted.localizedMessage])
+
+        controller.licenceAccepted = true
+        controller.licenceAcceptanceChanged()
+        XCTAssertTrue(controller.canDownload, "ticking the box must actually unlock the action")
+    }
+
+    func testAPermissiveLicenceNeedsNoAcceptance() async {
+        let controller = makeController(metadata: metadata(license: "apache-2.0"))
+        controller.repositoryText = "owner/repo"
+        await controller.resolve()
+        XCTAssertFalse(controller.requiresLicenceAcceptance)
+        XCTAssertTrue(controller.canDownload)
+    }
+
+    func testABlockerKeepsTheActionDisabledAndWarningsDoNot() async {
+        // Unreadable free space blocks…
+        let blocked = makeController(freeDiskBytes: nil)
+        blocked.repositoryText = "owner/repo"
+        await blocked.resolve()
+        XCTAssertFalse(blocked.canDownload)
+
+        // …while a memory verdict that says "probably won't fit" only warns.
+        let warned = makeController(availableProcessBytes: 200_000_000)
+        warned.repositoryText = "owner/repo"
+        await warned.resolve()
+        XCTAssertTrue(warned.canDownload)
+        XCTAssertFalse(warned.fitPresentation?.warningMessages.isEmpty ?? true)
+    }
+
+    func testConfirmHandsThePipelineTheDescriptorAndTheAcceptedRevision() async {
+        let started = StartedBox()
+        let controller = makeController(metadata: metadata(license: "some-bespoke-licence"),
+                                        started: started)
+        controller.repositoryText = "owner/repo"
+        await controller.resolve()
+        controller.licenceAccepted = true
+        controller.licenceAcceptanceChanged()
+        await controller.confirm()
+
+        XCTAssertEqual(started.descriptor?.repositoryID, "owner/repo")
+        XCTAssertEqual(started.descriptor?.revision, revision, "pinned before any bytes move")
+        XCTAssertEqual(started.descriptor?.capabilities, [.text],
+                       "an import claims text and nothing else")
+        XCTAssertEqual(started.acceptedRevision, revision)
+        XCTAssertEqual(controller.stage, .started)
+    }
+
+    func testConfirmDoesNothingWhileABlockerStands() async {
+        let started = StartedBox()
+        let controller = makeController(freeDiskBytes: nil, started: started)
+        controller.repositoryText = "owner/repo"
+        await controller.resolve()
+        await controller.confirm()
+        XCTAssertNil(started.descriptor, "a blocked confirmation must not reach the pipeline")
+    }
+
+    // MARK: - Progress announcements
+
+    func testProgressIsAnnouncedOnlyAfterEnoughMovementAndEnoughTime() {
+        var announcer = LocalModelProgressAnnouncer(modelName: "Test model")
+        let start = Date(timeIntervalSince1970: 0)
+
+        XCTAssertNotNil(announcer.announcement(for: .progress(fraction: 0.12), at: start))
+        // Same second, more movement: refused on the time floor.
+        XCTAssertNil(announcer.announcement(for: .progress(fraction: 0.40), at: start))
+        // Later, but not enough movement: refused on the percent floor.
+        XCTAssertNil(announcer.announcement(for: .progress(fraction: 0.15),
+                                            at: start.addingTimeInterval(60)))
+        // Both floors cleared.
+        XCTAssertNotNil(announcer.announcement(for: .progress(fraction: 0.40),
+                                               at: start.addingTimeInterval(60)))
+    }
+
+    func testZeroPercentSaysNothing() {
+        var announcer = LocalModelProgressAnnouncer(modelName: "Test model")
+        XCTAssertNil(announcer.announcement(for: .progress(fraction: 0),
+                                            at: Date(timeIntervalSince1970: 0)))
+    }
+
+    func testCompletionAndFailureIgnoreBothFloors() {
+        var completed = LocalModelProgressAnnouncer(modelName: "Test model")
+        let start = Date(timeIntervalSince1970: 0)
+        _ = completed.announcement(for: .progress(fraction: 0.5), at: start)
+        XCTAssertNotNil(completed.announcement(for: .completed, at: start),
+                        "the event a person is actually waiting for is never suppressed")
+
+        var failed = LocalModelProgressAnnouncer(modelName: "Test model")
+        _ = failed.announcement(for: .progress(fraction: 0.5), at: start)
+        XCTAssertNotNil(failed.announcement(for: .failed("The connection dropped."), at: start))
+    }
+
+    func testNothingIsSaidAfterTheDownloadHasFinished() {
+        var announcer = LocalModelProgressAnnouncer(modelName: "Test model")
+        let start = Date(timeIntervalSince1970: 0)
+        XCTAssertNotNil(announcer.announcement(for: .completed, at: start))
+        XCTAssertNil(announcer.announcement(for: .progress(fraction: 0.9),
+                                            at: start.addingTimeInterval(600)))
+        XCTAssertNil(announcer.announcement(for: .completed, at: start.addingTimeInterval(600)))
+    }
+
+    func testARetryStartsAFreshAnnouncementBudget() {
+        var announcer = LocalModelProgressAnnouncer(modelName: "Test model")
+        let start = Date(timeIntervalSince1970: 0)
+        _ = announcer.announcement(for: .progress(fraction: 0.8), at: start)
+        _ = announcer.announcement(for: .failed("The connection dropped."), at: start)
+        announcer.restart()
+        XCTAssertNotNil(announcer.announcement(for: .progress(fraction: 0.05),
+                                               at: start.addingTimeInterval(1)),
+                        "the second attempt must not inherit the first one's ceiling")
+    }
+
+    func testLeavingTheScreenSaysTheDownloadContinues() {
+        let notice = LocalModelProgressAnnouncer.backgroundContinuationNotice(modelName: "Test model")
+        XCTAssertTrue(notice.contains("background"))
+        XCTAssertTrue(notice.contains("Test model"))
+    }
+
+    // MARK: - Helpers
+
+    private final class StartedBox {
+        var descriptor: LocalModelDescriptor?
+        var acceptedRevision: String?
+    }
+
+    private struct StubFetcher: LocalModelRepositoryMetadataFetching {
+        let metadata: LocalModelRepositoryMetadata
+        let files: [LocalModelRemoteFile]
+
+        func metadata(for reference: LocalModelRepositoryReference) async throws
+            -> LocalModelRepositoryMetadata { metadata }
+
+        func files(for reference: LocalModelRepositoryReference,
+                   revision: String) async throws -> [LocalModelRemoteFile] { files }
+    }
+
+    private func file(_ path: String, bytes: Int64 = 500_000_000) -> LocalModelRemoteFile {
+        LocalModelRemoteFile(path: path, byteCount: bytes,
+                             sha256: String(repeating: "a", count: 64))
+    }
+
+    private func metadata(isGated: Bool = false,
+                          license: String? = "apache-2.0") -> LocalModelRepositoryMetadata {
+        LocalModelRepositoryMetadata(revision: revision, licenseIdentifier: license,
+                                     isGated: isGated, isPrivate: false)
+    }
+
+    private func makeController(metadata: LocalModelRepositoryMetadata? = nil,
+                                files: [LocalModelRemoteFile]? = nil,
+                                freeDiskBytes: Int64? = 64 * 1_073_741_824,
+                                availableProcessBytes: Int64 = 8 * 1_073_741_824,
+                                started: StartedBox? = nil) -> LocalModelImportController {
+        let box = started ?? StartedBox()
+        return LocalModelImportController(
+            planner: LocalModelImportPlanner(fetcher: StubFetcher(
+                metadata: metadata ?? self.metadata(),
+                files: files ?? [file("model-Q4_K_M.gguf")])),
+            makeFit: { descriptor, accepted in
+                LocalModelFitReport.make(.init(descriptor: descriptor,
+                                                availableStorageBytes: freeDiskBytes,
+                                                availableProcessBytes: availableProcessBytes,
+                                                acceptedLicenseRevision: accepted))
+            },
+            startDownload: { descriptor, accepted in
+                box.descriptor = descriptor
+                box.acceptedRevision = accepted
+            })
+    }
+}

--- a/OpenGlassesTests/LocalModelManagerStateTests.swift
+++ b/OpenGlassesTests/LocalModelManagerStateTests.swift
@@ -1,0 +1,369 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DZ P2 — what a row of the local-model manager says, and why.
+///
+/// The screen has five states that overlap, a badge set that must never carry meaning in colour
+/// alone, and an incompatibility vocabulary that has to come from the runtime's own typed errors
+/// rather than from a string match on a description. All three are pure, so all three are pinned
+/// here rather than by looking at the screen.
+final class LocalModelManagerStateTests: XCTestCase {
+
+    private let gigabyte: Int64 = 1_073_741_824
+
+    // MARK: - Row state truth table
+
+    func testNothingInstalledAndNothingStagedIsNotInstalled() {
+        XCTAssertEqual(LocalModelRowState.derive(.init(descriptor: ggufDescriptor())), .notInstalled)
+    }
+
+    func testInstalledWithNothingElseTrueIsInstalled() {
+        let state = LocalModelRowState.derive(.init(descriptor: ggufDescriptor(),
+                                                    installation: installation()))
+        XCTAssertEqual(state, .installed)
+    }
+
+    func testResidencyBeatsInstalled() {
+        let state = LocalModelRowState.derive(.init(descriptor: ggufDescriptor(),
+                                                    installation: installation(),
+                                                    isResident: true))
+        XCTAssertEqual(state, .loaded)
+    }
+
+    func testARecordedIncompatibilityBeatsResidency() {
+        // A stale reason on a resident model should never read as "installed and fine"; the
+        // ordering says what happens rather than leaving it to whichever branch ran first.
+        let state = LocalModelRowState.derive(.init(
+            descriptor: ggufDescriptor(),
+            installation: installation(),
+            isResident: true,
+            recordedIncompatibility: .missingArchitectureMetadata))
+        XCTAssertEqual(state, .incompatible(.missingArchitectureMetadata))
+    }
+
+    func testStagingBeatsEverythingIncludingAnInstalledCopy() {
+        // Re-downloading an update over an installed, resident model: bytes are moving, and that is
+        // what the row is about.
+        let state = LocalModelRowState.derive(.init(
+            descriptor: ggufDescriptor(),
+            installation: installation(),
+            plan: plan(state: .downloading(fileIndex: 0)),
+            isResident: true,
+            recordedIncompatibility: .weightsMissing))
+        guard case .staged(let staging) = state else { return XCTFail("expected staged, got \(state)") }
+        XCTAssertEqual(staging.phase, .downloading)
+    }
+
+    func testASwitchedOffRuntimeOutranksARecordedReason() {
+        // "GGUF is switched off" is why the load would fail *now*, whatever failed last time.
+        let state = LocalModelRowState.derive(.init(
+            descriptor: ggufDescriptor(),
+            installation: installation(),
+            recordedIncompatibility: .missingArchitectureMetadata,
+            runtimeAvailability: .disabled))
+        XCTAssertEqual(state, .incompatible(.runtimeDisabled(.llamaCpp)))
+    }
+
+    func testAMissingBackendIsReportedAsUnavailableNotAsAFileProblem() {
+        let state = LocalModelRowState.derive(.init(descriptor: ggufDescriptor(),
+                                                    installation: installation(),
+                                                    runtimeAvailability: .unavailable))
+        XCTAssertEqual(state, .incompatible(.runtimeUnavailable(.llamaCpp)))
+    }
+
+    func testADifferentPinnedRevisionIsAnUpdate() {
+        let installedAt = String(repeating: "1", count: 40)
+        let offeredAt = String(repeating: "2", count: 40)
+        let state = LocalModelRowState.derive(.init(
+            descriptor: ggufDescriptor(revision: offeredAt),
+            installation: installation(descriptor: ggufDescriptor(revision: installedAt))))
+        XCTAssertEqual(state, .updateAvailable(installedRevision: installedAt,
+                                               availableRevision: offeredAt))
+    }
+
+    func testUnpinnedRevisionsAreNeverAnUpdate() {
+        // Every legacy MLX record reads `unpinned-legacy`; treating that as a difference would put
+        // an Update badge on every model a user already has.
+        let legacy = LocalModelDescriptor.floatingRevision
+        let state = LocalModelRowState.derive(.init(
+            descriptor: mlxDescriptor(revision: legacy),
+            installation: installation(descriptor: mlxDescriptor(revision: legacy))))
+        XCTAssertEqual(state, .installed)
+    }
+
+    func testAFinishedPlanIsNotStaging() {
+        for finished: LocalModelDownloadPlan.State in [.installed, .cancelled,
+                                                       .failed(.terminal(.digestMismatch))] {
+            let state = LocalModelRowState.derive(.init(descriptor: ggufDescriptor(),
+                                                        installation: installation(),
+                                                        plan: plan(state: finished)))
+            XCTAssertEqual(state, .installed,
+                           "a \(finished) plan is over; the row's state comes from the installation")
+        }
+    }
+
+    func testARetryablePlanStagesWithARetryOfferAndNoCancel() {
+        let state = LocalModelRowState.derive(.init(
+            descriptor: ggufDescriptor(),
+            plan: plan(state: .failed(.retryable(.transport)))))
+        guard case .staged(let staging) = state else { return XCTFail("expected staged") }
+        XCTAssertTrue(staging.isRetryable)
+        XCTAssertFalse(staging.isCancellable, "a stopped plan has nothing in flight to cancel")
+    }
+
+    // MARK: - Staging progress
+
+    func testStagingProgressPrefersTheLiveReadingOverThePersistedOne() {
+        var persisted = plan(state: .downloading(fileIndex: 0))
+        persisted.recordProgress(fileIndex: 0, completedBytes: 0)
+
+        let fromDisk = LocalModelStagingSummary(plan: persisted)
+        XCTAssertEqual(fromDisk?.completedBytes, 0)
+
+        let live = LocalModelStagingSummary(plan: persisted, completedBytes: 250_000_000)
+        XCTAssertEqual(live?.completedBytes, 250_000_000)
+        XCTAssertEqual(live?.fractionCompleted ?? 0, 0.5, accuracy: 0.001)
+    }
+
+    // MARK: - Badges
+
+    func testEveryBadgeCarriesASpokenLabelThatIsNotJustItsDrawnText() {
+        let descriptor = ggufDescriptor(capabilities: [.text, .vision, .toolFriendly])
+        let badges = LocalModelPresentation.rowBadges(state: .installed, descriptor: descriptor)
+
+        XCTAssertTrue(badges.contains { $0.id == "runtime.gguf" })
+        XCTAssertTrue(badges.contains { $0.id == "quantization" })
+        XCTAssertTrue(badges.contains { $0.id == "capability.vision" })
+        XCTAssertTrue(badges.contains { $0.id == "capability.tools" })
+
+        for badge in badges {
+            XCTAssertFalse(badge.spokenLabel.isEmpty, "\(badge.id) has no spoken label")
+            XCTAssertNotEqual(badge.spokenLabel, badge.text,
+                              "\(badge.id) speaks its drawn abbreviation rather than a sentence")
+        }
+    }
+
+    func testTextOnlyModelsWearNoCapabilityBadge() {
+        // A badge every row wears carries no information.
+        XCTAssertTrue(LocalModelPresentation.capabilityBadges([.text]).isEmpty)
+    }
+
+    func testEveryRowStateSpeaksSomethingSpecific() {
+        let states: [LocalModelRowState] = [
+            .notInstalled,
+            .installed,
+            .loaded,
+            .updateAvailable(installedRevision: String(repeating: "1", count: 40),
+                             availableRevision: String(repeating: "2", count: 40)),
+            .incompatible(.missingArchitectureMetadata),
+            .staged(LocalModelStagingSummary(plan: plan(state: .downloading(fileIndex: 0)),
+                                             completedBytes: 250_000_000)!),
+        ]
+        var spoken = Set<String>()
+        for state in states {
+            XCTAssertFalse(state.badgeText.isEmpty)
+            XCTAssertFalse(state.spokenLabel.isEmpty)
+            XCTAssertTrue(spoken.insert(state.spokenLabel).inserted,
+                          "two states speak identically: \(state.spokenLabel)")
+        }
+    }
+
+    func testADownloadingRowSpeaksItsPercentage() {
+        let staging = LocalModelStagingSummary(plan: plan(state: .downloading(fileIndex: 0)),
+                                               completedBytes: 250_000_000)!
+        XCTAssertTrue(LocalModelRowState.staged(staging).spokenLabel.contains("50 percent"),
+                      LocalModelRowState.staged(staging).spokenLabel)
+    }
+
+    // MARK: - Incompatibility mapping
+
+    func testTypedRuntimeErrorsMapToWhatIsMissing() {
+        XCTAssertEqual(LocalModelIncompatibility.from(LlamaBackendError.runtimeDisabled),
+                       .runtimeDisabled(.llamaCpp))
+        XCTAssertEqual(LocalModelIncompatibility.from(LlamaBackendError.unsupportedArchitecture),
+                       .missingArchitectureMetadata)
+        XCTAssertEqual(LocalModelIncompatibility.from(
+            LlamaBackendError.unsupportedChatTemplate(.absent)),
+                       .unsupportedChatTemplate(.absent))
+        XCTAssertEqual(LocalModelIncompatibility.from(LlamaBackendError.contextTooSmall(tokens: 128)),
+                       .contextTooSmall(tokens: 128))
+        XCTAssertEqual(LocalModelIncompatibility.from(
+            LlamaBackendError.weightsMissing(LocalModelID("a/b"))), .weightsMissing)
+        XCTAssertEqual(LocalModelIncompatibility.from(
+            LocalInferenceError.noBackend(.llamaCpp)), .runtimeUnavailable(.llamaCpp))
+    }
+
+    func testTransientFailuresAreNotIncompatibilities() {
+        // Telling someone their model is broken because they had a video call open is the failure
+        // this filter exists to prevent.
+        let transient: [Error] = [
+            LlamaBackendError.insufficientMemory(neededBytes: 1, availableBytes: 0),
+            LlamaBackendError.alreadyGenerating,
+            LlamaBackendError.promptTooLong(promptTokens: 9, reserveTokens: 1, contextTokens: 4),
+            LocalInferenceError.transitionInProgress,
+            LocalInferenceError.backgrounded,
+            CancellationError(),
+        ]
+        for error in transient {
+            XCTAssertNil(LocalModelIncompatibility.from(error), "\(error) is a moment, not a model")
+        }
+    }
+
+    func testEveryIncompatibilityNamesWhatIsMissing() {
+        let reasons: [LocalModelIncompatibility] = [
+            .runtimeDisabled(.llamaCpp), .runtimeUnavailable(.mlx), .missingArchitectureMetadata,
+            .unsupportedChatTemplate(.noAssistantHeader), .contextTooSmall(tokens: 200),
+            .weightsMissing, .installationIncomplete,
+        ]
+        for reason in reasons {
+            XCTAssertFalse(reason.badgeText.isEmpty)
+            XCTAssertGreaterThan(reason.explanation.count, 40,
+                                 "\(reason) explains nothing a person can act on")
+            XCTAssertTrue(reason.spokenLabel.hasPrefix("Can't be loaded."))
+        }
+        // Only the switch-shaped ones are fixable without touching the file.
+        XCTAssertTrue(LocalModelIncompatibility.runtimeDisabled(.llamaCpp).isResolvableBySetting)
+        XCTAssertFalse(LocalModelIncompatibility.missingArchitectureMetadata.isResolvableBySetting)
+    }
+
+    func testEveryChatTemplateFaultIsExplainedDistinctly() {
+        let faults: [LlamaChatTemplateFault] = [
+            .absent, .renderFailed, .emptyRender, .dropsUserContent, .dropsAssistantContent,
+            .noAssistantHeader,
+        ]
+        var explanations = Set<String>()
+        for fault in faults {
+            let explanation = LocalModelIncompatibility.unsupportedChatTemplate(fault).explanation
+            XCTAssertTrue(explanations.insert(explanation).inserted,
+                          "two template faults read identically")
+        }
+    }
+
+    // MARK: - Filters
+
+    func testRuntimeAndCapabilityFiltersAreIndependent() {
+        XCTAssertTrue(LocalModelPresentation.RuntimeFilter.all.accepts(.mlx))
+        XCTAssertTrue(LocalModelPresentation.RuntimeFilter.gguf.accepts(.llamaCpp))
+        XCTAssertFalse(LocalModelPresentation.RuntimeFilter.gguf.accepts(.mlx))
+
+        // "Text only" must exclude vision models, or it is indistinguishable from "all".
+        XCTAssertTrue(LocalModelPresentation.CapabilityFilter.text.accepts([.text]))
+        XCTAssertFalse(LocalModelPresentation.CapabilityFilter.text.accepts([.text, .vision]))
+        XCTAssertTrue(LocalModelPresentation.CapabilityFilter.vision.accepts([.text, .vision]))
+    }
+
+    func testFilterTitlesAndSpokenLabelsDiffer() {
+        for filter in LocalModelPresentation.RuntimeFilter.allCases {
+            XCTAssertNotEqual(filter.title, filter.spokenLabel)
+        }
+        for filter in LocalModelPresentation.CapabilityFilter.allCases {
+            XCTAssertNotEqual(filter.title, filter.spokenLabel)
+        }
+    }
+
+    // MARK: - Fit rendering
+
+    func testBlockersDisableTheActionAndSayWhy() {
+        let report = LocalModelFitReport.make(.init(descriptor: ggufDescriptor(),
+                                                    availableStorageBytes: nil,
+                                                    availableProcessBytes: 8 * gigabyte))
+        let presentation = LocalModelPresentation.present(report)
+        XCTAssertFalse(presentation.canProceed)
+        XCTAssertNotNil(presentation.refusalSummary)
+        XCTAssertEqual(presentation.blockerMessages,
+                       [LocalModelFitReport.Blocker.freeSpaceUnreadable.localizedMessage],
+                       "the blocker's own words, not a paraphrase")
+    }
+
+    func testWarningsInformAndPermit() {
+        let report = LocalModelFitReport.make(.init(
+            descriptor: ggufDescriptor(weightsBytes: 6 * gigabyte),
+            availableStorageBytes: 64 * gigabyte,
+            availableProcessBytes: gigabyte))
+        let presentation = LocalModelPresentation.present(report)
+        XCTAssertTrue(presentation.canProceed, "a memory verdict warns; it does not block")
+        XCTAssertTrue(presentation.blockerMessages.isEmpty)
+        XCTAssertFalse(presentation.warningMessages.isEmpty)
+    }
+
+    func testTheConsentFactsCoverSizeStorageMemoryAndVerdict() {
+        let report = LocalModelFitReport.make(.init(descriptor: ggufDescriptor(),
+                                                    availableStorageBytes: 20 * gigabyte,
+                                                    availableProcessBytes: 8 * gigabyte))
+        let ids = Set(LocalModelPresentation.present(report).facts.map(\.id))
+        XCTAssertTrue(ids.isSuperset(of: ["download", "storage", "memory", "verdict", "licence"]))
+    }
+
+    func testUnreadableFreeSpaceIsShownAsUnreadableNotAsZero() {
+        let report = LocalModelFitReport.make(.init(descriptor: ggufDescriptor(),
+                                                    availableStorageBytes: nil,
+                                                    availableProcessBytes: 8 * gigabyte))
+        let storage = LocalModelPresentation.present(report).facts.first { $0.id == "storage" }
+        XCTAssertEqual(storage?.value, "Couldn't be read")
+    }
+
+    func testEstimatedResidentBytesMatchesWhatTheFitReportJudged() {
+        // The row and the consent screen print the same figure, or one of them is lying.
+        let descriptor = ggufDescriptor(minimumHeadroomBytes: 128 * 1024 * 1024)
+        let report = LocalModelFitReport.make(.init(descriptor: descriptor,
+                                                    availableStorageBytes: 64 * gigabyte,
+                                                    availableProcessBytes: 8 * gigabyte))
+        XCTAssertEqual(LocalModelPresentation.estimatedResidentBytes(descriptor),
+                       report.estimatedResidentBytes)
+    }
+
+    // MARK: - Helpers
+
+    private func file(bytes: Int64 = 500_000_000, path: String = "m.gguf") -> LocalModelFile {
+        LocalModelFile(relativePath: path, byteCount: bytes,
+                       sha256: String(repeating: "a", count: 64), role: .weights)
+    }
+
+    private func ggufDescriptor(revision: String = String(repeating: "b", count: 40),
+                                weightsBytes: Int64 = 500_000_000,
+                                minimumHeadroomBytes: Int64 = 0,
+                                capabilities: Set<LocalModelCapability> = [.text])
+        -> LocalModelDescriptor {
+        LocalModelDescriptor(
+            id: LocalModelID("owner/repo#m.gguf"),
+            displayName: "Test model",
+            runtime: .llamaCpp,
+            repositoryID: "owner/repo",
+            revision: revision,
+            files: [file(bytes: weightsBytes)],
+            quantization: "Q4_K_M",
+            capabilities: capabilities,
+            contextLength: 4096,
+            estimatedWeightsBytes: weightsBytes,
+            estimatedWorkingBytes: LocalModelBudget.workingSetBytes(for: .llamaCpp),
+            minimumHeadroomBytes: minimumHeadroomBytes,
+            license: .unverified)
+    }
+
+    private func mlxDescriptor(revision: String) -> LocalModelDescriptor {
+        LocalModelDescriptor(
+            id: LocalModelID("mlx-community/thing-4bit"),
+            displayName: "Thing",
+            runtime: .mlx,
+            repositoryID: "mlx-community/thing-4bit",
+            revision: revision,
+            capabilities: [.text],
+            contextLength: 4096,
+            estimatedWeightsBytes: 0,
+            estimatedWorkingBytes: 0,
+            minimumHeadroomBytes: 0)
+    }
+
+    private func installation(descriptor: LocalModelDescriptor? = nil) -> InstalledLocalModel {
+        let descriptor = descriptor ?? ggufDescriptor()
+        return InstalledLocalModel(descriptor: descriptor,
+                                   storage: .managed(directoryName: descriptor.id.storageComponent),
+                                   installedAt: Date(timeIntervalSince1970: 0))
+    }
+
+    private func plan(state: LocalModelDownloadPlan.State) -> LocalModelDownloadPlan {
+        var plan = LocalModelDownloadPlan(descriptor: ggufDescriptor(), origin: .curatedCatalog)!
+        plan.state = state
+        return plan
+    }
+}

--- a/OpenGlassesTests/LocalModelSelectionMigrationTests.swift
+++ b/OpenGlassesTests/LocalModelSelectionMigrationTests.swift
@@ -1,0 +1,184 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DZ P2 — the selected on-device model becomes a stable id, with the legacy string field
+/// retained and synchronized for one compatibility release.
+///
+/// Two properties carry the whole risk, and both are here:
+///
+///  - **The migration is forward-only and read-back-verified.** A preferences write that did not
+///    land must not be stamped as done, and a stamped device must never re-run.
+///  - **Downgrade safety.** An MLX selection always survives a downgrade to a build without this
+///    plan; a GGUF selection never corrupts one.
+final class LocalModelSelectionMigrationTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    /// Stands in for `ModelConfig.model` on the on-device provider, so nothing here touches the
+    /// Keychain.
+    private var legacyField = ""
+    private var runtimes: [String: LocalModelRuntime] = [:]
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "LocalModelSelectionMigrationTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        legacyField = ""
+        runtimes = [:]
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    private func makeStore() -> LocalModelSelectionStore {
+        LocalModelSelectionStore(
+            defaults: defaults,
+            legacySelection: { [self] in legacyField },
+            setLegacySelection: { [self] in legacyField = $0 },
+            runtimeForID: { [self] in runtimes[$0.rawValue] ?? .mlx },
+            now: { Date(timeIntervalSince1970: 1_700_000_000) })
+    }
+
+    // MARK: - The legacy shape
+
+    func testALegacyStringSelectionMigratesToARecord() {
+        legacyField = "mlx-community/Qwen2.5-3B-Instruct-4bit"
+        let store = makeStore()
+
+        XCTAssertEqual(store.migrateIfNeeded(),
+                       .migrated(LocalModelID("mlx-community/Qwen2.5-3B-Instruct-4bit")))
+        XCTAssertEqual(store.record()?.id.rawValue, "mlx-community/Qwen2.5-3B-Instruct-4bit")
+        XCTAssertEqual(store.record()?.version, LocalModelSelectionRecord.currentVersion)
+        XCTAssertEqual(legacyField, "mlx-community/Qwen2.5-3B-Instruct-4bit",
+                       "the migration reads the legacy field; it has nothing to write back")
+    }
+
+    func testAnIdIsReadableBeforeTheMigrationHasRun() {
+        // The behaviour a device gets if the migration is deferred or cannot write: exactly what it
+        // had before.
+        legacyField = "mlx-community/thing-4bit"
+        XCTAssertEqual(makeStore().selectedID()?.rawValue, "mlx-community/thing-4bit")
+    }
+
+    func testTheMigrationIsForwardOnlyAndIdempotent() {
+        legacyField = "mlx-community/first"
+        let store = makeStore()
+        XCTAssertEqual(store.migrateIfNeeded(), .migrated(LocalModelID("mlx-community/first")))
+
+        // A later legacy change must not be re-migrated over a deliberate selection.
+        legacyField = "mlx-community/second"
+        XCTAssertEqual(store.migrateIfNeeded(), .alreadyMigrated)
+        XCTAssertEqual(store.record()?.id.rawValue, "mlx-community/first")
+    }
+
+    func testNothingToMigrateStillStamps() {
+        let store = makeStore()
+        XCTAssertEqual(store.migrateIfNeeded(), .nothingToMigrate)
+        XCTAssertEqual(defaults.integer(forKey: LocalModelSelectionStore.migrationVersionKey),
+                       LocalModelSelectionStore.migrationVersion)
+        XCTAssertNil(store.selectedID())
+    }
+
+    func testARecordWrittenByANewerBuildIsNotOverwrittenOrHalfRead() {
+        // Version 99 means "written by a build whose fields may mean something else".
+        let future = try! JSONEncoder.iso8601.encode(
+            LocalModelSelectionRecord(id: LocalModelID("future/model"),
+                                      updatedAt: Date(), version: 99))
+        defaults.set(future, forKey: LocalModelSelectionStore.recordKey)
+        legacyField = "mlx-community/thing"
+        let store = makeStore()
+
+        XCTAssertNil(store.record(), "a newer record is ignored, not decoded partially")
+        // The migration sees no readable record, so it carries the legacy field forward — which is
+        // the only value this build can honestly act on.
+        XCTAssertEqual(store.migrateIfNeeded(), .migrated(LocalModelID("mlx-community/thing")))
+    }
+
+    // MARK: - Synchronization and downgrade safety
+
+    func testAnMLXSelectionWritesBothFields() {
+        runtimes["mlx-community/thing-4bit"] = .mlx
+        let store = makeStore()
+        XCTAssertTrue(store.select(LocalModelID("mlx-community/thing-4bit")))
+        XCTAssertEqual(store.selectedID()?.rawValue, "mlx-community/thing-4bit")
+        XCTAssertEqual(legacyField, "mlx-community/thing-4bit",
+                       "for every model that exists today the id IS the hub repository id")
+    }
+
+    func testAGGUFSelectionLeavesTheLastMLXSelectionInTheLegacyField() {
+        runtimes["mlx-community/thing-4bit"] = .mlx
+        runtimes["owner/repo#m-Q4_K_M.gguf"] = .llamaCpp
+        let store = makeStore()
+
+        store.select(LocalModelID("mlx-community/thing-4bit"))
+        store.select(LocalModelID("owner/repo#m-Q4_K_M.gguf"))
+
+        XCTAssertEqual(store.selectedID()?.rawValue, "owner/repo#m-Q4_K_M.gguf",
+                       "this build reads the record")
+        XCTAssertEqual(legacyField, "mlx-community/thing-4bit",
+                       "a build without this plan must be left an id it can actually fetch")
+    }
+
+    func testAGGUFSelectionNeverPutsAGGUFIdInTheLegacyField() {
+        runtimes["owner/repo#m-Q4_K_M.gguf"] = .llamaCpp
+        runtimes["other/repo#n-Q5_K_M.gguf"] = .llamaCpp
+        legacyField = "other/repo#n-Q5_K_M.gguf"   // as if an earlier build had got this wrong
+        let store = makeStore()
+
+        store.select(LocalModelID("owner/repo#m-Q4_K_M.gguf"))
+        XCTAssertEqual(legacyField, "",
+                       "an id the older build cannot fetch is cleared, not left to fail every launch")
+    }
+
+    func testDowngradingWithAGGUFSelectionLeavesTheMLXSelectionUsable() {
+        // The property, end to end: pick MLX, then pick GGUF, then read the world as a pre-plan
+        // build would — which is the legacy field and nothing else.
+        runtimes["mlx-community/Qwen2.5-3B-Instruct-4bit"] = .mlx
+        runtimes["owner/repo#m-Q4_K_M.gguf"] = .llamaCpp
+        let store = makeStore()
+        store.select(LocalModelID("mlx-community/Qwen2.5-3B-Instruct-4bit"))
+        store.select(LocalModelID("owner/repo#m-Q4_K_M.gguf"))
+
+        let whatAnOlderBuildSees = legacyField
+        XCTAssertEqual(whatAnOlderBuildSees, "mlx-community/Qwen2.5-3B-Instruct-4bit")
+        XCTAssertEqual(LocalModelCatalog.resolveDescriptor(forLegacyMLXModelID: whatAnOlderBuildSees)
+                        .runtime, .mlx)
+    }
+
+    func testClearingForgetsTheRecordAndOnlyTheMatchingLegacyValue() {
+        runtimes["mlx-community/thing-4bit"] = .mlx
+        let store = makeStore()
+        store.select(LocalModelID("mlx-community/thing-4bit"))
+        store.clearSelection()
+        XCTAssertNil(store.record())
+        XCTAssertEqual(legacyField, "", "the legacy field named the model being forgotten")
+
+        // A legacy value naming a *different* model is still a usable answer for an older build.
+        runtimes["owner/repo#m.gguf"] = .llamaCpp
+        legacyField = "mlx-community/other-4bit"
+        store.select(LocalModelID("owner/repo#m.gguf"))
+        store.clearSelection()
+        XCTAssertEqual(legacyField, "mlx-community/other-4bit")
+    }
+
+    // MARK: - Runtime resolved from the descriptor
+
+    func testAnIdWithNoRecordResolvesToTheMLXCompatibilityInstallation() {
+        let installation = LocalModelSelection.compatibilityInstallation(
+            for: LocalModelID("someone/typed-by-hand"))
+        XCTAssertEqual(installation.runtime, .mlx,
+                       "MLX is the only runtime that could have produced an existing installation")
+        XCTAssertTrue(installation.storage.isLegacy)
+    }
+}
+
+private extension JSONEncoder {
+    static var iso8601: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+}

--- a/OpenGlassesTests/LocalRuntimeDiagnosticsTests.swift
+++ b/OpenGlassesTests/LocalRuntimeDiagnosticsTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Plan DZ P2 — the diagnostics card.
+///
+/// The card's whole claim is that its numbers *are* the ones the runtime recorded. So what is
+/// tested is the derivation (tokens per second, which is the only figure the card computes) and the
+/// row set — including the honest empty state, and the rule that keeps a no-op reload from wiping
+/// the timings of the turn before it.
+final class LocalRuntimeDiagnosticsTests: XCTestCase {
+
+    // MARK: - Derived rate
+
+    func testTokensPerSecondMeasuresDecodeAndExcludesPrefill() {
+        // 41 tokens, first at 500 ms, finished at 2500 ms: 40 tokens produced across 2 seconds.
+        let sample = generation(generatedTokens: 41, firstTokenMilliseconds: 500,
+                                totalMilliseconds: 2500)
+        XCTAssertEqual(sample.tokensPerSecond ?? 0, 20, accuracy: 0.001)
+    }
+
+    func testTokensPerSecondIsUnreportedWhenThereIsNothingToDivide() {
+        XCTAssertNil(generation(generatedTokens: 0, firstTokenMilliseconds: nil,
+                                totalMilliseconds: 900).tokensPerSecond)
+        XCTAssertNil(generation(generatedTokens: 1, firstTokenMilliseconds: 100,
+                                totalMilliseconds: 900).tokensPerSecond,
+                     "one token is the token produced at first-token time, not a rate")
+        XCTAssertNil(generation(generatedTokens: 40, firstTokenMilliseconds: 500,
+                                totalMilliseconds: 540).tokensPerSecond,
+                     "a 40 ms window measures the clock, not the model")
+        XCTAssertNil(load().tokensPerSecond, "a load produces no tokens")
+    }
+
+    // MARK: - Card rows
+
+    func testTheCardCoversEveryFieldThePlanNames() {
+        let required = ["framework", "modelRevision", "context", "firstToken", "rate", "memory",
+                        "thermal"]
+        let rows = LocalRuntimeDiagnosticsCard.rows(sample: generation(),
+                                                     frameworkDescription: "llama.cpp v0.3.0 (abc)")
+        let ids = Set(rows.map(\.id))
+        let missing = required.filter { !ids.contains($0) }
+        XCTAssertTrue(missing.isEmpty, "missing rows: \(missing)")
+        for row in rows { XCTAssertFalse(row.spokenLabel.isEmpty) }
+    }
+
+    func testWithNoRunRecordedTheCardSaysSoRatherThanShowingZeroes() {
+        let rows = LocalRuntimeDiagnosticsCard.rows(sample: nil,
+                                                     frameworkDescription: "llama.cpp (unknown)")
+        XCTAssertEqual(rows.map(\.id), ["framework", "empty"])
+        XCTAssertFalse(rows.contains { $0.value.contains("0 ms") })
+    }
+
+    func testAnUnpinnedModelRevisionIsSaidToBeUnpinnedNotShownAsAHash() {
+        let sample = generation(modelRevision: LocalModelDescriptor.floatingRevision)
+        let row = LocalRuntimeDiagnosticsCard.rows(sample: sample, frameworkDescription: "x")
+            .first { $0.id == "modelRevision" }
+        XCTAssertEqual(row?.value, "Not pinned")
+    }
+
+    func testTheMemoryDeltaIsSignedAndSpokenInWords() {
+        let lost = LocalRuntimeDiagnosticsCard.rows(sample: generation(headroomDelta: -200_000_000),
+                                                     frameworkDescription: "x")
+            .first { $0.id == "memory" }
+        XCTAssertTrue(lost?.value.hasPrefix("−") ?? false, lost?.value ?? "")
+        XCTAssertTrue(lost?.spokenValue?.contains("less free") ?? false)
+
+        let unchanged = LocalRuntimeDiagnosticsCard.rows(sample: generation(headroomDelta: 0),
+                                                         frameworkDescription: "x")
+            .first { $0.id == "memory" }
+        XCTAssertEqual(unchanged?.value, "unchanged")
+    }
+
+    func testALoadSampleReportsLoadTimeRatherThanAFabricatedFirstToken() {
+        let rows = LocalRuntimeDiagnosticsCard.rows(sample: load(), frameworkDescription: "x")
+        XCTAssertTrue(rows.contains { $0.id == "loadTime" })
+        XCTAssertFalse(rows.contains { $0.id == "firstToken" })
+    }
+
+    // MARK: - Store
+
+    func testTheStoreKeepsTheLatestSamplePerRuntime() {
+        let store = LocalRuntimeDiagnostics()
+        store.record(generation(recordedAt: Date(timeIntervalSince1970: 10)))
+        store.record(generation(generatedTokens: 99, recordedAt: Date(timeIntervalSince1970: 20)))
+        XCTAssertEqual(store.latest(for: .llamaCpp)?.generatedTokens, 99)
+        XCTAssertNil(store.latest(for: .mlx))
+        XCTAssertEqual(store.latest?.generatedTokens, 99)
+    }
+
+    func testALoadOfTheAlreadyMeasuredModelDoesNotWipeItsTimings() {
+        // Re-loading a resident model is a no-op; letting its load sample replace the generation
+        // sample would blank the card between turns.
+        let store = LocalRuntimeDiagnostics()
+        store.record(generation(generatedTokens: 42))
+        store.record(load())
+        XCTAssertEqual(store.latest(for: .llamaCpp)?.generatedTokens, 42)
+
+        // A *different* model's load is real news and does replace it.
+        store.record(load(modelID: LocalModelID("other/model")))
+        XCTAssertEqual(store.latest(for: .llamaCpp)?.kind, .load)
+    }
+
+    // MARK: - Helpers
+
+    private func generation(modelID: LocalModelID = LocalModelID("owner/repo#m.gguf"),
+                            modelRevision: String = String(repeating: "b", count: 40),
+                            generatedTokens: Int = 41,
+                            firstTokenMilliseconds: Int? = 500,
+                            totalMilliseconds: Int = 2500,
+                            headroomDelta: Int64 = -100_000_000,
+                            recordedAt: Date = Date(timeIntervalSince1970: 0))
+        -> LocalRuntimeDiagnosticsSample {
+        LocalRuntimeDiagnosticsSample(
+            kind: .generation, modelID: modelID, runtime: .llamaCpp, modelRevision: modelRevision,
+            contextTokens: 4096, promptTokens: 120, generatedTokens: generatedTokens,
+            firstTokenMilliseconds: firstTokenMilliseconds, totalMilliseconds: totalMilliseconds,
+            headroomDeltaBytes: headroomDelta, footprintBytes: 900_000_000,
+            thermalState: .fair, recordedAt: recordedAt)
+    }
+
+    private func load(modelID: LocalModelID = LocalModelID("owner/repo#m.gguf"))
+        -> LocalRuntimeDiagnosticsSample {
+        LocalRuntimeDiagnosticsSample(
+            kind: .load, modelID: modelID, runtime: .llamaCpp,
+            modelRevision: String(repeating: "b", count: 40),
+            contextTokens: 4096, promptTokens: 0, generatedTokens: 0,
+            firstTokenMilliseconds: nil, totalMilliseconds: 1800,
+            headroomDeltaBytes: 0, footprintBytes: 900_000_000,
+            thermalState: .nominal, recordedAt: Date(timeIntervalSince1970: 30))
+    }
+}


### PR DESCRIPTION
## Summary

The round that makes the GGUF work usable. The existing manager screen is **extended, not duplicated**: runtime and capability filters, runtime/quantization badges, download + on-disk + working-memory facts with a live fit verdict, per-file progress with cancel and retry, and load / unload / remove / "why won't this run" actions. The import sheet drives PR4's parser and renders its typed rejection messages verbatim (they were written for people and never echo the input); the fit report's blockers disable the action, its warnings inform without blocking.

**What a person can do after this** (with `ggufModelsEnabled` on): filter to GGUF, pick a curated entry or paste `owner/repo`, choose a quantization, accept the licence, read the verdict, confirm — the download runs on a background session that survives leaving the screen and app termination, installs atomically, then loads and answers. With the flag off (shipping default) it's the MLX manager as before, plus the better facts and badges.

Design notes worth review:

- **One row state, not five flags**: `staged > incompatible > loaded > updateAvailable > installed > notInstalled`, with a documented truth table. Staged outranks loaded because it's the only state with a clock and a cancel. An unpinned revision is never an "update", so legacy MLX records stay quiet.
- **Diagnostics is a second sink, not a second stopwatch** — the card reads the same two measurement sites the GGUF backend already had, so a bug report's log and the on-screen card describe the same run. Tokens/second is the only derived figure, excludes prefill, and is `nil` rather than invented when the window is too short to measure.
- **Downgrade safety in the selection migration**: an MLX selection still mirrors into the legacy string field (identical string by construction, so existing readers are untouched), but a GGUF selection deliberately does not — a pre-DZ build would otherwise try to fetch `owner/repo#file.gguf` from the MLX hub every launch. Versioned, forward-only, stamped after a verified read-back; tested for legacy decode and the downgrade property.
- **Memory failures are not "incompatible"** — insufficient headroom, backgrounding and transition-in-progress stay retryable load errors with the live headroom readout, not a permanent badge.
- Accessibility per the plan: bounded progress announcements with immediate completion/failure, badges with full VoiceOver labels rather than colour, removal confirmations that name whether staged *and* installed files go, incompatibility explanations that say which metadata or capability is missing, and a background-continuation notice that is both spoken and visible.

## Verification

- Full suite: **4474 tests, 0 failures** (4 env-gated skips) — **65 new** across 4 classes
- Release build (generic iOS): green
- **Device-only, unchanged from PR2–PR4's honest list**: a real GGUF load and generation on Metal, background-session delivery after termination, and the diagnostics card's measured numbers. The curated entries remain `fileMetadataOnly` — no capability badge is claimed without device evidence.
- MLX downloads deliberately still use the old hub fetch: MLX descriptors are unpinned with no digests, so `installationFaults()` refuses them from the verified pipeline by design. Migrating them means pinning those repos file-by-file — a separate decision.
- New UI strings listed in the branch report for the next catalog sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)