### PR TITLE
Refresh READMEs with capability-led messaging and offline AI details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,437 +1,103 @@
 # OpenGlasses
 
-[中文文档 (Chinese)](README.zh-CN.md)
+### Look up. Ask anything. Keep going.
 
-A source-available voice-powered AI assistant for Meta smart glasses — Ray-Ban Meta, Ray-Ban Display, Oakley Meta (HSTN / Vanguard), and Meta's own frames — with the EVEN Realities G2 supported as an alternate in-lens HUD. 85+ built-in tools, multi-LLM support (cloud + on-device) with automatic model routing, a **fully offline voice mode** (on-device speech-to-text, AI, and voice), personas with simultaneous wake words, an in-lens HUD with hands-free task control on Ray-Ban Display glasses, an on-device knowledge graph, live translation, hands-free field-service guidance, real-time vision coaching, MCP tool servers, and CarPlay + Apple Watch companions — all controlled hands-free by voice.
+Turn your smart glasses into an AI assistant for the world in front of you. Ask about what you see, translate a conversation, remember the details, and get things done—without reaching for your phone.
 
-> **Note**: The Meta Wearables SDK is currently in **developer preview**. App Store distribution is pending approval — each user must build the app from source with their own Meta developer credentials.
+**Your choice of AI. Hands-free by voice. Offline when you need it.**
 
-<!-- TODO(gallery): "## See It" section goes here — captioned rows of device screenshots in docs/media/
-     (voice tab, Settings hub, Developer panel, modes; then lens HUD photo/GIF, live translation,
-     walking navigation banner). Capture on a device with glasses connected — no error banners. -->
-
+[Get started](#quick-start) · [Explore capabilities](docs/CAPABILITIES.md) · [For teams](#expertise-where-the-work-happens) · [简体中文](README.zh-CN.md)
 
 ---
+
+## A little help, right when you need it
+
+### See it. Understand it. Act on it.
+
+Read a sign, ask about a piece of equipment, or turn a business card into a contact. OpenGlasses brings the camera into the conversation, with scene descriptions, text recognition, smart capture, and live visual coaching.
+
+*“What am I looking at?” · “Save this card.” · “Log this receipt.”*
+
+[Explore vision and capture →](docs/CAPABILITIES.md#see-and-capture)
+
+### Keep the conversation flowing
+
+Ask a quick question or settle into a live voice conversation. Translate spoken language, follow along with captions, and switch between assistants with their own voices, models, and wake words. Start with your voice, Siri, or a tap.
+
+*“Start translating Spanish to English.” · “Hey Jarvis…”*
+
+[Explore voice and translation →](docs/CAPABILITIES.md#talk-and-translate)
+
+### Remember the details that matter
+
+Save where you parked, keep notes about people and places, and turn captured conversations into meeting notes. With memory rewind enabled, catch up on what was just said. Your saved context becomes something you can ask about later.
+
+*“Remember my car is in lot B, level 3.” · “What did they just say?”*
+
+[Explore memory and recall →](docs/CAPABILITIES.md#remember-and-recall)
+
+### Say it. Get it done.
+
+Check your calendar, set a reminder, find directions, control your music, or turn on the lights. Connect Home Assistant, Siri Shortcuts, MCP tool servers, and OpenClaw to bring your own services into the conversation. Teach the assistant a routine, then call it by name.
+
+*“What's on my calendar?” · “Turn on the living room lights.”*
+
+[Explore actions and integrations →](docs/CAPABILITIES.md#take-action)
+
+### Share your point of view
+
+Capture photos and video by voice, broadcast over RTMP, or share a live view in a browser over WebRTC. Compatible display glasses can put answers, captions, and the next task in your line of sight.
+
+[Explore capture →](docs/CAPABILITIES.md#see-and-capture) · [Check display support →](docs/CAPABILITIES.md#devices-and-displays)
+
+## Your assistant. Your choice.
+
+Use a cloud model, run a model on your own server, or keep the voice loop on your iPhone. OpenGlasses lets you choose the AI, speech recognition, and spoken voice separately—and route different requests to different models.
+
+### Offline AI, right on your iPhone
+
+Take your assistant beyond Wi-Fi and mobile coverage. Run compatible local models with **Apple MLX** or **llama.cpp**, including support for importing **GGUF** models. Pair them with **SenseVoice** speech recognition and **Kokoro** voices for an on-device voice conversation—no cloud API key required.
+
+Download the models once, select the local engines, and enable Offline Mode for tools. Model fit and performance depend on your iPhone; vision and tool calling depend on the selected model. Connected services still need a network.
+
+You also control which tools are enabled, inspect the context sent to the assistant, and review network activity.
+
+[Choose your AI →](docs/CAPABILITIES.md#choose-your-ai) · [Privacy controls →](docs/CAPABILITIES.md#privacy-and-control)
+
+## Expertise where the work happens
+
+**Field Assist** puts procedures and reference knowledge within speaking distance. Follow guided steps, report a reading, look up a fault, and bring in a remote expert when the job needs another pair of eyes.
+
+Teams can add their own manuals and knowledge vaults for answers with source references and exportable session records. Clinical recording features add biometric access, retention controls, audit records, and medical export options.
+
+These features have separate access tiers. [Explore professional capabilities](docs/CAPABILITIES.md#field-and-clinical-work), [build a field knowledge vault](docs/field-assist-vault-guide.md), or [contact Skunkworks NZ](mailto:g@skunkworks.kiwi) about team access.
 
 ## Quick Start
 
-1. **Clone and generate the Xcode project** — `OpenGlasses.xcodeproj` is not in git; each developer creates it locally with [XcodeGen](https://github.com/yonaskolb/XcodeGen) (avoids `project.pbxproj` merge conflicts):
+Start on an **iPhone running iOS 26+**. Pair compatible **Meta smart glasses** for hands-free camera and audio use; phone-based features and camera fallback also let you explore without glasses.
 
-   ```bash
-   git clone https://github.com/straff2002/OpenGlasses.git
-   cd OpenGlasses
-   brew install xcodegen
-   ./Scripts/generate-xcodeproj.sh
-   open OpenGlasses.xcodeproj
-   ```
+1. **Build the app.** Follow the [source setup guide](docs/BUILDING.md) for Xcode 26+, dependencies, signing, and Meta developer configuration.
+2. **Choose your AI.** Open **Settings → AI Models** and connect a provider or download a compatible local model.
+3. **Connect your glasses.** Pair them in the Meta AI app, complete developer setup, then connect and grant camera access in OpenGlasses.
+4. **Start talking.** Enable listening and say **“OpenGlasses”**, or tap the microphone. Try asking about something in front of you.
 
-   After `git pull`, run `./Scripts/generate-xcodeproj.sh` again if `project.base.yml` changed. Meta credentials, team ID, and signing: [Building from Source](#building-from-source) (optional `./Scripts/setup-local-dev.sh` for a personal overlay).
+Camera and display features depend on the device and SDK support. Ray-Ban Display has an in-lens display path; **EVEN G2 support is experimental**. See [device notes](docs/CAPABILITIES.md#devices-and-displays) before choosing a setup.
 
-2. **Build on your iPhone** from Xcode (⌘R) — set signing team if prompted
-3. Add an AI model in **Settings → AI Models** (Anthropic, OpenAI, Gemini, or a local model)
-4. Pair your Ray-Ban or Oakley Meta glasses via the Meta AI app
-5. Say **"OpenGlasses"** and ask anything
+## Go further
 
----
-
-## Features
-
-At a glance — every item links to its section below:
-
-| | |
+| Make it yours | Start here |
 |---|---|
-| **Talk** | [Personas](#personas--multiple-ai-personalities) · [Hey Siri](#hey-siri--ask-by-voice-without-the-wake-word) · [Fully Offline Voice](#fully-offline-voice-mode) · [Text-to-Speech](#text-to-speech) · [Realtime Modes](#realtime-modes) · [Barge-In](#barge-in) |
-| **Think** | [85+ Native Tools](#85-native-tools) · [On-Device LLM](#on-device-local-llm) · [Self-Hosted Server](#self-hosted-local-server-ollama-llamacpp-vllm) · [Smart Routing](#smart-model-routing) · [Prompt Presets](#prompt-presets) · [Custom Tools](#custom-tools) · [MCP Servers](#mcp-servers-model-context-protocol) · [Voice-Taught Skills](#voice-taught-skills) |
-| **See** | [Live Coach](#live-coach--real-time-vision-coaching) · [Smart Capture](#smart-capture) · [Object Memory](#object-memory) · [Live Translation](#live-translation) · [Camera & Streaming](#camera--streaming) · [Display HUD](#ray-ban-display-hud) |
-| **Remember** | [Social Context](#social-context) · [Knowledge Brain](#on-device-knowledge-brain) · [Meeting Recorder](#meeting-recorder) |
-| **Connect** | [Home Assistant](#home-assistant-integration) · [CarPlay & Apple Watch](#carplay--apple-watch) · [Transparency & Privacy](#transparency--privacy) |
-| **Work** | [Field Assist](#field-assist--guided-field-service) · [Medical Compliance](#medical-compliance) |
+| Explore features, examples, and configuration | [Capability guide](docs/CAPABILITIES.md) |
+| Build, configure, or troubleshoot the app | [Building from source](docs/BUILDING.md) |
+| Bring your own field manuals and procedures | [Field Assist vault guide](docs/field-assist-vault-guide.md) |
+| Create reusable assistant capabilities | [Skill pack authoring](docs/skillpack-authoring.md) |
+| Publish packs | [Skill packs](skillpacks/README.md) · [Vault packs](vaultpacks/README.md) |
+| Explore engineering work and future plans | [Development plans](docs/plans/README.md) |
 
-### Personas — Multiple AI Personalities
+## Build with us
 
-Each persona has its own wake word, AI model, and personality. All listen simultaneously.
+Contributions are welcome—from new tools and integrations to better local inference, translations, and everyday usability. Fork the project and open a pull request.
 
-| Say | What Happens |
-|-----|-------------|
-| "Hey Claude" | Routes to Claude Sonnet with your professional prompt |
-| "Hey Jarvis" | Routes to a local on-device model with a concise style |
-| "Hey Computer" | Routes to GPT-4o with a technical personality |
+OpenGlasses is **source-available under [BSL 1.1](LICENSE)**, with non-commercial use permitted and a stated change date of March 24, 2030 to Apache 2.0. Commercial use requires a separate licence: [g@skunkworks.kiwi](mailto:g@skunkworks.kiwi).
 
-**Configure:** Settings → Personas → Add. Pick a wake word, assign a model and prompt preset.
-
-### "Hey Siri" — Ask by Voice Without the Wake Word
-
-OpenGlasses ships App Intents + Siri Shortcuts, so you can drive it straight from Siri — handy when the glasses' own "Hey Meta" is busy, or to start a query hands-free without waiting for the in-app wake word:
-
-| Say | What Happens |
-|-----|-------------|
-| "Hey Siri, ask **Claude** on OpenGlasses what's on my calendar" | Runs the question under that **persona's** model + prompt, **Siri reads the answer back**, then restores your active model |
-| "Hey Siri, ask OpenGlasses a question" | Siri asks **"What would you like to ask?"**, you speak the question, it's answered under your active persona |
-| "Hey Siri, OpenGlasses take a photo" | Captures via the glasses and describes the scene |
-| "Hey Siri, OpenGlasses describe surroundings" | Accessibility scene description |
-
-Beyond the pre-made phrases above, **Capture Glasses Photo** (a silent capture saved to your library) and **Record Glasses Video** are available as **Shortcuts actions** you can add to Siri, the Action button, or your own automations.
-
-The first time, iOS surfaces these in the **Shortcuts** app and the Siri phrase picker (you can rename the phrase to anything you like). A **persona name** can ride in the phrase ("ask Claude…") because it's a fixed, resolvable choice; the **question** can't (iOS only lets App Shortcut phrases embed fixed choices, not free-form text), so it's asked **two-step** — Siri prompts and awaits your spoken reply. Consecutive asks within a few minutes continue the **same conversation thread**, and Siri shows the answer in a result card. The intent runs in the background and speaks the result — no need to bring the app forward. If Siri ever says OpenGlasses isn't running, enable **Settings → Voice → Open App for Siri Questions** to have it launch the app first.
-
-#### Choose What Siri Can Run — and Add Your Own Actions
-
-**Settings → Siri & Search** is the control panel for the whole Siri surface:
-
-- **Built-in actions** — photo, recording, live modes, listening, **daily briefing**, **memory rewind** ("what did they just say?"), **teleprompter**, **meeting summary**, **save this location**, **broadcast** — each individually toggleable. Anything you turn off, Siri politely refuses.
-- **Your capabilities** — capture flows, procedures, playbooks, and custom tools you've authored appear automatically as candidates (off by default). Turn one on and **"Run *pump inspection* on OpenGlasses"** works by voice — no extra setup.
-- **Custom actions** — invent your own: a spoken name (plus synonyms) bound to a canned instruction for the assistant or a single tool call. "Run *morning rundown* on OpenGlasses."
-
-#### Your Content in Spotlight
-
-Notes, meeting summaries, saved locations, teleprompter scripts, playbooks, and study decks appear in **Spotlight and Siri search** — "the compressor job from Tuesday" finds the field session, and opening a result deep-links into the app. Privacy-tiered: **conversations** (titles only) and **Field Assist sessions** (metadata only, opted in per vault) are off until you enable them; health data, recognized people, and audio are **never indexed**; Medical Compliance Mode disables all donation and purges the index.
-
-#### Pre-Trained Siri Phrasing (App Schemas)
-
-OpenGlasses adopts Apple's **camera** and **assistant** App Intent schemas, so Apple-trained phrasing works with no custom shortcut: "take a photo", "start recording a video". Siri can also resolve **"this"** against the open chat thread — "summarize this" just works.
-
-The assistant schema additionally registers OpenGlasses for the **side-button voice-assistant slot** (replace Siri with OpenGlasses) — currently a **Japan-only** surface (iOS 26.2+, Apple Account region set to Japan, required by Japan's Mobile Software Competition Act; expected to reach more regions as regulation spreads). Everywhere else, the Action button route via **Settings → Action Button → Shortcut → "Ask OpenGlasses"** works today.
-
-### On-Device Local LLM
-
-Run AI models entirely on your iPhone — no internet, no cloud, no API keys.
-
-1. Settings → AI Models → Add Model → pick **"Local (On-Device)"**
-2. **Download & Manage Models** → download from HuggingFace
-3. Select your downloaded model and tap **Add**
-
-**Recommended models:**
-
-| Model | Size | Best For |
-|-------|------|----------|
-| **Gemma 4 E2B** (default agent) | 3.6 GB | Best on-device agent — vision, tool calling, 140+ languages (8 GB RAM minimum, 12 GB recommended — uses ~4 GB while running) |
-| SmolVLM2 2.2B | 1.5 GB | Vision — sees photos + video |
-| Qwen 2.5 3B | 1.8 GB | Strong text reasoning + tool use |
-| Gemma 2 2B | 1.5 GB | Lightweight general purpose |
-| Qwen 2.5 0.5B | 0.4 GB | Ultra-light, basic |
-
-**Gemma 4 E2B** is the default on-device agent — it runs automatically when no cloud model is configured. Models are stored persistently and work fully offline after download. Toggle **Offline Mode** in Settings → Tools to disable internet-dependent tools.
-
-**Memory:** a loaded model occupies its full weight size in RAM plus working memory while generating — Gemma 4 E2B uses ~4 GB, a real load even on a 12 GB iPhone with other apps open. OpenGlasses checks available headroom before loading: if the model won't fit it tells you how much to free (swipe apps away in the app switcher) instead of letting iOS silently kill the app, and voice requests automatically fall over to a cloud model if one is configured. **Settings → AI Models → Download & Manage Models** shows the app's live memory use and remaining headroom.
-
-### Self-Hosted Local Server (Ollama, llama.cpp, vLLM…)
-
-Prefer to run a bigger model on a desktop or home server and keep everything on your own network? Point OpenGlasses at any **OpenAI-compatible** endpoint — no cloud, no API key:
-
-1. Settings → AI Models → Add Model → pick **"Custom (OpenAI-compatible)"**
-2. Set the **Base URL** to your server, e.g. `http://your-mac.local:11434/v1` (Ollama), and **leave the API Key blank**
-3. Tap **Fetch models** to list what the server has, or type a model ID (e.g. `llava` for vision). Turn on **Vision** to send glasses photos.
-
-Works with **Ollama, llama.cpp server, LM Studio, vLLM, and LocalAI**. Your photos, voice, and conversations never leave the machine running the server.
-
-> **Reaching the server:** use the host's **`.local` mDNS name** (`http://mymac.local:11434/v1`) or a **Tailscale** address (`*.ts.net`, already allow-listed) rather than a raw `192.168.x.x` IP — iOS App Transport Security can block cleartext `http://` to a bare private IP, but allows `.local`, loopback, and the Tailscale exception.
-
-### Fully Offline Voice Mode
-
-Run the **entire voice loop on-device** — nothing leaves your iPhone:
-
-- **Speech-to-text** — an on-device SenseVoice recognizer (multilingual, ~240 MB). No audio is sent to any server.
-- **The AI** — a local LLM (Gemma / Qwen via MLX, or Apple Intelligence).
-- **Text-to-speech** — an on-device Kokoro neural voice (~185 MB) — natural, far better than the robotic system voice.
-
-Speech recognition and the spoken voice are CPU/ONNX (not Metal), so they keep working **even while the app is backgrounded**. Choose the engines under **Settings → Services → Speech Recognition / Voice Engine** and download the models once — then you have a private assistant that works on a plane, in a tunnel, or anywhere with no signal. Each tier also degrades gracefully: with no model (or no cloud), it falls back to Apple Speech and the iOS voice.
-
-### 85+ Native Tools
-
-All voice-activated. Say what you need naturally — the AI picks the right tool.
-
-| Category | Tools |
-|----------|-------|
-| **Information** | Web Search (Perplexity + DuckDuckGo), News, Weather, Date/Time, Dictionary, Currency |
-| **Productivity** | Calendar, Reminders, Alarms, Timers, Pomodoro, Notes, Contextual Notes (GPS+time tagged), Clipboard |
-| **Communication** | Phone Calls, iMessage, WhatsApp, Telegram, Email, Contact Lookup |
-| **Navigation** | Directions (Apple/Google Maps), Nearby Places, Save Locations, Geofencing Alerts |
-| **Media** | Music Control (play/pause/skip + search by song/artist), Shazam Song ID, Open Apps |
-| **Smart Home** | HomeKit (lights, switches, fans, thermostats, locks, scenes), Home Assistant (REST API), Siri Shortcuts |
-| **Vision** | QR/Barcode Scanner, Face Recognition, Smart Capture (business cards/receipts/flyers → action), Money/Medication/Color ID (accessibility), Privacy Filter |
-| **Memory** | Object Memory ("where are my keys?"), Social Context (per-person facts), User Memory, Voice-Taught Skills |
-| **AI Features** | Live Translation, Live Coach (real-time vision coaching), Memory Rewind (ambient audio recall), Ambient Captions, Meeting Summaries, Conversation Summaries |
-| **Fitness** | Workout Tracking, Exercise Logging, HealthKit, Pose Analysis, Step Goals |
-| **Device** | Flashlight, Brightness, Device Info, Step Count |
-| **Safety** | Emergency Info (local numbers + GPS), Daily Briefing, Navigation Assistance (accessibility preset) |
-| **Integration** | OpenClaw Gateway (50+ skills), MCP Servers (universal tool protocol), Custom Tools |
-
-### Live Coach — Real-Time Vision Coaching
-
-The glasses watch what you're doing and give short, spoken corrections on a loop — one tight sentence at a time, no repetition. Built-in domains: posture, cooking technique, guitar, climbing, sports tactics — or define your own.
-
-| Say | What Happens |
-|-----|-------------|
-| "Coach my posture" | Periodic spoken feedback on your alignment |
-| "Watch my knife technique" | Live cooking-form coaching |
-| "Stop coaching" | Ends the session |
-
-### Smart Capture
-
-Point at a business card, receipt, or event flyer — OpenGlasses reads it on-device and offers to act.
-
-| Say | What Happens |
-|-----|-------------|
-| "Save this card" | Extracts name/company/phone/email → save to Contacts |
-| "Log this receipt" | Extracts merchant/total/date → log the expense |
-| "Add this event" | Extracts title/date/location → create a calendar event |
-
-### Voice-Taught Skills
-
-Teach the AI new behaviors at runtime — no code needed.
-
-| Say | What Happens |
-|-----|-------------|
-| "Learn that when I say expense this, create a note tagged EXPENSE" | Skill saved, auto-applies forever |
-| "Learn that when I say goodnight, turn off all lights" | Triggers HomeKit/HA on the phrase |
-| "List skills" | Shows all taught skills |
-| "Forget expense this" | Removes the skill |
-
-### Object Memory
-
-Remember where you put things. Uses GPS to calculate distance.
-
-| Say | What Happens |
-|-----|-------------|
-| "Remember my car is in lot B level 3" | Saves with GPS + timestamp |
-| "Where are my keys?" | "Your keys were on the kitchen counter, 2 hours ago. That's very close to where you are now." |
-| "Where did I park?" | Retrieves car location with distance |
-
-### Live Translation
-
-Continuous real-time translation of spoken foreign language.
-
-| Say | What Happens |
-|-----|-------------|
-| "Start translating Spanish to English" | Begins continuous translation |
-| "Stop translating" | Ends session, reports count |
-| "Switch to Japanese to English" | Changes languages on the fly |
-
-Supports 25+ languages including Spanish, French, German, Japanese, Chinese, Korean, Arabic, and more.
-
-### Social Context
-
-Build dossiers about people you meet.
-
-| Say | What Happens |
-|-----|-------------|
-| "Remember Sarah works at Google and likes hiking" | Fact saved |
-| "What do I know about Sarah?" | "About Sarah: works at Google, likes hiking. First noted 3 days ago." |
-
-Works alongside face recognition — when the AI recognizes someone, it can recall your notes about them.
-
-### On-Device Knowledge Brain
-
-A private, on-device knowledge graph that quietly connects what you tell it — people, places, things, and how they relate — with zero cloud calls. Notes, social context, face encounters, and meeting summaries all feed it, and the AI can query the whole graph in one step.
-
-| Say | What Happens |
-|-----|-------------|
-| "Who did I meet at the conference?" | Recalls people and where/when you encountered them |
-| "How do I know Sarah?" | Traces the facts and relationships linking you |
-
-Native-first — it works without any external gateway, and everything stays on the phone.
-
-### Barge-In
-
-Interrupt the AI mid-sentence by saying any wake word. It stops immediately and starts listening to your new question.
-
-### Prompt Presets
-
-Switch AI personality without reconfiguring. Built-in presets:
-
-| Preset | Style |
-|--------|-------|
-| **Default** | Balanced, 2-4 sentences, conversational |
-| **Concise** | 1-2 sentences max, no filler |
-| **Technical** | Precise, jargon-appropriate, data-dense |
-| **Creative** | Playful, witty, expressive |
-| **Navigation Aid** | Spatial awareness, obstacle detection, sign reading |
-
-Create your own in Settings → System Prompt.
-
-### Custom Tools
-
-Define new tools without writing code. Map to Siri Shortcuts or URL schemes.
-
-Settings → Transparency → Custom Tools → Add:
-- **Shortcut tool**: triggers a Siri Shortcut by name
-- **URL tool**: opens a URL with parameter substitution
-
-Example: a "log_water" tool that runs your "Log Water" shortcut when the AI decides you need it.
-
-### MCP Servers (Model Context Protocol)
-
-Connect to any MCP-compatible tool server directly from your phone.
-
-Settings → Transparency → MCP Servers → Add:
-- Enter server URL + auth headers
-- Tap "Discover Tools" — all tools auto-appear
-- The AI can call them alongside native tools
-
-Popular MCP servers: Home Assistant, Notion, GitHub, Slack, Todoist, and hundreds more.
-
-### Home Assistant Integration
-
-Direct REST API control of your HA instance — works alongside or instead of HomeKit.
-
-Settings → Services → Home Assistant:
-- **HA URL**: e.g. `http://192.168.1.100:8123`
-- **Token**: Long-Lived Access Token (HA → Profile → Security)
-
-Voice commands: "Turn on the living room lights", "Set thermostat to 72", "Run the goodnight automation", "List all sensors"
-
-### Transparency & Privacy
-
-See exactly what data the AI receives and what network calls are made.
-
-| Setting | What It Shows |
-|---------|--------------|
-| **Tools** | All 85+ tools with enable/disable toggles |
-| **Prompt Inspector** | Full system prompt, injected context, token estimate |
-| **Network Activity** | All HTTP requests categorized by Meta/AI/App/Other |
-| **Offline Mode** | One toggle disables all internet-requiring tools |
-
-**No telemetry — ours or the SDK's.** OpenGlasses has no developer backend and no account, so no usage analytics and no crash reports ever reach us — in any build. The glasses SDK collects its own (connection sessions, camera streams, permission checks, crashes) and uploads them to Meta by default; the app opts out in its `Info.plist` *and* blocks those uploads from leaving the phone, because an opt-out is only a request to a closed-source binary. Settings shows whether anything had to be blocked, and the self-test in Diagnostics & Support shows how much. Pairing still contacts Meta once to verify the app may talk to your glasses — that's what makes the connection work, and it carries no usage data.
-
-The agentic path is hardened against **prompt injection** — untrusted content (web pages, scanned text, tool output) can't hijack the assistant into running sensitive tools. High-impact actions stay behind explicit confirmation and the agent-mode gate.
-
-### Camera & Streaming
-
-- **Voice-Activated Photo Capture** — "take a picture" or "what's this?"
-- **QR/Barcode Scanner** — "scan this code" (Vision framework, works offline)
-- **Live Camera Preview** — real-time view of glasses POV
-- **Video Recording** — MP4 with configurable bitrate, glasses-mic audio muxed in, optional live transcription. **No recording time limit** — say "record a video" and it runs until you say "stop recording" (built for meetings and long sessions; the practical limits are glasses battery/thermals and phone storage, not the app). If storage is low it warns with the estimated minutes left, and if the glasses stop mid-recording (battery, thermal shutdown, out of range) it automatically stops, saves everything captured, and tells you.
-- **RTMP Broadcasting** — live stream to YouTube, Twitch, Kick
-- **Chat Read-Aloud** — while broadcasting, Twitch chat is spoken into your ear (read-only, no OAuth): rate-capped and de-duplicated, mentions jump the queue, assistant speech always wins, and it goes quiet during realtime sessions. Opt-in, with a mentions-only mode
-- **WebRTC Browser Streaming** — shareable URL for peer-to-peer viewing
-- **Privacy Filter** — auto-blurs bystander faces before a frame leaves the device: AI providers, recordings, RTMP broadcast, browser streaming and expert calls all get the blurred frame from one shared pass. Detection and blurring are on-device. On video the blur tracks faces between detections, so someone stepping into shot can be briefly visible before the next pass; faces you've enrolled are matched unblurred so recognition still works
-
-### Meeting Recorder
-
-One tap on the **Record button** in the quick actions bar (or by voice) captures a meeting through the glasses mic — with live captions on screen while it records, even if wake-word listening is off. Recordings are **preserved** in an in-app library with playback, and each one gets a transcript automatically: speaker-labeled cloud transcription when Deepgram is configured, with the downloaded on-device model as the private/offline fallback. Medical Compliance Mode keeps transcription fully on-device.
-
-### Ray-Ban Display HUD
-
-On **Ray-Ban Display** glasses (the Meta frames with an in-lens display + Neural Band), OpenGlasses mirrors content into the heads-up display and lets you act on it hands-free. Additive and off by default (Settings → Hardware → Glasses Display). It's gated on the device's display capability — not the brand — so camera/audio frames like Ray-Ban Meta and Oakley Meta are simply unaffected. The same HUD can instead render on an **EVEN Realities G2** (Settings → Hardware → Display Backend): display + temple-gesture control only, over open Bluetooth with no Meta permission gate — voice stays on the phone, and there's no camera.
-
-- **AI responses & live captions** — spoken answers and the ambient-caption line appear in-lens as they happen.
-- **Notification & navigation cards** — calendar and geofence reminders, plus turn-by-turn Navigation Assist guidance, rendered with icons and a safety treatment.
-- **Interactive task cards** — run a workflow or a Field Assist procedure as a **Now / Next** card and complete steps with the Neural Band (Done / Skip / Back, or branch choices) or by voice ("next", "done", "skip", "back").
-
-Built on Meta's on-device display design system, so contrast, colour, and legibility are tuned for the waveguide automatically.
-
-### Text-to-Speech
-
-24 ElevenLabs voices (10 female, 14 male) with iOS fallback:
-- **Female**: Rachel, Sarah, Matilda, Emily, Charlotte, Alice, Lily, Dorothy, Serena, Nicole
-- **Male**: Brian, Adam, Daniel, George, Chris, Charlie, James, Dave, Drew, Callum, Bill, Fin, Liam, Thomas
-
-**Emotion-Aware TTS** adjusts tone automatically — warmer for good news, calmer for instructions, concerned for warnings.
-
-### Realtime Modes
-
-| Mode | How It Works |
-|------|-------------|
-| **Voice Mode** | Wake word → transcription → any LLM → TTS (most flexible) |
-| **Gemini Live** | Real-time audio/video streaming with Google Gemini |
-| **OpenAI Realtime** | Real-time audio/video streaming with OpenAI |
-
-### Smart Model Routing
-
-Assign models to **Fast**, **Balanced**, and **Best** tiers, then let OpenGlasses pick per request — a quick local model for live coaching, your best cloud model for hard diagnostics. Or turn routing off and pin everything to one model.
-
-**Configure:** Settings → AI Models → Model Routing.
-
-### CarPlay & Apple Watch
-
-- **CarPlay** — hands-free voice assistant on your car's display.
-- **Apple Watch** — companion app and widget for quick control and glanceable status, including **taking a photo or starting/stopping a video recording on the glasses** straight from your wrist.
-
----
-
-## Enterprise
-
-Commercial features for teams and regulated industries. These are licensed separately from the source-available core — see [License](#license) or contact Skunkworks NZ at [g@skunkworks.kiwi](mailto:g@skunkworks.kiwi).
-
-### Field Assist — Guided Field Service
-
-Hands-free, step-by-step guidance for technicians and other hands-busy work. Procedures branch on what you report or what the camera sees, surface safety reminders before each step, cite their source material, and write an audited session log you can export. Stuck? Escalate to a live remote expert with glasses video. Domain knowledge lives in **vaults** (e.g. refrigeration, HVAC, electrical) you author and extend yourself.
-
-| Say | What Happens |
-|-----|-------------|
-| "Start a refrigeration session" | Loads the vault and begins the procedure |
-| "The gauge reads 38 psi" | AI evaluates the reading and branches to the right next step |
-| "Next step" / "Go back" / "Repeat that" | Navigate the procedure hands-free |
-| "Call an expert" | Bridges to a remote human with live glasses video |
-
-**Access:** Field Assist unlocks with a signed license code (teams — issued with your purchase order) or a one-time in-app purchase. TestFlight builds unlock through the StoreKit sandbox at no charge, so beta testers don't need a code. Want to evaluate it? [Email us](mailto:g@skunkworks.kiwi?subject=Field%20Assist%20trial%20license) for a temporary trial license.
-
-### Medical Compliance
-
-Professional-grade safeguards for clinical recordings, available as an in-app subscription.
-
-- **Encryption at rest** — recordings and transcripts protected with `NSFileProtectionComplete`
-- **Biometric app lock** — Face ID / Touch ID required on every launch
-- **Audit logging** — every data-access event timestamped and exportable
-- **Medical export** — FHIR R4, HL7, and PDF export to Epic, Cerner, and more
-- **Data retention** — configurable auto-purge with secure deletion
-- **Leakage prevention** — cloud tools disabled, excluded from iCloud backup
-- **International frameworks** — HIPAA, GDPR, AU Privacy Act, NZ HIPC, PIPEDA, UK DPA
-
----
-
-## Requirements
-
-- **iOS 26+**
-- **Xcode 26+** and **[XcodeGen](https://github.com/yonaskolb/XcodeGen)** (`brew install xcodegen`)
-- **Physical iPhone** (Bluetooth, camera, microphone required)
-- **Meta smart glasses** — Ray-Ban Meta, Ray-Ban Display, Oakley Meta HSTN / Vanguard, and Meta's own frames (paired via the Meta AI app); full functionality on all, in-lens HUD on display-equipped models such as **Ray-Ban Display**
-- **EVEN Realities G2** (optional, no Meta account needed) — alternate **HUD backend only**: cards, captions, navigation, and hands-free task control render on the G2; voice stays on the phone/earbuds and camera features are unavailable (the G2 has no camera). Can run alongside Meta glasses — Meta camera + G2 HUD works
-- At least one LLM: API key (Anthropic, OpenAI, Gemini, etc.) OR a downloaded local model
-
----
-
-## Building from Source
-
-Meta developer credentials, Universal Links, personal signing, in-app configuration
-(API keys + services), and troubleshooting all live in **[docs/BUILDING.md](docs/BUILDING.md)**.
-
----
-
-## Dependencies
-
-| Package | Purpose |
-|---------|---------|
-| [meta-wearables-dat-ios](https://github.com/facebook/meta-wearables-dat-ios) | Glasses connection + camera |
-| [HaishinKit](https://github.com/shogo4405/HaishinKit.swift) | RTMP broadcasting |
-| [mlx-swift-lm](https://github.com/ml-explore/mlx-swift-lm) | On-device LLM inference |
-| [llama.cpp](https://github.com/ggml-org/llama.cpp) | On-device GGUF inference engine — vendored under `Vendor/LlamaCpp`, pinned by commit; the built xcframework is committed, and a weekly job rebuilds it from the pinned sources to prove the committed bytes still match |
-| [WebRTC](https://github.com/stasel/WebRTC) | Peer-to-peer browser streaming + expert video |
-| [SystemNotification](https://github.com/danielsaidi/SystemNotification) | In-app notification banners |
-
----
-
-## Contributing
-
-Contributions welcome! This is source-available under the Business Source License 1.1 (free for non-commercial use; converts to Apache 2.0 in 2030). Fork, improve, submit PRs.
-
-Key areas for contribution:
-- New native tools
-- Local model optimization
-- Translation quality improvements
-- Additional MCP server integrations
-- UI/UX improvements
-
-## License
-
-Business Source License 1.1 — free for non-commercial use. Commercial use requires a separate license from Skunk0 / Skunkworks NZ — contact [g@skunkworks.kiwi](mailto:g@skunkworks.kiwi). Converts to Apache 2.0 on March 24, 2030. See LICENSE file for details.
-
-## Credits
-
-Built by [Skunk0](https://github.com/straff2002) at Skunkworks NZ
-
-Powered by [Anthropic Claude](https://www.anthropic.com/), [Meta Wearables SDK](https://wearables.developer.meta.com/), [Apple MLX](https://github.com/ml-explore/mlx-swift), [ElevenLabs](https://elevenlabs.io/), [HaishinKit](https://github.com/shogo4405/HaishinKit.swift)
-
----
-
-**Note**: Independent source-available project, not affiliated with Meta or Anthropic.
+Built by [Skunk0](https://github.com/straff2002) at **Skunkworks NZ**. Independent of Meta and Anthropic.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,404 +1,105 @@
 # OpenGlasses
 
-[English](README.md)
+### 抬头看世界，开口就有帮手。
 
-一款源代码可用（source-available）的语音 AI 助手应用，专为 Meta 智能眼镜（Ray-Ban Meta、Ray-Ban Display、Oakley Meta HSTN / Vanguard 及 Meta 自有品牌眼镜）打造，并支持 EVEN Realities G2 作为备选镜内 HUD。内置 85+ 原生工具，支持多 LLM（云端 + 本地设备）并自动路由模型，**完全离线语音模式**（端侧语音转文字、AI 与语音），多角色同时唤醒，在 Ray-Ban Display 眼镜上提供镜内 HUD 与免提任务操作，本地设备知识图谱，实时翻译，免提现场作业指导，实时视觉教练，MCP 工具服务器，以及 CarPlay + Apple Watch 配套应用——全部通过语音免提控制。
+让智能眼镜成为随身 AI 助手。眼前看不懂的，开口问；听不懂的，随时翻译；值得记住的，留下线索。从获取答案到完成小事，无需掏出手机。
 
-> **注意**：Meta Wearables SDK 目前处于**开发者预览**阶段。尚不支持 App Store 分发——每位用户需使用自己的 Meta 开发者凭据从源码构建应用。
+**AI 由你选，开口就能用，离线也能聊。**
 
----
-
-<!-- TODO(gallery): 「## 界面预览」放在这里 — docs/media/ 中的设备截图（语音页、设置中心、
-     开发者面板、模式页；之后是镜内 HUD 照片/GIF、实时翻译、步行导航）。请在连接眼镜的真机上
-     截图 — 不要出现错误横幅。 -->
-
-## 快速开始
-
-1. 构建并安装到你的 iPhone 上（参见[从源码构建](#从源码构建)）
-2. 在 **设置 → AI 模型** 中添加 AI 模型（Anthropic、OpenAI、Gemini 或本地模型）
-3. 通过 Meta AI 应用配对你的 Ray-Ban 或 Oakley Meta 眼镜
-4. 说 **"OpenGlasses"** 然后提问
+[开始使用](#开始使用) · [探索功能](docs/CAPABILITIES.md) · [团队应用](#让专业知识来到工作现场) · [English](README.md)
 
 ---
 
-## 功能特性
+## 需要帮助时，开口就好
 
-一览（详见下方各节）：
+### 看见，理解，然后行动
 
-| | |
+读懂一块标牌，了解眼前的设备，或把名片上的信息保存为联系人。OpenGlasses 让相机参与对话，提供场景描述、文字识别、智能采集与实时视觉指导。
+
+*“我面前是什么？” · “保存这张名片。” · “记下这张收据。”*
+
+[了解视觉与采集 →](docs/CAPABILITIES.md#see-and-capture)
+
+### 让交流自然继续
+
+随口问个问题，也可以开启连续的语音对话。翻译外语、查看实时字幕，或切换拥有不同声音、模型和唤醒词的助手。用语音、Siri，或轻点一下，就能开始。
+
+*“开始把西班牙语翻译成英语。” · “Hey Jarvis…”*
+
+[了解语音与翻译 →](docs/CAPABILITIES.md#talk-and-translate)
+
+### 记住那些值得记住的细节
+
+记下停车位置，保存有关人物和地点的笔记，把已采集的对话整理成会议记录。启用记忆回放后，还能补听刚才错过的内容。留下的线索，日后开口就能查。
+
+*“记住，我的车停在 B 区三层。” · “刚才说了什么？”*
+
+[了解记忆与回顾 →](docs/CAPABILITIES.md#remember-and-recall)
+
+### 想做什么，说出来
+
+查日程、设提醒、找路线、控制音乐，或打开客厅的灯。连接 Home Assistant、Siri 快捷指令、MCP 工具服务器和 OpenClaw，把常用服务带进对话。教会助手一套日常操作，再用你起的名字调用它。
+
+*“今天有什么安排？” · “打开客厅的灯。”*
+
+[了解操作与集成 →](docs/CAPABILITIES.md#take-action)
+
+### 分享你眼中的世界
+
+用语音拍照、录视频，通过 RTMP 直播，或通过 WebRTC 把实时画面分享给浏览器中的观众。兼容的显示眼镜还能将回答、字幕和下一步任务呈现在眼前。
+
+[了解拍摄与分享 →](docs/CAPABILITIES.md#see-and-capture) · [查看显示支持 →](docs/CAPABILITIES.md#devices-and-displays)
+
+## 你的助手，由你选择
+
+使用云端模型，在自己的服务器上运行 AI，或让整套语音交互都在 iPhone 上完成。OpenGlasses 允许你分别选择 AI 模型、语音识别和朗读引擎，也能为不同请求分配不同模型。
+
+### 没有网络，iPhone 上的 AI 也能陪你聊
+
+走出 Wi-Fi 和移动网络覆盖范围，助手依然随行。通过 **Apple MLX** 或 **llama.cpp** 运行兼容的本地模型，也支持导入 **GGUF** 模型。搭配 **SenseVoice** 语音识别与 **Kokoro** 语音合成，即可在手机上完成整套语音对话，无需云端 API 密钥。
+
+提前下载模型，选用本地引擎，并为工具启用离线模式。模型能否运行及其表现取决于 iPhone 的硬件；视觉理解与工具调用能力取决于所选模型。联网服务仍需网络连接。
+
+你还可以决定启用哪些工具，检查发送给助手的上下文，并查看网络活动。
+
+[选择 AI →](docs/CAPABILITIES.md#choose-your-ai) · [隐私控制 →](docs/CAPABILITIES.md#privacy-and-control)
+
+## 让专业知识来到工作现场
+
+**Field Assist 现场作业助手**让操作流程与参考资料随问随到。按步骤完成作业，口述读数，查询故障，遇到难题时请远程专家一起看现场。
+
+团队可以导入自己的手册与知识库，获取附有来源的答案，并导出会话记录。临床录音功能另提供生物识别访问控制、数据保留设置、审计记录及医疗数据导出选项。
+
+这些功能按不同权限等级开放。[了解专业功能](docs/CAPABILITIES.md#field-and-clinical-work)、[创建现场知识库](docs/field-assist-vault-guide.md)，或[联系 Skunkworks NZ](mailto:g@skunkworks.kiwi)了解团队授权。
+
+## 开始使用
+
+准备一台运行 **iOS 26 或更高版本的 iPhone**。配对兼容的 **Meta 智能眼镜**，即可免手持使用相机和音频功能；没有眼镜时，也可以先体验手机端功能，并使用手机相机作为替代。
+
+1. **构建应用。** 按照[源码构建指南](docs/BUILDING.md)准备 Xcode 26+、依赖项、签名及 Meta 开发者配置。
+2. **选择 AI。** 在 **设置 → AI 模型** 中连接服务商，或下载兼容的本地模型。
+3. **连接眼镜。** 在 Meta AI 应用中配对，完成开发者设置，然后在 OpenGlasses 中连接并授予相机权限。
+4. **开口试试。** 启用监听，说出 **“OpenGlasses”**，或轻点麦克风。先问问眼前的东西是什么。
+
+相机与显示功能取决于设备及 SDK 支持。Ray-Ban Display 提供镜内显示接入；**EVEN G2 支持仍处于实验阶段**。选择设备组合前，请查看[设备说明](docs/CAPABILITIES.md#devices-and-displays)。
+
+## 继续探索
+
+以下详细指南目前为英文。
+
+| 你想做什么 | 从这里开始 |
 |---|---|
-| **对话** | 角色（多唤醒词）· Hey Siri · 完全离线语音 · 文字转语音 · 实时模式 · 打断功能 |
-| **思考** | 85+ 原生工具 · 本地设备 LLM · 自托管服务器 · 智能模型路由 · 提示词预设 · 自定义工具 · MCP 服务器 · 语音教学技能 |
-| **视觉** | 实时教练 · 智能捕获 · 物品记忆 · 实时翻译 · 相机与直播 · 镜内 HUD |
-| **记忆** | 社交上下文 · 知识大脑 · 会议录音 |
-| **连接** | Home Assistant · CarPlay 与 Apple Watch · 透明度与隐私 |
-| **工作** | 现场作业助手 · 医疗合规 |
+| 了解功能、示例与配置 | [功能指南](docs/CAPABILITIES.md) |
+| 构建、配置或排查问题 | [源码构建指南](docs/BUILDING.md) |
+| 导入现场手册与操作流程 | [Field Assist 知识库指南](docs/field-assist-vault-guide.md) |
+| 创建可复用的助手能力 | [技能包编写指南](docs/skillpack-authoring.md) |
+| 发布扩展包 | [技能包](skillpacks/README.md) · [知识库包](vaultpacks/README.md) |
+| 了解工程进展与未来规划 | [开发计划](docs/plans/README.md) |
 
+## 一起把它做得更好
 
-### 角色 — 多 AI 个性
+欢迎贡献新的工具与集成，改进本地推理、翻译和日常使用体验。Fork 项目，提交 Pull Request 即可参与。
 
-每个角色都有自己的唤醒词、AI 模型和个性。所有角色同时监听。
+OpenGlasses 采用 **[BSL 1.1](LICENSE)，源代码可用**，允许非商业用途，注明于 2030 年 3 月 24 日转为 Apache 2.0。商业用途需要另行授权，请联系 [g@skunkworks.kiwi](mailto:g@skunkworks.kiwi)。
 
-| 语音指令 | 功能说明 |
-|---------|---------|
-| "Hey Claude" | 路由到 Claude Sonnet，使用你的专业提示词 |
-| "Hey Jarvis" | 路由到本地设备模型，简洁风格 |
-| "Hey Computer" | 路由到 GPT-4o，技术型人格 |
-
-**配置方法：** 设置 → 角色 → 添加。选择唤醒词，分配模型和提示词预设。
-
-### "Hey Siri" — 无需唤醒词，直接语音提问
-
-OpenGlasses 内置 App Intents + Siri 快捷指令，可以直接通过 Siri 驱动——当眼镜自带的 "Hey Meta" 被占用时，或想免提发起提问而不必等待应用内唤醒词时非常实用：
-
-| 说出 | 效果 |
-|-----|------|
-| "Hey Siri, ask **Claude** on OpenGlasses…" | 以该**角色**的模型 + 提示词运行问题，**Siri 朗读答案**，然后恢复你原来的模型 |
-| "Hey Siri, ask OpenGlasses a question" | Siri 询问**"你想问什么？"**，说出问题后由当前角色回答 |
-| "Hey Siri, OpenGlasses take a photo" | 通过眼镜拍照并描述画面 |
-| "Hey Siri, OpenGlasses describe surroundings" | 无障碍场景描述 |
-
-首次使用时，iOS 会在**快捷指令**应用和 Siri 短语选择器中展示这些指令（短语可随意改名）。**角色名**可以嵌入短语（"ask Claude…"），因为它是固定、可解析的选项；**问题本身**不行（iOS 的 App Shortcut 短语只能嵌入固定选项，不能嵌入自由文本），所以采用**两步式**——Siri 提示后等待你的语音回复。几分钟内的连续提问会延续**同一个对话线程**。意图在后台运行并朗读结果，无需把应用调到前台。
-
-#### 自选 Siri 能力——还能自建动作
-
-**设置 → Siri 与搜索** 是整个 Siri 面板的控制中心：
-
-- **内置动作** —— 拍照、录像、实时模式、监听开关、**每日简报**、**记忆回放**（"刚才他们说了什么？"）、**提词器**、**会议纪要**、**保存当前位置**、**直播推流**——每项可单独开关，关闭后 Siri 会礼貌拒绝。
-- **你的能力** —— 你创建的采集流程、作业程序、行动手册和自定义工具会自动成为候选项（默认关闭）。打开后即可语音执行 **"Run *pump inspection* on OpenGlasses"**，无需额外配置。
-- **自定义动作** —— 自建专属动作：一个语音名称（可加同义词），绑定一段发给助手的固定指令或单个工具调用。"Run *morning rundown* on OpenGlasses"。
-
-#### 内容进入 Spotlight 搜索
-
-笔记、会议纪要、已保存位置、提词稿、行动手册和学习卡组都会出现在 **Spotlight 与 Siri 搜索**中——搜"周二的压缩机工单"就能找到对应的现场会话，打开结果直接跳入应用。隐私分级：**对话**（仅标题）与 **Field Assist 现场会话**（仅元数据，按保险库逐个启用）默认关闭；健康数据、人脸识别对象和音频**永不索引**；医疗合规模式会禁用全部索引并清空已有条目。
-
-#### Apple 预训练 Siri 短语（App Schemas）
-
-OpenGlasses 采用了 Apple 的**相机**与**助手** App Intent Schema，因此 Apple 预训练的说法无需自定义快捷指令即可使用："拍张照片"、"开始录像"。Siri 还能把**"这个"**解析为当前打开的聊天线程——"总结一下这个"即可生效。
-
-助手 Schema 还将 OpenGlasses 注册为**侧边按钮语音助手**（用 OpenGlasses 替换 Siri）——该入口目前**仅限日本**（iOS 26.2+，Apple 账户地区需设为日本；源于日本《智能手机软件竞争促进法》，预计随各地监管推进会扩展到更多地区）。其他地区可通过 **设置 → 操作按钮 → 快捷指令 → "Ask OpenGlasses"** 实现同样效果。
-
-### 本地设备 LLM
-
-完全在 iPhone 上运行 AI 模型——无需互联网、无需云端、无需 API 密钥。
-
-1. 设置 → AI 模型 → 添加模型 → 选择 **"Local (On-Device)"**
-2. **下载与管理模型** → 从 HuggingFace 下载
-3. 选择已下载的模型并点击 **添加**
-
-**推荐模型：**
-
-| 模型 | 大小 | 最适用场景 |
-|------|------|-----------|
-| **Gemma 4 E2B**（默认 Agent） | 3.6 GB | 最佳本地 Agent——视觉、工具调用、140+ 种语言（需 8 GB 内存） |
-| SmolVLM2 2.2B | 1.5 GB | 视觉——识别照片 + 视频 |
-| Qwen 2.5 3B | 1.8 GB | 强大的文本推理 + 工具调用 |
-| Gemma 2 2B | 1.5 GB | 轻量级通用用途 |
-| Qwen 2.5 0.5B | 0.4 GB | 超轻量，基础功能 |
-
-**Gemma 4 E2B** 是默认的本地 Agent——未配置云端模型时会自动运行。模型持久化存储，下载后可完全离线运行。在 设置 → 工具 中启用 **离线模式** 可禁用需要互联网的工具。
-
-### 完全离线语音模式
-
-让**整个语音环路都在端侧运行**——任何数据都不会离开你的 iPhone：
-
-- **语音转文字** — 端侧 SenseVoice 识别器（多语言，约 240 MB），不会向任何服务器发送音频。
-- **AI** — 本地 LLM（通过 MLX 运行的 Gemma / Qwen，或 Apple Intelligence）。
-- **文字转语音** — 端侧 Kokoro 神经网络语音（约 185 MB），自然流畅，远胜机械的系统语音。
-
-语音识别与朗读语音基于 CPU/ONNX（而非 Metal），因此即使应用在后台也能持续工作。在 **设置 → 服务 → 语音识别 / 语音引擎** 中选择引擎并一次性下载模型——你便拥有了一个可在飞机上、隧道里或任何无信号环境下使用的私密助手。每一层都能优雅降级：没有模型（或没有云端）时，会回退到 Apple 语音识别与 iOS 系统语音。
-
-### 85+ 原生工具
-
-全部通过语音激活。自然表达你的需求——AI 会选择合适的工具。
-
-| 类别 | 工具 |
-|------|------|
-| **信息查询** | 网络搜索（Perplexity + DuckDuckGo）、新闻、天气、日期/时间、词典、汇率 |
-| **生产力** | 日历、提醒事项、闹钟、计时器、番茄钟、备忘录、上下文笔记（GPS+时间标记）、剪贴板 |
-| **通讯** | 电话、iMessage、WhatsApp、Telegram、电子邮件、联系人查询 |
-| **导航** | 路线规划（Apple/Google Maps）、附近地点、保存位置、地理围栏提醒 |
-| **媒体** | 音乐控制（播放/暂停/跳过 + 按歌曲/艺术家搜索）、Shazam 歌曲识别、打开应用 |
-| **智能家居** | HomeKit（灯光、开关、风扇、恒温器、门锁、场景）、Home Assistant（REST API）、Siri 快捷指令 |
-| **视觉** | QR/条形码扫描器、人脸识别、智能捕获（名片/收据/海报 → 操作）、货币/药品/颜色识别（无障碍）、隐私滤镜 |
-| **记忆** | 物品记忆（"我的钥匙在哪里？"）、社交上下文（按人保存的信息）、用户记忆、语音教学技能 |
-| **AI 功能** | 实时翻译、实时教练（实时视觉指导）、记忆回放（环境音频回溯）、环境字幕、会议摘要、对话摘要 |
-| **健身** | 运动追踪、锻炼日志、HealthKit、姿势分析、步数目标 |
-| **设备** | 手电筒、亮度、设备信息、步数统计 |
-| **安全** | 紧急信息（本地号码 + GPS）、每日简报、导航辅助（无障碍预设） |
-| **集成** | OpenClaw Gateway（50+ 技能）、MCP 服务器（通用工具协议）、自定义工具 |
-
-### 实时教练 — 实时视觉指导
-
-眼镜会观察你正在做的事情，并循环给出简短的口头纠正——每次一句精炼的话，不重复。内置领域：体态、烹饪技巧、吉他、攀岩、运动战术——也可自定义。
-
-| 语音指令 | 功能说明 |
-|---------|---------|
-| "Coach my posture" | 定期对你的体态给出口头反馈 |
-| "Watch my knife technique" | 实时烹饪手法指导 |
-| "Stop coaching" | 结束会话 |
-
-### 智能捕获
-
-对准名片、收据或活动海报——OpenGlasses 在本地设备读取并主动提供操作。
-
-| 语音指令 | 功能说明 |
-|---------|---------|
-| "Save this card" | 提取 姓名/公司/电话/邮箱 → 保存到通讯录 |
-| "Log this receipt" | 提取 商家/金额/日期 → 记录开支 |
-| "Add this event" | 提取 标题/日期/地点 → 创建日历事件 |
-
-### 语音教学技能
-
-在运行时教 AI 新行为——无需编写代码。
-
-| 语音指令 | 功能说明 |
-|---------|---------|
-| "Learn that when I say expense this, create a note tagged EXPENSE" | 保存技能，永久自动应用 |
-| "Learn that when I say goodnight, turn off all lights" | 触发 HomeKit/HA 执行指令 |
-| "List skills" | 显示所有已学技能 |
-| "Forget expense this" | 删除该技能 |
-
-### 物品记忆
-
-记住你放置物品的位置。使用 GPS 计算距离。
-
-| 语音指令 | 功能说明 |
-|---------|---------|
-| "Remember my car is in lot B level 3" | 保存位置（含 GPS + 时间戳） |
-| "Where are my keys?" | "你的钥匙在厨房台面上，2 小时前放的。距离你现在的位置很近。" |
-| "Where did I park?" | 检索车辆位置及距离 |
-
-### 实时翻译
-
-持续实时翻译外语口语。
-
-| 语音指令 | 功能说明 |
-|---------|---------|
-| "Start translating Spanish to English" | 开始持续翻译 |
-| "Stop translating" | 结束翻译会话，报告翻译计数 |
-| "Switch to Japanese to English" | 即时切换语言 |
-
-支持 25+ 种语言，包括西班牙语、法语、德语、日语、中文、韩语、阿拉伯语等。
-
-### 社交上下文
-
-建立关于你遇到的人的信息档案。
-
-| 语音指令 | 功能说明 |
-|---------|---------|
-| "Remember Sarah works at Google and likes hiking" | 信息已保存 |
-| "What do I know about Sarah?" | "关于 Sarah：在 Google 工作，喜欢徒步旅行。首次记录于 3 天前。" |
-
-配合人脸识别使用——当 AI 识别某人时，可以回忆你关于他们的笔记。
-
-### 本地设备知识大脑
-
-一个私密的本地设备知识图谱，悄无声息地将你告诉它的一切——人物、地点、事物及其相互关系——串联起来，完全无需云端调用。笔记、社交上下文、人脸相遇记录和会议摘要都会汇入其中，AI 可以一步查询整个图谱。
-
-| 语音指令 | 功能说明 |
-|---------|---------|
-| "Who did I meet at the conference?" | 回忆你遇到的人以及相遇的地点与时间 |
-| "How do I know Sarah?" | 追溯将你与对方联系起来的事实与关系 |
-
-原生优先——无需任何外部网关即可工作，所有数据都保留在手机本地。
-
-### 会议录音
-
-轻点快捷操作栏中的**录音按钮**（或语音指令）即可通过眼镜麦克风录制会议——录制过程中屏幕上实时显示字幕，即使唤醒词监听已关闭也能使用。录音会**保留**在应用内的录音库中，支持回放，并自动生成文字稿：配置了 Deepgram 时使用带说话人标注的云端转写，否则回退到已下载的本地设备模型（私密/离线）。医疗合规模式下转写完全在设备本地进行。
-
-### 打断功能
-
-在 AI 说话时随时说出任意唤醒词即可打断。AI 会立即停止并开始聆听你的新问题。
-
-### 提示词预设
-
-无需重新配置即可切换 AI 个性。内置预设：
-
-| 预设 | 风格 |
-|------|------|
-| **默认** | 均衡，2-4 句，对话式 |
-| **简洁** | 最多 1-2 句，无废话 |
-| **技术** | 精确，专业术语，信息密集 |
-| **创意** | 有趣，机智，富有表现力 |
-| **导航辅助** | 空间感知，障碍物检测，标志阅读 |
-
-在 设置 → 系统提示词 中创建自定义预设。
-
-### 自定义工具
-
-无需编写代码即可定义新工具。映射到 Siri 快捷指令或 URL Scheme。
-
-设置 → 透明度 → 自定义工具 → 添加：
-- **快捷指令工具**：按名称触发 Siri 快捷指令
-- **URL 工具**：打开带参数替换的 URL
-
-示例：创建一个 "log_water" 工具，当 AI 判断你需要时运行你的 "Log Water" 快捷指令。
-
-### MCP 服务器（Model Context Protocol）
-
-从手机直接连接任何 MCP 兼容的工具服务器。
-
-设置 → 透明度 → MCP 服务器 → 添加：
-- 输入服务器 URL + 认证头
-- 点击 "发现工具"——所有工具自动出现
-- AI 可以与原生工具一起调用它们
-
-热门 MCP 服务器：Home Assistant、Notion、GitHub、Slack、Todoist 等数百种。
-
-### Home Assistant 集成
-
-通过 REST API 直接控制你的 HA 实例——可与 HomeKit 配合使用或替代 HomeKit。
-
-设置 → 服务 → Home Assistant：
-- **HA URL**：例如 `http://192.168.1.100:8123`
-- **Token**：长期访问令牌（HA → 个人资料 → 安全）
-
-语音指令："Turn on the living room lights"、"Set thermostat to 72"、"Run the goodnight automation"、"List all sensors"
-
-### 透明度与隐私
-
-清楚查看 AI 接收了什么数据以及发出了哪些网络请求。
-
-| 设置 | 显示内容 |
-|------|---------|
-| **工具** | 所有 85+ 工具及启用/禁用开关 |
-| **提示词检视器** | 完整系统提示词、注入的上下文、Token 估算 |
-| **网络活动** | 所有 HTTP 请求，按 Meta/AI/App/其他 分类 |
-| **离线模式** | 一键禁用所有需要互联网的工具 |
-
-针对**提示词注入**对智能体路径进行了加固——不可信内容（网页、扫描文本、工具输出）无法劫持助手去运行敏感工具。高影响操作仍需明确确认，并受智能体模式开关的限制。
-
-### 相机与直播
-
-- **语音拍照** — "take a picture" 或 "what's this?"
-- **QR/条形码扫描器** — "scan this code"（Vision 框架，离线可用）
-- **实时相机预览** — 实时查看眼镜视角
-- **视频录制** — MP4 格式，可配置比特率
-- **RTMP 直播** — 直播到 YouTube、Twitch、Kick
-- **弹幕朗读** — 直播时将 Twitch 聊天读进耳朵（只读、无需 OAuth）：限速去重、提及主播的消息优先，助手语音始终优先，实时会话期间自动静默。默认关闭，可选"仅提及"模式
-- **WebRTC 浏览器直播** — 可分享的 URL，点对点观看
-- **隐私滤镜** — 自动模糊旁观者面部
-
-### Ray-Ban Display HUD（镜内显示）
-
-在 **Ray-Ban Display** 眼镜（带镜内显示屏与 Neural Band 神经腕带的 Meta 款式）上，OpenGlasses 会将内容镜像到抬头显示（HUD），并让你免提操作。该功能为增量式，默认关闭（设置 → 硬件 → 眼镜显示）。它依据设备的显示能力而非品牌进行判断——因此 Ray-Ban Meta、Oakley Meta 等相机/音频款式不受影响。
-
-- **AI 回复与实时字幕** — 语音回答和环境字幕会实时显示在镜内。
-- **通知与导航卡片** — 日历与地理围栏提醒，以及逐步导航辅助指引，配有图标和安全提示样式。
-- **交互式任务卡片** — 将工作流或现场作业流程以 **当前 / 下一步** 卡片呈现，并通过 Neural Band（完成 / 跳过 / 返回，或分支选择）或语音（"next"、"done"、"skip"、"back"）完成各步骤。
-
-基于 Meta 的本地显示设计系统构建，因此对比度、颜色和易读性会自动针对波导显示进行优化。
-
-### 文字转语音
-
-24 种 ElevenLabs 语音（10 种女声，14 种男声），支持 iOS 备用方案：
-- **女声**：Rachel、Sarah、Matilda、Emily、Charlotte、Alice、Lily、Dorothy、Serena、Nicole
-- **男声**：Brian、Adam、Daniel、George、Chris、Charlie、James、Dave、Drew、Callum、Bill、Fin、Liam、Thomas
-
-**情感感知 TTS** 自动调整语调——好消息更温暖，指令更沉稳，警告更谨慎。
-
-### 实时模式
-
-| 模式 | 工作原理 |
-|------|---------|
-| **语音模式** | 唤醒词 → 转录 → 任意 LLM → TTS（最灵活） |
-| **Gemini Live** | 与 Google Gemini 的实时音频/视频流 |
-| **OpenAI Realtime** | 与 OpenAI 的实时音频/视频流 |
-
-### 智能模型路由
-
-将模型分配到 **快速**、**均衡** 和 **最佳** 三个层级，然后让 OpenGlasses 按请求自动选择——用快速的本地模型做实时教练，用你最强的云端模型做疑难诊断。或者关闭路由，将所有请求固定到单一模型。
-
-**配置方法：** 设置 → AI 模型 → 模型路由。
-
-### CarPlay 与 Apple Watch
-
-- **CarPlay** — 在车载屏幕上免提使用语音助手。
-- **Apple Watch** — 配套应用与小组件，用于快速控制和一目了然的状态查看。
-
----
-
-## 企业版功能
-
-面向团队和受监管行业的商业功能。这些功能在源代码可用核心之外单独授权——参见[许可证](#许可证)或联系 Skunkworks NZ。
-
-### 现场作业助手 — 引导式现场服务
-
-为技术人员及其他双手忙碌的工作提供免提的分步指导。流程会根据你的口头报告或相机所见进行分支，在每一步之前提示安全注意事项，引用其来源资料，并写入可导出的审计会话日志。遇到难题？升级到带眼镜视频的远程真人专家。领域知识存放在你可以自行编写和扩展的 **Vault（知识库）**（如制冷、暖通空调、电气）中。
-
-| 语音指令 | 功能说明 |
-|---------|---------|
-| "Start a refrigeration session" | 加载知识库并开始流程 |
-| "The gauge reads 38 psi" | AI 评估读数并分支到正确的下一步 |
-| "Next step" / "Go back" / "Repeat that" | 免提导航流程 |
-| "Call an expert" | 通过实时眼镜视频接通远程真人 |
-
-### 医疗合规
-
-为临床录音提供专业级保护措施，以应用内订阅形式提供。
-
-- **静态加密** — 录音和转录文本以 `NSFileProtectionComplete` 加密保护
-- **生物识别应用锁** — 每次启动均需 Face ID / Touch ID
-- **审计日志** — 每个数据访问事件都带时间戳并可导出
-- **医疗导出** — 支持 FHIR R4、HL7 及 PDF 导出到 Epic、Cerner 等
-- **数据保留** — 可配置自动清除与安全删除
-- **防数据泄露** — 禁用云端工具，排除在 iCloud 备份之外
-- **国际合规框架** — HIPAA、GDPR、澳大利亚隐私法、新西兰 HIPC、PIPEDA、英国 DPA
-
----
-
-## 系统要求
-
-- **iOS 26+**
-- **Xcode 26+**
-- **实体 iPhone**（需要 Bluetooth、相机、麦克风）
-- **Meta 智能眼镜** —— Ray-Ban Meta、Ray-Ban Display、Oakley Meta HSTN / Vanguard 及 Meta 自有品牌眼镜（通过 Meta AI 应用配对）；所有型号均具备完整功能，镜内 HUD 需要带显示屏的型号（如 **Ray-Ban Display**）
-- **EVEN Realities G2**（可选，无需 Meta 账号）—— 仅作为**备选 HUD 后端**：卡片、字幕、导航与免提任务操作可渲染到 G2；语音仍走手机/耳机，且因 G2 无摄像头，相机相关功能不可用。可与 Meta 眼镜同时使用 —— Meta 摄像头 + G2 HUD 组合可行
-- 至少一个 LLM：API 密钥（Anthropic、OpenAI、Gemini 等）或已下载的本地模型
-
----
-
-## 从源码构建
-
-Meta 开发者凭据、Universal Links、个人签名、应用内配置（API 密钥与服务）以及故障排除，
-全部收录于 **[docs/BUILDING.md](docs/BUILDING.md)**（英文）。
-
----
-
-## 依赖项
-
-| 包 | 用途 |
-|---|------|
-| [meta-wearables-dat-ios](https://github.com/facebook/meta-wearables-dat-ios) | 眼镜连接 + 相机 |
-| [HaishinKit](https://github.com/shogo4405/HaishinKit.swift) | RTMP 直播推流 |
-| [mlx-swift-lm](https://github.com/ml-explore/mlx-swift-lm) | 本地设备 LLM 推理 |
-| [WebRTC](https://github.com/stasel/WebRTC) | 点对点浏览器直播 + 专家视频 |
-| [SystemNotification](https://github.com/danielsaidi/SystemNotification) | 应用内通知横幅 |
-
----
-
-## 参与贡献
-
-欢迎贡献！本项目采用 Business Source License 1.1，源代码可用（非商业用途免费，2030 年转为 Apache 2.0）。Fork、改进、提交 PR。
-
-主要贡献方向：
-- 新的原生工具
-- 本地模型优化
-- 翻译质量改进
-- 更多 MCP 服务器集成
-- UI/UX 改进
-
-## 许可证
-
-BSL 1.1（Business Source License 1.1）——非商业用途免费。商业用途需从 Skunk0 / Skunkworks NZ 获取单独许可（联系 [g@skunkworks.kiwi](mailto:g@skunkworks.kiwi)）。2030 年 3 月 24 日转换为 Apache 2.0。详见 LICENSE 文件。
-
-## 致谢
-
-由 [Skunk0](https://github.com/straff2002) 在 Skunkworks NZ 构建
-
-技术支持：[Anthropic Claude](https://www.anthropic.com/)、[Meta Wearables SDK](https://wearables.developer.meta.com/)、[Apple MLX](https://github.com/ml-explore/mlx-swift)、[ElevenLabs](https://elevenlabs.io/)、[HaishinKit](https://github.com/shogo4405/HaishinKit.swift)
-
----
-
-**注意**：这是一个独立的源代码可用项目，与 Meta 或 Anthropic 无关联。
+由 **Skunkworks NZ** 的 [Skunk0](https://github.com/straff2002) 开发。本项目独立于 Meta 和 Anthropic。

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -83,11 +83,12 @@ On iPhone: Meta AI app → Settings → About → tap version number **5 times**
 
 ### 6. Build & Run
 
-Same as [Quick Start](#quick-start) step 1. The repo ships [`project.base.yml`](project.base.yml) plus optional [`project.local.yml`](project.local.yml.example); XcodeGen writes `OpenGlasses.xcodeproj` locally. Do not commit the generated project.
+The repo ships [`project.base.yml`](../project.base.yml) plus an optional [`project.local.yml`](../project.local.yml.example) overlay; XcodeGen writes `OpenGlasses.xcodeproj` locally. Do not commit the generated project.
 
 ```bash
 brew install xcodegen cmake
 ./Scripts/fetch-mediapipe-frameworks.sh    # vendored binaries, fetched not committed
+./Scripts/fetch-llamacpp-framework.sh      # fetch or build the pinned local inference engine
 ./Scripts/generate-xcodeproj.sh
 open OpenGlasses.xcodeproj
 ```

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -1,0 +1,177 @@
+# OpenGlasses capability guide
+
+Practical examples, setup notes, and device requirements for the capabilities introduced in the [English README](../README.md) and [中文 README](../README.zh-CN.md).
+
+[Talk](#talk-and-translate) · [See](#see-and-capture) · [Remember](#remember-and-recall) · [Act](#take-action) · [Work](#field-and-clinical-work) · [AI choices](#choose-your-ai) · [Devices](#devices-and-displays) · [Privacy](#privacy-and-control)
+
+## Talk and translate
+
+Use the microphone button, an enabled wake word, or Siri to start a request. Standard voice mode combines speech recognition, your selected AI model, and text-to-speech. Gemini Live and OpenAI Realtime provide separate live conversation modes with their respective provider configuration.
+
+### Make the assistant your own
+
+In **Settings → Personas**, give an assistant its own wake word, model, and prompt preset. For example, set up “Hey Jarvis” for short answers from a local model and “Hey Claude” for a cloud assistant. Wake words can listen together; saying an enabled wake word can also interrupt a spoken answer.
+
+Prompt presets adjust the response style. Model routing can assign requests to your configured Fast, Balanced, or Best tier, or you can keep one model selected.
+
+### Siri and shortcuts
+
+Try “Hey Siri, ask OpenGlasses a question.” Siri prompts for the question, then returns the answer. Configure built-in actions and opt your own capabilities into **Settings → Siri & Search**. Photo and video actions are also available in Shortcuts, including for the Action button.
+
+If Siri reports that the app is not running, enable **Settings → Voice → Open App for Siri Questions**. Available Siri phrasing depends on iOS and your language settings.
+
+### Translation and captions
+
+Try “Start translating Spanish to English,” then “Stop translating” when finished. Ambient captions provide a running transcript; compatible displays can show captions in the lens. Language coverage and offline availability depend on the selected speech and translation engines and downloaded language assets.
+
+## See and capture
+
+Camera-assisted questions use a captured image or a stream frame. A vision-capable AI model is needed to interpret scenes; text and barcode recognition also have on-device paths.
+
+| Try saying | What it does |
+|---|---|
+| “What am I looking at?” | Ask the assistant about the camera view |
+| “Save this card” | Read contact details and offer to save them |
+| “Log this receipt” | Extract the merchant, total, and date for an expense note |
+| “Add this event” | Read an event flyer and offer a calendar action |
+| “Scan this code” | Recognize a QR code or barcode |
+| “Coach my posture” | Start periodic spoken visual feedback |
+
+Smart capture performs OCR on the phone, then passes extracted fields to the assistant. Saving a contact, note, or event is a separate tool action with its own permissions. Local OCR does not make the rest of a cloud-model conversation local.
+
+Live coaching can also use cooking, guitar, climbing, sports, or a custom topic. Say “Stop coaching” to end it. The quality of visual responses depends on the view, lighting, and selected model.
+
+### Photos, recording, and sharing
+
+- Capture photos and record video with voice controls or app controls.
+- Keep audio recordings in the recording library for playback and transcription.
+- Configure an RTMP destination and stream key for broadcasting.
+- Share video to a browser over WebRTC; remote expert sessions use the configured expert transport.
+- Optionally read Twitch chat aloud during a broadcast, with rate and mentions-only settings.
+
+Streaming destinations and remote expert connections need their own network configuration. [Build and service setup](BUILDING.md) covers the app settings; the repository includes a [WebRTC signaling server](webrtc/signaling-server.js) and [expert browser client](webrtc/expert-client.html).
+
+## Remember and recall
+
+OpenGlasses combines explicit notes, saved locations, conversation records, and an on-device knowledge graph so you can return to useful context later.
+
+| Try saying | What it uses |
+|---|---|
+| “Remember my car is in lot B, level 3” | An object-memory entry, with location when permitted |
+| “Where did I park?” | Your previously saved location |
+| “Remember Sarah likes hiking” | A saved fact about a person |
+| “What do I know about Sarah?” | Facts you have recorded |
+| “Summarize the meeting” | Available ambient-caption history |
+| “What did they just say?” | Recent audio, when memory rewind is enabled |
+
+**Enable capture before you need recall.** Memory rewind uses an opt-in rolling audio buffer; it cannot recover speech from before buffering started. Meeting summaries need a captured transcript—start ambient captions before the conversation. Audio recording is a separate capture path with its own library.
+
+Local storage and local search do not determine where an AI answer is generated. If you choose a cloud assistant, retrieved context may be included in its request. Choose local engines when you want processing to stay on the phone.
+
+## Take action
+
+The assistant can call enabled tools as part of a conversation. Services and permissions determine which actions are available.
+
+| Use case | Examples |
+|---|---|
+| Plan your day | Calendar, reminders, timers, notes, daily briefing |
+| Find your way | Directions, nearby places, saved locations |
+| Stay connected | Contact lookup, calls, message and email workflows |
+| Control your environment | Music, HomeKit, Home Assistant |
+| Find information | Web search, weather, news, calculations, unit conversion |
+| Extend the assistant | Siri Shortcuts, custom tools, MCP servers, OpenClaw |
+
+### Connect your services
+
+**Home Assistant:** add your instance URL and a long-lived access token in its service settings. Ask to list devices or control a configured entity.
+
+**MCP:** add a compatible remote server URL and authentication in MCP settings, then discover its tools. Availability depends on the server's transport and authentication requirements.
+
+**Custom tools:** map a named tool to a Siri Shortcut or a URL with parameter substitution. Voice-taught skills can save instructions for familiar phrases. Execution still depends on the underlying tools and permissions.
+
+**Skill packs:** package reusable prompts, tools, and workflows. Start with [skill pack authoring](skillpack-authoring.md); maintainers can use the [catalog publishing guide](../skillpacks/README.md).
+
+Review enabled tools and action confirmations in the app. Some communication actions open another app or a compose screen to complete the task.
+
+## Field and clinical work
+
+### Field Assist
+
+Field Assist combines domain knowledge, guided procedures, session records, and remote expert escalation. Procedures can branch on reported readings or visual findings and provide source references alongside guidance.
+
+Try “Start a refrigeration session,” report a reading, then use “Next step,” “Go back,” or “Repeat that.” Expert escalation requires an available expert and a configured connection.
+
+| Access tier | Capability |
+|---|---|
+| Solo | Bundled vaults, guided procedures, domain calculators, session log, expert escalation |
+| Team | Solo capabilities plus custom vaults and manuals, and audited export |
+| Enterprise | Team capabilities with separately agreed commercial terms |
+
+Use **Settings → Field Assist** to review access and activate a signed licence. Purchase and trial availability depend on the build and distribution channel. Contact [Skunkworks NZ](mailto:g@skunkworks.kiwi) for team or evaluation access.
+
+For your own reference material, follow the [Field Assist vault guide](field-assist-vault-guide.md). It covers PDF, scanned manuals, EPUB, Markdown, and plain text, including source-page references. The [vault pack guide](../vaultpacks/README.md) covers packaging and publishing.
+
+### Clinical recording controls
+
+The Medical Compliance feature has separate subscription access and provides protected recordings and transcripts, biometric access controls, audit records, retention settings, and FHIR, HL7, and PDF export options.
+
+Its **Local LLM Only** setting enforces local model selection when Medical Compliance Mode is active. If no usable local model is available, the request is refused instead of sent to a cloud model. Configure export destinations and retention to match the intended workflow; these are application controls, not a claim of regulatory certification.
+
+## Choose your AI
+
+Choose models under **Settings → AI Models**. Speech recognition and spoken voice have separate service settings.
+
+| Run the AI | Setup | Considerations |
+|---|---|---|
+| Cloud provider | Add provider credentials and select a model | Network access; provider terms and usage charges apply |
+| On your iPhone | Download or import a compatible local model | No cloud API key; model size, memory, and capability must fit the device |
+| On your server | Add a Custom (OpenAI-compatible) endpoint | Your iPhone must reach the server; speech services are configured separately |
+
+Local inference includes MLX and a llama.cpp path for compatible GGUF models. Use the model manager to check downloads and memory fit. Vision and tool calling depend on the model; not every local model supports both.
+
+### Set up offline voice
+
+1. Download a compatible local AI model and select it.
+2. Select the on-device speech recognizer and download its SenseVoice assets.
+3. Select a local voice engine, such as Kokoro with downloaded assets or the system voice.
+4. Enable **Offline Mode** in tool settings to disable internet-dependent tools.
+5. Try a voice request with the network disconnected before relying on the setup away from coverage.
+
+Offline Mode is a tool control, not a replacement for selecting local AI and speech engines. Cloud live modes, web search, and remote integrations need a connection. Background availability varies by engine and iOS session state.
+
+### Connect your own model server
+
+Select **Custom (OpenAI-compatible)** and enter the server's base URL, such as `http://your-mac.local:11434/v1`. Fetch the available models or enter an ID. Supply authentication if your server requires it, and enable vision only for a model that supports images.
+
+Use a reachable HTTPS endpoint or an allowed local hostname; iOS transport restrictions can block cleartext private-IP URLs. The model request goes to your server, while separately configured cloud speech or tools can still contact their providers.
+
+## Devices and displays
+
+The app targets **iOS 26+**; source builds require **Xcode 26+**. See [Building from Source](BUILDING.md) for dependency installation, personal signing, and Meta credentials.
+
+| Device or surface | Role and limits |
+|---|---|
+| iPhone | Runs the app and models; provides microphone and camera fallback for phone-based use |
+| Compatible Meta glasses | Hands-free audio and camera through the Meta integration; pair with Meta AI and complete registration and permissions |
+| Ray-Ban Display | In-lens answers, captions, cards, and task controls on display-capable hardware |
+| EVEN Realities G2 | Experimental alternate display backend; hardware protocol validation is incomplete |
+| Apple Watch | Companion controls and status, including photo and video controls |
+| CarPlay | Voice-assistant interface on the vehicle display |
+
+**Meta display session limitation:** the current display backend owns a device session separately from the camera. While that display session is held, the camera may need the iPhone fallback. Do not assume simultaneous glasses-camera and HUD access.
+
+**EVEN G2 status:** rendering and transport code exist, but the render service identifier is a placeholder awaiting validation and temple-gesture decoding is not implemented. Treat it as development support. It is a display backend, not a camera or audio replacement.
+
+Camera availability depends on SDK and glasses firmware compatibility, registration, permissions, and session state. The [troubleshooting guide](BUILDING.md#troubleshooting) covers common connection and camera failures.
+
+## Privacy and control
+
+- **Tool switches:** choose which capabilities the assistant can use.
+- **Prompt inspection:** review the system prompt and supplied context.
+- **Network activity:** inspect recorded requests and their categories.
+- **Offline configuration:** choose local engines and disable network-dependent tools.
+- **Capture controls:** explicitly enable recording, captions, or memory rewind for their respective features.
+
+The app includes Meta SDK telemetry opt-out configuration and a telemetry-blocking layer. That does not eliminate the connections needed for Meta registration or services you choose to use.
+
+Cloud models, cloud speech, remote tools, and broadcasts each have their own data path. Review the selected services as well as where notes and recordings are stored.


### PR DESCRIPTION
## Summary

The English and Simplified Chinese READMEs mixed a long feature catalogue with setup details. Rewrite both as concise product introductions, leading with practical uses for vision, voice, memory, actions, sharing, and field work.

- Highlight offline voice with Apple MLX, llama.cpp, GGUF imports, SenseVoice, and Kokoro.
- Move configuration examples and device limitations into a linked capability guide, including experimental EVEN G2 support and Meta display/camera session limits.
- Fix relative links and add the missing llama.cpp dependency preparation step in the build guide.

## Validation

- Checked 70 local links and anchors and matching guide destinations across both languages.
- Reviewed device and offline claims against the implementation.
- `git diff --check` passes. Documentation only; no application tests run.
