### PR TITLE
Filter iOS TTS voices by the wearer's languages

### DIFF
--- a/OpenGlasses/Sources/Services/TextToSpeechService.swift
+++ b/OpenGlasses/Sources/Services/TextToSpeechService.swift
@@ -683,7 +683,7 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
     private func speakWithiOS(text: String) async {
         let utterance = AVSpeechUtterance(string: text)
 
-        // Pick the best available voice for the wearer's languages: premium > enhanced > default
+        // Respect the saved voice and device language order before voice quality.
         let voice = Self.bestAvailableVoice()
         utterance.voice = voice
         // A voice identifier is treated as an identifier, not a catalog name: a wearer who has
@@ -711,63 +711,35 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
             return voice
         }
 
-        // Auto-select: the best-quality voice in the wearer's preferred languages
-        // (mirrors `SpeechLocaleResolver`), then best-quality English as fallback.
-        if let best = availableVoices().first, best.quality.rawValue >= 2 {
-            return best
+        let allVoices = AVSpeechSynthesisVoice.speechVoices()
+        if let selected = TTSVoiceResolver.resolve(
+            savedIdentifier: preferred,
+            preferredLanguages: Locale.preferredLanguages,
+            voices: allVoices.map(voiceDescriptor)
+        ) {
+            return allVoices.first { $0.identifier == selected.identifier }
         }
-
-        // Fallback to standard en-US
         return AVSpeechSynthesisVoice(language: "en-US")
     }
 
-    /// Voices available on this device, filtered to the wearer's language setup and sorted by
-    /// quality (premium > enhanced > default) then display name.
-    ///
-    /// Selection mirrors `SpeechLocaleResolver`: the device's preferred languages plus any
-    /// explicitly chosen voice (which always stays visible whatever its language), matched by
-    /// canonical identifier and then language code — so a Chinese interface is offered Chinese
-    /// voices and a manual pick survives a language change. Falls back to English voices only
-    /// when the preferred languages match nothing installed.
+    /// Installed voices in the user's languages, plus English and their saved voice.
     static func availableVoices() -> [AVSpeechSynthesisVoice] {
-        let allVoices = AVSpeechSynthesisVoice.speechVoices()
-        let preferred = languagePreferences()
-        let matched = allVoices.filter { voice in
-            preferred.contains(canonical(voice.language))
-                || preferred.contains(languageCode(of: voice.language))
+        var allVoices = AVSpeechSynthesisVoice.speechVoices()
+        let saved = Config.iosTTSVoiceId
+        if !saved.isEmpty, !allVoices.contains(where: { $0.identifier == saved }),
+           let voice = AVSpeechSynthesisVoice(identifier: saved) {
+            allVoices.append(voice)
         }
-        let base = matched.isEmpty
-            ? allVoices.filter { languageCode(of: $0.language) == "en" }
-            : matched
-        return base.sorted { lhs, rhs in
-            if lhs.quality != rhs.quality { return lhs.quality.rawValue > rhs.quality.rawValue }
-            return lhs.name < rhs.name
-        }
+        return TTSVoiceResolver.available(
+            savedIdentifier: saved,
+            preferredLanguages: Locale.preferredLanguages,
+            voices: allVoices.map(voiceDescriptor)
+        ).compactMap { descriptor in allVoices.first { $0.identifier == descriptor.identifier } }
     }
 
-    /// Locales a voice should match: the device's preferred languages (in canonical and
-    /// language-code forms) plus the language of the explicitly selected voice, so a manual
-    /// choice is never filtered out of the picker.
-    private static func languagePreferences() -> Set<String> {
-        var keys: Set<String> = []
-        for language in Locale.preferredLanguages {
-            keys.insert(canonical(language))
-            keys.insert(languageCode(of: language))
-        }
-        if !Config.iosTTSVoiceId.isEmpty,
-           let chosen = AVSpeechSynthesisVoice(identifier: Config.iosTTSVoiceId) {
-            keys.insert(canonical(chosen.language))
-            keys.insert(languageCode(of: chosen.language))
-        }
-        return keys
-    }
-
-    private static func canonical(_ identifier: String) -> String {
-        identifier.replacingOccurrences(of: "_", with: "-").lowercased()
-    }
-
-    private static func languageCode(of identifier: String) -> String {
-        canonical(identifier).components(separatedBy: "-").first ?? identifier
+    private static func voiceDescriptor(_ voice: AVSpeechSynthesisVoice) -> TTSVoiceResolver.Voice {
+        .init(identifier: voice.identifier, language: voice.language,
+              quality: voice.quality.rawValue, name: voice.name)
     }
 
     // MARK: - AVSpeechSynthesizerDelegate (iOS fallback)

--- a/OpenGlasses/Sources/Services/TextToSpeechService.swift
+++ b/OpenGlasses/Sources/Services/TextToSpeechService.swift
@@ -683,7 +683,7 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
     private func speakWithiOS(text: String) async {
         let utterance = AVSpeechUtterance(string: text)
 
-        // Pick the best available English voice: premium > enhanced > default
+        // Pick the best available voice for the wearer's languages: premium > enhanced > default
         let voice = Self.bestAvailableVoice()
         utterance.voice = voice
         // A voice identifier is treated as an identifier, not a catalog name: a wearer who has
@@ -711,14 +711,9 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
             return voice
         }
 
-        // Auto-select: best quality English voice available
-        let allVoices = AVSpeechSynthesisVoice.speechVoices()
-        let englishVoices = allVoices.filter { $0.language.hasPrefix("en") }
-
-        // Sort by quality descending (premium=3, enhanced=2, default=1)
-        let sorted = englishVoices.sorted { $0.quality.rawValue > $1.quality.rawValue }
-
-        if let best = sorted.first, best.quality.rawValue >= 2 {
+        // Auto-select: the best-quality voice in the wearer's preferred languages
+        // (mirrors `SpeechLocaleResolver`), then best-quality English as fallback.
+        if let best = availableVoices().first, best.quality.rawValue >= 2 {
             return best
         }
 
@@ -726,14 +721,53 @@ class TextToSpeechService: NSObject, ObservableObject, AVSpeechSynthesizerDelega
         return AVSpeechSynthesisVoice(language: "en-US")
     }
 
-    /// All English voices available on this device, grouped by quality.
+    /// Voices available on this device, filtered to the wearer's language setup and sorted by
+    /// quality (premium > enhanced > default) then display name.
+    ///
+    /// Selection mirrors `SpeechLocaleResolver`: the device's preferred languages plus any
+    /// explicitly chosen voice (which always stays visible whatever its language), matched by
+    /// canonical identifier and then language code — so a Chinese interface is offered Chinese
+    /// voices and a manual pick survives a language change. Falls back to English voices only
+    /// when the preferred languages match nothing installed.
     static func availableVoices() -> [AVSpeechSynthesisVoice] {
-        AVSpeechSynthesisVoice.speechVoices()
-            .filter { $0.language.hasPrefix("en") }
-            .sorted { lhs, rhs in
-                if lhs.quality != rhs.quality { return lhs.quality.rawValue > rhs.quality.rawValue }
-                return lhs.name < rhs.name
-            }
+        let allVoices = AVSpeechSynthesisVoice.speechVoices()
+        let preferred = languagePreferences()
+        let matched = allVoices.filter { voice in
+            preferred.contains(canonical(voice.language))
+                || preferred.contains(languageCode(of: voice.language))
+        }
+        let base = matched.isEmpty
+            ? allVoices.filter { languageCode(of: $0.language) == "en" }
+            : matched
+        return base.sorted { lhs, rhs in
+            if lhs.quality != rhs.quality { return lhs.quality.rawValue > rhs.quality.rawValue }
+            return lhs.name < rhs.name
+        }
+    }
+
+    /// Locales a voice should match: the device's preferred languages (in canonical and
+    /// language-code forms) plus the language of the explicitly selected voice, so a manual
+    /// choice is never filtered out of the picker.
+    private static func languagePreferences() -> Set<String> {
+        var keys: Set<String> = []
+        for language in Locale.preferredLanguages {
+            keys.insert(canonical(language))
+            keys.insert(languageCode(of: language))
+        }
+        if !Config.iosTTSVoiceId.isEmpty,
+           let chosen = AVSpeechSynthesisVoice(identifier: Config.iosTTSVoiceId) {
+            keys.insert(canonical(chosen.language))
+            keys.insert(languageCode(of: chosen.language))
+        }
+        return keys
+    }
+
+    private static func canonical(_ identifier: String) -> String {
+        identifier.replacingOccurrences(of: "_", with: "-").lowercased()
+    }
+
+    private static func languageCode(of identifier: String) -> String {
+        canonical(identifier).components(separatedBy: "-").first ?? identifier
     }
 
     // MARK: - AVSpeechSynthesizerDelegate (iOS fallback)

--- a/OpenGlasses/Sources/Utils/TTSVoiceResolver.swift
+++ b/OpenGlasses/Sources/Utils/TTSVoiceResolver.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Pure selection policy, independent of the voices installed on the test device.
+enum TTSVoiceResolver {
+    struct Voice: Equatable {
+        let identifier: String
+        let language: String
+        let quality: Int
+        let name: String
+    }
+
+    static func resolve(savedIdentifier: String, preferredLanguages: [String], voices: [Voice]) -> Voice? {
+        if let saved = voices.first(where: { $0.identifier == savedIdentifier }) { return saved }
+        for language in preferredLanguages + ["en-US"] {
+            let exact = voices.filter { canonical($0.language) == canonical(language) }
+            if let best = exact.sorted(by: qualityOrder).first { return best }
+            let compatible = voices.filter { matchesLanguage($0.language, language) }
+            if let best = compatible.sorted(by: qualityOrder).first { return best }
+        }
+        return nil
+    }
+
+    /// Include all qualities in preferred languages, English, and the saved voice.
+    static func available(savedIdentifier: String, preferredLanguages: [String], voices: [Voice]) -> [Voice] {
+        voices.filter { voice in
+            voice.identifier == savedIdentifier || (preferredLanguages + ["en-US"]).contains {
+                matchesLanguage(voice.language, $0)
+            }
+        }.sorted(by: qualityOrder)
+    }
+
+    private static func matchesLanguage(_ lhs: String, _ rhs: String) -> Bool {
+        let left = Locale.Language(identifier: lhs)
+        let right = Locale.Language(identifier: rhs)
+        guard let code = left.languageCode, code == right.languageCode else { return false }
+        // Foundation infers scripts for regional locales too (zh-TW → Hant), so
+        // a region fallback never substitutes Simplified for Traditional Chinese.
+        if let leftScript = left.script, let rightScript = right.script {
+            return leftScript == rightScript
+        }
+        return true
+    }
+
+    private static func canonical(_ language: String) -> String {
+        language.replacingOccurrences(of: "_", with: "-").lowercased()
+    }
+
+    private static func qualityOrder(_ lhs: Voice, _ rhs: Voice) -> Bool {
+        if lhs.quality != rhs.quality { return lhs.quality > rhs.quality }
+        if lhs.name != rhs.name { return lhs.name < rhs.name }
+        return lhs.identifier < rhs.identifier
+    }
+}

--- a/OpenGlassesTests/TTSVoiceResolverTests.swift
+++ b/OpenGlassesTests/TTSVoiceResolverTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import OpenGlasses
+
+final class TTSVoiceResolverTests: XCTestCase {
+    private func voice(_ id: String, _ language: String, _ quality: Int = 1) -> TTSVoiceResolver.Voice {
+        .init(identifier: id, language: language, quality: quality, name: id)
+    }
+
+    func testSavedVoiceOverridesDeviceLanguages() {
+        let voices = [voice("english", "en-US", 3), voice("japanese", "ja-JP")]
+        XCTAssertEqual(TTSVoiceResolver.resolve(savedIdentifier: "japanese", preferredLanguages: ["en-US"],
+                                                voices: voices)?.identifier, "japanese")
+    }
+
+    func testMissingSavedVoiceFallsBackToStandardQualityPrimaryLanguage() {
+        let voices = [voice("english", "en-US", 3), voice("french", "fr-FR")]
+        XCTAssertEqual(TTSVoiceResolver.resolve(savedIdentifier: "removed", preferredLanguages: ["fr-FR", "en-US"],
+                                                voices: voices)?.identifier, "french")
+    }
+
+    func testExactRegionWinsBeforeQuality() {
+        let voices = [voice("canadian", "fr-CA"), voice("france", "fr-FR", 3)]
+        XCTAssertEqual(TTSVoiceResolver.resolve(savedIdentifier: "", preferredLanguages: ["FR_ca"],
+                                                voices: voices)?.identifier, "canadian")
+    }
+
+    func testPrimaryLanguageRegionFallbackWinsBeforeSecondaryLanguage() {
+        let voices = [voice("french", "fr-FR"), voice("english", "en-US", 3)]
+        XCTAssertEqual(TTSVoiceResolver.resolve(savedIdentifier: "", preferredLanguages: ["fr-CA", "en-US"],
+                                                voices: voices)?.identifier, "french")
+    }
+
+    func testQualityWinsWithinMatchingLocale() {
+        let voices = [voice("standard", "de-DE"), voice("enhanced", "de-DE", 2), voice("premium", "de-DE", 3)]
+        XCTAssertEqual(TTSVoiceResolver.resolve(savedIdentifier: "", preferredLanguages: ["de-DE"],
+                                                voices: voices)?.identifier, "premium")
+    }
+
+    func testRegionalFallbackPreservesInferredScript() {
+        let voices = [voice("simplified", "zh-CN", 3), voice("traditional", "zh-HK")]
+        XCTAssertEqual(TTSVoiceResolver.resolve(savedIdentifier: "", preferredLanguages: ["zh-TW"],
+                                                voices: voices)?.identifier, "traditional")
+    }
+
+    func testExplicitScriptDoesNotFallBackToIncompatibleVoice() {
+        let voices = [voice("cyrillic", "sr-RS", 3), voice("english", "en-US")]
+        XCTAssertEqual(TTSVoiceResolver.resolve(savedIdentifier: "", preferredLanguages: ["sr-Latn"],
+                                                voices: voices)?.identifier, "english")
+    }
+
+    func testUnsupportedPrimaryLanguageTriesNextPreference() {
+        let voices = [voice("german", "de-DE"), voice("english", "en-US", 3)]
+        XCTAssertEqual(TTSVoiceResolver.resolve(savedIdentifier: "", preferredLanguages: ["ja-JP", "de-DE"],
+                                                voices: voices)?.identifier, "german")
+    }
+
+    func testEnglishFallbackAndEmptyCatalog() {
+        XCTAssertEqual(TTSVoiceResolver.resolve(savedIdentifier: "", preferredLanguages: ["ja-JP"],
+                                                voices: [voice("english", "en-GB")])?.identifier, "english")
+        XCTAssertNil(TTSVoiceResolver.resolve(savedIdentifier: "", preferredLanguages: [], voices: []))
+    }
+
+    func testPickerIncludesPreferredLanguagesEnglishAndSavedVoice() {
+        let voices = [voice("fr", "fr-FR"), voice("de", "de-DE", 2), voice("en", "en-US"),
+                      voice("saved", "ja-JP"), voice("unrelated", "es-ES")]
+        let available = TTSVoiceResolver.available(savedIdentifier: "saved", preferredLanguages: ["fr-CA", "de-DE"], voices: voices)
+        XCTAssertEqual(Set(available.map(\.identifier)), Set(["fr", "de", "en", "saved"]))
+        XCTAssertEqual(available.first?.identifier, "de")
+    }
+}


### PR DESCRIPTION
The iOS fallback voice picker and automatic selection only offered English voices. Offer installed voices in the wearer’s preferred languages and retain their saved voice, while keeping English available.

Automatic selection now respects a saved voice first, then device language order, exact locale and compatible script before voice quality. A standard-quality French voice therefore wins over a premium secondary-language English voice, and regional fallback preserves distinctions such as Traditional versus Simplified Chinese. English is used when no preferred language matches.

A pure TTSVoiceResolver keeps the policy testable independently of installed device voices. Ten regression tests cover saved and removed selections, language order, exact regions, inferred and explicit scripts, quality ranking, picker visibility, and fallback.

Validation: all ten resolver tests pass in an isolated macOS Swift package using unchanged production resolver and test files; resolver typecheck, privacy logging, and git diff checks pass. The app builds with Xcode 27 and all ten voice tests also pass on the iPhone 17 Pro / iOS 27 simulator.

Scope: iOS system voice selection only. Model-saving fixes are handled separately in #474.
