### PR TITLE
Send a tool's photo to the model as pixels, and let a switched-off toggle end the turn

### DIFF
--- a/GlassesActivityWidget/SharedAppState.swift
+++ b/GlassesActivityWidget/SharedAppState.swift
@@ -15,7 +15,10 @@ enum SharedAppState {
     }
 
     static var isListening: Bool {
-        get { defaults.bool(forKey: "listeningEnabled") }
+        // Absent means "never toggled", and the app's default for that is ON (`Config.listeningEnabled`).
+        // `bool(forKey:)` answered false here, so a fresh install rendered the Control as off and a
+        // press from that state wrote a real `false` into the App Group — listening silently disabled.
+        get { defaults.object(forKey: "listeningEnabled") as? Bool ?? true }
         set {
             defaults.set(newValue, forKey: "listeningEnabled")
             postListeningChanged()

--- a/OpenGlasses/Sources/App/OpenGlassesApp.swift
+++ b/OpenGlasses/Sources/App/OpenGlassesApp.swift
@@ -485,7 +485,15 @@ struct OpenGlassesApp: App {
                             return
                         }
 
-                        if !appState.wakeWordService.isListening && !appState.isListening && appState.isConnected && !appState.micMuted && !Config.silentMode {
+                        // The master toggle belongs here too: without it the app brought the
+                        // listener up on foreground and heard a wake word while listening was
+                        // switched off (issue 427 follow-up).
+                        if WakeAutoRestartPolicy.shouldRestart(
+                            listeningEnabled: appState.listeningEnabled,
+                            silentMode: Config.silentMode,
+                            isConnected: appState.isConnected,
+                            micMuted: appState.micMuted,
+                            alreadyListening: appState.wakeWordService.isListening || appState.isListening) {
                             // Re-configure audio session in case Bluetooth route changed
                             await appState.wakeWordService.reconfigureAudioSessionIfNeeded()
                             // Small delay for route to stabilize after foregrounding
@@ -2028,6 +2036,11 @@ class AppState: ObservableObject, AppStateProtocol {
                 self.glassesDisplay.flash("⚠️ \(error.localizedDescription)")
             }
         }
+
+        // A wake word must not be heard while the master toggle is off. The service restarts
+        // itself on route changes and after interruptions, so it needs the toggle too — the
+        // AppState-side callers already check it (issue 427 follow-up).
+        wakeWordService.shouldAutoRestart = { Config.listeningEnabled }
 
         wakeWordService.onWakeWordDetected = { [weak self] matchedPhrase in
             Task { @MainActor in
@@ -3653,17 +3666,28 @@ class AppState: ObservableObject, AppStateProtocol {
     /// - Parameter ensureEngine: run the audio-engine keepalive first — needed after TTS playback,
     ///   which may have interrupted the engine.
     private func resumeListeningOrReturnToWakeWord(ensureEngine: Bool = false) async {
-        // The user may have disabled listening while the turn was finishing — a finish stage
-        // must never turn the microphone back on behind their back. Log it: a silent return here
-        // is indistinguishable in the field from the mic failing to reopen after the reply.
-        guard listeningEnabled else {
-            PrivacyLog.wakeWord(.listenerSkippedDisabled)
+        // The user may have disabled listening while the turn was finishing — a finish stage must
+        // never turn the microphone back on behind their back. But it must still CLOSE the
+        // conversation: returning with `inConversation` left true stranded the app until a
+        // force-quit, because every later wake word was then dropped as `alreadyProcessing`.
+        // `returnToWakeWord()` re-checks the toggle before it goes near the mic.
+        if FinishStagePolicy.action(listeningEnabled: listeningEnabled,
+                                    inConversation: inConversation) == .endConversation {
+            if !listeningEnabled { PrivacyLog.wakeWord(.listenerSkippedDisabled) }
+            await returnToWakeWord()
             return
         }
-        if inConversation {
+        do {
             if ensureEngine { try? await wakeWordService.ensureAudioEngineRunning() }
-            // The engine keepalive suspends; re-check the user didn't flip the toggle meanwhile.
-            guard listeningEnabled, inConversation else { return }
+            // The engine keepalive suspends; re-check the user didn't flip the toggle meanwhile —
+            // and close the conversation if they did, for the same reason as above.
+            guard listeningEnabled else {
+                PrivacyLog.wakeWord(.listenerSkippedDisabled)
+                await returnToWakeWord()
+                return
+            }
+            // Someone else ended the conversation while we were suspended; they own the teardown.
+            guard inConversation else { return }
             isListening = true
             // CO Item 4: if what we just said was a question, give the user room to think before
             // the silence window ends the conversation out from under them.
@@ -3671,8 +3695,6 @@ class AppState: ObservableObject, AppStateProtocol {
             transcriptionService.startRecording()
             // CO Item 3: a turn is over, so anything held while it ran can be answered now.
             replayHeldUtteranceIfFresh()
-        } else {
-            await returnToWakeWord()
         }
     }
 

--- a/OpenGlasses/Sources/Services/Flow/FinishStagePolicy.swift
+++ b/OpenGlasses/Sources/Services/Flow/FinishStagePolicy.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// What the end of a turn should do with the microphone and the conversation.
+///
+/// Issue 427 follow-up. The finish stage used to be an `if listeningEnabled` guard with a bare
+/// `return`, which looked like "don't touch the mic" but actually meant "leave the conversation
+/// open forever": `inConversation` stayed `true`, and `onWakeWordDetected`'s
+/// `guard !inConversation && !isProcessing` then dropped every later wake word as
+/// `alreadyProcessing` until the app was force-quit. Field trace (build 371):
+/// `tts finished; wakeWord listenerSkippedDisabled` at 16:11:10, then `wakeWord detected;
+/// app alreadyProcessing detail=wakeWord` at 16:11:49.
+///
+/// Turning the master toggle off must still *end* the conversation — it only forbids re-opening
+/// the mic, and `returnToWakeWord()` already checks the toggle again before it does that.
+enum FinishStagePolicy {
+
+    enum Action: Equatable {
+        /// Stay in the conversation and listen for a follow-up utterance.
+        case resumeDictation
+        /// Reset conversation state and hand back to `returnToWakeWord()`, which re-checks the
+        /// master toggle (and silent mode, connection, mute) before touching the microphone.
+        case endConversation
+    }
+
+    /// - Parameters:
+    ///   - listeningEnabled: the user's master listening toggle.
+    ///   - inConversation: whether a conversation is still open.
+    static func action(listeningEnabled: Bool, inConversation: Bool) -> Action {
+        // The toggle being off never means "do nothing" — that is the stranding bug. It means
+        // close the conversation and leave the mic shut.
+        guard listeningEnabled else { return .endConversation }
+        return inConversation ? .resumeDictation : .endConversation
+    }
+}

--- a/OpenGlasses/Sources/Services/Flow/WakeAutoRestartPolicy.swift
+++ b/OpenGlasses/Sources/Services/Flow/WakeAutoRestartPolicy.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Whether an *automatic* wake-word restart may open the microphone.
+///
+/// Issue 427 follow-up. The master listening toggle was enforced by some callers and not others:
+/// `AppState.returnToWakeWord()` checked it, but the foreground restart did not, and neither did
+/// `WakeWordService`'s own route-change / interruption-ended restarts. So with the toggle off the
+/// app still brought the listener up and still heard a wake word — field trace (build 371):
+/// `becameActive; routeChanged reconfigure; engineReused; listenerStarted` at 16:11:46-47, then
+/// `wakeWord detected` at 16:11:49, with `listenerSkippedDisabled` proving the toggle was off.
+///
+/// A wake word must not be heard while the master toggle is off. This is the one place that rule
+/// lives, so a new auto-start path either uses it or is visibly not using it.
+enum WakeAutoRestartPolicy {
+
+    /// - Parameters:
+    ///   - listeningEnabled: the user's master toggle. Off ⇒ never.
+    ///   - silentMode: push-to-talk. Suppresses the always-on listener.
+    ///   - isConnected: glasses link. Off ⇒ don't grab the phone mic behind the user's back.
+    ///   - micMuted: explicit mute.
+    ///   - alreadyListening: nothing to restart.
+    static func shouldRestart(listeningEnabled: Bool,
+                              silentMode: Bool,
+                              isConnected: Bool,
+                              micMuted: Bool,
+                              alreadyListening: Bool) -> Bool {
+        guard listeningEnabled else { return false }
+        guard !silentMode else { return false }
+        guard isConnected else { return false }
+        guard !micMuted else { return false }
+        return !alreadyListening
+    }
+}

--- a/OpenGlasses/Sources/Services/LLM/ToolResultImage.swift
+++ b/OpenGlasses/Sources/Services/LLM/ToolResultImage.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Pulls a captured photo back out of a tool's text result so it can be sent to the model as
+/// **pixels** rather than as a wall of base64.
+///
+/// Issue 427 follow-up. `CapturePhotoTool`, `PhotoLogTool` and `MoneyIdentifierTool` all return
+/// `"[IMAGE_CAPTURED:<base64>] <text>"`, and nothing in the app ever parsed that marker — so every
+/// provider's tool loop appended ~134k characters of base64 as the tool message's *text*. The model
+/// was handed a transcript of an image it could not see, the turn logged `textOnly`, and a
+/// vision-capable model answered a photo question from nothing. Field trace (build 371):
+/// `toolRun succeeded characters=134076` immediately followed by `requestSent bytes=239548
+/// detail=textOnly`.
+///
+/// Pure and headless on purpose: the marker grammar is the contract between the three emitters and
+/// the four provider loops, and it is the kind of thing that only ever breaks silently.
+enum ToolResultImage {
+
+    /// Opening delimiter written by the emitting tools. The payload runs to the next `]`, which is
+    /// unambiguous because `]` is not in the base64 alphabet.
+    static let marker = "[IMAGE_CAPTURED:"
+
+    /// Appended when a single result carried more than one image. Only the first is attached —
+    /// the provider shapes below all model "one image per tool result" — so say so rather than
+    /// dropping the others silently.
+    static let extraImagesNote = "(note: this result carried more than one image; only the first is attached.)"
+
+    /// Split a tool result into the text the model should read and the image it should see.
+    ///
+    /// - Returns: the result text with every marker removed and trimmed, plus the first image that
+    ///   decoded. When no marker is present — or when nothing in it decodes as base64 — the text is
+    ///   returned **exactly as it came in** and `image` is `nil`: an undecodable payload is not
+    ///   known to be an image, and silently eating it would lose whatever the tool actually said.
+    static func extract(from text: String) -> (text: String, image: Data?) {
+        guard text.contains(marker) else { return (text, nil) }
+
+        var remaining = text
+        var firstImage: Data?
+        var markersFound = 0
+
+        while let start = remaining.range(of: marker) {
+            guard let close = remaining[start.upperBound...].firstIndex(of: "]") else {
+                // An unterminated marker is malformed; leave the rest of the string alone.
+                break
+            }
+            markersFound += 1
+            let payload = String(remaining[start.upperBound..<close])
+            if firstImage == nil, let decoded = Data(base64Encoded: payload), !decoded.isEmpty {
+                firstImage = decoded
+            }
+            remaining.removeSubrange(start.lowerBound...close)
+        }
+
+        // Nothing usable came out: hand back the original, untouched.
+        guard firstImage != nil else { return (text, nil) }
+
+        var cleaned = remaining.trimmingCharacters(in: .whitespacesAndNewlines)
+        if markersFound > 1 {
+            cleaned = cleaned.isEmpty ? extraImagesNote : cleaned + " " + extraImagesNote
+        }
+        return (cleaned, firstImage)
+    }
+
+    /// The line substituted for the image when the model configuration cannot accept one.
+    ///
+    /// The base64 must never be sent as text in this case either — that is the whole bug. The
+    /// model is told plainly that there was an image and that it cannot see it, which is what
+    /// stops it from inventing a description.
+    static let visionDisabledNote = "(image omitted: vision is disabled for this model)"
+
+    /// The tool result text to send when an image was extracted but the model cannot receive it.
+    static func textWithImageOmitted(_ text: String) -> String {
+        text.isEmpty ? visionDisabledNote : text + "\n" + visionDisabledNote
+    }
+
+    /// The one-line user-turn caption that carries a tool's image on the chat-shaped providers
+    /// (OpenAI-compatible and ChatGPT), whose `tool` messages cannot hold image parts.
+    static func attachmentCaption(toolName: String) -> String {
+        "[Attached: the photo returned by \(toolName).]"
+    }
+
+    /// Whether an already-built message array carries an image part in any provider shape.
+    ///
+    /// Used to keep the `requestSent` log honest: before this, a request was reported `withImage`
+    /// only when the *user turn* carried a photo, so a tool-returned image — the entire point of
+    /// `capture_photo` — was logged as `textOnly` even once it was being sent correctly.
+    static func historyCarriesImage(_ messages: [[String: Any]]) -> Bool {
+        messages.contains { message in
+            let blocks = (message["content"] as? [[String: Any]])
+                ?? (message["parts"] as? [[String: Any]])
+                ?? []
+            return blocks.contains(where: isImageBlock)
+        }
+    }
+
+    /// An image block in any of the shapes the shared history holds: Anthropic (`type: image`),
+    /// OpenAI-compatible / ChatGPT (`type: image_url`), Gemini (`inlineData`). Deliberately the
+    /// same three-shape rule `HistoryHygiene.isImageBlock` prunes on — a shape one of them
+    /// recognised and the other did not would either re-upload forever or report dishonestly.
+    private static func isImageBlock(_ block: [String: Any]) -> Bool {
+        if let type = block["type"] as? String, type == "image" || type == "image_url" { return true }
+        return block["inlineData"] != nil
+    }
+}

--- a/OpenGlasses/Sources/Services/LLMService.swift
+++ b/OpenGlasses/Sources/Services/LLMService.swift
@@ -1722,11 +1722,31 @@ class LLMService: ObservableObject {
                     case .success(let text): resultContent = text
                     case .failure(let error): resultContent = "Error: \(error)"
                     }
+                    // A capture tool returns its photo as a base64 marker inside its text. Send it
+                    // as pixels — a transcript of an image is not an image (issue 427).
+                    let split = ToolResultImage.extract(from: resultContent)
+                    let canSeeIt = split.image != nil && config.visionEnabled
                     // Frame untrusted external content as data, not instructions.
-                    let framed = self.wrapToolResultForModel(toolName: outcome.invocation.name, content: resultContent)
+                    let framed = self.wrapToolResultForModel(
+                        toolName: outcome.invocation.name,
+                        content: split.image != nil && !canSeeIt
+                            ? ToolResultImage.textWithImageOmitted(split.text)
+                            : split.text)
+                    var toolResult: [String: Any] = [
+                        "type": "tool_result", "tool_use_id": id, "content": framed,
+                    ]
+                    if canSeeIt, let image = split.image {
+                        // Anthropic tool_result content takes the same typed blocks a user turn
+                        // does, so the image rides inside the result itself.
+                        toolResult["content"] = [
+                            ["type": "text", "text": framed],
+                            ["type": "image",
+                             "source": ["type": "base64", "media_type": "image/jpeg",
+                                        "data": image.base64EncodedString()]],
+                        ]
+                    }
                     self.conversationHistory.append([
-                        "role": "user",
-                        "content": [["type": "tool_result", "tool_use_id": id, "content": framed]]
+                        "role": "user", "content": [toolResult],
                     ] as [String: Any])
                 }
                 for id in state.malformedIds {
@@ -1915,7 +1935,10 @@ class LLMService: ObservableObject {
                 // Shape of the request, not its contents — and not `baseURL` either: a custom
                 // endpoint URL is the wearer's own server, often on their home network.
                 let messageCount = (body["messages"] as? [[String: Any]])?.count ?? 0
-                let hasImage = imageData != nil && supportsVision
+                // Honest even when the image came from a tool result rather than the user turn:
+                // a `capture_photo` round-trip used to log `textOnly` while carrying a photo.
+                let hasImage = (imageData != nil && supportsVision)
+                    || ToolResultImage.historyCarriesImage(messages)
                 let bodySize = request.httpBody?.count ?? 0
                 PrivacyLog.model(.requestSent, provider: PrivacyToken(provider.rawValue),
                                  model: PrivacyToken(config.model), count: messageCount,
@@ -2033,13 +2056,32 @@ class LLMService: ObservableObject {
                     case .success(let text): resultContent = text
                     case .failure(let error): resultContent = "Error: \(error)"
                     }
+                    // See the Anthropic path: a capture tool's photo must reach the model as an
+                    // image part, not as base64 in the tool message's text (issue 427).
+                    let split = ToolResultImage.extract(from: resultContent)
+                    let canSeeIt = split.image != nil && config.visionEnabled
                     // Frame untrusted external content as data, not instructions.
-                    let framed = self.wrapToolResultForModel(toolName: outcome.invocation.name, content: resultContent)
+                    let framed = self.wrapToolResultForModel(
+                        toolName: outcome.invocation.name,
+                        content: split.image != nil && !canSeeIt
+                            ? ToolResultImage.textWithImageOmitted(split.text)
+                            : split.text)
                     self.conversationHistory.append([
                         "role": "tool",
                         "tool_call_id": callId,
                         "content": framed
                     ])
+                    // An OpenAI `tool` message may only carry text, so the image follows as its
+                    // own user turn. `image_url` is the shape `HistoryHygiene.pruneImages`
+                    // recognises, so a stale tool photo is pruned exactly like a stale user photo.
+                    if canSeeIt, let image = split.image {
+                        self.conversationHistory.append(["role": "user", "content": [
+                            ["type": "text",
+                             "text": ToolResultImage.attachmentCaption(toolName: outcome.invocation.name)],
+                            ["type": "image_url",
+                             "image_url": ["url": "data:image/jpeg;base64,\(image.base64EncodedString())"]],
+                        ]])
+                    }
                 }
             },
             finalize: { [weak self] turn in
@@ -2142,9 +2184,25 @@ class LLMService: ObservableObject {
                     case .success(let text): resultContent = text
                     case .failure(let error): resultContent = "Error: \(error)"
                     }
+                    // Same split as the OpenAI-compatible path — this backend speaks the chat
+                    // shape too, so the image cannot ride inside the `tool` message (issue 427).
+                    let split = ToolResultImage.extract(from: resultContent)
+                    let canSeeIt = split.image != nil && config.visionEnabled
                     // Frame untrusted external content as data, not instructions.
-                    let framed = self.wrapToolResultForModel(toolName: outcome.invocation.name, content: resultContent)
+                    let framed = self.wrapToolResultForModel(
+                        toolName: outcome.invocation.name,
+                        content: split.image != nil && !canSeeIt
+                            ? ToolResultImage.textWithImageOmitted(split.text)
+                            : split.text)
                     self.conversationHistory.append(["role": "tool", "tool_call_id": callId, "content": framed])
+                    if canSeeIt, let image = split.image {
+                        self.conversationHistory.append(["role": "user", "content": [
+                            ["type": "text",
+                             "text": ToolResultImage.attachmentCaption(toolName: outcome.invocation.name)],
+                            ["type": "image_url",
+                             "image_url": ["url": "data:image/jpeg;base64,\(image.base64EncodedString())"]],
+                        ]])
+                    }
                 }
             },
             finalize: { [weak self] turn in
@@ -2637,13 +2695,26 @@ class LLMService: ObservableObject {
                 guard let self else { return }
                 // Gemini batches all function responses into one `function` message.
                 var functionResponseParts: [[String: Any]] = []
+                // Images ride in a user turn after it — a functionResponse carries JSON, not parts.
+                var attachedImages: [(name: String, data: Data)] = []
                 for outcome in outcomes {
                     let name = outcome.invocation.name
                     let resultContent: [String: Any]
                     switch outcome.result {
                     case .success(let text):
+                        // A capture tool's photo becomes an `inlineData` part below, never base64
+                        // text in the function response (issue 427).
+                        let split = ToolResultImage.extract(from: text)
+                        let canSeeIt = split.image != nil && config.visionEnabled
+                        if canSeeIt, let image = split.image {
+                            attachedImages.append((name: name, data: image))
+                        }
                         // Frame untrusted external content as data, not instructions.
-                        resultContent = ["result": self.wrapToolResultForModel(toolName: name, content: text)]
+                        resultContent = ["result": self.wrapToolResultForModel(
+                            toolName: name,
+                            content: split.image != nil && !canSeeIt
+                                ? ToolResultImage.textWithImageOmitted(split.text)
+                                : split.text)]
                     case .failure(let error):
                         resultContent = ["error": error]
                     }
@@ -2652,6 +2723,15 @@ class LLMService: ObservableObject {
                     ])
                 }
                 self.conversationHistory.append(["role": "function", "parts": functionResponseParts])
+                for attached in attachedImages {
+                    // `inlineData` is both Gemini's user-image shape and what
+                    // `HistoryHygiene.pruneImages` strips, so these prune like user photos.
+                    self.conversationHistory.append(["role": "user", "parts": [
+                        ["text": ToolResultImage.attachmentCaption(toolName: attached.name)],
+                        ["inlineData": ["mimeType": "image/jpeg",
+                                        "data": attached.data.base64EncodedString()]],
+                    ]])
+                }
             },
             finalize: { [weak self] turn in
                 guard let self else { throw LLMError.invalidResponse("Gemini") }

--- a/OpenGlasses/Sources/Services/WakeWordService.swift
+++ b/OpenGlasses/Sources/Services/WakeWordService.swift
@@ -49,6 +49,16 @@ class WakeWordService: NSObject, ObservableObject {
     /// consumed instead of auto-restarting a competing recognizer. `private(set)` rather than
     /// `private` so the shared-engine handoff can be asserted in tests.
     private(set) var suppressAutoRestart = false
+
+    /// Whether an automatic restart (route change, interruption ended, `resumeListening`) may
+    /// re-open the microphone. Injected by `AppState` from the master listening toggle.
+    ///
+    /// `startListening()` enforces push-to-talk but never knew about the master toggle, so the
+    /// service restarted itself on a route change and heard a wake word while listening was
+    /// switched off (issue 427 follow-up). Explicit callers still decide for themselves — this
+    /// gates only the restarts the service initiates on its own. Defaults to "allowed" so the
+    /// service keeps working standalone (and in tests) until AppState wires the toggle in.
+    var shouldAutoRestart: () -> Bool = { true }
     private var speechRecognizer: SFSpeechRecognizer?
     private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest? {
         didSet { tapState.setRequest(recognitionRequest) }   // keep the tap's view in sync (Plan BE)
@@ -323,6 +333,11 @@ class WakeWordService: NSObject, ObservableObject {
             // Only restart if Bluetooth (glasses) route is available
             let route = AVAudioSession.sharedInstance().currentRoute
             let hasBluetooth = route.inputs.contains { $0.portType == .bluetoothHFP }
+            guard shouldAutoRestart() else {
+                PrivacyLog.audio(.wakeWord, .interruptionEndedNotResuming,
+                                 detail: PrivacyToken("listeningDisabled"))
+                return
+            }
             if hasBluetooth {
                 PrivacyLog.audio(.wakeWord, .interruptionEnded,
                                  detail: PrivacyToken("bluetoothActive"))
@@ -371,6 +386,11 @@ class WakeWordService: NSObject, ObservableObject {
                 cleanupAudioEngine()
                 isListening = false
                 onBluetoothReconnected?()
+                // The glasses coming back is not permission to listen: the master toggle decides.
+                guard shouldAutoRestart() else {
+                    PrivacyLog.wakeWord(.listenerSkippedDisabled)
+                    return
+                }
                 Task {
                     try? await Task.sleep(nanoseconds: 500_000_000)
                     audioSessionConfigured = false
@@ -483,6 +503,10 @@ class WakeWordService: NSObject, ObservableObject {
 
     func resumeListening() {
         guard !isListening else { return }
+        guard shouldAutoRestart() else {
+            PrivacyLog.wakeWord(.listenerSkippedDisabled)
+            return
+        }
         Task { try? await startListening() }
     }
 

--- a/OpenGlassesTests/ListeningPolicyTests.swift
+++ b/OpenGlassesTests/ListeningPolicyTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Issue 427 follow-up: turning listening off must END the conversation, not strand it.
+///
+/// The finish stage used to `return` early when the master toggle was off, leaving
+/// `inConversation == true`. `onWakeWordDetected`'s `guard !inConversation && !isProcessing` then
+/// dropped every later wake word. Field trace (build 371): `tts finished; wakeWord
+/// listenerSkippedDisabled` at 16:11:10, then at 16:11:49 `wakeWord detected` immediately followed
+/// by `app alreadyProcessing detail=wakeWord` — and no recovery short of a force-quit.
+final class FinishStagePolicyTests: XCTestCase {
+
+    func testListeningOnMidConversationKeepsTheMicOpenForAFollowUp() {
+        XCTAssertEqual(FinishStagePolicy.action(listeningEnabled: true, inConversation: true),
+                       .resumeDictation)
+    }
+
+    func testListeningOnWithNoConversationGoesBackToWakeWord() {
+        XCTAssertEqual(FinishStagePolicy.action(listeningEnabled: true, inConversation: false),
+                       .endConversation)
+    }
+
+    /// The regression proper.
+    func testListeningDisabledMidConversationStillEndsTheConversation() {
+        XCTAssertEqual(FinishStagePolicy.action(listeningEnabled: false, inConversation: true),
+                       .endConversation,
+                       "a disabled toggle must close the conversation, not leave it open forever")
+    }
+
+    func testListeningDisabledWithNoConversationIsAlsoTheEndPath() {
+        XCTAssertEqual(FinishStagePolicy.action(listeningEnabled: false, inConversation: false),
+                       .endConversation)
+    }
+
+    /// There is no input pair that means "do nothing" — that state was the bug.
+    func testNoCombinationStrandsTheConversation() {
+        for listening in [true, false] {
+            for inConversation in [true, false] {
+                let action = FinishStagePolicy.action(listeningEnabled: listening,
+                                                      inConversation: inConversation)
+                if action == .resumeDictation {
+                    XCTAssertTrue(listening && inConversation,
+                                  "only an enabled toggle inside a conversation may reopen the mic")
+                }
+            }
+        }
+    }
+}
+
+/// Issue 427 follow-up: a wake word must not be heard while the master toggle is off.
+///
+/// The toggle was enforced by `AppState.returnToWakeWord()` but not by the foreground restart
+/// (`OpenGlassesApp.swift`) and not by `WakeWordService`'s own route-change / interruption
+/// restarts. Field trace (build 371): `becameActive; routeChanged reconfigure; engineReused;
+/// listenerStarted` at 16:11:46-47 and `wakeWord detected` at 16:11:49 — with the toggle off.
+final class WakeAutoRestartPolicyTests: XCTestCase {
+
+    private func restart(listening: Bool = true,
+                         silent: Bool = false,
+                         connected: Bool = true,
+                         muted: Bool = false,
+                         already: Bool = false) -> Bool {
+        WakeAutoRestartPolicy.shouldRestart(listeningEnabled: listening,
+                                            silentMode: silent,
+                                            isConnected: connected,
+                                            micMuted: muted,
+                                            alreadyListening: already)
+    }
+
+    func testRestartsWhenEverythingIsReady() {
+        XCTAssertTrue(restart())
+    }
+
+    /// The regression proper.
+    func testTheMasterToggleVetoesTheRestart() {
+        XCTAssertFalse(restart(listening: false))
+    }
+
+    /// And it vetoes regardless of how favourable everything else is.
+    func testTheMasterToggleVetoesEvenWhenEveryOtherConditionIsPerfect() {
+        for silent in [true, false] {
+            for connected in [true, false] {
+                for muted in [true, false] {
+                    for already in [true, false] {
+                        XCTAssertFalse(restart(listening: false, silent: silent,
+                                               connected: connected, muted: muted, already: already),
+                                       "listening off must always win")
+                    }
+                }
+            }
+        }
+    }
+
+    func testPushToTalkSuppressesTheAlwaysOnListener() {
+        XCTAssertFalse(restart(silent: true))
+    }
+
+    func testDisconnectedGlassesDoNotHandTheListenerThePhoneMic() {
+        XCTAssertFalse(restart(connected: false))
+    }
+
+    func testMutedMicDoesNotRestart() {
+        XCTAssertFalse(restart(muted: true))
+    }
+
+    func testAlreadyListeningIsANoOp() {
+        XCTAssertFalse(restart(already: true))
+    }
+}

--- a/OpenGlassesTests/ToolResultImageTests.swift
+++ b/OpenGlassesTests/ToolResultImageTests.swift
@@ -1,0 +1,182 @@
+import XCTest
+@testable import OpenGlasses
+
+/// Issue 427 follow-up: a photo returned by a tool must reach the model as pixels.
+///
+/// `CapturePhotoTool`, `PhotoLogTool` and `MoneyIdentifierTool` emit
+/// `"[IMAGE_CAPTURED:<base64>] <text>"`, and until now **nothing parsed it** — every provider's
+/// tool loop appended the base64 as the tool message's text. Field trace (build 371):
+/// `toolRun succeeded tool=capture_photo characters=134076` followed 3 ms later by
+/// `requestSent count=4 bytes=239548 detail=textOnly`.
+final class ToolResultImageTests: XCTestCase {
+
+    /// Real JPEG-ish bytes; only the round-trip matters, not the pixels.
+    private let payload = Data([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46])
+    private var base64: String { payload.base64EncodedString() }
+
+    private func marked(_ trailing: String) -> String {
+        "[IMAGE_CAPTURED:\(base64)] \(trailing)"
+    }
+
+    // MARK: - extract
+
+    func testNoMarkerLeavesTheTextExactlyAsItCame() {
+        let result = ToolResultImage.extract(from: "Photo logged to the session (98 KB).")
+        XCTAssertEqual(result.text, "Photo logged to the session (98 KB).")
+        XCTAssertNil(result.image)
+    }
+
+    func testEmptyStringIsUntouched() {
+        let result = ToolResultImage.extract(from: "")
+        XCTAssertEqual(result.text, "")
+        XCTAssertNil(result.image)
+    }
+
+    func testMarkerAtStartYieldsTheImageAndTheTrailingText() {
+        let result = ToolResultImage.extract(from: marked("Photo captured successfully (98 KB). Analyze the image."))
+        XCTAssertEqual(result.image, payload)
+        XCTAssertEqual(result.text, "Photo captured successfully (98 KB). Analyze the image.")
+        XCTAssertFalse(result.text.contains(base64), "the base64 must never survive into the text")
+    }
+
+    func testMarkerWithNoTrailingTextYieldsEmptyText() {
+        let result = ToolResultImage.extract(from: "[IMAGE_CAPTURED:\(base64)]")
+        XCTAssertEqual(result.image, payload)
+        XCTAssertEqual(result.text, "")
+    }
+
+    func testMarkerInTheMiddleIsStrippedAndTheSurroundingTextIsJoined() {
+        let result = ToolResultImage.extract(from: "Before [IMAGE_CAPTURED:\(base64)] after")
+        XCTAssertEqual(result.image, payload)
+        XCTAssertEqual(result.text, "Before  after".trimmingCharacters(in: .whitespacesAndNewlines))
+        XCTAssertFalse(result.text.contains("IMAGE_CAPTURED"))
+    }
+
+    /// Only one image can ride a tool result in any of the provider shapes, so the first wins —
+    /// but the others must not vanish without a word.
+    func testMultipleMarkersTakeTheFirstStripAllAndSaySo() {
+        let second = Data([0x01, 0x02, 0x03]).base64EncodedString()
+        let result = ToolResultImage.extract(
+            from: "[IMAGE_CAPTURED:\(base64)] middle [IMAGE_CAPTURED:\(second)] end")
+        XCTAssertEqual(result.image, payload, "the first decodable image is the one attached")
+        XCTAssertFalse(result.text.contains("IMAGE_CAPTURED"), "every marker is stripped")
+        XCTAssertTrue(result.text.contains(ToolResultImage.extraImagesNote))
+        XCTAssertTrue(result.text.contains("middle"))
+        XCTAssertTrue(result.text.contains("end"))
+    }
+
+    /// A payload that is not base64 is not known to be an image. Mangling the message would lose
+    /// whatever the tool actually said, so the text comes back byte-for-byte.
+    func testMalformedBase64LeavesTheTextAlone() {
+        let original = "[IMAGE_CAPTURED:!!!not base64!!!] Photo captured."
+        let result = ToolResultImage.extract(from: original)
+        XCTAssertNil(result.image)
+        XCTAssertEqual(result.text, original)
+    }
+
+    func testUnterminatedMarkerLeavesTheTextAlone() {
+        let original = "[IMAGE_CAPTURED:\(base64) never closed"
+        let result = ToolResultImage.extract(from: original)
+        XCTAssertNil(result.image)
+        XCTAssertEqual(result.text, original)
+    }
+
+    func testEmptyPayloadIsNotAnImage() {
+        let original = "[IMAGE_CAPTURED:] Photo captured."
+        let result = ToolResultImage.extract(from: original)
+        XCTAssertNil(result.image)
+        XCTAssertEqual(result.text, original)
+    }
+
+    /// The exact strings the three emitters produce today.
+    func testTheShippedEmitterFormatsAllRoundTrip() {
+        let cases = [
+            "[IMAGE_CAPTURED:\(base64)] Photo captured successfully (98 KB). Analyze the image to respond to the user.",
+            "[IMAGE_CAPTURED:\(base64)] Photo logged to the session (98 KB). Analyze the image to read any values, then continue.",
+            "[IMAGE_CAPTURED:\(base64)] Identify the denomination of the banknote.",
+        ]
+        for text in cases {
+            let result = ToolResultImage.extract(from: text)
+            XCTAssertEqual(result.image, payload, text)
+            XCTAssertFalse(result.text.isEmpty, "the instruction text must survive: \(text)")
+            XCTAssertFalse(result.text.contains(base64))
+        }
+    }
+
+    // MARK: - vision disabled
+
+    func testVisionDisabledNoteReplacesTheImageWithoutResendingBase64() {
+        let split = ToolResultImage.extract(from: marked("Photo captured successfully (98 KB)."))
+        let omitted = ToolResultImage.textWithImageOmitted(split.text)
+        XCTAssertTrue(omitted.contains("Photo captured successfully (98 KB)."))
+        XCTAssertTrue(omitted.contains(ToolResultImage.visionDisabledNote))
+        XCTAssertFalse(omitted.contains(base64), "the whole point: never send the image as text")
+    }
+
+    // MARK: - historyCarriesImage
+
+    func testHistoryCarriesImageRecognisesEveryProviderShape() {
+        let anthropic: [[String: Any]] = [["role": "user", "content": [
+            ["type": "text", "text": "hi"],
+            ["type": "image", "source": ["type": "base64", "media_type": "image/jpeg", "data": base64]],
+        ]]]
+        let openAI: [[String: Any]] = [["role": "user", "content": [
+            ["type": "text", "text": "hi"],
+            ["type": "image_url", "image_url": ["url": "data:image/jpeg;base64,\(base64)"]],
+        ]]]
+        let gemini: [[String: Any]] = [["role": "user", "parts": [
+            ["text": "hi"],
+            ["inlineData": ["mimeType": "image/jpeg", "data": base64]],
+        ]]]
+
+        XCTAssertTrue(ToolResultImage.historyCarriesImage(anthropic))
+        XCTAssertTrue(ToolResultImage.historyCarriesImage(openAI))
+        XCTAssertTrue(ToolResultImage.historyCarriesImage(gemini))
+    }
+
+    func testHistoryCarriesImageIsFalseForPlainText() {
+        let plain: [[String: Any]] = [
+            ["role": "system", "content": "sys"],
+            ["role": "user", "content": "what am I looking at"],
+            ["role": "tool", "tool_call_id": "c1", "content": "Photo captured successfully."],
+        ]
+        XCTAssertFalse(ToolResultImage.historyCarriesImage(plain))
+    }
+
+    /// The bug in one assertion: base64 sitting in a tool message's *text* is not an image, and
+    /// must not be reported as one.
+    func testBase64InToolTextIsNotCountedAsAnImage() {
+        let smuggled: [[String: Any]] = [
+            ["role": "tool", "tool_call_id": "c1", "content": marked("Photo captured.")],
+        ]
+        XCTAssertFalse(ToolResultImage.historyCarriesImage(smuggled))
+    }
+
+    // MARK: - pruning compatibility
+
+    /// Tool images must age out of the history exactly like user images, or every later turn
+    /// re-uploads the photo. `pruneImages` keys off the same three shapes this attaches.
+    func testEveryAttachedShapeIsPrunedByHistoryHygiene() {
+        func history(_ imageBlock: [String: Any], key: String) -> [[String: Any]] {
+            let older: [String: Any] = ["role": "user", key: [["type": "text", "text": "old"], imageBlock]]
+            let newer: [String: Any] = ["role": "user", key: [["type": "text", "text": "new"], imageBlock]]
+            return [older, newer]
+        }
+
+        let shapes: [(String, [String: Any], String)] = [
+            ("anthropic", ["type": "image",
+                           "source": ["type": "base64", "media_type": "image/jpeg", "data": base64]], "content"),
+            ("openAI", ["type": "image_url",
+                        "image_url": ["url": "data:image/jpeg;base64,\(base64)"]], "content"),
+            ("gemini", ["inlineData": ["mimeType": "image/jpeg", "data": base64]], "parts"),
+        ]
+
+        for (label, block, key) in shapes {
+            let pruned = HistoryHygiene.pruneImages(history(block, key: key), keepLast: 1)
+            XCTAssertFalse(ToolResultImage.historyCarriesImage([pruned[0]]),
+                           "\(label): the older image must be pruned")
+            XCTAssertTrue(ToolResultImage.historyCarriesImage([pruned[1]]),
+                          "\(label): the newest image must be kept")
+        }
+    }
+}

--- a/project.base.yml
+++ b/project.base.yml
@@ -142,7 +142,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "371"
+        CURRENT_PROJECT_VERSION: "372"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -259,7 +259,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "371"
+        CURRENT_PROJECT_VERSION: "372"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -297,7 +297,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "371"
+        CURRENT_PROJECT_VERSION: "372"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "371"
+        CURRENT_PROJECT_VERSION: "372"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "371"
+        CURRENT_PROJECT_VERSION: "372"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
Follow-up to #430 / #427, from the reporter's build-371 log. Capture-by-voice now works end to end (Grok emitted `capture_photo`, 278 KB photo captured and saved), and two things went wrong after it.

## Tool photos never reached the model as an image

`capture_photo`, `photo_log` and `money_identifier` all return `"[IMAGE_CAPTURED:<base64>] <text>"`. Nothing parsed that marker, so all four provider tool loops sent ~134k characters of base64 as the tool message's **text**. The model got a transcript of an image it could not see, and the request logged `textOnly` (`toolRun succeeded characters=134076` → `requestSent bytes=239548 detail=textOnly`).

- New pure `ToolResultImage` splits the marker out (first image decoded; undecodable payload leaves the text untouched; multiple markers noted).
- Each loop attaches the bytes in its provider's shape: inside the `tool_result` for Anthropic; a following `user` turn with `image_url` for the OpenAI-compatible and ChatGPT paths (OpenAI `tool` messages cannot carry image parts); a `user` part with `inlineData` for Gemini.
- Vision off: the base64 is dropped and the model is told `(image omitted: vision is disabled for this model)`.
- The image shapes are the same three `HistoryHygiene` prunes on, so a stale tool photo ages out like a stale user photo (pinned by test).
- `requestSent` now reports `withImage` when any message carries an image part, not only the user turn.

## A switched-off listening toggle stranded the conversation

The finish stage's "listening disabled" guard returned without closing the conversation. `inConversation` stayed true, so every later wake word was dropped as `alreadyProcessing` until a force-quit (`tts finished; listenerSkippedDisabled` … `wakeWord detected; alreadyProcessing`). `FinishStagePolicy` maps that state to ending the conversation via `returnToWakeWord()`, which already re-checks the toggle before touching the microphone.

## The toggle was enforced inconsistently

The foreground restart and `WakeWordService`'s own route-change, interruption-ended and `resumeListening` restarts ignored the master toggle, which is how a wake word was heard with listening off (`becameActive; routeChanged reconfigure; engineReused; listenerStarted; wakeWord detected`). `WakeAutoRestartPolicy` is now the one place the rule lives; the service consults an injected `shouldAutoRestart` before any restart it initiates itself.

Related: the Control widget read the listening key with a `false` default while the app defaults to `true`, so a fresh install rendered the control as off and a press from that state wrote a real `false` into the App Group. The widget now uses the app's default. (The intents still write `UserDefaults.standard` before the App Group; left as is, separate change.)

## Verification

- Full `OpenGlassesTests` bundle: 4688 tests, 0 failures, 9 environment-gated skips. New: `ToolResultImageTests` (15), `ListeningPolicyTests` (`FinishStagePolicy` 5, `WakeAutoRestartPolicy` 9), plus a `WakeWordHardeningTests` case.
- Release build (`-configuration Release`, generic iOS) succeeded. `Localizable.xcstrings` untouched. Build bumped to 372.
- Not covered end to end: the four loop wirings are verified by inspection and shape-contract tests, not through a stubbed provider round-trip.
- Test-run note: `-collect-test-diagnostics never` removed the 600 s post-pass simulator stall entirely (full bundle 103 s wall clock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
