### PR TITLE
Move the mlx-swift-lm pin to the revision that builds on the Xcode 27 RC

### DIFF
--- a/ci_scripts/Package.resolved
+++ b/ci_scripts/Package.resolved
@@ -50,7 +50,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "d6614025fa1f6133e34c4fe0cea2815d672d8742"
+        "revision" : "14414441fa44f45eee35a61e9fa0bab577cf9734"
       }
     },
     {

--- a/project.base.yml
+++ b/project.base.yml
@@ -74,13 +74,14 @@ packages:
     # declare k_proj/v_proj) is fixed upstream in 09deb8c, and no released tag contains it —
     # the newest, 3.31.4, predates it. Go back to `version:` as soon as a tag ships that does.
     #
-    # Why *this* revision and not upstream's tip: the next commit after it (14414441) retargets
-    # MLXFoundationModels at the Xcode 27 beta 5 SDK (27A5237l), and MLXHuggingFace — which we
-    # link for `#hubDownloader` — pulls that module in through a default-on package trait. On an
-    # earlier 27.0 beta the retarget does not compile (`updateMetadata` takes
-    # `[String: any Sendable & Codable & Equatable]` there, not `ConvertibleToGeneratedContent`).
-    # So: on beta 5 or later, move to 14414441 or newer; before it, stay here.
-    revision: d6614025fa1f6133e34c4fe0cea2815d672d8742
+    # Why *this* revision: it is the first that compiles against the Xcode 27 RC / iOS 27.0 SDK
+    # (24A430). MLXFoundationModels tracks the FoundationModels API, and MLXHuggingFace — which we
+    # link for `#hubDownloader` — pulls that module in through a default-on package trait, so its
+    # build breakage is ours even though we never import it. Against the RC SDK the previous pin
+    # fails on the shifted API (`LanguageModelCapabilities` is now unlabelled, `updateMetadata`
+    # takes `[String: any ConvertibleToGeneratedContent]`); this revision retargets it. Chosen as
+    # the minimal step — two commits past the previous pin — rather than upstream's tip.
+    revision: 14414441fa44f45eee35a61e9fa0bab577cf9734
   swift-huggingface:
     # Same 0.x exposure as the DAT SDK, and it already drifted: the spec said `from: "0.1.0"` while
     # Package.resolved had walked to 0.9.0 — eight minor versions of a pre-1.0 package, adopted


### PR DESCRIPTION
## Summary
Unblocks archiving on Xcode 27 RC (27A266a, iOS 27.0 SDK 24A430). The RC replaced the beta outright and the app stopped compiling inside `mlx-swift-lm`:

```
MLXFoundationModels/MLXLanguageModel.swift:565:54 Extraneous argument label 'capabilities:' in call
MLXFoundationModels/MLXLanguageModel.swift:718:84 Cannot convert value of type '[String : any Sendable & Codable & Equatable]' to expected argument type '[String : any ConvertibleToGeneratedContent]'
```

We never import MLXFoundationModels, but MLXHuggingFace's default-on `FoundationModelsIntegration` trait compiles it into every build, so its API drift is ours. The pin moves two commits forward to upstream's fix for exactly this shift, the minimal step rather than upstream's tip (30 commits further, touching weight loading, KV cache and Qwen fusions). The pin stays a revision rather than a tag because no tag yet contains the Gemma 4 `k_norm` fix.

The choice was checked against the RC SDK itself before building: both edits match the FoundationModels `.swiftinterface` (unlabelled `LanguageModelCapabilities(_:)`, `updateMetadata` taking `ConvertibleToGeneratedContent`), and the RC `.tbd` exports the three-parameter `updateUsage` symbol whose absence in the beta dylib was a launch-abort risk.

`ci_scripts/Package.resolved` moves by the same single line. Four unrelated pins (swift-asn1, swift-crypto, swift-jinja, swift-transformers) wanted to walk forward during a fresh resolve and were deliberately held where they are.

## Verification (RC toolchain)
- Release build for `generic/platform=iOS`: succeeded, zero errors, no new warnings from the RC compiler in `OpenGlasses/Sources` beyond the five known async-marker notes.
- Unit tests, iPhone 17 Pro simulator: 5318 executed, 13 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
