### PR TITLE
Make the stale-mask drop test wait for an idle pipeline

### DIFF
--- a/OpenGlasses/Sources/Services/Vision/OutboundFrameRelay.swift
+++ b/OpenGlasses/Sources/Services/Vision/OutboundFrameRelay.swift
@@ -32,6 +32,11 @@ final class OutboundFrameRelay: ObservableObject {
     @Published private(set) var droppedFrameCount = 0
     @Published private(set) var privacyDroppedFrameCount = 0
 
+    /// No frame in flight and none pending — every frame this relay has accepted has been either
+    /// published or counted as dropped. Read-only; lets a caller (in practice the tests) wait for
+    /// the background detector/compositor hops to finish instead of guessing how long they take.
+    var isIdle: Bool { !coalescer.isProcessing }
+
     private let filter: PrivacyFilterService
     private var coalescer = FrameCoalescer<UIImage>()
     private var rectCache: FaceRectCache

--- a/OpenGlassesTests/OutboundFrameStalenessTests.swift
+++ b/OpenGlassesTests/OutboundFrameStalenessTests.swift
@@ -125,6 +125,27 @@ final class OutboundFrameStalenessTests: XCTestCase {
         return (filter, source, relay)
     }
 
+    /// Wait until every frame sent so far has been published or dropped. The detector and
+    /// compositor run on the relay's background queue, so a fixed sleep races them — on a loaded
+    /// CI runner the last pending frame can still be in flight when the sleep ends. A requeueing
+    /// bug never goes idle, so it fails here on the deadline rather than passing by accident.
+    @MainActor
+    private func waitUntilIdle(_ relay: OutboundFrameRelay,
+                               timeout: TimeInterval = 5,
+                               file: StaticString = #filePath,
+                               line: UInt = #line) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !relay.isIdle {
+            guard Date() < deadline else {
+                XCTFail("relay still busy after \(timeout)s — a frame never finished", file: file, line: line)
+                return
+            }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+    }
+
+    /// Give anything that might still be scheduled a chance to run. Only meaningful *after*
+    /// `waitUntilIdle`, as a check that the pipeline stays quiet — never as the wait itself.
     private func settle() async {
         for _ in 0..<6 { await Task.yield() }
         try? await Task.sleep(nanoseconds: 30_000_000)
@@ -146,10 +167,10 @@ final class OutboundFrameStalenessTests: XCTestCase {
         let token = relay.publisher.sink { received.append($0) }
 
         source.send(makeImage())
-        await settle()
+        await waitUntilIdle(relay)
         clock.set(0.4)
         source.send(makeImage())
-        await settle()
+        await waitUntilIdle(relay)
 
         XCTAssertEqual(received.count, 2)
         XCTAssertTrue(received.allSatisfy { $0 === masked }, "both frames left masked")
@@ -173,16 +194,16 @@ final class OutboundFrameStalenessTests: XCTestCase {
         let token = relay.publisher.sink { received.append($0) }
 
         source.send(makeImage())
-        await settle()
+        await waitUntilIdle(relay)
         clock.set(0.6)                       // past the ceiling, and no detection is due
         source.send(makeImage())
-        await settle()
+        await waitUntilIdle(relay)
 
         XCTAssertEqual(received.count, 1, "the stale frame is dropped, not published")
         XCTAssertEqual(relay.privacyDroppedFrameCount, 1)
 
         source.send(makeImage())             // the cache was cleared, so this one re-detects
-        await settle()
+        await waitUntilIdle(relay)
         XCTAssertEqual(detections.count, 2)
         XCTAssertEqual(received.count, 2)
         XCTAssertTrue(received.allSatisfy { $0 === masked })
@@ -203,12 +224,12 @@ final class OutboundFrameStalenessTests: XCTestCase {
         let token = relay.publisher.sink { received.append($0) }
 
         source.send(makeImage())
-        await settle()
+        await waitUntilIdle(relay)
         clock.set(5)                          // the cached detection is now hopelessly old
 
         for _ in 0..<10 {
             source.send(makeImage())
-            await settle()
+            await waitUntilIdle(relay)
         }
 
         XCTAssertTrue(received.allSatisfy { $0 === masked }, """
@@ -237,21 +258,23 @@ final class OutboundFrameStalenessTests: XCTestCase {
         let token = relay.publisher.sink { received.append($0) }
 
         for _ in 0..<12 { source.send(makeImage()) }
-        await settle()
-        await settle()
+        // The coalescer holds one in flight and one pending, so a backlog cannot form — a relay
+        // that requeued would never go idle and fails here on the deadline.
+        await waitUntilIdle(relay)
 
         XCTAssertTrue(received.isEmpty, """
             Every mask was obsolete by the time it was ready, so nothing was publishable. \
             Publishing here would mean sending pixels masked against a scene that had moved on.
             """)
         XCTAssertGreaterThan(relay.privacyDroppedFrameCount, 0)
-        // The coalescer holds one in flight and one pending; a backlog would show up as a drop
-        // count that keeps climbing after the source stops sending.
-        let settled = relay.droppedFrameCount
+        // Idle means every frame has been dropped; none may be counted twice (requeueing) or
+        // left uncounted (still in the pipeline).
+        XCTAssertEqual(relay.droppedFrameCount, 12,
+                       "every frame is accounted for exactly once — more would mean requeueing")
+        // And once idle it stays idle: the drop count must not climb after the source stops.
         await settle()
-        XCTAssertEqual(relay.droppedFrameCount, settled, "the pipeline must go quiet, not chew a backlog")
-        XCTAssertLessThanOrEqual(relay.droppedFrameCount, 12,
-                                 "no frame may be counted more than once — that would mean requeueing")
+        XCTAssertTrue(relay.isIdle)
+        XCTAssertEqual(relay.droppedFrameCount, 12, "the pipeline must go quiet, not chew a backlog")
         withExtendedLifetime(token) {}
     }
 

--- a/OpenGlassesTests/PrivacyFilterAvailabilityTests.swift
+++ b/OpenGlassesTests/PrivacyFilterAvailabilityTests.swift
@@ -172,12 +172,19 @@ final class PrivacyFilterAvailabilityTests: XCTestCase {
             relay.publisher.sink { [weak self] in self?.published.append($0) }.store(in: &tokens)
         }
 
-        /// Send a frame and let the relay's queue hops settle.
-        func send(_ image: UIImage) async {
+        /// Send a frame and wait until the relay has published or dropped it. The detector and
+        /// compositor hop through a background queue, so a fixed sleep races them on a loaded
+        /// runner; a frame that never finishes fails here on the deadline instead.
+        func send(_ image: UIImage, file: StaticString = #filePath, line: UInt = #line) async {
             source.send(image)
-            for _ in 0..<6 { await Task.yield() }
-            try? await Task.sleep(nanoseconds: 30_000_000)
-            for _ in 0..<6 { await Task.yield() }
+            let deadline = Date().addingTimeInterval(5)
+            while !relay.isIdle {
+                guard Date() < deadline else {
+                    XCTFail("relay still busy after 5s — a frame never finished", file: file, line: line)
+                    return
+                }
+                try? await Task.sleep(nanoseconds: 1_000_000)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`OutboundFrameStalenessTests.testDetectorSlowerThanTheFrameIntervalDropsRatherThanPublishing` has failed on CI twice with the same assertion:

```
OutboundFrameStalenessTests.swift:252: XCTAssertEqual failed: ("12") is not equal to ("11") - the pipeline must go quiet, not chew a backlog
```

- on `main`, the merge of #463: https://github.com/straff2002/OpenGlasses/actions/runs/34454351589
- on #466, a CallKit-removal PR that doesn't touch this code: https://github.com/straff2002/OpenGlasses/actions/runs/34593341011

### The race

The test sends 12 frames. The detector runs on the relay's background queue and advances the fake clock past `maxDetectionAge`, so every frame is dropped. After the sends, the test waited a fixed `settle()` (yields + 30 ms sleep) twice, took a snapshot of `droppedFrameCount`, waited once more, and asserted the count hadn't moved.

The coalescer holds one frame in flight and one pending. On a loaded runner the pending frame (frame 12) was still on the background queue when the snapshot was taken, and its drop landed during the final `settle()`. The count of 12 equals the number of frames sent, so nothing was counted twice and there was no backlog. The final frame was just late. The test was racing wall-clock time against a dispatch queue.

### The fix

- `OutboundFrameRelay.isIdle` is a read-only view of `FrameCoalescer.isProcessing`. It becomes true once no frame is in flight and none is pending, which means every accepted frame has been published or counted as dropped. It doesn't change behaviour.
- The tests now call `waitUntilIdle(relay)` (poll `isIdle` with a 5 s deadline) instead of the fixed `settle()` before asserting.
- The slow-detector test's intent is kept, and its assertions are tighter:
  - Nothing is published (unchanged).
  - `droppedFrameCount == 12` once idle. This replaces the old `<= 12` check: every frame is accounted for exactly once.
  - A relay that requeued would never go idle and now fails on the deadline instead of depending on timing.
  - After idle, a further `settle()` must leave it idle with the count unchanged. This is still the "goes quiet" check, but it now runs after the pipeline is known to be drained.
- The other three relay tests in the file (`…JustUnderTheCeiling…`, `…JustOverTheCeiling…`, `…BurstAfterAStaleDetection…`) used the same fixed sleep before asserting, so they were exposed to the same race. They now wait for idle too.
- `PrivacyFilterAvailabilityTests.Harness.send` had the same fixed-sleep wait behind its four relay tests (background/lock drop-then-fresh-detection, filter toggled on mid-stream, detector failing). It now waits for idle as well.

No privacy assertion was weakened.

## Test plan

All runs on a dedicated iPhone 17 Pro simulator (iOS 27.0) with isolated DerivedData, `-collect-test-diagnostics never` and `SWIFT_EMIT_LOC_STRINGS=NO`, after `fetch-mediapipe-frameworks.sh` and `generate-xcodeproj.sh`:

- [x] `OutboundFrameStalenessTests` × 20 iterations: 240 tests, 0 failures.
- [x] `OutboundFrameStalenessTests` + `PrivacyFilterAvailabilityTests` × 30 iterations, with one `yes` busy loop per core (8) started once the suite began: 750 tests, 0 failures. The host was already heavily loaded, with a load average of about 470 from other work.
  - Loading the machine during app launch instead got the test host killed before it connected, with 0 tests run. That's an environment limit, not a test result, so the load starts after launch.
- [x] Checked that the test bundle that ran contains the new code (the harness's deadline message and the exact-accounting message are both in the binary).
- [x] Release `build-for-testing` (`ENABLE_TESTABILITY=YES CODE_SIGNING_ALLOWED=NO`): the app target and all three changed files compile, and the app links.
  - The test build still fails, but the only errors are an existing problem on `main`: `MetaTelemetryBlockTests` calls `MetaTelemetryBlock.resetCountForTesting()`, which only exists in Debug (`#if DEBUG`). Nothing in this change touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
