### PR TITLE
Keep conflict baselines across relaunch, and stop a conflict moving them

### DIFF
--- a/OpenGlasses/Sources/Services/Offline/ConflictResolver.swift
+++ b/OpenGlasses/Sources/Services/Offline/ConflictResolver.swift
@@ -6,32 +6,71 @@ enum ConflictDecision: Equatable {
     case conflict(reason: String)  // server advanced while we were offline — surface it
 }
 
+/// Where a `ConflictResolver` keeps its per-session baselines. Small on purpose: the resolver reads
+/// through it on every call, so there is no cached copy that can drift from what's on disk.
+@MainActor
+protocol ConflictBaselineStore: AnyObject {
+    func baseline(for sessionId: String) -> Int?
+    func setBaseline(_ version: Int, for sessionId: String)
+}
+
+/// Non-durable baselines — the default, and all a unit test or a single flush needs.
+@MainActor
+final class InMemoryConflictBaselineStore: ConflictBaselineStore {
+    private var versions: [String: Int] = [:]
+
+    func baseline(for sessionId: String) -> Int? { versions[sessionId] }
+
+    func setBaseline(_ version: Int, for sessionId: String) { versions[sessionId] = version }
+}
+
 /// Single-writer conflict detection (Plan T), reduced from the vector-clock idea to a per-session
 /// version counter. The technician's device is the only writer in v1; the only "conflict" is the
 /// server having moved on (e.g. tasks reassigned, a procedure version bumped) while the device was
 /// offline. Pure and deterministic — a real networked `SyncSink` consults this; v1's local sink
 /// doesn't need it. Multi-writer reconciliation is explicitly out of scope.
+///
+/// Two properties the callers depend on:
+/// - **The baseline outlives the process.** Backed by `OfflineQueue`, it lives in the queue's own
+///   SQLite file, beside the ops it gates, so a relaunch mid-outage doesn't reset every session to
+///   version 0 and manufacture (or miss) conflicts on the first flush after restart.
+/// - **A conflict never advances the baseline.** Every later op in the same session keeps comparing
+///   against the version the device actually synced to, so a flush surfaces all of the affected ops
+///   instead of silently last-writer-wins-ing everything after the first. Adoption is an explicit,
+///   separate step: `acknowledge(serverVersion:for:)`, called once the wearer has seen the conflict
+///   and resolved it.
+@MainActor
 final class ConflictResolver {
-    /// The last server version this device knew about, per session.
-    private var knownVersion: [String: Int] = [:]
+    private let store: ConflictBaselineStore
+
+    /// `nil` gets the non-durable default (a default *argument* can't build one — it would be
+    /// evaluated outside the main actor). Pass `OfflineQueue` for baselines that survive a relaunch.
+    init(store: ConflictBaselineStore? = nil) {
+        self.store = store ?? InMemoryConflictBaselineStore()
+    }
 
     /// Record the server version the device last synced to for a session.
     func setKnownVersion(_ version: Int, for sessionId: String) {
-        knownVersion[sessionId] = version
+        store.setBaseline(version, for: sessionId)
     }
 
     func knownVersion(for sessionId: String) -> Int {
-        knownVersion[sessionId] ?? 0
+        store.baseline(for: sessionId) ?? 0
+    }
+
+    /// Adopt a server version the wearer has been shown — the resolution step after `resolve`
+    /// returned `.conflict`. This is the only way a conflicting version becomes the new baseline.
+    func acknowledge(serverVersion: Int, for sessionId: String) {
+        store.setBaseline(serverVersion, for: sessionId)
     }
 
     /// Decide an op against the server's current version for its session. If the server advanced
-    /// beyond what we knew, it's a conflict; otherwise accept (last-writer-wins) and adopt the
-    /// server version so subsequent ops in the same flush compare against the fresh baseline.
+    /// beyond what we knew, it's a conflict and the baseline stays put; otherwise accept
+    /// (last-writer-wins) and keep the baseline current.
     func resolve(op: QueuedOp, serverVersion: Int) -> ConflictDecision {
-        let known = knownVersion[op.sessionId] ?? 0
+        let known = knownVersion(for: op.sessionId)
         if serverVersion > known {
             let delta = serverVersion - known
-            setKnownVersion(serverVersion, for: op.sessionId)
             return .conflict(reason: "\(delta) change\(delta == 1 ? "" : "s") happened on the server while you were offline")
         }
         // Server is at or behind what we knew — our write wins; keep the baseline current.

--- a/OpenGlasses/Sources/Services/Offline/OfflineQueue.swift
+++ b/OpenGlasses/Sources/Services/Offline/OfflineQueue.swift
@@ -6,7 +6,7 @@ import SQLite3
 /// here synchronously, so a dropped connection mid-procedure never loses work. Ops are inserted
 /// once and only their `state`/`attempts` mutate; `done` rows are tombstones until `purgeDone`.
 @MainActor
-final class OfflineQueue {
+final class OfflineQueue: ConflictBaselineStore {
     private var db: OpaquePointer?
 
     /// `path` is injectable so tests can use a throwaway file (and reopen it to prove survival).
@@ -34,6 +34,12 @@ final class OfflineQueue {
         )
         """)
         exec("CREATE INDEX IF NOT EXISTS idx_ops_state ON ops(state)")
+        exec("""
+        CREATE TABLE IF NOT EXISTS conflict_baselines (
+            session_id TEXT PRIMARY KEY,
+            version INTEGER NOT NULL
+        )
+        """)
         recoverInFlight()
     }
 
@@ -153,6 +159,31 @@ final class OfflineQueue {
 
     var pendingCount: Int { count(where: "state = 'pending'") }
     var conflictCount: Int { count(where: "state = 'conflict'") }
+
+    // MARK: - Conflict baselines
+
+    /// Durable per-session sync baselines for `ConflictResolver`, kept in this same file so they
+    /// can't drift from the ops they gate — and so a relaunch mid-outage doesn't reset every
+    /// session to version 0 and manufacture conflicts on the first flush after restart.
+    func baseline(for sessionId: String) -> Int? {
+        var stmt: OpaquePointer?
+        let sql = "SELECT version FROM conflict_baselines WHERE session_id = ?"
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_finalize(stmt) }
+        bindText(stmt, 1, sessionId)
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
+        return Int(sqlite3_column_int(stmt, 0))
+    }
+
+    func setBaseline(_ version: Int, for sessionId: String) {
+        var stmt: OpaquePointer?
+        let sql = "INSERT OR REPLACE INTO conflict_baselines (session_id, version) VALUES (?, ?)"
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return }
+        defer { sqlite3_finalize(stmt) }
+        bindText(stmt, 1, sessionId)
+        sqlite3_bind_int(stmt, 2, Int32(version))
+        _ = sqlite3_step(stmt)
+    }
 
     // MARK: - SQLite plumbing
 

--- a/OpenGlassesTests/OfflineQueueTests.swift
+++ b/OpenGlassesTests/OfflineQueueTests.swift
@@ -296,7 +296,67 @@ final class OfflineQueueTests: XCTestCase {
         guard case .conflict = resolver.resolve(op: op("s", at: 2), serverVersion: 5) else {
             return XCTFail("server advance should conflict")
         }
-        XCTAssertEqual(resolver.knownVersion(for: "s"), 5)   // baseline adopted
+        XCTAssertEqual(resolver.knownVersion(for: "s"), 3, "a conflict must not move the baseline")
+    }
+
+    func testConflictDoesNotAdvanceBaselineForLaterOpsInTheSameFlush() {
+        // The whole point of surfacing a conflict: every later op in that session is measured
+        // against the version the device actually synced to, not the one that just conflicted.
+        let resolver = ConflictResolver()
+        resolver.setKnownVersion(3, for: "s")
+        let first = resolver.resolve(op: op("s", at: 1), serverVersion: 5)
+        let second = resolver.resolve(op: op("s", at: 2), serverVersion: 5)
+        guard case .conflict(let firstReason) = first, case .conflict(let secondReason) = second else {
+            return XCTFail("both ops in the flush should conflict")
+        }
+        XCTAssertEqual(firstReason, secondReason, "the delta is measured from the same baseline")
+        XCTAssertEqual(resolver.knownVersion(for: "s"), 3)
+    }
+
+    func testAcknowledgeAdoptsServerVersionAndUnblocksTheNextOp() {
+        let resolver = ConflictResolver()
+        resolver.setKnownVersion(3, for: "s")
+        guard case .conflict = resolver.resolve(op: op("s", at: 1), serverVersion: 5) else {
+            return XCTFail("server advance should conflict")
+        }
+        resolver.acknowledge(serverVersion: 5, for: "s")
+        XCTAssertEqual(resolver.knownVersion(for: "s"), 5)
+        XCTAssertEqual(resolver.resolve(op: op("s", at: 2), serverVersion: 5), .accept(newVersion: 5))
+    }
+
+    func testAcceptAdvancesBaselineAndOtherSessionsAreIndependent() {
+        let resolver = ConflictResolver()
+        XCTAssertEqual(resolver.knownVersion(for: "s"), 0, "in-memory default starts fresh")
+        XCTAssertEqual(resolver.resolve(op: op("s", at: 1), serverVersion: 0), .accept(newVersion: 0))
+        resolver.setKnownVersion(2, for: "s")
+        XCTAssertEqual(resolver.resolve(op: op("s", at: 2), serverVersion: 1), .accept(newVersion: 2),
+                       "a server behind us keeps our higher baseline")
+        XCTAssertEqual(resolver.knownVersion(for: "s"), 2)
+        guard case .conflict = resolver.resolve(op: op("other", at: 3), serverVersion: 1) else {
+            return XCTFail("a different session tracks its own baseline")
+        }
+        XCTAssertEqual(resolver.knownVersion(for: "s"), 2)
+    }
+
+    func testConflictBaselineSurvivesRestart() {
+        // Backed by the queue file, a relaunch mid-outage must not reset the session to version 0
+        // and manufacture a conflict on the first flush after restart.
+        let path = tempPath()
+        do {
+            let queue = OfflineQueue(path: path)
+            let resolver = ConflictResolver(store: queue)
+            resolver.setKnownVersion(4, for: "s")
+            XCTAssertEqual(resolver.resolve(op: op("s", at: 1), serverVersion: 7), .conflict(
+                reason: "3 changes happened on the server while you were offline"))
+            resolver.acknowledge(serverVersion: 7, for: "s")
+        }   // released → db closed
+
+        let reopened = OfflineQueue(path: path)
+        let resolver = ConflictResolver(store: reopened)
+        XCTAssertEqual(resolver.knownVersion(for: "s"), 7, "baseline persisted in the queue file")
+        XCTAssertEqual(resolver.resolve(op: op("s", at: 2), serverVersion: 7), .accept(newVersion: 7),
+                       "no spurious conflict on the first flush after relaunch")
+        XCTAssertEqual(resolver.knownVersion(for: "unseen"), 0)
     }
 }
 


### PR DESCRIPTION
## Defect

`ConflictResolver` (Plan T) had two latent bugs, both flagged in the 2026-07-10 review and re-verified in yesterday's plan audit as the top buildable item:

1. `resolve()` set the baseline to the server version **inside the `.conflict` branch**, so only the first op of a session surfaced as a conflict; every later op in the same flush compared against the already-advanced baseline and silently last-writer-won.
2. `knownVersion` was an in-memory dictionary, so a relaunch mid-outage reset every session to version 0 and the first flush after restart produced spurious conflicts (or missed real ones).

## Change

- A conflict no longer moves the baseline. Adoption is an explicit `acknowledge(serverVersion:for:)`, the step a resolution flow calls once the wearer has seen the conflict.
- Baselines go through a tiny `ConflictBaselineStore` seam. `OfflineQueue` conforms, backed by a new `conflict_baselines (session_id PRIMARY KEY, version)` table in the queue's own SQLite file, so the baseline lives beside the ops it gates. `InMemoryConflictBaselineStore` stays the default, so existing call sites and tests are untouched.
- The resolver reads through the store on every call; there is no cached copy to drift from disk.

No production consumer yet (`EndpointSyncSink` maps HTTP 409 itself); this is the named prerequisite for the peer sink that waits on Plan BL.

## Tests

`OfflineQueueTests`: the assertion that encoded the bug (`knownVersion == 5 // baseline adopted`) is inverted, plus four new cases: later ops in the same flush still conflict with the same delta; `acknowledge` unblocks the next op; accept still advances and sessions are independent; a baseline survives closing and reopening the queue file with no spurious conflict after "relaunch".

## Gates

| Gate | Result |
|---|---|
| `OfflineQueueTests` focused | 25 tests, 0 failures |
| Full suite (Debug, iPhone 17 Pro sim, Xcode-beta) | 4870 tests, 13 skipped, 0 failures |
| `xcodebuild build -configuration Release` | BUILD SUCCEEDED, 0 errors |

No build-number bump. Plan docs (T's status bullet, the index row, the roundup's §A1 row) are updated in #442 rather than here, to avoid a merge conflict between the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
