### PR TITLE
Give the recall coordinator ten seconds to come up in tests

### DIFF
--- a/OpenGlassesTests/ConversationRecallCoordinatorTests.swift
+++ b/OpenGlassesTests/ConversationRecallCoordinatorTests.swift
@@ -28,7 +28,8 @@ final class ConversationRecallCoordinatorTests: XCTestCase {
     }
 
     private func waitUntilReady(_ coordinator: ConversationRecallCoordinator) async {
-        for _ in 0..<200 {
+        // Ten seconds is a ceiling, not a race: a loaded CI runner once took more than a second to bring the coordinator up.
+        for _ in 0..<2000 {
             if case .ready = coordinator.state { return }
             try? await Task.sleep(nanoseconds: 5_000_000)
         }
@@ -37,7 +38,8 @@ final class ConversationRecallCoordinatorTests: XCTestCase {
 
     private func waitUntil(_ predicate: @escaping () -> Bool,
                            failure: String) async {
-        for _ in 0..<200 {
+        // Ten seconds is a ceiling, not a race: a loaded CI runner once took more than a second to bring the coordinator up.
+        for _ in 0..<2000 {
             if predicate() { return }
             try? await Task.sleep(nanoseconds: 5_000_000)
         }

--- a/OpenGlassesTests/MemoryRecallServiceTests.swift
+++ b/OpenGlassesTests/MemoryRecallServiceTests.swift
@@ -29,7 +29,8 @@ final class MemoryRecallServiceTests: XCTestCase {
     }
 
     private func waitUntilReady(_ coordinator: ConversationRecallCoordinator) async {
-        for _ in 0..<200 {
+        // Ten seconds is a ceiling, not a race: a loaded CI runner once took more than a second to bring the coordinator up.
+        for _ in 0..<2000 {
             if case .ready = coordinator.state { return }
             try? await Task.sleep(nanoseconds: 5_000_000)
         }


### PR DESCRIPTION
## What failed

The "Unit Tests" run on main (f0e653d) failed in `OpenGlassesTests/ConversationRecallCoordinatorTests.swift`:

```
:35: error: -[… testFailedConversationSaveDoesNotReachProjection] : failed - Recall coordinator did not become ready
:216: error: -[… testFailedConversationSaveDoesNotReachProjection] : failed - Expected ready search
```

## Why one second was a race

Line 35 is the `waitUntilReady(_:)` helper: 200 iterations of a 5 ms sleep, so a one-second budget for the coordinator to reach `.ready`. That run took 88 seconds for the whole suite against 42 seconds locally, and the same test passed on the two previous main runs — the coordinator's start-up simply exceeded a second on a loaded runner. Nothing about the coordinator changed; the budget was just too tight to be a ceiling.

## What changed

All three readiness loops (the two in `ConversationRecallCoordinatorTests` — `waitUntilReady` and `waitUntil(_:failure:)` — and the identical `waitUntilReady` in `MemoryRecallServiceTests`) go from 200 to 2000 iterations of the same 5 ms poll: a ten-second ceiling. Each loop returns the moment the state is ready, so the passing case is exactly as fast as before. A one-line comment in each records why.

No build number bump: this is a test-only change, deliberately left off the build counter.

## Test plan

- `ConversationRecallCoordinatorTests` and `MemoryRecallServiceTests` green locally on iPhone 17 Pro (iOS Simulator): `Executed 17 tests, with 0 failures`. The full suite is not needed for a test-timeout change.
- The CI run on this PR is the real check — it exercises the same loaded-runner conditions that produced the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)