### PR TITLE
Fix saving account-based and keyless models

### DIFF
--- a/OpenGlasses/Sources/App/Views/AddModelView.swift
+++ b/OpenGlasses/Sources/App/Views/AddModelView.swift
@@ -3,6 +3,10 @@ import SwiftUI
 struct AddModelView: View {
     @Environment(\.dismiss) private var dismiss
 
+    @ObservedObject private var claudeOAuth = ClaudeOAuthService.shared
+    @ObservedObject private var chatgptOAuth = ChatGPTOAuthService.shared
+    @ObservedObject private var googleOAuth = GoogleOAuthService.shared
+
     @State private var name: String = ""
     @State private var selectedProvider: LLMProvider = .anthropic
     @State private var apiKey: String = ""
@@ -64,10 +68,19 @@ struct AddModelView: View {
                         onAdd(config)
                         dismiss()
                     }
-                    .disabled(selectedProvider == .local ? model.isEmpty : apiKey.isEmpty)
+                    .disabled(!canAdd)
                 }
             }
         }
+    }
+
+    private var canAdd: Bool {
+        ModelFormValidation.canAdd(
+            provider: selectedProvider, model: model, baseURL: baseURL, apiKey: apiKey,
+            claudeConnected: claudeOAuth.isConnected,
+            chatgptConnected: chatgptOAuth.isConnected,
+            googleConnected: googleOAuth.isConnected
+        )
     }
 
     // MARK: - Pre-fill from existing saved model

--- a/OpenGlasses/Sources/App/Views/ModelFormView.swift
+++ b/OpenGlasses/Sources/App/Views/ModelFormView.swift
@@ -32,6 +32,7 @@ struct ModelFormView: View {
     // Account sign-in state (Anthropic + ChatGPT — rendered via the shared OAuthSignInRows)
     @ObservedObject private var claudeOAuth = ClaudeOAuthService.shared
     @ObservedObject private var chatgptOAuth = ChatGPTOAuthService.shared
+    @ObservedObject private var googleOAuth = GoogleOAuthService.shared
 
     @Environment(\.appAccent) private var accent
     /// Row heights that have to grow with the type beside them, so every
@@ -260,7 +261,7 @@ struct ModelFormView: View {
             }
             .frame(minHeight: rowMinHeight)
         }
-        .disabled((apiKey.isEmpty && selectedProvider != .custom && !accountOAuthReady) || isFetchingModels)
+        .disabled(!credentialsReady || isFetchingModels)
         .accessibilityLabel(
             keyValidated
                 ? "\(availableModels.count) models available. Check again"
@@ -504,11 +505,13 @@ struct ModelFormView: View {
 
     // MARK: - Account sign-in (OAuth)
 
-    /// True when the selected provider can authenticate without a pasted key.
-    private var accountOAuthReady: Bool {
-        (selectedProvider == .anthropic && claudeOAuth.isConnected)
-            || (selectedProvider == .chatgpt && chatgptOAuth.isConnected)
-            || (selectedProvider == .geminiVertex && GoogleOAuthService.shared.isConnected)
+    private var credentialsReady: Bool {
+        ModelFormValidation.credentialsReady(
+            provider: selectedProvider, apiKey: apiKey,
+            claudeConnected: claudeOAuth.isConnected,
+            chatgptConnected: chatgptOAuth.isConnected,
+            googleConnected: googleOAuth.isConnected
+        )
     }
 
     private var anthropicKeyPlaceholder: String {

--- a/OpenGlasses/Sources/Utils/ModelFormValidation.swift
+++ b/OpenGlasses/Sources/Utils/ModelFormValidation.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Shared credential rules for adding a model and fetching its available model IDs.
+enum ModelFormValidation {
+    static func credentialsReady(
+        provider: LLMProvider, apiKey: String,
+        claudeConnected: Bool, chatgptConnected: Bool, googleConnected: Bool
+    ) -> Bool {
+        let hasKey = !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        switch provider {
+        case .local, .appleOnDevice, .custom:
+            return true
+        case .chatgpt:
+            return chatgptConnected
+        case .geminiVertex:
+            return googleConnected
+        case .anthropic:
+            return hasKey || claudeConnected
+        case .openai, .gemini, .groq, .zai, .qwen, .minimax, .xai, .openrouter:
+            return hasKey
+        }
+    }
+
+    static func canAdd(
+        provider: LLMProvider, model: String, baseURL: String, apiKey: String,
+        claudeConnected: Bool, chatgptConnected: Bool, googleConnected: Bool
+    ) -> Bool {
+        guard !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        if provider.showBaseURL {
+            guard let url = URL(string: baseURL),
+                  let scheme = url.scheme?.lowercased(), ["http", "https"].contains(scheme),
+                  let host = url.host, !host.isEmpty else { return false }
+        }
+        return credentialsReady(
+            provider: provider, apiKey: apiKey,
+            claudeConnected: claudeConnected, chatgptConnected: chatgptConnected,
+            googleConnected: googleConnected
+        )
+    }
+}

--- a/OpenGlassesTests/ModelFormValidationTests.swift
+++ b/OpenGlassesTests/ModelFormValidationTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import OpenGlasses
+
+final class ModelFormValidationTests: XCTestCase {
+    private func canAdd(_ provider: LLMProvider, key: String = "", model: String = "model",
+                        url: String = "http://mac.local:11434/v1", claude: Bool = false,
+                        chatgpt: Bool = false, google: Bool = false) -> Bool {
+        ModelFormValidation.canAdd(
+            provider: provider, model: model, baseURL: url, apiKey: key,
+            claudeConnected: claude, chatgptConnected: chatgpt, googleConnected: google
+        )
+    }
+
+    func testAccountProvidersFollowTheirOwnConnectionState() {
+        XCTAssertFalse(canAdd(.chatgpt))
+        XCTAssertTrue(canAdd(.chatgpt, chatgpt: true))
+        XCTAssertFalse(canAdd(.chatgpt, key: "stale-key", claude: true, google: true))
+        XCTAssertFalse(canAdd(.geminiVertex))
+        XCTAssertTrue(canAdd(.geminiVertex, google: true))
+        XCTAssertFalse(canAdd(.geminiVertex, key: "stale-key", chatgpt: true))
+        // Disconnection must disable Add again, even if the form still holds a model ID.
+        XCTAssertFalse(canAdd(.chatgpt, chatgpt: false))
+        XCTAssertFalse(canAdd(.geminiVertex, google: false))
+    }
+
+    func testClaudeAcceptsEitherAuthenticationRoute() {
+        XCTAssertFalse(canAdd(.anthropic))
+        XCTAssertTrue(canAdd(.anthropic, key: "key"))
+        XCTAssertTrue(canAdd(.anthropic, claude: true))
+        XCTAssertFalse(canAdd(.anthropic, chatgpt: true, google: true))
+    }
+
+    func testKeylessProvidersCanBeSaved() {
+        for provider: LLMProvider in [.local, .appleOnDevice, .custom] {
+            XCTAssertTrue(canAdd(provider), provider.rawValue)
+        }
+    }
+
+    func testAPIProvidersStillRequireAKeyEvenWithAccountsConnected() {
+        for provider: LLMProvider in [.openai, .gemini, .groq, .zai, .qwen, .minimax, .xai, .openrouter] {
+            XCTAssertFalse(canAdd(provider, key: " \n", claude: true, chatgpt: true, google: true), provider.rawValue)
+            XCTAssertTrue(canAdd(provider, key: "key"), provider.rawValue)
+        }
+    }
+
+    func testModelsAndEditableEndpointsMustBeUsable() {
+        for provider in LLMProvider.allCases {
+            XCTAssertFalse(canAdd(provider, key: "key", model: " \n", claude: true,
+                                  chatgpt: true, google: true), provider.rawValue)
+        }
+        for url in ["", "mac.local:11434", "file:///tmp/model", "https://"] {
+            XCTAssertFalse(canAdd(.custom, url: url), url)
+        }
+        XCTAssertTrue(canAdd(.custom, url: "https://inference.example/v1"))
+        XCTAssertTrue(canAdd(.appleOnDevice, url: ""))
+    }
+}


### PR DESCRIPTION
The Add Model button required an API key for every provider except local models, blocking ChatGPT and Gemini Vertex sign-in, Claude account authentication, Apple Intelligence, and custom servers with optional keys.

Use a shared provider-specific credential policy for Add and Fetch models, observe all three account services so controls update after sign-in or disconnection, and require a nonempty model plus a valid HTTP(S) URL for editable endpoints.

Validation: five ModelFormValidationTests pass in an isolated macOS Swift package using the production policy and provider case/endpoint definitions extracted from LLMProvider. Privacy logging and git diff checks pass. The app builds with Xcode 27 and all five model-validation tests also pass on the iPhone 17 Pro / iOS 27 simulator.

Based on the broader model-saving fix identified in yyyug/OpenGlasses commit 1cb91fe31b62ba0c7a7e3c34cb56cb3f3e7adfaf. Voice improvements are handled separately in #473.
