### PR TITLE
Give Grok its tools, let the wake word restart, and unlatch a locked-launch store

### DIFF
--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -3654,8 +3654,12 @@ class AppState: ObservableObject, AppStateProtocol {
     ///   which may have interrupted the engine.
     private func resumeListeningOrReturnToWakeWord(ensureEngine: Bool = false) async {
         // The user may have disabled listening while the turn was finishing — a finish stage
-        // must never turn the microphone back on behind their back.
-        guard listeningEnabled else { return }
+        // must never turn the microphone back on behind their back. Log it: a silent return here
+        // is indistinguishable in the field from the mic failing to reopen after the reply.
+        guard listeningEnabled else {
+            PrivacyLog.wakeWord(.listenerSkippedDisabled)
+            return
+        }
         if inConversation {
             if ensureEngine { try? await wakeWordService.ensureAudioEngineRunning() }
             // The engine keepalive suspends; re-check the user didn't flip the toggle meanwhile.

--- a/OpenGlasses/Sources/App/Views/PromptInspectorView.swift
+++ b/OpenGlasses/Sources/App/Views/PromptInspectorView.swift
@@ -104,14 +104,18 @@ struct PromptInspectorView: View {
             isPresent: true
         ))
 
+        // Vision is always part of the prompt — the only question is whether this section's copy
+        // was auto-injected or is already written into the wearer's own system prompt. Both are
+        // "on", so both render as present: an inactive-looking row here was read as "vision is
+        // off" by someone whose prompt simply already covered it.
         let visionAutoInjected = !basePrompt.lowercased().contains("vision") && !basePrompt.lowercased().contains("camera")
         secs.append(PromptSection(
             name: "Vision & Camera",
             icon: "eye.fill",
             content: visionAutoInjected
                 ? "Auto-injected: tells the AI it can see images from the glasses camera, handle OCR, translation, and object identification."
-                : "Already covered in your system prompt.",
-            isPresent: visionAutoInjected
+                : "Included in your system prompt. A camera frame is attached when a question needs one and the glasses camera is available.",
+            isPresent: true
         ))
 
         secs.append(PromptSection(

--- a/OpenGlasses/Sources/Services/Camera/MetaCameraBackend.swift
+++ b/OpenGlasses/Sources/Services/Camera/MetaCameraBackend.swift
@@ -73,6 +73,15 @@ final class MetaCameraBackend: GlassesCameraBackend {
     /// BR P2: listener on the DeviceSession's error stream (update-required and terminal
     /// device errors surface here, not on the camera Stream's errorPublisher).
     private var sessionErrorTask: Task<Void, Never>?
+    /// The most recent error the DeviceSession's error stream delivered, kept only for the
+    /// duration of one `ensureSession()` attempt.
+    ///
+    /// The watcher used to log each session error and then drop it unless
+    /// `DATCompatibilityMessage` recognised it, so a session that died 120 ms into startup was
+    /// still waited on for the full grace window and then reported as the generic
+    /// `streamNotReady` — four attempts, ~21 s, and a user-facing reason that named nothing.
+    /// Holding the error lets the start wait fail fast *with the SDK's own reason*.
+    private var lastSessionError: Error?
     /// The most recent stream error seen while waiting for `.streaming`. Cleared at the top of
     /// each warmup wait, so it only ever describes the attempt in progress.
     private var lastStreamError: StreamError?
@@ -211,6 +220,9 @@ final class MetaCameraBackend: GlassesCameraBackend {
     private func ensureSession() async throws {
         guard streamSession == nil else { return }
 
+        // Fresh attempt, fresh verdict: an error from a previous attempt must not abort this one.
+        lastSessionError = nil
+
         // First call: start tracking the devices list, and give the listener a beat to
         // deliver the current snapshot before we pick a selector.
         if devicesListenerToken == nil {
@@ -260,6 +272,15 @@ final class MetaCameraBackend: GlassesCameraBackend {
             let stoppedGraceEnd = ContinuousClock.now + .seconds(2)
             while ContinuousClock.now < deadline {
                 if deviceSession.state == .started { break }
+                // The SDK has already said why this session will not start. Waiting out the rest
+                // of the window cannot change that, and the generic timeout that follows throws
+                // away the only useful diagnostic — so stop here and carry the real error.
+                if let sessionError = lastSessionError, deviceSession.state != .started {
+                    PrivacyLog.camera(.glasses, .sessionStartAborted,
+                                      state: PrivacyToken(String(describing: deviceSession.state)),
+                                      error: SafeErrorSummary(sessionError))
+                    throw sessionError
+                }
                 // .stopped inside the first moments can be the pre-transition resting state;
                 // only treat it as terminal once the state machine has had time to move.
                 if deviceSession.state == .stopped && ContinuousClock.now > stoppedGraceEnd { break }
@@ -270,6 +291,10 @@ final class MetaCameraBackend: GlassesCameraBackend {
         guard deviceSession.state == .started else {
             PrivacyLog.camera(.glasses, .sessionNotStarted,
                               state: PrivacyToken(String(describing: deviceSession.state)))
+            // Prefer the SDK's reason over "stream not ready" whenever there is one: the retry
+            // loop's `sessionAttemptFailed` line and the error the caller finally sees should
+            // both name what actually happened.
+            if let sessionError = lastSessionError { throw sessionError }
             throw CameraError.streamNotReady
         }
 
@@ -319,6 +344,7 @@ final class MetaCameraBackend: GlassesCameraBackend {
             for await error in session.errorStream() {
                 guard let self, !Task.isCancelled else { return }
                 PrivacyLog.camera(.glasses, .sessionError, error: SafeErrorSummary(error))
+                self.lastSessionError = error
                 if let notice = DATCompatibilityMessage.message(for: error) {
                     self.compatibilityNotice = notice
                     self.debug(notice)

--- a/OpenGlasses/Sources/Services/ConversationStore.swift
+++ b/OpenGlasses/Sources/Services/ConversationStore.swift
@@ -85,7 +85,8 @@ class ConversationStore: ObservableObject {
 
     /// True after a read failure on an existing conversations file (e.g. file protection while
     /// locked): the on-disk data may be intact, so saves are suppressed until a load succeeds.
-    private var saveBlocked = false
+    /// `private(set)` rather than `private` so the unlock retry can be asserted in tests.
+    private(set) var saveBlocked = false
 
     /// Serializes encrypted saves so an older snapshot can never finish after — and overwrite —
     /// a newer one.
@@ -491,9 +492,104 @@ class ConversationStore: ObservableObject {
 
     /// Rebuild only from the still-authoritative in-memory snapshot. A biometrically locked store
     /// remains closed until its normal unlock flow supplies decrypted threads.
+    ///
+    /// One exception: if the launch-time read failed *because* the device was locked, the
+    /// in-memory snapshot is not authoritative — it is empty, and saves have been refused ever
+    /// since. Now that protected data is readable, re-run the load before rebuilding recall.
     func protectedDataDidBecomeAvailable() {
         guard !isLocked else { return }
+        if saveBlocked, retryBlockedLoad() { return }
         recallCoordinator?.storeDidUnlock(threads: threads)
+    }
+
+    /// Re-read a conversations file whose launch-time load failed under file protection.
+    ///
+    /// Field trace: the app launched before first unlock, `Data(contentsOf:)` returned Cocoa 257
+    /// on the `.completeFileProtection` file, `saveBlocked` latched, and **every** turn for the
+    /// rest of the process was dropped with `saveSkipped detail=loadFailed` — the store only ever
+    /// loaded from `init`, so nothing could clear the latch.
+    ///
+    /// - Returns: `true` when a retry succeeded, or when an asynchronous decrypt was started. The
+    ///   caller must not fall through to `storeDidUnlock` on either: the plaintext branch has
+    ///   already published the merged list, and the decrypt branch will publish its own once it
+    ///   resolves — publishing here would hand recall the stale empty snapshot.
+    @discardableResult
+    private func retryBlockedLoad() -> Bool {
+        // An encrypted file must never reach the plaintext reader. `isFileEncrypted(at:)` answers
+        // `false` for a file it cannot *read*, so a locked-device launch with encryption on
+        // latched `saveBlocked` down the plaintext branch of `loadThreads()` exactly like an
+        // unencrypted store. Handing those `OGENC1` bytes to `JSONStore.loadArray` decodes as
+        // `.corrupt`, which moves the user's whole history aside and starts empty — turning a
+        // save outage into data loss for precisely the wearers who asked for more protection.
+        if encryption.isEnabled, encryption.isFileEncrypted(at: storageURL) {
+            retryBlockedDecrypt()
+            return true
+        }
+
+        let decoded: [ConversationThread]
+        switch JSONStore.loadArray(ConversationThread.self, at: storageURL, name: "conversations") {
+        case .loaded(let loaded):
+            decoded = loaded
+        case .recovered(let loaded, _):
+            decoded = loaded
+        case .corrupt:
+            // The original is preserved by StoreRecovery; the file is readable, so the latch has
+            // done its job and can come off.
+            decoded = []
+        case .absent:
+            decoded = []
+        case .unreadable:
+            // Still protected (or genuinely unreadable). Stay blocked rather than overwrite.
+            return false
+        }
+
+        adoptReloadedThreads(decoded, detail: "retried")
+        return true
+    }
+
+    /// The encrypted half of `retryBlockedLoad()`: decrypt off the main actor, then merge through
+    /// the same path the plaintext branch uses.
+    ///
+    /// Mirrors `loadThreads()`'s encrypted branch, including holding `isLocked` for the window —
+    /// `save()` refuses to write while locked, which is what keeps a half-finished decrypt from
+    /// putting an empty history over the ciphertext. A failure leaves the store locked and the
+    /// latch on, and reports `.awaitingAuthentication`: the file is intact and simply needs the
+    /// normal unlock flow.
+    private func retryBlockedDecrypt() {
+        isLocked = true
+        let url = storageURL
+        let enc = encryption
+        Task { @MainActor [weak self] in
+            do {
+                let data = try await enc.decryptFile(at: url)
+                let decoded = try JSONDecoder().decode([ConversationThread].self, from: data)
+                guard let self else { return }
+                self.isLocked = false
+                self.adoptReloadedThreads(decoded, detail: "retriedEncrypted")
+            } catch {
+                self?.isLocked = true
+                PrivacyLog.conversation(.conversations, .awaitingAuthentication)
+            }
+        }
+    }
+
+    /// Merge a freshly re-read on-disk list into the in-memory one and reopen the store for writes.
+    ///
+    /// The merge is not a replace. Threads created while saves were blocked exist only in memory
+    /// and have never been written, so discarding them would turn a save outage into data loss;
+    /// on-disk threads win on id collision because they are the ones the store has been unable to
+    /// touch. The merged list is re-sorted newest-first, which is the ordering
+    /// `startThread`'s `insert(at: 0)` maintains everywhere else.
+    private func adoptReloadedThreads(_ decoded: [ConversationThread], detail: String) {
+        let onDiskIds = Set(decoded.map(\.id))
+        let unsaved = threads.filter { !onDiskIds.contains($0.id) }
+        threads = (decoded + unsaved).sorted { $0.updatedAt > $1.updatedAt }
+        trimOldThreads()
+        saveBlocked = false
+        PrivacyLog.conversation(.conversations, .loaded, count: threads.count,
+                                detail: PrivacyToken(detail))
+        recallCoordinator?.storeDidUnlock(threads: threads)
+        save()
     }
 
     // MARK: - Persistence

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -1768,6 +1768,33 @@ class LLMService: ObservableObject {
     /// closure; a bool flag with one realistic writer needs no stronger isolation.
     nonisolated(unsafe) private static var customEndpointRejectsTools = false
 
+    /// Whether a provider reaching the OpenAI-compatible path can be handed a `tools` payload.
+    ///
+    /// This is an exhaustive switch on purpose. The bug it exists to prevent (issue 427) was a
+    /// hand-written `||` chain that silently omitted `.xai` and `.minimax` when they were added
+    /// to the `sendOpenAICompatible` route — the turn logged `nativeTools` while the request
+    /// carried none, so voice commands never triggered a tool call on those providers. An
+    /// exhaustive switch makes the next provider a compile error instead of a silent omission.
+    ///
+    /// The providers returning `false` here (`anthropic`, `chatgpt`, `gemini`, `geminiVertex`,
+    /// `local`, `appleOnDevice`) each have their own request builder and never reach this
+    /// predicate; `false` is simply the answer for "an OpenAI-style `tools` array", not a
+    /// statement that they lack tool calling.
+    nonisolated static func providerSupportsTools(_ provider: LLMProvider,
+                                                  customEndpointRejectsTools: Bool) -> Bool {
+        switch provider {
+        case .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter:
+            return true
+        // Custom endpoints get tools too (Gemini/vLLM/newer Ollama all speak OpenAI function
+        // calling); the ones that 400 on a `tools` payload are retried once without tools and
+        // remembered for the rest of the session.
+        case .custom:
+            return !customEndpointRejectsTools
+        case .anthropic, .chatgpt, .gemini, .geminiVertex, .local, .appleOnDevice:
+            return false
+        }
+    }
+
     private func sendOpenAICompatible(_ text: String, systemPrompt: String, config: ModelConfig, includeTools: Bool, imageData: Data?, smallContext: Bool = false, onToken: ((String) -> Void)? = nil, onStreamReset: (() -> Void)? = nil) async throws -> String {
         try enforceMedicalRemoteBoundary(config)
         let provider = config.llmProvider
@@ -1861,11 +1888,10 @@ class LLMService: ObservableObject {
                                         disableThinking: smallContext || (imageData != nil && supportsVision))
 
                 // Only attach Tools if the provider reliably supports function calling.
-                // Custom endpoints get tools too (Gemini/vLLM/newer Ollama all speak OpenAI
-                // function calling); the ones that 400 on a `tools` payload are retried once
-                // without tools below and remembered for the rest of the session.
-                let providerSupportsTools = provider == .openai || provider == .groq || provider == .zai || provider == .qwen || provider == .openrouter
-                    || (provider == .custom && !Self.customEndpointRejectsTools)
+                let providerSupportsTools = Self.providerSupportsTools(
+                    provider,
+                    customEndpointRejectsTools: Self.customEndpointRejectsTools
+                )
 
                 if includeTools && providerSupportsTools {
                     let includeOpenClaw = Config.isOpenClawAgentActive && self.openClawBridge != nil

--- a/OpenGlasses/Sources/Services/TranscriptionService.swift
+++ b/OpenGlasses/Sources/Services/TranscriptionService.swift
@@ -96,7 +96,12 @@ class TranscriptionService: ObservableObject {
     }
 
     func startRecording() {
-        guard !isRecording else { return }
+        // A second start on a live recorder is a no-op, and a silent one used to leave no trace
+        // at all — the other half of "the assistant spoke and then nothing happened".
+        guard !isRecording else {
+            PrivacyLog.speech(.dictation, .startSkippedAlreadyRecording)
+            return
+        }
 
         didReceiveSpeech = false
         lastSpeechObservedAt = nil

--- a/OpenGlasses/Sources/Services/WakeWordService.swift
+++ b/OpenGlasses/Sources/Services/WakeWordService.swift
@@ -45,12 +45,15 @@ class WakeWordService: NSObject, ObservableObject {
     /// Set before an *intentional* recognition cancel (e.g. pausing the wake-word task so
     /// only the buffer forwarder feeds TranscriptionService). Tells `handleRecognitionResult`
     /// to ignore the resulting cancellation error instead of auto-restarting a competing recognizer.
-    private var suppressAutoRestart = false
+    /// Set when a recognition task is cancelled on purpose, so the resulting error callback is
+    /// consumed instead of auto-restarting a competing recognizer. `private(set)` rather than
+    /// `private` so the shared-engine handoff can be asserted in tests.
+    private(set) var suppressAutoRestart = false
     private var speechRecognizer: SFSpeechRecognizer?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest? {
         didSet { tapState.setRequest(recognitionRequest) }   // keep the tap's view in sync (Plan BE)
     }
-    private var recognitionTask: SFSpeechRecognitionTask?
+    private(set) var recognitionTask: SFSpeechRecognitionTask?
     private var audioSessionConfigured: Bool = false
     /// Our claim on the shared session with the coordinator. Wake word is the always-on baseline
     /// owner: it self-activates with its tuned config and registers ownership so a live session
@@ -494,14 +497,28 @@ class WakeWordService: NSObject, ObservableObject {
         // Engine is nil or stopped — restart it (without starting recognition)
         PrivacyLog.audio(.wakeWord, .engineRestarted, detail: PrivacyToken("sharedUse"))
         try await startListening()
-        // Pause recognition so only the buffer forwarder is active. Mark the cancel as
-        // intentional so its error callback doesn't auto-restart a competing recognizer
-        // (which would fight TranscriptionService and make tap-to-talk stop immediately).
+        pauseRecognitionForSharedEngine()
+    }
+
+    /// Hand the running audio engine over to another consumer: tear down the wake-word recognizer
+    /// but leave the engine (and its buffer forwarders) alive.
+    ///
+    /// The cancel is marked intentional so its error callback doesn't auto-restart a competing
+    /// recognizer — that would fight `TranscriptionService` and make tap-to-talk stop the instant
+    /// it starts.
+    ///
+    /// `isListening` **must** drop with the recognizer. `startListening()` opens with
+    /// `guard !isListening else { return }`, so leaving the flag set after the recognizer is gone
+    /// made every later auto-restart a silent no-op: the service reported that it was listening
+    /// while nothing was recognising, and the wake word worked exactly once per launch (issue 427).
+    /// `pauseRecognition()` already drops the flag for the same reason.
+    func pauseRecognitionForSharedEngine() {
         suppressAutoRestart = true
         recognitionTask?.cancel()
         recognitionTask = nil
         recognitionRequest?.endAudio()
         recognitionRequest = nil
+        isListening = false
     }
 
     /// Start the shared engine for an explicit audio-buffer consumer even when always-on wake-word

--- a/OpenGlasses/Sources/Utils/PrivacyLog.swift
+++ b/OpenGlasses/Sources/Utils/PrivacyLog.swift
@@ -521,6 +521,10 @@ enum PrivacyLog {
         case permissionRevalidating, registrationState, notRegistered
         case permissionRetry, permissionChecked, permissionFailed
         case sessionBound, sessionNotStarted, sessionError, sessionAttemptFailed
+        /// The start wait stopped early because the SDK had already reported a session error —
+        /// that error is then thrown instead of the generic "stream not ready", so the attempt
+        /// carries the real reason.
+        case sessionStartAborted
         case incompatibleDevice, capabilityCreated, capabilityTornDown, capabilityStopTimedOut
         case resolutionFloored, sessionReset, tornDown, idleTeardown
         case streamState, streamPausedWhileWanted, streamPausedAfterCapture
@@ -1185,6 +1189,10 @@ enum PrivacyLog {
     /// distance: a small integer confidence bucket, not a fragment of what was heard.
     enum WakeEvent: String {
         case listenerStarted, listenerSkippedPushToTalk, listenAttemptFailed
+        /// A finish stage declined to re-open the mic because the wearer had disabled listening.
+        /// Without this line the turn simply ends and the log goes quiet, which reads in the
+        /// field as "after TTS nothing happened".
+        case listenerSkippedDisabled
         case onDeviceUnavailable, contextConfigured
         case detected, fuzzyDetected, bargeIn, stopCommand
         case recognitionFailed, sustainedSilence, audioResumed
@@ -1216,6 +1224,10 @@ enum PrivacyLog {
 
     enum SpeechEvent: String {
         case started, stopped, suspended, resumed, reconfigured
+        /// `startRecording()` called while a recording was already in flight — a no-op that is
+        /// otherwise invisible, and one of the two ways a turn can silently fail to re-open the
+        /// mic after the assistant finishes speaking.
+        case startSkippedAlreadyRecording
         case recognizerUnavailable, engineShared, engineDedicated, engineRebuilt
         case engineFailed, sessionFailed
         case transcriptDelivered, noSpeechDetected, recognitionFailed

--- a/OpenGlasses/Sources/Utils/SafeErrorSummary.swift
+++ b/OpenGlasses/Sources/Utils/SafeErrorSummary.swift
@@ -89,8 +89,17 @@ struct SafeErrorSummary: Equatable, CustomStringConvertible {
         let bridged = error as NSError
         let detail = PrivacyToken.caseName(of: error)
             ?? PrivacyToken(String(describing: type(of: error)))
-        let isKnownDomain = bridged.domain == NSURLErrorDomain || bridged.domain == NSCocoaErrorDomain
-        self.init(category: isKnownDomain ? .badServerResponse : .unknown,
+        // The bridged domain says which subsystem failed, so it picks the category. Cocoa's
+        // domain is the file/archiving layer, not the network: a locked-device read failure
+        // (NSFileReadNoPermissionError, 257) used to render as `badServerResponse`, which sent
+        // every reader of that line looking at the wrong subsystem entirely.
+        let category: Category
+        switch bridged.domain {
+        case NSURLErrorDomain: category = .badServerResponse
+        case NSCocoaErrorDomain: category = .storage
+        default: category = .unknown
+        }
+        self.init(category: category,
                   detail: detail,
                   code: bridged.code == 0 ? nil : bridged.code)
     }

--- a/OpenGlassesTests/ConversationStoreLoadRetryTests.swift
+++ b/OpenGlassesTests/ConversationStoreLoadRetryTests.swift
@@ -1,0 +1,218 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Issue 427: a conversations file that could not be read at launch blocked saves for the rest of
+/// the process.
+///
+/// The file is written with `.completeFileProtection`, so an app that launches before the device's
+/// first unlock reads Cocoa 257 and latches `saveBlocked`. `loadThreads()` only ever ran from
+/// `init`, and `protectedDataDidBecomeAvailable()` rebuilt recall from memory without re-reading —
+/// so nothing could ever clear the latch. Field trace: launched 07:19 locked, active at 07:51,
+/// every single turn afterwards dropped with `saveSkipped detail=loadFailed`.
+@MainActor
+final class ConversationStoreLoadRetryTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var fileURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ConversationStoreLoadRetryTests-\(UUID().uuidString)",
+                                    isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        fileURL = tempDir.appendingPathComponent("conversations.json")
+    }
+
+    override func tearDown() {
+        // Always restore permissions or the directory cannot be removed.
+        try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: fileURL.path)
+        try? FileManager.default.removeItem(at: tempDir)
+        Config.setConversationEncryptionEnabled(false)
+        super.tearDown()
+    }
+
+    private func writeThreads(_ threads: [ConversationThread]) throws {
+        try JSONEncoder().encode(threads).write(to: fileURL, options: .atomic)
+    }
+
+    private func readThreadsFromDisk() throws -> [ConversationThread] {
+        try JSONDecoder().decode([ConversationThread].self, from: Data(contentsOf: fileURL))
+    }
+
+    /// Makes the file unreadable and confirms the OS actually enforces it in this test process —
+    /// a root test runner could read a 0o000 file and quietly invalidate the whole scenario.
+    private func denyReadsOrSkip() throws {
+        try FileManager.default.setAttributes([.posixPermissions: 0o000],
+                                              ofItemAtPath: fileURL.path)
+        if (try? Data(contentsOf: fileURL)) != nil {
+            throw XCTSkip("this process can read a 0o000 file (running as root?) — "
+                          + "the unreadable-load path cannot be simulated here")
+        }
+    }
+
+    func testLoadFailureBlocksSavesAndTheUnlockRetryRestoresThem() throws {
+        let onDisk = ConversationThread(mode: "direct", title: "Written before the lock")
+        try writeThreads([onDisk])
+
+        try denyReadsOrSkip()
+
+        // Launch with the file unreadable — exactly the locked-device case.
+        let store = ConversationStore(directory: tempDir)
+        XCTAssertTrue(store.saveBlocked, "an unreadable existing file must block saves")
+        XCTAssertTrue(store.threads.isEmpty, "nothing was loaded")
+
+        // A conversation happens anyway. It lives only in memory: the save is refused.
+        let live = store.startThread(mode: "direct", personaId: nil)
+        store.appendMessage(role: "user", content: "does this survive the unlock?")
+        XCTAssertTrue(store.saveBlocked, "still blocked — nothing has re-read the file")
+
+        // The device is unlocked: protected data becomes available.
+        try FileManager.default.setAttributes([.posixPermissions: 0o644],
+                                              ofItemAtPath: fileURL.path)
+        store.protectedDataDidBecomeAvailable()
+
+        XCTAssertFalse(store.saveBlocked, "a successful re-read must lift the latch")
+        let ids = Set(store.threads.map(\.id))
+        XCTAssertEqual(ids, [onDisk.id, live.id],
+                       "the on-disk thread is recovered and the unsaved live one is kept")
+
+        // And the merged set is now actually on disk — the retry persists it.
+        let persisted = try readThreadsFromDisk()
+        XCTAssertEqual(Set(persisted.map(\.id)), [onDisk.id, live.id])
+        XCTAssertEqual(persisted.first(where: { $0.id == live.id })?.messages.count, 1)
+
+        // Saves work from here on.
+        store.appendMessage(role: "assistant", content: "it did")
+        XCTAssertFalse(store.saveBlocked)
+        XCTAssertEqual(try readThreadsFromDisk().first(where: { $0.id == live.id })?.messages.count, 2)
+    }
+
+    /// A file that is still unreadable when the notification fires must leave the latch on —
+    /// writing now would put an empty history over data that may be perfectly intact.
+    func testRetryLeavesSavesBlockedWhileTheFileIsStillUnreadable() throws {
+        let onDisk = ConversationThread(mode: "direct", title: "Untouched")
+        try writeThreads([onDisk])
+        try denyReadsOrSkip()
+
+        let store = ConversationStore(directory: tempDir)
+        XCTAssertTrue(store.saveBlocked)
+
+        store.protectedDataDidBecomeAvailable()
+        XCTAssertTrue(store.saveBlocked, "still unreadable — the store must stay closed for writes")
+
+        // The original bytes are untouched.
+        try FileManager.default.setAttributes([.posixPermissions: 0o644],
+                                              ofItemAtPath: fileURL.path)
+        XCTAssertEqual(try readThreadsFromDisk().map(\.id), [onDisk.id])
+    }
+
+    /// The merge keeps the store's newest-first ordering rather than parking a brand-new
+    /// conversation at the bottom of the list.
+    func testMergedThreadsStayNewestFirst() throws {
+        let old = ConversationThread(mode: "direct", title: "Older")
+        try writeThreads([old])
+        try denyReadsOrSkip()
+
+        let store = ConversationStore(directory: tempDir)
+        let live = store.startThread(mode: "direct", personaId: nil)
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o644],
+                                              ofItemAtPath: fileURL.path)
+        store.protectedDataDidBecomeAvailable()
+
+        XCTAssertEqual(store.threads.first?.id, live.id,
+                       "the thread started during the outage is the most recent one")
+    }
+
+    // MARK: - Encrypted stores
+
+    /// The retry must never hand an encrypted file to the plaintext reader.
+    ///
+    /// `ConversationEncryptionService.isFileEncrypted(at:)` answers `false` for a file it cannot
+    /// *read*, so a locked-device launch with encryption on latches `saveBlocked` down the same
+    /// plaintext branch an unencrypted store takes. If the retry then re-read it as plaintext, the
+    /// `OGENC1` bytes would decode as `.corrupt`, `StoreRecovery` would move the user's history
+    /// aside, and `save()` would write an empty file over the top — a save outage turned into data
+    /// loss for exactly the wearers who opted into more protection.
+    ///
+    /// The decrypt itself cannot succeed in a test process (no Keychain key, so `retrieveKey()`
+    /// returns `errSecItemNotFound` without prompting — and any other Keychain outcome fails the
+    /// same way on a payload that was never sealed with a real key). That is the point: whatever
+    /// the decrypt does, the ciphertext on disk must come back byte-for-byte identical.
+    func testEncryptedFileIsNotClobberedByTheRetry() throws {
+        Config.setConversationEncryptionEnabled(true)
+
+        // A plausible encrypted file: the magic header plus opaque bytes.
+        var ciphertext = Data("OGENC1".utf8)
+        ciphertext.append(Data(repeating: 0xAB, count: 256))
+        try ciphertext.write(to: fileURL, options: .atomic)
+
+        try denyReadsOrSkip()
+
+        let store = ConversationStore(directory: tempDir)
+        XCTAssertTrue(store.saveBlocked,
+                      "an unreadable file latches the same way whether or not it is encrypted")
+
+        // A conversation happens during the outage, as in the plaintext case.
+        _ = store.startThread(mode: "direct", personaId: nil)
+        store.appendMessage(role: "user", content: "written while saves were blocked")
+
+        // Protected data becomes available.
+        try FileManager.default.setAttributes([.posixPermissions: 0o644],
+                                              ofItemAtPath: fileURL.path)
+        store.protectedDataDidBecomeAvailable()
+
+        // Taking the decrypt branch is observable: only that branch closes the store while it runs.
+        XCTAssertTrue(store.isLocked,
+                      "an encrypted file must go through the decrypt path, not the plaintext reader")
+        XCTAssertTrue(store.saveBlocked,
+                      "the latch stays on until a decrypt actually succeeds")
+
+        // The bytes are the whole point.
+        XCTAssertEqual(try Data(contentsOf: fileURL), ciphertext,
+                       "the encrypted history must be untouched by the retry")
+    }
+
+    /// The decrypt branch actually runs, actually fails here, and still leaves the file alone.
+    ///
+    /// The wait is observable rather than timed: a local `DiagnosticRing` taps the privacy log and
+    /// the test blocks until the failure event appears, so this cannot pass by asserting before the
+    /// task has run.
+    func testFailedDecryptLeavesTheStoreClosedAndTheFileIntact() async throws {
+        Config.setConversationEncryptionEnabled(true)
+
+        var ciphertext = Data("OGENC1".utf8)
+        ciphertext.append(Data(repeating: 0xCD, count: 128))
+        try ciphertext.write(to: fileURL, options: .atomic)
+
+        try denyReadsOrSkip()
+        let store = ConversationStore(directory: tempDir)
+        XCTAssertTrue(store.saveBlocked)
+
+        let ring = DiagnosticRing(capacity: 200)
+        ring.attach()
+        defer { ring.detach() }
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o644],
+                                              ofItemAtPath: fileURL.path)
+        store.protectedDataDidBecomeAvailable()
+
+        // Wait for the decrypt task to report its failure.
+        var reported = false
+        for _ in 0..<200 {
+            if ring.entries.contains(where: { $0.line.contains("awaitingAuthentication") }) {
+                reported = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(reported,
+                      "the retry must have gone through the decrypt path and reported its failure")
+
+        XCTAssertTrue(store.isLocked, "a store whose decrypt failed stays closed")
+        XCTAssertTrue(store.saveBlocked, "and stays unwritable")
+        XCTAssertEqual(try Data(contentsOf: fileURL), ciphertext,
+                       "the ciphertext is untouched by a failed retry")
+    }
+}

--- a/OpenGlassesTests/PrivacyLogTests.swift
+++ b/OpenGlassesTests/PrivacyLogTests.swift
@@ -559,6 +559,39 @@ final class PrivacyLogTests: XCTestCase {
         XCTAssertEqual(summary.description, "timedOut(URLError)#\(URLError.Code.timedOut.rawValue)")
     }
 
+    /// Issue 427: when the DAT session reports an error during startup, the abort line has to
+    /// carry the SDK's own reason — the whole point of the change is that the failure stops
+    /// reading as a generic `streamNotReady`.
+    func testCameraSessionStartAbortedCarriesTheUnderlyingReason() {
+        let line = PrivacyEventEncoder.encode(
+            PrivacyLog.camera(.glasses, .sessionStartAborted,
+                              state: PrivacyToken("starting"),
+                              error: SafeErrorSummary(MaliciousEnumError.refusedHost("SENTINELHOST"))))
+        XCTAssertTrue(line.contains("event=sessionStartAborted"), line)
+        XCTAssertTrue(line.contains("state=starting"), line)
+        XCTAssertTrue(line.contains("refusedHost"), line)
+        XCTAssertFalse(line.contains("SENTINEL"), line)
+    }
+
+    /// Issue 427: `NSCocoaErrorDomain` used to share `NSURLErrorDomain`'s mapping, so a
+    /// locked-device read failure (`NSFileReadNoPermissionError`, 257) — the exact error that
+    /// blocked conversation saves for a whole process — was logged as `badServerResponse` and
+    /// sent every reader of that line to the network layer.
+    func testCocoaErrorsMapToStorageNotBadServerResponse() {
+        let cocoa = NSError(domain: NSCocoaErrorDomain, code: NSFileReadNoPermissionError)
+        let summary = SafeErrorSummary(cocoa)
+        XCTAssertEqual(summary.category, .storage)
+        XCTAssertEqual(summary.description, "storage(NSError)#257")
+
+        // The URL domain keeps the mapping it had.
+        let url = NSError(domain: NSURLErrorDomain, code: NSURLErrorBadServerResponse)
+        XCTAssertEqual(SafeErrorSummary(url).category, .badServerResponse)
+
+        // Anything else is still `unknown`.
+        let other = NSError(domain: "com.example.Sentinel", code: 42)
+        XCTAssertEqual(SafeErrorSummary(other).category, .unknown)
+    }
+
     func testHTTPStatusesMapToBoundedCategories() {
         XCTAssertEqual(SafeErrorSummary.http(status: 401).category, .unauthorized)
         XCTAssertEqual(SafeErrorSummary.http(status: 403).category, .forbidden)

--- a/OpenGlassesTests/ProviderToolSupportTests.swift
+++ b/OpenGlassesTests/ProviderToolSupportTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Which providers get an OpenAI-style `tools` array attached to their request.
+///
+/// Issue 427: `.xai` and `.minimax` were added to the `sendOpenAICompatible` route but never to
+/// the hand-written `||` chain that decided whether to attach tools, so a grok-4.6 turn logged
+/// `turnStarted detail=nativeTools` while the request carried no tool definitions at all —
+/// "take a photo" simply came back as prose. The predicate is now an exhaustive switch, and
+/// these tests pin it to the routing table so the two can't drift again.
+final class ProviderToolSupportTests: XCTestCase {
+
+    /// Every provider whose `completeStateless` / `sendMessage` route is `sendOpenAICompatible`.
+    /// Keep this list in step with those two switch statements in `LLMService`.
+    private static let openAICompatibleRoute: [LLMProvider] = [
+        .openai, .groq, .zai, .qwen, .minimax, .xai, .openrouter, .custom,
+    ]
+
+    /// Providers with their own request builder — they never reach this predicate.
+    private static let ownRequestBuilder: [LLMProvider] = [
+        .anthropic, .chatgpt, .gemini, .geminiVertex, .local, .appleOnDevice,
+    ]
+
+    func testEveryOpenAICompatibleProviderGetsTools() {
+        for provider in Self.openAICompatibleRoute {
+            XCTAssertTrue(
+                LLMService.providerSupportsTools(provider, customEndpointRejectsTools: false),
+                "\(provider.rawValue) routes to sendOpenAICompatible and must be handed tools"
+            )
+        }
+    }
+
+    /// The regression guard proper: the two providers issue 427 was actually about.
+    func testXAIAndMiniMaxGetTools() {
+        XCTAssertTrue(LLMService.providerSupportsTools(.xai, customEndpointRejectsTools: false))
+        XCTAssertTrue(LLMService.providerSupportsTools(.minimax, customEndpointRejectsTools: false))
+        // The remembered-rejection flag is about `.custom` alone and must not silence them.
+        XCTAssertTrue(LLMService.providerSupportsTools(.xai, customEndpointRejectsTools: true))
+        XCTAssertTrue(LLMService.providerSupportsTools(.minimax, customEndpointRejectsTools: true))
+    }
+
+    func testCustomEndpointLosesToolsOnceItHasRejectedThem() {
+        XCTAssertTrue(LLMService.providerSupportsTools(.custom, customEndpointRejectsTools: false))
+        XCTAssertFalse(LLMService.providerSupportsTools(.custom, customEndpointRejectsTools: true))
+    }
+
+    func testProvidersWithTheirOwnRequestBuilderAreNotHandedAnOpenAIToolsArray() {
+        for provider in Self.ownRequestBuilder {
+            XCTAssertFalse(
+                LLMService.providerSupportsTools(provider, customEndpointRejectsTools: false),
+                "\(provider.rawValue) builds its own request and never reaches this predicate"
+            )
+        }
+    }
+
+    /// Nothing may fall through the two lists — a newly added provider has to be classified.
+    func testEveryProviderIsAccountedFor() {
+        let classified = Set(Self.openAICompatibleRoute + Self.ownRequestBuilder)
+        for provider in LLMProvider.allCases {
+            XCTAssertTrue(classified.contains(provider),
+                          "\(provider.rawValue) is unclassified — decide whether it takes tools")
+        }
+    }
+}

--- a/OpenGlassesTests/WakeWordHardeningTests.swift
+++ b/OpenGlassesTests/WakeWordHardeningTests.swift
@@ -86,6 +86,29 @@ final class WakeWordHardeningTests: XCTestCase {
         box.dispatch(buffer)   // no request, no forwarders → must be a safe no-op
     }
 
+    // MARK: - Shared-engine handoff (issue 427)
+
+    /// Handing the running engine to `TranscriptionService` tears down the wake-word recognizer.
+    /// `isListening` has to fall with it: `startListening()` opens with
+    /// `guard !isListening else { return }`, so a stale `true` turned every later auto-restart
+    /// into a silent no-op — the wake word worked exactly once per launch, and the only cure in
+    /// the field was force-quitting the app.
+    ///
+    /// `startListening()` is deliberately not called here: it requests speech permission.
+    @MainActor
+    func testSharedEnginePauseClearsIsListeningSoARestartCanTakeHold() {
+        let svc = WakeWordService()
+        svc.isListening = true
+
+        svc.pauseRecognitionForSharedEngine()
+
+        XCTAssertFalse(svc.isListening,
+                       "the recognizer is gone, so startListening's guard must not see a listener")
+        XCTAssertTrue(svc.suppressAutoRestart,
+                      "the cancel is intentional — its error callback must not spin up a rival recognizer")
+        XCTAssertNil(svc.recognitionTask)
+    }
+
     // MARK: - Config flag
 
     func testOnDeviceWakeWordDefaultsOn() {

--- a/project.base.yml
+++ b/project.base.yml
@@ -142,7 +142,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "370"
+        CURRENT_PROJECT_VERSION: "371"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -259,7 +259,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "370"
+        CURRENT_PROJECT_VERSION: "371"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -297,7 +297,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "370"
+        CURRENT_PROJECT_VERSION: "371"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "370"
+        CURRENT_PROJECT_VERSION: "371"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "370"
+        CURRENT_PROJECT_VERSION: "371"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
Closes #427.

## What the logs actually showed

The reporter's headline ("photo captured, model request stays textOnly") was the Developer panel's subsystem self-test: a camera probe, then a stateless `Reply with exactly: OK` query (2 messages, ~184 bytes, no `turnStarted`), then a 9-character TTS probe, back to back. The real capture path attaches the image and never ran in either export. Behind that misread were four genuine defects.

## Fixes

- **xAI and MiniMax never received tool definitions.** The OpenAI-compatible path gated `tools` on a hand-written provider list that omitted both, so a Grok turn logged `nativeTools` while sending none, and voice could never trigger a tool call. Replaced by an exhaustive switch (`LLMService.providerSupportsTools`) so the next provider is a compile error, not a silent omission.
- **Wake word worked once per launch.** Handing the audio engine to dictation cancelled the recognizer but left `isListening` true, so every later auto-restart hit `startListening()`'s early-return guard. The handoff now drops the flag (`pauseRecognitionForSharedEngine`). Three other readers of that flag were also being misled, including the session recorder never stopping the engine it started.
- **A locked-device launch disabled saving for the whole process.** The protected conversations file read Cocoa 257 before first unlock, `saveBlocked` latched, and nothing ever re-read the file. The store now retries on `protectedDataDidBecomeAvailable`, merging unsaved in-memory threads with the on-disk ones. An encrypted file is routed through the decrypt path, never the plaintext reader, so it cannot be moved aside as corrupt.
- **Camera session errors were swallowed.** A DeviceSession error 120 ms into startup was logged and dropped; the app waited out the grace window and reported a generic "stream not ready", four times over ~21 s. The start wait now aborts (`sessionStartAborted`) and throws the SDK's own reason.

Also: `SafeErrorSummary` classifies Cocoa errors as `storage` rather than `badServerResponse`; the Prompt Inspector no longer renders Vision as inactive when the wearer's own prompt already covers it (which is what convinced the reporter vision was off); and the two silent exits after TTS now log (`listenerSkippedDisabled`, `startSkippedAlreadyRecording`).

## Not in this PR

- A vision-classified turn whose camera capture fails still goes out text-only under a prompt that says the model can see. Same shape as the on-device vision-honesty guard; deserves its own change.
- The underlying `unexpectedError` from the glasses is a device-side refusal (typically another app holding the camera). The app now says so instead of "stream not ready".

## Verification

- Full `OpenGlassesTests` bundle: 4661 tests, 0 failures, 9 environment-gated skips.
- New tests: `ProviderToolSupportTests` (5), `ConversationStoreLoadRetryTests` (5, including a real 0o000-permission unreadable file and an encrypted-file no-clobber case), plus additions to `WakeWordHardeningTests` and `PrivacyLogTests`.
- Release build (`-configuration Release`, generic iOS) succeeded. `Localizable.xcstrings` untouched.
- Build bumped to 371.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
