### PR TITLE
Email the job report to a contact by name

### DIFF
--- a/OpenGlasses/Info.plist
+++ b/OpenGlasses/Info.plist
@@ -143,7 +143,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>OpenGlasses needs camera access to capture photos and video for the AI to analyze.</string>
 	<key>NSContactsUsageDescription</key>
-	<string>OpenGlasses looks up contacts so you can make calls and send messages by name through your glasses.</string>
+	<string>OpenGlasses looks up contacts so you can make calls, send messages and address email by name through your glasses.</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>OpenGlasses reads your health data (steps, workouts) to report fitness activity through your glasses. If you turn on "Share Health Data with AI" in Settings, your workout history may also be sent to your chosen AI provider so the fitness coach can discuss it; it stays on-device otherwise.</string>
 	<key>NSHealthUpdateUsageDescription</key>

--- a/OpenGlasses/Sources/Services/NativeTools/ContactLookupHelper.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/ContactLookupHelper.swift
@@ -1,14 +1,20 @@
 import Foundation
 import Contacts
 
-/// Shared helper for resolving contact names to phone numbers.
-/// Used by SendMessageTool, PhoneCallTool, and ContactsTool.
+/// Shared helper for resolving contact names to phone numbers and email addresses.
+/// Used by SendMessageTool, PhoneCallTool, ContactsTool and DeliverReportTool.
 enum ContactLookupHelper {
 
     struct ResolvedContact {
         let name: String
         let phoneNumber: String
         let phoneLabel: String
+    }
+
+    struct ResolvedEmail: Equatable {
+        let name: String
+        let address: String
+        let label: String
     }
 
     /// Returns true if the string looks like a phone number (mostly digits/+)
@@ -21,32 +27,8 @@ enum ContactLookupHelper {
     /// Look up a contact by name and return matching contacts with phone numbers.
     /// Returns empty array if no match or contacts access denied.
     static func resolve(name: String) -> [ResolvedContact] {
-        let store = CNContactStore()
-
-        // Check access synchronously (already granted by this point in most cases)
-        let status = CNContactStore.authorizationStatus(for: .contacts)
-        guard status == .authorized else { return [] }
-
-        let keysToFetch: [CNKeyDescriptor] = [
-            CNContactGivenNameKey as CNKeyDescriptor,
-            CNContactFamilyNameKey as CNKeyDescriptor,
-            CNContactNicknameKey as CNKeyDescriptor,
-            CNContactPhoneNumbersKey as CNKeyDescriptor,
-        ]
-
-        let predicate = CNContact.predicateForContacts(matchingName: name)
-
-        guard let contacts = try? store.unifiedContacts(matching: predicate, keysToFetch: keysToFetch) else {
-            return []
-        }
-
         var results: [ResolvedContact] = []
-        for contact in contacts {
-            let fullName = [contact.givenName, contact.familyName]
-                .filter { !$0.isEmpty }
-                .joined(separator: " ")
-            let displayName = fullName.isEmpty ? name : fullName
-
+        forEachMatch(name: name) { contact, displayName in
             for phone in contact.phoneNumbers {
                 let label = CNLabeledValue<CNPhoneNumber>.localizedString(forLabel: phone.label ?? "")
                 results.append(ResolvedContact(
@@ -56,7 +38,76 @@ enum ContactLookupHelper {
                 ))
             }
         }
-
         return results
+    }
+
+    /// Look up a contact by name and return matching contacts with email addresses.
+    /// Returns empty array if no match or contacts access denied.
+    static func resolveEmails(name: String) -> [ResolvedEmail] {
+        var results: [ResolvedEmail] = []
+        forEachMatch(name: name) { contact, displayName in
+            for email in contact.emailAddresses {
+                let address = (email.value as String).trimmingCharacters(in: .whitespaces)
+                guard !address.isEmpty else { continue }
+                let label = CNLabeledValue<NSString>.localizedString(forLabel: email.label ?? "")
+                results.append(ResolvedEmail(name: displayName, address: address, label: label))
+            }
+        }
+        return results
+    }
+
+    /// Which contact a set of matches actually points at.
+    ///
+    /// One person with a home and a work address is still one person — the composer shows the
+    /// address before anybody taps Send, so picking the first is a choice the technician can see
+    /// and correct. Two people who answer to the same spoken name is a different problem, and the
+    /// only safe answer there is to ask.
+    enum EmailPick: Equatable {
+        case none
+        case one(ResolvedEmail)
+        case ambiguous(names: [String])
+    }
+
+    static func pickEmail(from matches: [ResolvedEmail]) -> EmailPick {
+        guard let first = matches.first else { return .none }
+
+        var distinctNames: [String] = []
+        var seen: Set<String> = []
+        for match in matches where seen.insert(match.name.lowercased()).inserted {
+            distinctNames.append(match.name)
+        }
+
+        return distinctNames.count == 1 ? .one(first) : .ambiguous(names: distinctNames)
+    }
+
+    // MARK: - The one fetch both paths share
+
+    /// The single trip to Contacts: authorization, keys, name predicate and the display name every
+    /// caller assembles the same way. Not authorized means no matches, not an error — the tools
+    /// above phrase that as "no contact I can use" rather than leaking the permission state.
+    private static func forEachMatch(name: String, body: (CNContact, String) -> Void) {
+        let status = CNContactStore.authorizationStatus(for: .contacts)
+        guard status == .authorized else { return }
+
+        let store = CNContactStore()
+        let keysToFetch: [CNKeyDescriptor] = [
+            CNContactGivenNameKey as CNKeyDescriptor,
+            CNContactFamilyNameKey as CNKeyDescriptor,
+            CNContactNicknameKey as CNKeyDescriptor,
+            CNContactPhoneNumbersKey as CNKeyDescriptor,
+            CNContactEmailAddressesKey as CNKeyDescriptor,
+        ]
+        let predicate = CNContact.predicateForContacts(matchingName: name)
+
+        guard let contacts = try? store.unifiedContacts(matching: predicate, keysToFetch: keysToFetch) else {
+            return
+        }
+
+        for contact in contacts {
+            let fullName = [contact.givenName, contact.familyName]
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+            body(contact, fullName.isEmpty ? name : fullName)
+        }
     }
 }

--- a/OpenGlasses/Sources/Services/NativeTools/DeliverReportTool.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/DeliverReportTool.swift
@@ -43,17 +43,23 @@ final class DeliverReportTool: NativeTool {
     private let injectedSession: FieldSessionService?
     /// The delivery rules in force. Injectable so a test does not depend on this device's settings.
     private let settings: () -> DeliverySettings
-    /// Contact-name → address resolution. Injected so a headless test never touches Contacts.
+    /// Contact-name → phone number resolution. Injected so a headless test never touches Contacts.
     private let resolveContact: (String) -> [String]
+    /// Contact-name → email resolution. Injected for the same reason.
+    private let resolveEmail: (String) -> [ContactLookupHelper.ResolvedEmail]
 
     init(sessionService: FieldSessionService? = nil,
          settings: @escaping () -> DeliverySettings = { DeliverySettings.load() },
          resolveContact: @escaping (String) -> [String] = { name in
              ContactLookupHelper.resolve(name: name).map(\.phoneNumber)
+         },
+         resolveEmail: @escaping (String) -> [ContactLookupHelper.ResolvedEmail] = { name in
+             ContactLookupHelper.resolveEmails(name: name)
          }) {
         self.injectedSession = sessionService
         self.settings = settings
         self.resolveContact = resolveContact
+        self.resolveEmail = resolveEmail
     }
 
     private var session: FieldSessionService { injectedSession ?? .shared }
@@ -95,11 +101,11 @@ final class DeliverReportTool: NativeTool {
 
     /// What the technician said turned into an address this channel can use.
     ///
-    /// A name only becomes a number through the contact lookup the messaging tools already use.
-    /// Email is different and deliberately so: Contacts is asked for phone numbers here, so a name
-    /// cannot become an email address — the tool says that plainly rather than guessing an address,
-    /// which is the one mistake in this whole flow nobody would notice until the wrong person had
-    /// the customer's job record.
+    /// A name becomes a number — or an address — through the contact lookup the messaging tools
+    /// already use. Either way the tool never invents a recipient: a name Contacts does not know,
+    /// or one that fits two people, gets a question rather than a guess, because the wrong inbox is
+    /// the one mistake in this whole flow nobody would notice until the wrong person had the
+    /// customer's job record.
     private func resolve(spoken raw: String?, for channel: DeliveryChannel) -> RecipientResolution {
         let wanted = (raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !wanted.isEmpty else { return .resolved([]) }
@@ -109,11 +115,16 @@ final class DeliverReportTool: NativeTool {
             // Neither takes a recipient; naming one is not an error, it is simply not used.
             return .resolved([])
         case .email:
-            guard wanted.contains("@") else {
-                return .refused("I can only address an email to an address, and '\(wanted)' isn't one. "
+            if wanted.contains("@") { return .resolved([wanted]) }
+            switch ContactLookupHelper.pickEmail(from: resolveEmail(wanted)) {
+            case .one(let match):
+                return .resolved([match.address])
+            case .none:
+                return .refused("No contact matching '\(wanted)' has an email address I can use. "
                                 + "Say the address, or set the office address in Settings → Field Assist → Job reports.")
+            case .ambiguous(let names):
+                return .refused("'\(wanted)' could be \(Self.orList(names)). Say which one, or say the address.")
             }
-            return .resolved([wanted])
         case .messages, .whatsapp, .telegram:
             if ContactLookupHelper.isPhoneNumber(wanted) { return .resolved([wanted]) }
             let matches = resolveContact(wanted)
@@ -123,6 +134,12 @@ final class DeliverReportTool: NativeTool {
             }
             return .resolved([first])
         }
+    }
+
+    /// Names read back the way a person would say them: "Dave Smith or Dave Jones".
+    private static func orList(_ names: [String]) -> String {
+        guard let last = names.last, names.count > 1 else { return names.first ?? "" }
+        return names.dropLast().joined(separator: ", ") + " or " + last
     }
 
     /// An address this channel can use, or the sentence explaining why there is none.

--- a/OpenGlassesTests/ContactLookupHelperTests.swift
+++ b/OpenGlassesTests/ContactLookupHelperTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import OpenGlasses
+
+/// The part of contact resolution that decides, kept away from the part that reads Contacts.
+///
+/// `pickEmail` is pure by design: no `CNContactStore` is touched here, so the rule about which
+/// match a spoken name actually points at can be pinned headlessly.
+final class ContactLookupHelperTests: XCTestCase {
+
+    private func email(_ name: String, _ address: String, _ label: String = "work") -> ContactLookupHelper.ResolvedEmail {
+        ContactLookupHelper.ResolvedEmail(name: name, address: address, label: label)
+    }
+
+    func testANameNobodyAnswersToPicksNothing() {
+        XCTAssertEqual(ContactLookupHelper.pickEmail(from: []), .none)
+    }
+
+    func testOnePersonWithTwoAddressesIsStillOnePerson() {
+        let matches = [email("Dave Smith", "dave@work.example", "work"),
+                       email("Dave Smith", "dave@home.example", "home")]
+        XCTAssertEqual(ContactLookupHelper.pickEmail(from: matches), .one(matches[0]))
+    }
+
+    func testTheSameNameOnTwoPeopleIsAmbiguousAndNamesThemInTheOrderTheyWereFound() {
+        let matches = [email("Dave Smith", "dave@work.example"),
+                       email("Dave Jones", "djones@work.example"),
+                       email("Dave Smith", "dave@home.example")]
+        XCTAssertEqual(ContactLookupHelper.pickEmail(from: matches),
+                       .ambiguous(names: ["Dave Smith", "Dave Jones"]))
+    }
+
+    func testTheSameNameSpelledWithDifferentCaseIsTheSamePerson() {
+        let matches = [email("Dave Smith", "dave@work.example"),
+                       email("dave smith", "dave@home.example")]
+        XCTAssertEqual(ContactLookupHelper.pickEmail(from: matches), .one(matches[0]))
+    }
+}

--- a/OpenGlassesTests/DeliveryTests.swift
+++ b/OpenGlassesTests/DeliveryTests.swift
@@ -346,10 +346,52 @@ final class DeliveryTests: XCTestCase {
 
     func testTheToolWillNotGuessAnEmailAddressFromAName() async throws {
         let service = try liveSession()
-        let tool = DeliverReportTool(sessionService: service, settings: { self.settings() })
+        let tool = DeliverReportTool(sessionService: service, settings: { self.settings() },
+                                     resolveEmail: { _ in [] })
         let reply = try await tool.execute(args: ["channel": "email", "to": "Dave"])
-        XCTAssertTrue(reply.contains("isn't one"), reply)
-        XCTAssertNil(service.stagedDelivery)
+        XCTAssertTrue(reply.contains("has an email address I can use"), reply)
+        XCTAssertNil(service.stagedDelivery, "a name nobody can address stages nothing")
+    }
+
+    func testTheToolEmailsTheContactWhoseNameTheTechnicianSaid() async throws {
+        let service = try liveSession()
+        let tool = DeliverReportTool(sessionService: service, settings: { self.settings() },
+                                     resolveEmail: { name in
+                                         name.lowercased() == "dave"
+                                             ? [.init(name: "Dave Smith", address: "dave@example.com", label: "work")]
+                                             : []
+                                     })
+
+        let reply = try await tool.execute(args: ["channel": "email", "to": "Dave"])
+        XCTAssertEqual(service.stagedDelivery?.channel, .email)
+        XCTAssertEqual(service.stagedDelivery?.recipients, ["dave@example.com"])
+        XCTAssertTrue(reply.contains("dave@example.com"), reply)
+    }
+
+    func testTheToolAsksWhichDaveWhenTheNameFitsTwoPeople() async throws {
+        let service = try liveSession()
+        let tool = DeliverReportTool(sessionService: service, settings: { self.settings() },
+                                     resolveEmail: { _ in
+                                         [.init(name: "Dave Smith", address: "dave@example.com", label: "work"),
+                                          .init(name: "Dave Jones", address: "djones@example.com", label: "home")]
+                                     })
+
+        let reply = try await tool.execute(args: ["channel": "email", "to": "Dave"])
+        XCTAssertTrue(reply.contains("Dave Smith"), reply)
+        XCTAssertTrue(reply.contains("Dave Jones"), reply)
+        XCTAssertNil(service.stagedDelivery, "an ambiguous name stages nothing")
+    }
+
+    func testAnEmailAddressSpokenOutrightNeverReachesTheContactLookup() async throws {
+        let service = try liveSession()
+        let tool = DeliverReportTool(sessionService: service, settings: { self.settings() },
+                                     resolveEmail: { name in
+                                         XCTFail("an address is already an address: \(name)")
+                                         return []
+                                     })
+
+        _ = try await tool.execute(args: ["channel": "email", "to": "site@example.com"])
+        XCTAssertEqual(service.stagedDelivery?.recipients, ["site@example.com"])
     }
 
     func testTheToolNeedsASessionAndSaysSo() async throws {

--- a/docs/plans/EM-work-record-and-parts.md
+++ b/docs/plans/EM-work-record-and-parts.md
@@ -265,10 +265,13 @@ A phone with no Mail account, or an iPad with no SMS, has the same problem. `Rep
 resolves the channel against what the device can actually do and falls back to the share sheet with
 both files, saying so out loud — a composer that cannot appear is worse than a different route.
 
-**A name cannot become an email address here.** `ContactLookupHelper` returns phone numbers, which
-is all `send_via` ever needed. So a spoken contact resolves for Messages/WhatsApp/Telegram and an
-email needs an actual address; the tool says that rather than guessing, because the wrong inbox is
-the one mistake in this flow nobody would notice until the customer's job record was in it.
+**A name can become an email address, but only an unambiguous one.** `ContactLookupHelper` now
+returns email addresses alongside phone numbers, so a spoken contact resolves for email as well as
+Messages/WhatsApp/Telegram. One contact — home and work addresses included, since the composer
+shows the address before anybody taps Send — is used. A name Contacts has no address for, or one
+that fits two people, still asks for the address and names the candidates rather than guessing,
+because the wrong inbox is the one mistake in this flow nobody would notice until the customer's
+job record was in it.
 
 **The bearer token is absent from `DeliverySettings` by construction, not by discipline.** Its
 `CodingKeys` omit it, so it cannot reach the stored blob, a future exported organisation profile,

--- a/project.base.yml
+++ b/project.base.yml
@@ -142,7 +142,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "372"
+        CURRENT_PROJECT_VERSION: "373"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -259,7 +259,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "372"
+        CURRENT_PROJECT_VERSION: "373"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -297,7 +297,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "372"
+        CURRENT_PROJECT_VERSION: "373"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "372"
+        CURRENT_PROJECT_VERSION: "373"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "372"
+        CURRENT_PROJECT_VERSION: "373"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
Saying "email the job report to Dave" used to be refused: the contact lookup returned phone
numbers, so a name could become a text-message recipient but never an email address. It can now.

**What changed**

- `ContactLookupHelper` gained `resolveEmails(name:)` and `ResolvedEmail`, reading
  `CNContactEmailAddressesKey` alongside the phone numbers. Both paths now go through one private
  fetch, so the authorization guard, the keys, the name predicate and the display-name assembly are
  written once. `resolve(name:)` and `ResolvedContact` are untouched — `SendMessageTool`,
  `PhoneCallTool` and `SendEmailTool` see no change.
- A pure `pickEmail(from:)` decides which contact a spoken name points at, so the rule is testable
  without touching a contacts database.
- `DeliverReportTool` takes an injected `resolveEmail` closure the same way it already takes
  `resolveContact`, and uses it for the email channel.

**What it refuses, and how**

- A `to` containing "@" is used as-is and the lookup is never consulted.
- One contact — including a person with both a home and a work address, since the composer shows
  the address before anybody taps Send — is used.
- No contact with an address: *"No contact matching 'Dave' has an email address I can use. Say the
  address, or set the office address in Settings → Field Assist → Job reports."* Nothing is staged.
- Two people answering to the name: *"'Dave' could be Dave Smith or Dave Jones. Say which one, or
  say the address."* Nothing is staged.

`NSContactsUsageDescription` now mentions addressing email by name, and the plan's note on why a
name could not become an address is amended in place. `PrivacyInfo.xcprivacy` is unchanged —
Contacts is not a required-reason API and the app already read it.

**Gates**

- Debug `OpenGlassesTests` on the iPhone 17 Pro simulator: `** TEST SUCCEEDED **` —
  `Executed 4777 tests, with 13 tests skipped and 0 failures (0 unexpected) in 39.805 seconds`.
  The four new delivery tests and the four new `ContactLookupHelperTests` all pass.
- Release build on the same destination: `** BUILD SUCCEEDED **`.
- No compiler warnings on either touched source file; no `.xcstrings` churn left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
