### PR TITLE
Get the accessibility audit green: large-text clipping on the Voice home and the picked-conversation test

### DIFF
--- a/OpenGlasses/Sources/App/Views/BottomControlBar.swift
+++ b/OpenGlasses/Sources/App/Views/BottomControlBar.swift
@@ -101,10 +101,17 @@ struct BottomControlBar: View {
                                      showsActions: showsActions)
     }
 
-    /// Four tiles at their floor width need ~268 pt, which every supported width provides. At
-    /// accessibility sizes a tile lays its glyph beside its label and needs the width of a phrase,
-    /// so the same four columns would shred every caption — two is the honest count there.
-    private var columnCount: Int { typeSize.isAccessibilitySize ? 2 : 4 }
+    /// Four tiles at their floor width need ~268 pt, which every supported width provides — at the
+    /// default text size. Above it the captions grow and the column does not, so a caption that
+    /// fits at Large ("Push-Talk") is cut to "Push-T…" by xxxLarge; three across gives each one
+    /// the room back. At accessibility sizes a tile lays its glyph beside its label and needs the
+    /// width of a phrase, and even two across cut every caption to a letter and an ellipsis by
+    /// AX4, so it is one column there — the grid already scrolls vertically inside its bounded
+    /// height. The accessibility audit reports each of those cuts as clipped text.
+    private var columnCount: Int {
+        if typeSize.isAccessibilitySize { return 1 }
+        return typeSize > .large ? 3 : 4
+    }
 
     /// The two scaled parts a tile is made of, so the panel snaps to the height the tile actually
     /// draws rather than to a constant that happens to match at one text size. `BarButton` composes
@@ -868,7 +875,11 @@ private struct BarButton: View {
                     Text(label)
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(foreground)   // .secondary was illegible over the ambience tint
-                        .lineLimit(1)
+                        // One line under the glyph, where the grid is three or four across. Beside the
+                        // glyph at accessibility sizes the caption has a whole row, so a phrase
+                        // wraps at its spaces there instead of losing its end to an ellipsis.
+                        .lineLimit(typeSize.isAccessibilitySize ? nil : 1)
+                        .fixedSize(horizontal: false, vertical: typeSize.isAccessibilitySize)
                         .truncationMode(truncateLabel ? .middle : .tail)
                 }
             }

--- a/OpenGlasses/Sources/App/Views/StatusIndicator.swift
+++ b/OpenGlasses/Sources/App/Views/StatusIndicator.swift
@@ -11,6 +11,7 @@ struct StatusIndicator: View {
     @ObservedObject var openAISession: OpenAIRealtimeSessionManager
     @ObservedObject var openClawBridge: OpenClawBridge
     @Environment(\.appAccent) private var accent
+    @Environment(\.dynamicTypeSize) private var typeSize
     @State private var showDisconnectConfirm = false
 
     /// The status tile, and the glyph inside it. Scaled rather than fixed so the
@@ -119,14 +120,24 @@ struct StatusIndicator: View {
 
             // Bottom row: active mode + the connection pills (formerly a separate band above
             // the card — merged here so the home screen is one status surface, not two).
-            HStack(spacing: 8) {
+            //
+            // Stacked at accessibility sizes: the badge on its own line, the pills under it. Sharing
+            // one line there left the persona name — one user-supplied word — too little width, and
+            // it broke mid-word ("Open-Glass-es"), with "Mode:" splitting from its colon a size
+            // later. The accessibility audit reports that as clipped text. `AnyLayout` rather than
+            // two branches, so the row's elements keep their identity across a text-size change;
+            // swapping subtrees reads to the audit as text that stopped scaling.
+            footerLayout {
                 activeModeBadge
-                Spacer()
+                if !typeSize.isAccessibilitySize {
+                    Spacer()
+                }
                 glassesPill
                 if Config.isOpenClawConfigured {
                     openClawPill
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 16)
             // The pills now carry a full 44pt target, which is taller than the
             // capsules they draw — so the row's own bottom padding comes off to
@@ -232,6 +243,20 @@ struct StatusIndicator: View {
 
     // MARK: - Active Mode Badge
 
+    private var footerLayout: AnyLayout {
+        typeSize.isAccessibilitySize
+            ? AnyLayout(VStackLayout(alignment: .leading, spacing: 6))
+            : AnyLayout(HStackLayout(spacing: 8))
+    }
+
+    /// The badge's own line break, for the same reason as the row's: at accessibility sizes the
+    /// name gets a line of its own under "Mode:", so it wraps at word boundaries or not at all.
+    private var badgeLayout: AnyLayout {
+        typeSize.isAccessibilitySize
+            ? AnyLayout(VStackLayout(alignment: .leading, spacing: 2))
+            : AnyLayout(HStackLayout(spacing: 6))
+    }
+
     private var activeModeBadge: some View {
         let persona = appState.activePersona
         let name = persona?.name ?? "OpenGlasses"
@@ -242,25 +267,27 @@ struct StatusIndicator: View {
         let dotColor: Color = connected ? OGTheme.ok : OGTheme.secondaryLabel
         let nameColor: Color = connected ? OGTheme.okLabel : OGTheme.secondaryLabel
 
-        return HStack(spacing: 6) {
-            Circle()
-                .fill(dotColor)
-                .frame(width: statusDot, height: statusDot)
-                .accessibilityHidden(true)
-            Group {
-                if icon == "OpenGlassesLogo" {
-                    LogoIcon(size: pillGlyph)
-                } else {
-                    Image(systemName: icon)
-                        .font(.caption.weight(.medium))
+        return badgeLayout {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(dotColor)
+                    .frame(width: statusDot, height: statusDot)
+                    .accessibilityHidden(true)
+                Group {
+                    if icon == "OpenGlassesLogo" {
+                        LogoIcon(size: pillGlyph)
+                    } else {
+                        Image(systemName: icon)
+                            .font(.caption.weight(.medium))
+                    }
                 }
-            }
-            .foregroundStyle(nameColor)
-            .accessibilityHidden(true)
-            Text(connected ? "Active mode:" : "Mode:")
-                .font(.caption)
-                .foregroundStyle(OGTheme.secondaryLabel)
-                .fixedSize(horizontal: false, vertical: true)
+                .foregroundStyle(nameColor)
+                .accessibilityHidden(true)
+                Text(connected ? "Active mode:" : "Mode:")
+                    .font(.caption)
+                    .foregroundStyle(OGTheme.secondaryLabel)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
             Text(name)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(nameColor)

--- a/OpenGlassesUITests/ConversationPageTests.swift
+++ b/OpenGlassesUITests/ConversationPageTests.swift
@@ -9,9 +9,21 @@ import XCTest
 /// halves were individually correct.
 final class ConversationPageTests: AccessibilityAuditCase {
 
-    /// A line from the older seeded conversation (see `UITestSupport.longExchange`).
-    private let seededReply = "It's galvanised steel"
-    private let seededQuestion = "What's the flashing on the roof made of?"
+    /// The newest exchange of the older seeded conversation (see `UITestSupport.longExchange`).
+    ///
+    /// The newest, deliberately. The page lands a picked thread on its latest message — that is
+    /// the product rule (`ConversationThreadTranscript` scrolls to the bottom on appear and on a
+    /// thread switch), and the long seed is long precisely so the page has to scroll. Its bubbles
+    /// sit in a lazy stack, so the thread's *first* exchange is above the fold and never reaches
+    /// the accessibility tree at all: asserting on it failed with the conversation fully rendered
+    /// on screen. The question is also not the thread's first user message, so it cannot be
+    /// satisfied by the header, which names the thread after that message.
+    ///
+    /// None of this loosens what the file is for. Before the fix the page rendered no stored
+    /// message whatsoever — only the live turn's cards over "Nothing said yet." — so any line from
+    /// the picked thread, from either side, is proof it is being drawn.
+    private let seededReply = "the black rubbery kind"
+    private let seededQuestion = "Remind me what tape you said."
 
     func testPickingAConversationShowsWhatWasSaidInIt() {
         let app = launch([.configured, .seedConversations])


### PR DESCRIPTION
The nightly **Accessibility Audit** has failed on `main` every night since 1 September on three UI tests. This PR fixes all three. Two are product fixes to the session surface. The third is a test that asserted on lines the page, by design, never puts in the accessibility tree.

## 1 and 2. Session surface audits (Voice tab, captions overlay)

**Findings, verbatim** (from a local reproduction on `origin/main`, Xcode 27 RC, iOS 27 simulator; the same on both tests):

```
Session surface — Voice tab: 2 accessibility audit issue(s).

• [textClipped] Text clipped
  Text of this element may be clipped at larger Dynamic Type sizes.

• [textClipped] Text clipped
  Text of this SwiftUI.AccessibilityNode may be clipped at larger Dynamic Type sizes.
  element: Attributes: StaticText, 0x113239a40, {{108.7, 160.8}, {77.7, 14.3}}, label: 'OpenGlasses'
```

The captions overlay reported the same pair locally (CI's first line said 1 issue there).

These are not contrast failures. Both are `textClipped` from the audit's larger-Dynamic-Type pass. The test's screen recording shows that pass stepping the app down to xSmall, up through xLarge and xxxLarge, then to AX5, and back.

**Finding A: `'OpenGlasses'`** is the persona name in the status card's mode badge. Its footer row, `[badge, Spacer, glasses pill]`, cannot fit on one line from AX2 up, so the single word breaks mid-word: "Open-Glasses" at AX2, "Open-Glass-es" at AX3, with "Mode:" splitting from its colon at AX4 (screenshots taken at each size). `.layoutPriority` did not help: the row genuinely does not fit.

**Finding B: the element-less one** was found by elimination. One build carried temporary launch-environment switches, each hiding one component, and each variant ran `.textClipped` alone. It was 1 with the status card, My Day, either pager page or the capsule hidden, and **0 only with the grid page hidden**. A second round on the grid: **0 with captions allowed to wrap, 0 with three columns**, still 1 with the viewport unsnapped or the page dots hidden. It is the four-across grid cutting captions that fit at the default size ("Push-Talk" → "Push-T…" at xxxLarge). At accessibility sizes, two across cut them further ("Conn…" at AX1, "Mo…"/"Co…" by AX4).

**Root cause and the commit that introduced it:** dbf1c376 ("Voice home grid, unified dock…", 31 Aug).
- It removed `VoiceTab`'s `typeSize.isAccessibilitySize` branch (`accessibleConversationZone`). Before it, the status card the audit measured at the default size was swapped for a different subtree at accessibility sizes, so the audit's larger-size pass never followed it there. The unified zone keeps the same card at every size, so the pass now reaches the mid-word break. `StatusIndicator.swift` is unchanged since the last green run (d6f616e5); only its container changed.
- It also added the four-across grid, which kept its column count while its captions grew.

**Fix:**
- `StatusIndicator`: at accessibility sizes the footer stacks (badge above the pills) and the badge puts the name on its own line under "Mode:". This uses `AnyLayout` (`HStackLayout` ↔ `VStackLayout`) rather than two branches. A `ViewThatFits` version was tried first and rejected: swapping subtrees made the audit report `[dynamicType] Dynamic Type font sizes are partially unsupported` on both texts, because the elements it measured stopped existing. Default sizes are unchanged.
- `BottomControlBar`: the grid is 4 columns at the default size and below, 3 above it, and 1 at accessibility sizes. At accessibility sizes, where the glyph sits beside the caption, the caption wraps at its spaces instead of truncating.
- No colours changed.

**Deferrals: none added, none widened.** `contrastThroughGlass` and `focusableCaptionHistory` are untouched, and no assertion in `SessionSurfaceAccessibilityTests` changed.

## 3. `ConversationPageTests.testPickingAConversationShowsWhatWasSaidInIt`

**Verdict: a test bug. The product fix from ba6feda7 holds.**

Evidence: the accessibility hierarchy XCTest captured at the moment of failure (local reproduction on `origin/main`). After the pick, the header reads `Conversation: What's the flashing on the roof…`, and the transcript renders the thread's bubbles ("The lifted section can be re-fastened…", "What would a roofer charge for that?", "Remind me what tape you said.", "Butyl tape — the black rubbery kind…"), scrolled to 97%. Missing are exactly the two lines the test asserted on: the thread's *first* question and reply.

`ConversationThreadTranscript` scrolls to the newest message on appear and on a thread switch (the product rule), and its bubbles are in a `LazyVStack`. The long seed is long precisely so the page has to scroll, so the first exchange is above the fold and is never realised into the tree. The header truncates the title, so the question assertion could not pass on the header either.

**Test change:** the assertions now use the newest reply ("the black rubbery kind") and question ("Remind me what tape you said.") of the same picked thread. There are still three assertions (reply, question, not "Nothing said yet."), none weakened. The question is not the thread's first user message, so it cannot be satisfied by the header, which is titled after that message. Before the fix this guards, the page drew no stored message at all, so any line from the picked thread proves it is rendered.

## Local gates

All on a dedicated iOS 27 simulator (iPhone 17 Pro), Xcode 27 RC, mirroring the workflow's invocation (`-skipPackagePluginValidation -skipMacroValidation -onlyUsePackageVersionsFromResolvedFile SWIFT_EMIT_LOC_STRINGS=NO`, plus `-collect-test-diagnostics never`).

| Gate | Result |
|---|---|
| The three target tests, run 1 | `Executed 3 tests, with 0 failures (0 unexpected) in 70.845 (70.862) seconds` — `** TEST SUCCEEDED **` |
| The three target tests, run 2 (consecutive) | `Executed 3 tests, with 0 failures (0 unexpected) in 70.584 (70.599) seconds` — `** TEST SUCCEEDED **` |
| Full `OpenGlassesUITests` scheme | `Executed 27 tests, with 0 failures (0 unexpected) in 658.442 (658.509) seconds` — `** TEST SUCCEEDED **` |
| Full `OpenGlassesTests` unit target (scheme `OpenGlasses`, Debug, signed) | `Executed 5327 tests, with 13 tests skipped and 0 failures (0 unexpected) in 92.366 (94.618) seconds` — `** TEST SUCCEEDED **` |
| Release simulator build, scheme `OpenGlasses`, run alone (`-configuration Release CODE_SIGNING_ALLOWED=NO`) | `** BUILD SUCCEEDED **` |

One local-only note: a freshly reset simulator shows the system HomeKit prompt over the app at launch, which keeps the captions seed from surfacing if the captions test runs *first*. In CI (and in the runs above) an earlier test's interaction clears it through XCTest's interruption handler, so the target tests were always run with `ConversationPageTests` first. No test or product change for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
