### PR TITLE
Clear the Xcode 27 beta concurrency and deprecation warnings

### DIFF
--- a/OpenGlasses/Sources/Services/Accessibility/SessionAnnouncer.swift
+++ b/OpenGlasses/Sources/Services/Accessibility/SessionAnnouncer.swift
@@ -17,7 +17,7 @@ import UIKit
 final class SessionAnnouncer {
 
     /// The sink for an approved line. Injected so tests observe decisions rather than side effects.
-    private let post: (SessionAnnouncement) -> Void
+    private let post: @MainActor (SessionAnnouncement) -> Void
     /// The audio situation at the moment of the transition, read lazily — the announcer is wired
     /// once at launch and the answer changes turn by turn.
     private let context: () -> AnnouncementContext
@@ -34,7 +34,7 @@ final class SessionAnnouncer {
 
     init(context: @escaping () -> AnnouncementContext,
          now: @escaping () -> Date = Date.init,
-         post: @escaping (SessionAnnouncement) -> Void = SessionAnnouncer.postToVoiceOver) {
+         post: @escaping @MainActor (SessionAnnouncement) -> Void = SessionAnnouncer.postToVoiceOver) {
         self.context = context
         self.now = now
         self.post = post

--- a/OpenGlasses/Sources/Services/Entitlement/FieldAssistEntitlementProvider.swift
+++ b/OpenGlasses/Sources/Services/Entitlement/FieldAssistEntitlementProvider.swift
@@ -134,7 +134,7 @@ final class FieldAssistEntitlement: @unchecked Sendable {
     #endif
 
     init(provider: FieldAssistEntitlementProvider = LiveFieldAssistEntitlementProvider(),
-         clock: @escaping @Sendable () -> Date = Date.init) {
+         clock: @escaping @Sendable () -> Date = { Date() }) {
         self.storedProvider = provider
         self.storedClock = clock
     }

--- a/OpenGlasses/Sources/Services/LicenseService.swift
+++ b/OpenGlasses/Sources/Services/LicenseService.swift
@@ -194,16 +194,16 @@ final class LicenseService: ObservableObject {
 
     // MARK: - Codable config (shared by sign + verify so the format stays in lockstep)
 
-    /// `nonisolated(unsafe)` because `decode(code:publicKeyBase64:)` runs off the main actor; both
-    /// are configured once here and only read afterwards.
-    nonisolated(unsafe) static let encoder: JSONEncoder = {
+    /// `nonisolated` because `decode(code:publicKeyBase64:)` runs off the main actor; both are
+    /// configured once here and only read afterwards.
+    nonisolated static let encoder: JSONEncoder = {
         let e = JSONEncoder()
         e.dateEncodingStrategy = .iso8601
         e.outputFormatting = [.sortedKeys]
         return e
     }()
 
-    nonisolated(unsafe) static let decoder: JSONDecoder = {
+    nonisolated static let decoder: JSONDecoder = {
         let d = JSONDecoder()
         d.dateDecodingStrategy = .iso8601
         return d

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelDownloadManager.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelDownloadManager.swift
@@ -61,7 +61,7 @@ actor LocalModelDownloadManager {
     init(repository: LocalModelRepository,
          transfer: any LocalModelFileTransferring,
          fileManager: FileManager = .default,
-         now: @escaping @Sendable () -> Date = Date.init,
+         now: @escaping @Sendable () -> Date = { Date() },
          unloadIfResident: @escaping @Sendable (LocalModelID) async -> Void = { _ in }) {
         self.repository = repository
         self.transfer = transfer

--- a/OpenGlasses/Sources/Services/LocalInference/LocalModelSelection.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/LocalModelSelection.swift
@@ -63,7 +63,8 @@ struct LocalModelSelectionStore: Sendable {
         case readBackFailed
     }
 
-    let defaults: UserDefaults
+    /// `UserDefaults` is documented thread-safe, but the SDK does not mark it `Sendable`.
+    nonisolated(unsafe) let defaults: UserDefaults
     /// The legacy string field — `ModelConfig.model` for the on-device provider, in production.
     let legacySelection: @Sendable () -> String
     let setLegacySelection: @Sendable (String) -> Void
@@ -77,7 +78,7 @@ struct LocalModelSelectionStore: Sendable {
          legacySelection: @escaping @Sendable () -> String,
          setLegacySelection: @escaping @Sendable (String) -> Void,
          runtimeForID: @escaping @Sendable (LocalModelID) -> LocalModelRuntime,
-         now: @escaping @Sendable () -> Date = Date.init) {
+         now: @escaping @Sendable () -> Date = { Date() }) {
         self.defaults = defaults
         self.legacySelection = legacySelection
         self.setLegacySelection = setLegacySelection

--- a/OpenGlasses/Sources/Services/LocalInference/MLXLocalInferenceBackend.swift
+++ b/OpenGlasses/Sources/Services/LocalInference/MLXLocalInferenceBackend.swift
@@ -170,14 +170,14 @@ final class MLXLocalInferenceBackend: LocalInferenceBackend, @unchecked Sendable
             runtime: .mlx,
             contextLength: configuration.contextLength,
             capabilities: capabilities)
-        lock.lock(); resident = loaded; lock.unlock()
+        lock.withLock { resident = loaded }
         return loaded
     }
 
     func unload() async {
         await cancelGeneration()
         await MainActor.run { service.unloadModel() }
-        lock.lock(); resident = nil; lock.unlock()
+        lock.withLock { resident = nil }
     }
 
     // MARK: Generation

--- a/OpenGlasses/Sources/Services/MyDay/EventKitDayStore.swift
+++ b/OpenGlasses/Sources/Services/MyDay/EventKitDayStore.swift
@@ -40,9 +40,7 @@ final class EventKitDayStore {
     }
 
     var hasCalendarReadAccess: Bool {
-        let status = EKEventStore.authorizationStatus(for: .event)
-        if #available(iOS 17.0, *) { return status == .fullAccess }
-        return status == .authorized
+        EKEventStore.authorizationStatus(for: .event) == .fullAccess
     }
 
     /// Scheduled My Day must never trigger a first-use permission sheet. A denied/restricted
@@ -56,31 +54,17 @@ final class EventKitDayStore {
     }
 
     func requestCalendarAccess() async throws -> Bool {
-        if #available(iOS 17.0, *) {
-            switch EKEventStore.authorizationStatus(for: .event) {
-            case .fullAccess: return true
-            case .notDetermined: return try await eventStore.requestFullAccessToEvents()
-            default: return false
-            }
-        }
         switch EKEventStore.authorizationStatus(for: .event) {
-        case .authorized: return true
-        case .notDetermined: return try await eventStore.requestAccess(to: .event)
+        case .fullAccess: return true
+        case .notDetermined: return try await eventStore.requestFullAccessToEvents()
         default: return false
         }
     }
 
     func requestRemindersAccess() async throws -> Bool {
-        if #available(iOS 17.0, *) {
-            switch EKEventStore.authorizationStatus(for: .reminder) {
-            case .fullAccess: return true
-            case .notDetermined: return try await eventStore.requestFullAccessToReminders()
-            default: return false
-            }
-        }
         switch EKEventStore.authorizationStatus(for: .reminder) {
-        case .authorized: return true
-        case .notDetermined: return try await eventStore.requestAccess(to: .reminder)
+        case .fullAccess: return true
+        case .notDetermined: return try await eventStore.requestFullAccessToReminders()
         default: return false
         }
     }

--- a/OpenGlasses/Sources/Services/NativeTools/OperationJournal.swift
+++ b/OpenGlasses/Sources/Services/NativeTools/OperationJournal.swift
@@ -237,7 +237,7 @@ final class OperationResourceSerializer {
 final class ProtectedOperationJournal: OperationJournal {
     static let shared = ProtectedOperationJournal()
 
-    static let fileProtection = FileProtectionType.completeUntilFirstUserAuthentication
+    nonisolated static let fileProtection = FileProtectionType.completeUntilFirstUserAuthentication
 
     private let storage: OperationJournalStorage
     private let retention: OperationJournalRetention

--- a/OpenGlasses/Sources/Services/NetworkMonitorService.swift
+++ b/OpenGlasses/Sources/Services/NetworkMonitorService.swift
@@ -145,7 +145,13 @@ final class NetworkInterceptor: URLProtocol {
         let mutableRequest = (request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
         URLProtocol.setProperty(true, forKey: Self.monitoredKey, in: mutableRequest)
 
-        let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+        // The delegate is a separate object, not `self`: `URLSessionDelegate` now requires
+        // `Sendable`, and `URLProtocol`'s `Sendable` conformance is unavailable on iOS, so a
+        // `URLProtocol` subclass can no longer be its own session delegate. The forwarder holds
+        // the interceptor weakly — the URL loading system owns it for the life of the load.
+        let session = URLSession(configuration: .default,
+                                 delegate: Delegate(interceptor: self),
+                                 delegateQueue: nil)
         let task = session.dataTask(with: mutableRequest as URLRequest)
         task.resume()
     }
@@ -153,22 +159,21 @@ final class NetworkInterceptor: URLProtocol {
     override func stopLoading() {
         // Cleanup handled by delegate
     }
-}
 
-extension NetworkInterceptor: URLSessionDataDelegate {
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+    // MARK: Delegate callbacks, forwarded from `Delegate`
+
+    private func received(_ data: Data) {
         responseData.append(data)
         client?.urlProtocol(self, didLoad: data)
     }
 
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+    private func received(_ response: URLResponse) {
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        completionHandler(.allow)
     }
 
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+    private func completed(response: URLResponse?, error: Error?) {
         let duration = startTime.map { Date().timeIntervalSince($0) } ?? 0
-        let statusCode = (task.response as? HTTPURLResponse)?.statusCode ?? 0
+        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
 
         if let id = entryId {
             Task { @MainActor in
@@ -185,6 +190,33 @@ extension NetworkInterceptor: URLSessionDataDelegate {
             client?.urlProtocol(self, didFailWithError: error)
         } else {
             client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+
+    /// The session delegate for the forwarded request.
+    ///
+    /// It exists only because `URLSessionDelegate` requires `Sendable` and `URLProtocol`'s
+    /// conformance to `Sendable` is unavailable on iOS, so the interceptor cannot be its own
+    /// delegate. Every callback is a straight forward back to the interceptor, which the URL
+    /// loading system keeps alive across the load, so the reference is weak.
+    private final class Delegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+        private weak var interceptor: NetworkInterceptor?
+
+        init(interceptor: NetworkInterceptor) {
+            self.interceptor = interceptor
+        }
+
+        func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+            interceptor?.received(data)
+        }
+
+        func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
+            interceptor?.received(response)
+            completionHandler(.allow)
+        }
+
+        func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+            interceptor?.completed(response: task.response, error: error)
         }
     }
 }

--- a/OpenGlasses/Sources/Services/Privacy/ErasureLedger.swift
+++ b/OpenGlasses/Sources/Services/Privacy/ErasureLedger.swift
@@ -74,7 +74,7 @@ final class ErasureLedger {
         protectStorage()
     }
 
-    static let fileProtection = FileProtectionType.completeUntilFirstUserAuthentication
+    nonisolated static let fileProtection = FileProtectionType.completeUntilFirstUserAuthentication
 
     var lastID: Int { entries.map(\.id).max() ?? 0 }
 

--- a/OpenGlasses/Sources/Services/Security/ConsentRecord.swift
+++ b/OpenGlasses/Sources/Services/Security/ConsentRecord.swift
@@ -203,7 +203,7 @@ struct SubjectConsentEvidence: Sendable, Equatable {
 final class ConsentStore {
     static let shared = ConsentStore()
 
-    static let fileProtection = FileProtectionType.completeUntilFirstUserAuthentication
+    nonisolated static let fileProtection = FileProtectionType.completeUntilFirstUserAuthentication
     /// A ceiling, so a misbehaving caller cannot turn the register into a data store. Oldest
     /// *settled* rows go first; a live agreement is never evicted to make room.
     static let capacity = 500

--- a/OpenGlasses/Sources/Services/Security/ToolDefinitionDigestStore.swift
+++ b/OpenGlasses/Sources/Services/Security/ToolDefinitionDigestStore.swift
@@ -19,7 +19,7 @@ struct ToolDefinitionReview: Codable, Equatable {
 final class ToolDefinitionDigestStore {
     static let shared = ToolDefinitionDigestStore()
 
-    static let fileProtection = FileProtectionType.completeUntilFirstUserAuthentication
+    nonisolated static let fileProtection = FileProtectionType.completeUntilFirstUserAuthentication
 
     private let directory: URL
     private let fileURL: URL


### PR DESCRIPTION
## Summary
Silences the batch of Swift 6 / iOS 27 SDK warnings the latest Xcode 27 beta raises in our sources. Behaviour-preserving throughout; the project stays in Swift 5.9 mode.

- **NetworkMonitorService**: `URLSessionDelegate` now requires `Sendable` and `URLProtocol`'s conformance is unavailable on iOS, so `NetworkInterceptor` can no longer be its own session delegate. A nested forwarder holds it weakly and passes the three callbacks back. Nested rather than top-level so the transport-route scrape in `NetworkRouteRegistryTests` keeps attributing the session to the interceptor, which already carries the exemption.
- **MLXLocalInferenceBackend**: the two `NSLock` lock/unlock pairs inside async functions become `withLock`.
- **`Date.init` → `{ Date() }`** where the closure type is `@Sendable` (three sites).
- **`nonisolated`** on the four `fileProtection` constants (all four owners are `@MainActor`) and on the LicenseService JSON coders, whose `(unsafe)` is redundant now that both coders are `Sendable` in the iOS 26.5 and 27 SDKs alike.
- **`LocalModelSelectionStore.defaults`** marked `nonisolated(unsafe)`: UserDefaults is documented thread-safe but not marked Sendable.
- **SessionAnnouncer**: the injected `post` sink is typed `@MainActor`, matching the class and its default.
- **EventKitDayStore**: the pre-iOS-17 `.authorized` / `requestAccess(to:)` fallbacks were dead on an iOS 26 target and are removed.

Deliberately left: the five "no async operations occur within await" notes in `OpenGlassesApp.swift` and `OpenClawSkillsTool.swift` (the beta infers those closures as MainActor-isolated; dropping the awaits trades a warning for a possible error on the stable toolchain), and the `constexpr if` warning inside mlx-swift's Metal headers.

## Verification
- Xcode 27 beta (27A5228h) Debug build: succeeded, no remaining warnings in `OpenGlasses/Sources` other than the five listed above.
- Release build: succeeded on the beta toolchain. Stable Xcode 26.6 on this Mac has no iOS platform installed, so it cannot build at all; the JSONEncoder/JSONDecoder Sendable question was settled by reading both SDKs' Foundation interfaces instead.
- Unit tests (iPhone 17 Pro sim, Debug): 5318 executed, 13 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)