### PR TITLE
Bump the build number to 376

### DIFF
--- a/project.base.yml
+++ b/project.base.yml
@@ -142,7 +142,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "375"
+        CURRENT_PROJECT_VERSION: "376"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -259,7 +259,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.GlassesActivityWidget
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "375"
+        CURRENT_PROJECT_VERSION: "376"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -297,7 +297,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.ShareExtension
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "375"
+        CURRENT_PROJECT_VERSION: "376"
         SWIFT_VERSION: "5.9"
         SKIP_INSTALL: "YES"
         CODE_SIGN_STYLE: Automatic

--- a/project.watch.yml
+++ b/project.watch.yml
@@ -20,7 +20,7 @@ targets:
         # project.local.yml when rebranding, or Watch install fails.
         WK_COMPANION_APP_BUNDLE_IDENTIFIER: com.openglasses.app
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "375"
+        CURRENT_PROJECT_VERSION: "376"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: OpenGlassesWatch/Info.plist
@@ -52,7 +52,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.openglasses.app.watchkitapp.watchwidget
         MARKETING_VERSION: "2026.9"
-        CURRENT_PROJECT_VERSION: "375"
+        CURRENT_PROJECT_VERSION: "376"
         SWIFT_VERSION: "5.9"
         CODE_SIGN_STYLE: Automatic
         SKIP_INSTALL: "YES"


### PR DESCRIPTION
Fourteen compliance pull requests (#446 to #459) merged since build 375 without a bump; the next archive needs a fresh build number. Version stays 2026.9, the current month. All four `CURRENT_PROJECT_VERSION` pairs in the XcodeGen specs move together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)