### PR TITLE
Offer a smaller on-device model on phones below the Gemma RAM floor

### DIFF
--- a/OpenGlasses/Sources/App/Views/AgenticFeaturesView.swift
+++ b/OpenGlasses/Sources/App/Views/AgenticFeaturesView.swift
@@ -132,7 +132,7 @@ struct AgenticFeaturesView: View {
                             HStack {
                                 Label(model.name, systemImage: "memorychip")
                                 Spacer()
-                                Text("Needs 8 GB RAM")
+                                Text("Needs \(Int(model.minimumRAMGB)) GB RAM")
                                     .font(.caption)
                                     .foregroundStyle(OGTheme.warnLabel)
                             }

--- a/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
+++ b/OpenGlasses/Sources/App/Views/LocalModelManagerView.swift
@@ -376,8 +376,10 @@ struct LocalModelManagerView: View {
 
     @ViewBuilder
     private func catalogRow(entry: LocalModelCatalog.Entry) -> some View {
-        let compatible = ProcessInfo.processInfo.physicalMemory
-            >= UInt64(entry.minimumRAMGB * 1_073_741_824)
+        // Against the *nominal* RAM size, not raw `physicalMemory`: an 8 GB iPhone reports about
+        // 7.5 GB, so the raw byte comparison this used to do hid the Download button on exactly
+        // the phones an 8 GB floor is written for.
+        let compatible = LocalLLMService.deviceMeetsRAMFloor(entry.minimumRAMGB)
         VStack(alignment: .leading, spacing: 6) {
             HStack {
                 VStack(alignment: .leading, spacing: 3) {

--- a/OpenGlasses/Sources/App/Views/OnboardingView.swift
+++ b/OpenGlasses/Sources/App/Views/OnboardingView.swift
@@ -354,7 +354,7 @@ struct OnboardingView: View {
                         providerRow(
                             .local,
                             name: "Start without an API key",
-                            model: LLMProvider.local.defaultModel,
+                            model: offeredLocalModelId,
                             detail: "Downloads a model to this iPhone. No account, works offline.",
                             icon: "iphone"
                         )
@@ -692,8 +692,20 @@ struct OnboardingView: View {
     private var offlineModelIsOfferable: Bool {
         guard let offlineOffer else { return false }
         switch offlineOffer {
-        case .offer, .alreadyDownloaded: return true
+        case .offer, .offerSmaller, .alreadyDownloaded: return true
         case .notEnoughStorage, .deviceTooSmall: return false
+        }
+    }
+
+    /// The model the keyless card would actually configure on this device: the primary where it
+    /// runs, the smaller fallback where it doesn't. The card must never name one model and
+    /// activate another.
+    private var offeredLocalModelId: String {
+        switch offlineOffer {
+        case .offer(let id, _), .offerSmaller(let id, _, _), .alreadyDownloaded(let id):
+            return id
+        case .notEnoughStorage, .deviceTooSmall, .none:
+            return LLMProvider.local.defaultModel
         }
     }
 
@@ -759,18 +771,25 @@ struct OnboardingView: View {
             .frame(minHeight: rowMinHeight)
 
         case .offer(let modelId, let sizeBytes):
-            offlineDownloadRow(modelId: modelId, sizeBytes: sizeBytes)
+            offlineDownloadRow(modelId: modelId, sizeBytes: sizeBytes, isSmaller: false)
+
+        case .offerSmaller(let modelId, let sizeBytes, _):
+            offlineDownloadRow(modelId: modelId, sizeBytes: sizeBytes, isSmaller: true)
         }
     }
 
     @ViewBuilder
-    private func offlineDownloadRow(modelId: String, sizeBytes: Int64) -> some View {
+    private func offlineDownloadRow(modelId: String,
+                                    sizeBytes: Int64,
+                                    isSmaller: Bool) -> some View {
         HStack(spacing: OGMetrics.rowSpacing) {
             OGIconTile(systemName: "arrow.down.circle")
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(OfflineModelOffer.title(
-                    appleIntelligenceAvailable: FirstRunDefaults.appleIntelligenceAvailable))
+                Text(isSmaller
+                     ? OfflineModelOffer.smallerTitle
+                     : OfflineModelOffer.title(
+                        appleIntelligenceAvailable: FirstRunDefaults.appleIntelligenceAvailable))
                     .font(.body)
                 // The size is stated here, beside the button, before anything is downloaded —
                 // not discovered halfway through a multi-gigabyte pull on cellular.
@@ -791,7 +810,9 @@ struct OnboardingView: View {
             } else {
                 Button("Download") { downloadOfflineModel(modelId) }
                     .buttonStyle(.ogProminentCompact)
-                    .accessibilityLabel("Download the offline model, \(OfflineModelOffer.formattedSize(sizeBytes))")
+                    .accessibilityLabel(isSmaller
+                        ? "Download a smaller offline model, \(OfflineModelOffer.formattedSize(sizeBytes))"
+                        : "Download the offline model, \(OfflineModelOffer.formattedSize(sizeBytes))")
             }
         }
         .frame(minHeight: rowMinHeight)
@@ -809,6 +830,12 @@ struct OnboardingView: View {
                  : OfflineModelOffer.detail(
                     appleIntelligenceAvailable: FirstRunDefaults.appleIntelligenceAvailable,
                     sizeBytes: sizeBytes))
+        case .offerSmaller(_, let sizeBytes, let primaryRequiredRAMGB):
+            Text(isDownloadingOfflineModel
+                 ? OfflineModelOffer.inProgressDetail
+                 : OfflineModelOffer.offerSmallerDetail(
+                    primaryRequiredRAMGB: primaryRequiredRAMGB,
+                    sizeBytes: sizeBytes))
         case .alreadyDownloaded, .notEnoughStorage, .deviceTooSmall:
             EmptyView()
         }
@@ -818,10 +845,12 @@ struct OnboardingView: View {
         let verdict = OfflineModelOffer.verdict(OfflineModelOffer.currentInputs(),
                                                 modelId: OfflineModelOffer.modelId)
         offlineOffer = verdict
-        // A model already on disk is the one this path should configure, so the id is settled
-        // before the user ever reaches Continue.
-        if case .alreadyDownloaded(let modelId) = verdict, selectedProvider == .local {
-            selectedModelId = modelId
+        // The id this path should configure is settled before the user ever reaches Continue —
+        // a model already on disk, or the one the offer would fetch. On a phone under the
+        // primary's RAM floor that is the smaller fallback, and defaulting to the primary there
+        // would activate a model the device cannot load.
+        if selectedProvider == .local {
+            selectedModelId = offeredLocalModelId
         }
     }
 
@@ -1502,7 +1531,10 @@ struct OnboardingView: View {
     private func saveModel() {
         guard let provider = selectedProvider else { return }
         let trimmedKey = apiKey.trimmingCharacters(in: .whitespaces)
-        let chosenModel = selectedModelId ?? provider.defaultModel
+        // For the local provider the default is whatever this device was actually offered — on a
+        // phone below the primary's RAM floor the provider default is a model it cannot run.
+        let chosenModel = selectedModelId
+            ?? (provider == .local ? offeredLocalModelId : provider.defaultModel)
 
         let model = ModelConfig(
             id: UUID().uuidString,

--- a/OpenGlasses/Sources/Services/LocalLLMService.swift
+++ b/OpenGlasses/Sources/Services/LocalLLMService.swift
@@ -1063,13 +1063,10 @@ struct RecommendedModel: Identifiable {
         self.minimumRAMGB = minimumRAMGB
     }
 
-    /// Whether the current device has enough RAM to run this model. Compared against the
-    /// *marketing* RAM size, not raw `physicalMemory`: a 12 GB device reports ~11.5 GB
-    /// (carve-outs), so a raw `>= 12` check blocked exactly the hardware it was meant to
-    /// allow.
+    /// Whether the current device has enough RAM to run this model. One rule, one place —
+    /// see `LocalLLMService.deviceMeetsRAMFloor(_:)`.
     var isCompatibleWithDevice: Bool {
-        guard minimumRAMGB > 0 else { return true }
-        return LocalLLMService.marketingRAMGB >= minimumRAMGB
+        LocalLLMService.deviceMeetsRAMFloor(minimumRAMGB)
     }
 }
 
@@ -1086,6 +1083,26 @@ extension LocalLLMService {
     /// device into a larger tier.
     nonisolated static var marketingRAMGB: Double {
         deviceRAMGB.rounded(.up)
+    }
+
+    /// Whether a device holding `marketingRAMGB` nominal gigabytes clears a model's RAM floor.
+    ///
+    /// The rounding is the entire point, and it is why every RAM gate in the app has to come
+    /// through here rather than comparing `ProcessInfo.physicalMemory` to `floor * 1_073_741_824`
+    /// on its own. Reported physical memory always sits a little under the number on the box —
+    /// an 8 GB iPhone reports about 7.5 GB — so a raw byte comparison excludes precisely the
+    /// hardware an 8 GB floor was written to include. A floor of 0 means no restriction.
+    ///
+    /// Takes the RAM as a parameter so the rule is testable without the tester's own phone;
+    /// `deviceMeetsRAMFloor(_:)` is the production entry point.
+    nonisolated static func deviceMeetsRAMFloor(_ minimumRAMGB: Double,
+                                                marketingRAMGB: Double) -> Bool {
+        minimumRAMGB <= 0 || marketingRAMGB >= minimumRAMGB
+    }
+
+    /// This device against a model's RAM floor.
+    nonisolated static func deviceMeetsRAMFloor(_ minimumRAMGB: Double) -> Bool {
+        deviceMeetsRAMFloor(minimumRAMGB, marketingRAMGB: marketingRAMGB)
     }
 }
 

--- a/OpenGlasses/Sources/Services/OfflineModelOffer.swift
+++ b/OpenGlasses/Sources/Services/OfflineModelOffer.swift
@@ -40,12 +40,42 @@ enum OfflineModelOffer {
     enum Verdict: Equatable {
         /// Offer it. The size is stated before anything starts downloading.
         case offer(modelId: String, sizeBytes: Int64)
+        /// This phone is under the primary model's floor, but the catalog has something that does
+        /// fit. Offer that instead, and say plainly that it is the smaller one — a 6 GB iPhone is
+        /// not a device with no on-device option, and telling it so was simply untrue.
+        case offerSmaller(modelId: String, sizeBytes: Int64, primaryRequiredRAMGB: Double)
         /// Already on disk from a previous run — there is nothing to download.
         case alreadyDownloaded(modelId: String)
         /// The device could run it, but there is not room for it right now.
         case notEnoughStorage(neededBytes: Int64, freeBytes: Int64)
-        /// This phone is below the bar. Say so plainly and point at the cloud providers.
+        /// Nothing in the catalog runs on this phone — not the primary, not the smallest entry.
+        /// Say so plainly and point at the cloud providers.
         case deviceTooSmall(requiredRAMGB: Double)
+    }
+
+    /// A catalog entry reduced to the three facts this decision needs. Keeps the fallback search
+    /// a value computation, so "what would a 6 GB iPhone be offered?" is a headless question.
+    struct Candidate: Equatable {
+        var modelId: String
+        /// Minimum device RAM (GB) to run it. 0 = no floor.
+        var minimumRAMGB: Double
+        var sizeBytes: Int64
+
+        init(modelId: String, minimumRAMGB: Double, sizeBytes: Int64) {
+            self.modelId = modelId
+            self.minimumRAMGB = minimumRAMGB
+            self.sizeBytes = sizeBytes
+        }
+    }
+
+    /// The catalog in picker order, as candidates. The order is the contract: the fallback is the
+    /// first entry that fits, so the list stays the one place the preference is expressed.
+    static var catalogCandidates: [Candidate] {
+        LocalModelCatalog.entries.map {
+            Candidate(modelId: $0.id.rawValue,
+                      minimumRAMGB: $0.minimumRAMGB,
+                      sizeBytes: LocalLLMService.expectedDownloadBytes(for: $0.id.rawValue) ?? 0)
+        }
     }
 
     /// Everything the decision depends on, as values.
@@ -57,35 +87,81 @@ enum OfflineModelOffer {
         /// Free disk usable for the download, or nil when it can't be read (then storage is not
         /// used as a reason to refuse — an unreadable volume is not a small one).
         var freeDiskBytes: Int64?
-        /// Stated download size, or nil for an id the catalog doesn't know.
+        /// Stated download size of the primary model, or nil for an id the catalog doesn't know.
         var expectedSizeBytes: Int64?
+        /// What the fallback may be drawn from, in preference order. Defaults to the shipping
+        /// catalog; a test supplies its own to construct devices the real catalog cannot.
+        var catalog: [Candidate]
 
         init(marketingRAMGB: Double,
              downloadedModelIds: [String],
              freeDiskBytes: Int64?,
-             expectedSizeBytes: Int64?) {
+             expectedSizeBytes: Int64?,
+             catalog: [Candidate] = OfflineModelOffer.catalogCandidates) {
             self.marketingRAMGB = marketingRAMGB
             self.downloadedModelIds = downloadedModelIds
             self.freeDiskBytes = freeDiskBytes
             self.expectedSizeBytes = expectedSizeBytes
+            self.catalog = catalog
         }
     }
 
     /// Decide, in the order the reasons matter: a model already here beats every other answer,
     /// then the capability gate, then room to put it.
+    ///
+    /// The gate no longer ends the conversation. Only the *primary* model carries an 8 GB floor;
+    /// most of the catalog carries none at all, and a phone under the floor was being told it
+    /// could not run a model on-device when several would have run there fine. So a device below
+    /// the primary's bar falls through to the first catalog entry it can actually run, with its
+    /// own size and its own storage check — and `deviceTooSmall` is kept for the only case that
+    /// deserves it, a device nothing in the catalog fits.
     static func verdict(_ inputs: Inputs, modelId: String) -> Verdict {
         if inputs.downloadedModelIds.contains(modelId) {
             return .alreadyDownloaded(modelId: modelId)
         }
         let required = minimumRAMGB
         guard inputs.marketingRAMGB >= required else {
-            return .deviceTooSmall(requiredRAMGB: required)
+            return smallerDeviceVerdict(inputs, excluding: modelId, primaryRequiredRAMGB: required)
         }
         let size = inputs.expectedSizeBytes ?? 0
-        if let free = inputs.freeDiskBytes, free < size + storageMarginBytes {
-            return .notEnoughStorage(neededBytes: size + storageMarginBytes, freeBytes: free)
-        }
+        if let shortfall = storageShortfall(inputs, sizeBytes: size) { return shortfall }
         return .offer(modelId: modelId, sizeBytes: size)
+    }
+
+    /// What to offer a phone under the primary's floor. Everything the primary path checks is
+    /// checked again here against the fallback's own numbers — a smaller model is still a download
+    /// that needs room, and one already on disk is still nothing to download.
+    private static func smallerDeviceVerdict(_ inputs: Inputs,
+                                             excluding primaryId: String,
+                                             primaryRequiredRAMGB: Double) -> Verdict {
+        let fitting = inputs.catalog.filter {
+            $0.modelId != primaryId && fits($0.minimumRAMGB, marketingRAMGB: inputs.marketingRAMGB)
+        }
+        // A fitting model already on disk wins, wherever it sits in the order — there is nothing
+        // to download, and offering a different one would be asking for a second copy.
+        if let here = fitting.first(where: { inputs.downloadedModelIds.contains($0.modelId) }) {
+            return .alreadyDownloaded(modelId: here.modelId)
+        }
+        guard let fallback = fitting.first else {
+            return .deviceTooSmall(requiredRAMGB: primaryRequiredRAMGB)
+        }
+        if let shortfall = storageShortfall(inputs, sizeBytes: fallback.sizeBytes) { return shortfall }
+        return .offerSmaller(modelId: fallback.modelId,
+                             sizeBytes: fallback.sizeBytes,
+                             primaryRequiredRAMGB: primaryRequiredRAMGB)
+    }
+
+    /// One RAM rule for the whole app, expressed against the nominal figure rather than the
+    /// reported one. See `LocalLLMService.deviceMeetsRAMFloor(_:marketingRAMGB:)`.
+    private static func fits(_ minimumRAMGB: Double, marketingRAMGB: Double) -> Bool {
+        LocalLLMService.deviceMeetsRAMFloor(minimumRAMGB, marketingRAMGB: marketingRAMGB)
+    }
+
+    /// Room for the download plus the margin, or the refusal that says both numbers.
+    private static func storageShortfall(_ inputs: Inputs, sizeBytes: Int64) -> Verdict? {
+        let needed = sizeBytes + storageMarginBytes
+        guard let free = inputs.freeDiskBytes, free < needed else { return nil }
+        return .notEnoughStorage(neededBytes: needed, freeBytes: free)
     }
 
     /// Free disk usable for the download. `importantUsage` rather than raw free space, so iOS's
@@ -137,12 +213,24 @@ enum OfflineModelOffer {
     static let alreadyDownloadedDetail =
         "An offline model is already on this iPhone, so the assistant works with no network."
 
+    /// The smaller model's title. Distinct from the primary's, because the one thing this row
+    /// must not do is let a user believe they are getting the full-size model.
+    static let smallerTitle = "Download a smaller offline model"
+
+    /// The honest version of what used to be a flat refusal: name the memory the full-size model
+    /// wants, say this iPhone gets a smaller one instead, and state what that one costs to fetch.
+    static func offerSmallerDetail(primaryRequiredRAMGB: Double, sizeBytes: Int64) -> String {
+        "The full-size model needs \(Int(primaryRequiredRAMGB)) GB of memory, which is more than "
+        + "this iPhone has. A smaller model runs here instead — a \(formattedSize(sizeBytes)) "
+        + "download, and the assistant still answers on-device with no network and no account."
+    }
+
     /// The refusal. It names the device's limit and where to go instead, because a dead end with
     /// no route out is how a first run gets abandoned.
     static func deviceTooSmallDetail(requiredRAMGB: Double) -> String {
-        "This iPhone has less than \(Int(requiredRAMGB)) GB of memory, which isn't enough to run a "
-        + "model on-device. Choose one of the providers instead — those run in the cloud and work "
-        + "on any iPhone."
+        "This iPhone doesn't have enough memory for any of the on-device models — the smallest "
+        + "one still needs more than it has, and the full-size model needs \(Int(requiredRAMGB)) GB. "
+        + "Choose one of the providers instead — those run in the cloud and work on any iPhone."
     }
 
     static func notEnoughStorageDetail(neededBytes: Int64, freeBytes: Int64) -> String {

--- a/OpenGlassesTests/OfflineModelOfferTests.swift
+++ b/OpenGlassesTests/OfflineModelOfferTests.swift
@@ -9,19 +9,32 @@ import XCTest
 /// told before a multi-gigabyte download starts is a promise, and on a device with no Apple
 /// Intelligence it is a different promise from the one on a device that has it.
 ///
+/// The third is the fallback: only the primary model carries an 8 GB floor, and a phone under it
+/// was being told no model runs on-device at all — untrue on any iPhone that can hold SmolVLM2.
+/// The tests below pin which model such a phone is offered, and that the fallback is subject to
+/// every check the primary is.
+///
 /// Nothing here touches the network, the filesystem or a real download: every input is a value.
 final class OfflineModelOfferTests: XCTestCase {
 
     private let modelId = "mlx-community/gemma-4-e2b-it-4bit"
     private let sizeBytes: Int64 = 3_865_470_566   // ~3.6 GB
 
+    /// What a phone under the primary's floor should be offered: the first catalog entry after
+    /// the primary whose RAM floor it clears.
+    private let fallbackId = "mlx-community/SmolVLM2-2.2B-Instruct-mlx"
+    private let fallbackSize: Int64 = 1_610_612_736   // 1.5 GB
+
     private func inputs(ramGB: Double,
                         downloaded: [String] = [],
-                        freeDisk: Int64? = 64 * 1_073_741_824) -> OfflineModelOffer.Inputs {
+                        freeDisk: Int64? = 64 * 1_073_741_824,
+                        catalog: [OfflineModelOffer.Candidate] = OfflineModelOffer.catalogCandidates)
+        -> OfflineModelOffer.Inputs {
         OfflineModelOffer.Inputs(marketingRAMGB: ramGB,
                                  downloadedModelIds: downloaded,
                                  freeDiskBytes: freeDisk,
-                                 expectedSizeBytes: sizeBytes)
+                                 expectedSizeBytes: sizeBytes,
+                                 catalog: catalog)
     }
 
     private func verdict(_ inputs: OfflineModelOffer.Inputs) -> OfflineModelOffer.Verdict {
@@ -40,13 +53,88 @@ final class OfflineModelOfferTests: XCTestCase {
         XCTAssertEqual(catalogued?.minimumRAMGB, OfflineModelOffer.minimumRAMGB)
     }
 
-    /// A device below the bar is not offered the download at all — the plan's whole point. It is
-    /// told why, and pointed at what does work there.
-    func testASmallDeviceIsNotOfferedTheDownload() {
+    /// A device below the bar is not offered the *primary* model — but it is not left with
+    /// nothing either. It gets the first catalog entry that actually runs there, and is told the
+    /// full-size one needs more memory than it has.
+    func testASmallDeviceIsOfferedTheSmallerModelInstead() {
         XCTAssertEqual(verdict(inputs(ramGB: 6)),
-                       .deviceTooSmall(requiredRAMGB: OfflineModelOffer.minimumRAMGB))
+                       .offerSmaller(modelId: fallbackId,
+                                     sizeBytes: fallbackSize,
+                                     primaryRequiredRAMGB: OfflineModelOffer.minimumRAMGB))
         XCTAssertEqual(verdict(inputs(ramGB: 4)),
+                       .offerSmaller(modelId: fallbackId,
+                                     sizeBytes: fallbackSize,
+                                     primaryRequiredRAMGB: OfflineModelOffer.minimumRAMGB))
+    }
+
+    /// The fallback is the first catalog entry, in picker order, that fits — not the smallest, not
+    /// an arbitrary one. Excluding the primary and the entry with the even higher floor, that is
+    /// SmolVLM2 2.2B on a 6 GB iPhone.
+    @MainActor
+    func testTheFallbackIsTheFirstCatalogEntryThatFits() {
+        let expected = LocalModelCatalog.entries.first {
+            $0.id.rawValue != modelId && $0.minimumRAMGB <= 6
+        }
+        XCTAssertEqual(expected?.id.rawValue, fallbackId)
+        XCTAssertEqual(fallbackId, "mlx-community/SmolVLM2-2.2B-Instruct-mlx")
+        XCTAssertEqual(LocalLLMService.expectedDownloadBytes(for: fallbackId), fallbackSize)
+    }
+
+    /// `deviceTooSmall` survives, for the one device that deserves it: nothing in the catalog
+    /// fits. Constructed by handing the pure decision a catalog whose every entry has a floor
+    /// above the device, which the shipping catalog (full of floorless entries) cannot express.
+    func testADeviceBelowEveryFloorIsStillToldPlainly() {
+        let unreachable = [
+            OfflineModelOffer.Candidate(modelId: "big/one", minimumRAMGB: 12, sizeBytes: 1),
+            OfflineModelOffer.Candidate(modelId: "big/two", minimumRAMGB: 16, sizeBytes: 1),
+        ]
+        XCTAssertEqual(verdict(inputs(ramGB: 6, catalog: unreachable)),
                        .deviceTooSmall(requiredRAMGB: OfflineModelOffer.minimumRAMGB))
+    }
+
+    /// The primary is never offered as its own fallback, however the catalog is ordered.
+    func testThePrimaryIsNeverOfferedAsTheFallback() {
+        let onlyPrimary = [
+            OfflineModelOffer.Candidate(modelId: modelId, minimumRAMGB: 0, sizeBytes: sizeBytes)
+        ]
+        XCTAssertEqual(verdict(inputs(ramGB: 6, catalog: onlyPrimary)),
+                       .deviceTooSmall(requiredRAMGB: OfflineModelOffer.minimumRAMGB))
+    }
+
+    // MARK: - The fallback is subject to every check the primary is
+
+    /// A fallback already on disk is not downloaded again — and the size checked against disk is
+    /// the fallback's own, not the 3.6 GB primary's, which would refuse a 1.5 GB download on a
+    /// phone with room for it.
+    func testAFallbackAlreadyOnDiskIsNotOfferedAgain() {
+        XCTAssertEqual(verdict(inputs(ramGB: 6, downloaded: [fallbackId])),
+                       .alreadyDownloaded(modelId: fallbackId))
+    }
+
+    /// Any fitting model on disk counts, wherever it sits in the order — offering a different one
+    /// would be asking a 6 GB phone for a second copy it does not need.
+    func testAFittingModelFurtherDownTheListCountsAsAlreadyDownloaded() {
+        let qwen = "mlx-community/Qwen2.5-0.5B-Instruct-4bit"
+        XCTAssertEqual(verdict(inputs(ramGB: 6, downloaded: [qwen])),
+                       .alreadyDownloaded(modelId: qwen))
+    }
+
+    /// Storage is measured against what is actually being fetched. Free space between the
+    /// fallback's requirement and the primary's is enough here and would not have been if the
+    /// primary's size leaked into this branch.
+    func testTheFallbackStorageCheckUsesTheFallbacksOwnSize() {
+        let tooLittle = fallbackSize + OfflineModelOffer.storageMarginBytes - 1
+        XCTAssertEqual(verdict(inputs(ramGB: 6, freeDisk: tooLittle)),
+                       .notEnoughStorage(neededBytes: fallbackSize + OfflineModelOffer.storageMarginBytes,
+                                         freeBytes: tooLittle))
+
+        // Exactly enough for the fallback — far short of the primary's 3.6 GB — is still a yes.
+        let justEnough = fallbackSize + OfflineModelOffer.storageMarginBytes
+        XCTAssertLessThan(justEnough, sizeBytes + OfflineModelOffer.storageMarginBytes)
+        XCTAssertEqual(verdict(inputs(ramGB: 6, freeDisk: justEnough)),
+                       .offerSmaller(modelId: fallbackId,
+                                     sizeBytes: fallbackSize,
+                                     primaryRequiredRAMGB: OfflineModelOffer.minimumRAMGB))
     }
 
     /// Exactly at the bar counts as in. The marketing figure is a ceiling of the reported one, so
@@ -92,10 +180,13 @@ final class OfflineModelOfferTests: XCTestCase {
         }
     }
 
-    /// The capability gate is checked before storage: a phone that cannot run the model is told
+    /// The capability gate is checked before storage: a phone that cannot run *any* model is told
     /// that, not sent to free up space for something that would never work.
     func testTheDeviceReasonWinsOverTheStorageReason() {
-        XCTAssertEqual(verdict(inputs(ramGB: 4, freeDisk: 0)),
+        let unreachable = [
+            OfflineModelOffer.Candidate(modelId: "big/one", minimumRAMGB: 12, sizeBytes: 1)
+        ]
+        XCTAssertEqual(verdict(inputs(ramGB: 4, freeDisk: 0, catalog: unreachable)),
                        .deviceTooSmall(requiredRAMGB: OfflineModelOffer.minimumRAMGB))
     }
 
@@ -150,6 +241,54 @@ final class OfflineModelOfferTests: XCTestCase {
         XCTAssertTrue(detail.contains("8 GB"), detail)
         XCTAssertTrue(detail.lowercased().contains("cloud"),
                       "The refusal has to say what does work on this phone: \(detail)")
+        // It is now reached only when the *smallest* model is out of reach too, and must say so
+        // rather than implying the 8 GB number alone is what excluded this phone.
+        XCTAssertTrue(detail.lowercased().contains("smallest"),
+                      "The refusal must say nothing in the catalog fits: \(detail)")
+    }
+
+    /// The smaller offer's copy is honest in all three directions: the memory the full-size model
+    /// wanted, that this one is smaller, and what it costs to download.
+    func testTheSmallerOfferStatesTheReasonAndTheSize() {
+        let detail = OfflineModelOffer.offerSmallerDetail(primaryRequiredRAMGB: 8,
+                                                          sizeBytes: fallbackSize)
+        XCTAssertTrue(detail.contains("8 GB"),
+                      "The full-size model's requirement is not named: \(detail)")
+        XCTAssertTrue(detail.contains("1.5 GB"),
+                      "The smaller download's size is not stated: \(detail)")
+        XCTAssertTrue(detail.lowercased().contains("smaller"),
+                      "The user must not think this is the full-size model: \(detail)")
+        XCTAssertFalse(detail.lowercased().contains("isn't enough to run a model on-device"),
+                       "The old dead-end claim must not survive: \(detail)")
+    }
+
+    /// The smaller row's title cannot read as the full-size one's, or the whole point is lost.
+    func testTheSmallerTitleIsDistinct() {
+        XCTAssertTrue(OfflineModelOffer.smallerTitle.lowercased().contains("smaller"),
+                      OfflineModelOffer.smallerTitle)
+        for available in [true, false] {
+            XCTAssertNotEqual(OfflineModelOffer.smallerTitle,
+                              OfflineModelOffer.title(appleIntelligenceAvailable: available))
+        }
+    }
+
+    // MARK: - The shared RAM rule
+
+    /// The rounding is the whole reason this helper exists. An 8 GB iPhone reports about 7.5 GB,
+    /// and the raw byte comparison the model manager used to do hid the Download button on
+    /// precisely the hardware an 8 GB floor was written to include.
+    func testTheRAMFloorIsMeasuredAgainstTheNominalSize() {
+        let eightGB = (7.5 as Double).rounded(.up)
+        XCTAssertTrue(LocalLLMService.deviceMeetsRAMFloor(8, marketingRAMGB: eightGB),
+                      "An 8 GB iPhone (reports ~7.5 GB) was excluded by its own tier's floor")
+
+        let sixGB = (5.9 as Double).rounded(.up)
+        XCTAssertFalse(LocalLLMService.deviceMeetsRAMFloor(8, marketingRAMGB: sixGB),
+                       "A 6 GB iPhone was let past an 8 GB floor")
+
+        // A floor of zero is no restriction at all, on any device.
+        XCTAssertTrue(LocalLLMService.deviceMeetsRAMFloor(0, marketingRAMGB: sixGB))
+        XCTAssertTrue(LocalLLMService.deviceMeetsRAMFloor(0, marketingRAMGB: 1))
     }
 
     /// The honest bit about leaving mid-download: it keeps going, and it resumes.


### PR DESCRIPTION
## What the user saw

On an iPhone with less than 8 GB of RAM (iPhone 14 Pro, iPhone 15, iPhone SE — 6 GB), first-run onboarding said:

> This iPhone has less than 8 GB of memory, which isn't enough to run a model on-device. Choose one of the providers instead

…and offered nothing. The statement was false. The 8 GB figure is the **primary** model's own catalog floor (Gemma 4 E2B); most of the catalog carries no floor at all — SmolVLM2 2.2B (1.5 GB), SmolVLM2 500M (0.35 GB), LFM2.5 2.6B, Qwen 2.5 3B and 0.5B all run on those phones. An App Store reviewer on such a device hit a dead end that did not need to exist.

## Three fixes

**1. The offer falls through instead of refusing.** `OfflineModelOffer.verdict` gains `.offerSmaller(modelId:sizeBytes:primaryRequiredRAMGB:)`. A device under the primary's floor is offered the first entry in `LocalModelCatalog.entries` order, excluding the primary, whose own floor it clears — deterministic, and the catalog order stays the one place the preference is expressed. On a 6 GB iPhone that is **SmolVLM2 2.2B (Vision), stated as 1.5 GB**.

The case is distinct from `.offer` so the copy can be honest that it is the smaller model: it names the memory the full-size one wanted, says a smaller model runs here instead, and states the download size. The fallback is subject to every check the primary is — a fitting model already on disk still short-circuits to `.alreadyDownloaded` (wherever it sits in the order), and the storage check uses the fallback's own size, not the primary's 3.6 GB, which would have refused a 1.5 GB download on a phone with room for it. `.deviceTooSmall` survives for the only case that deserves it, a device nothing in the catalog fits, and its copy now says the smallest model is out of reach too.

`Inputs` gains a `catalog: [Candidate]` field defaulting to the shipping catalog, so the decision stays pure and a test can construct devices the real catalog cannot express.

Onboarding renders the new case with the same download button and footer, and the keyless card now names and configures the model this device was actually offered rather than the provider default it cannot load.

**2. `LocalModelManagerView.catalogRow`** compared raw `ProcessInfo.processInfo.physicalMemory` against `minimumRAMGB * 1_073_741_824`. An 8 GB iPhone reports ~7.5 GB, so Gemma 4 E2B showed "Needs 8 GB" with no Download button on exactly the hardware its 8 GB floor was written to include.

**3. `AgenticFeaturesView`** hardcoded `"Needs 8 GB RAM"` for every incompatible model, including the 12 GB one. It now reads the model's own `minimumRAMGB`.

Both go through one shared helper, `LocalLLMService.deviceMeetsRAMFloor(_:marketingRAMGB:)`, which rounds reported memory up to the nominal size. `RecommendedModel.isCompatibleWithDevice` and the offer's own fallback search call it too, so the rounding rule lives in exactly one place. It takes the RAM as a parameter so the rule is testable without depending on the tester's own phone; `deviceMeetsRAMFloor(_:)` stays the production entry point.

## Tests

`OpenGlassesTests/OfflineModelOfferTests.swift`, 18 → 26 cases:

- 6 GB and 4 GB devices → `.offerSmaller` with SmolVLM2 2.2B at 1.5 GB
- the fallback is pinned to the first fitting catalog entry (cross-checked against `LocalModelCatalog.entries` and `expectedDownloadBytes`)
- 8 GB (threshold, inclusive) and 12 GB → still `.offer` with the primary
- fallback already downloaded → `.alreadyDownloaded`; a fitting model further down the list counts too
- fallback with too little disk → `.notEnoughStorage` using the fallback's size, and exactly-enough-for-the-fallback (far short of the primary's requirement) is still a yes
- a device below every floor, via an injected catalog → `.deviceTooSmall`
- the primary is never offered as its own fallback
- the new copy names the full-size requirement, the smaller size, and the word "smaller"; the old dead-end claim is asserted gone
- the shared helper passes a 7.5 GB device through an 8 GB floor and stops a 5.9 GB one; a 0 floor is no restriction
- `testTheGateMatchesTheCatalogRequirement` unchanged and green

## Gates

**Focused suites**
```
Test Suite 'OfflineModelOfferTests' passed
	 Executed 26 tests, with 0 failures (0 unexpected) in 0.030 (0.046) seconds
Test Suite 'LocalModelBudgetTests' passed
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.015 (0.022) seconds
Test Suite 'LocalModelGGUFCatalogTests' passed
	 Executed 10 tests, with 0 failures (0 unexpected) in 0.093 (0.097) seconds
Test Suite 'LocalModelManagerStateTests' passed
	 Executed 27 tests, with 0 failures (0 unexpected) in 0.019 (0.029) seconds
```

**Full unit target** (`-only-testing:OpenGlassesTests`, iPhone 17 Pro simulator)
```
Test Suite 'OpenGlassesTests.xctest' passed
	 Executed 5327 tests, with 13 tests skipped and 0 failures (0 unexpected) in 82.640 (84.624) seconds
** TEST SUCCEEDED **
```

**Release build** (simulator, run alone)
```
** BUILD SUCCEEDED **
```
No new warnings in any touched file.

## Deliberately not done

- No device run — no hardware below 8 GB here. The decision is pure and covered headlessly; the device-facing part is that the download button now appears where it previously did not.
- The `capabilityBadges`/vision implications of defaulting a small phone to a vision model are unchanged: SmolVLM2 2.2B is simply the first fitting catalog entry, and reordering the catalog is a product call, not a bug fix.
- `Localizable.xcstrings` untouched (`SWIFT_EMIT_LOC_STRINGS=NO` on every invocation); the new strings will be picked up by the next catalog-sync commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
