### PR TITLE
Declare the app's standard encryption for export compliance

### DIFF
--- a/OpenGlasses/Info.plist
+++ b/OpenGlasses/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<false/>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
`OpenGlasses/Info.plist` declared `ITSAppUsesNonExemptEncryption = false`. That is no longer true, so this flips it to `true`. One line, one file.

## Why

The Field Assist expert call goes through the bundled WebRTC library. `Sources/Services/FieldAssist/WebRTCPeerTransport.swift` is the only file in the app that imports `WebRTC`, and the framework it links (SwiftPM `WebRTC` 120.0.0, Google WebRTC M120) compiles in its own BoringSSL — 145 `third_party/boringssl/...` source paths appear in the `ios-arm64` binary's strings — and runs DTLS-SRTP over the media. The transport sets no crypto parameters at all (`RTCConfiguration()` gets only `sdpSemantics` and `iceServers`), so the library's defaults apply: a self-signed ECDSA P-256 certificate per session, DTLS 1.2 with ECDHE, and SRTP under `AES_CM_128_HMAC_SHA1_80` or the AES-GCM profiles.

Meta's glasses SDK is a second instance: the `MWDATCore` binary carries its own mbedtls elliptic-curve code (`mbedtls_ecp_*`, `Secp256r1`, `X25519`, ECDSA, HKDF, HMAC-SHA-256, AES-128/256 in GCM/CTR/CBC) for the phone-to-glasses link.

Either one on its own is "standard encryption algorithms instead of, or in addition to, using or accessing the encryption within Apple's operating system", which is the answer App Store Connect asks about. One non-exempt component settles it for the whole app.

## What stays exempt

Everything the app does itself still runs on Apple's cryptography, and none of it is what forces this change:

- ChaCha20-Poly1305 (CryptoKit, 256-bit) for stored conversations (`ConversationEncryptionService`) and face templates (`Privacy/ScopedKeyring`)
- Curve25519/Ed25519 signature verification for Field Assist licences, skill packs and vault packs, plus the device identity key for gateway handshakes
- SHA-256 for download and archive integrity, HMAC-SHA-256 for the audit-log checkpoint seal
- TLS 1.2/1.3 through URLSession, `URLSessionWebSocketTask` and `NWProtocolTLS`, and RTMPS through the RTMP module's Network.framework TLS

`swift-crypto` arrives transitively, uses SHA-256 only, and re-exports CryptoKit on Apple platforms. HaishinKit's SRT and WebRTC sub-products, which would bundle OpenSSL, are **not** linked — the app links only `HaishinKit` and `RTMPHaishinKit`, and the Release binary contains no OpenSSL, libsrt or libdatachannel strings. The MediaPipe, sherpa-onnx/onnxruntime and llama.cpp binaries carry no crypto library.

## What App Store Connect will ask

For each build until Apple issues a compliance code:

- *"What type of encryption algorithms does your app implement?"* → **Standard encryption algorithms instead of, or in addition to, using or accessing the encryption within Apple's operating system.** Not "proprietary", not "both", not "none".
- The France question → while France is excluded, answer that the app is not distributed in France, and upload nothing.

No `ITSEncryptionExportComplianceCode` is added here. Apple issues that code only after it has reviewed the uploaded documentation; it goes in later, in its own change.

## France

Apple requires a French encryption declaration for distribution on the French App Store. Under décret n° 2007-663 (Art. 3 1° and Art. 4) the declaration goes to ANSSI at least one month before supply begins, and ANSSI returns a receipt with a registration number; an incomplete file restarts the month (Art. 5). **France stays out of App Store availability until one month after ANSSI receives a complete file**, after which the declaration and receipt are uploaded in App Store Connect and France is switched back on. The declaration pack is drafted and held outside this repository, since this repository is public.

## United States

Nothing is filed. The app self-classifies as **ECCN 5D992.c** mass market software under Note 3 to Category 5 Part 2, self-classified by the producer under License Exception ENC §740.17(b)(1). No BIS classification request is needed, and no annual self-classification report is due: 15 CFR §740.17(e)(3) states that the report requirement "applies to 'mass market' encryption components and 'executable software'", where *'executable software'* means "software in executable form, from an existing hardware component excluded from ECCN 5A002 by the Cryptography Note" — which excludes complete binary images running on an end item. This app is a complete binary image running on an end item, so it falls outside that scope. The usual limits still apply (embargoed destinations, Russia/Belarus measures, prohibited end users and end uses).

## Verification

- `plutil -lint OpenGlasses/Info.plist` → OK
- `TelemetryOptOutGuardTests` and `MWDATConfigCheckTests` (both read Info.plist) on an iOS 27 simulator: 8 + 6 = 14 tests executed, 0 failures, `** TEST SUCCEEDED **`
- Release simulator build of scheme `OpenGlasses`: `** BUILD SUCCEEDED **`
- `plutil -p` on the built Release app's `Info.plist` → `"ITSAppUsesNonExemptEncryption" => true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)