### PR TITLE
Audit the Settings hub only once an unfolded card has settled

### DIFF
--- a/OpenGlassesUITests/SettingsAccessibilityTests.swift
+++ b/OpenGlassesUITests/SettingsAccessibilityTests.swift
@@ -136,6 +136,32 @@ final class SettingsAccessibilityTests: AccessibilityAuditCase {
                       "The unfolded category never appeared as a row — there is nothing for "
                       + "VoiceOver focus to be handed to")
 
+        // Hold the hub still before measuring it.
+        //
+        // Unfolding is an animated replacement: the card animates out of Discover while the row
+        // animates into the list above it. Two things follow from that, and both were measured
+        // rather than guessed — this case failed on CI in 3 runs out of 5 on an unchanged tree.
+        //
+        // The card sits under the finger when it is replaced, so the same tap can land a second
+        // time on the row that took its place, pushing the category screen. The audit then
+        // measures that screen instead of the hub: the findings came back as 'AI Models',
+        // 'Personality', 'How It Behaves' — the category's own copy, none of it this case's
+        // subject. So assert the hub is still what is on screen.
+        //
+        // And the audit must not run while the list is still moving. The card's pitch belongs to
+        // the card alone, so its disappearance is the replacement finishing — a settled list
+        // rather than a timer.
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 10),
+                      "Unfolding left the settings hub, so the audit would measure the pushed "
+                      + "category screen rather than the list the card moved into")
+
+        let pitch = app.staticTexts["Choose the model and give it a character."]
+        if pitch.exists {
+            let gone = expectation(for: NSPredicate(format: "exists == false"),
+                                   evaluatedWith: pitch)
+            wait(for: [gone], timeout: 10)
+        }
+
         audit(app, screen: "Settings hub — after unfolding a category",
               deferring: [.secondaryCopyContrast, .contentUnderTheTabBar(of: app)])
     }


### PR DESCRIPTION
## The finding

Verbatim, from the workflow_dispatch run on `818eabae` (run 34647173613, both attempts):

```
OpenGlassesUITests/SettingsAccessibilityTests.swift:139: error:
-[OpenGlassesUITests.SettingsAccessibilityTests testUnfoldingADiscoverCardMovesTheCategoryIntoTheList]
: failed - Settings hub — after unfolding a category: 17 accessibility audit issue(s).

• [dynamicType] Dynamic Type font sizes are partially unsupported
  User will not be able to change the font size of this SwiftUI.AccessibilityNode
```

…once per category title, subtitle and value on the hub, at x = 74.0 with heights of 15.7, 20.3 and 33.7 pt.

## The bisect does not split

Every run below is the **same runner image** (`macos-26-arm64/20260907.0351`) on the **same device**
(iPhone 16e, iOS 26.2 — read from the uploaded result bundles), per-test rather than per-workflow:

| revision | what it adds | target test | run |
|---|---|---|---|
| `8b76768c` | baseline | **passed** (31.7 s) | 34659776058 |
| `c16fb12d` | #468 string catalog + build 378 | **FAILED** (50.3 s) | 34659778235 |
| `baa046f3` | #470 status card / home grid | **passed** (42.0 s) | 34659779986 |
| `818eabae` | #469 relay `isIdle` | **passed** (34.2 s) | 34659781903 |
| `ebfc6028` | #472 encryption flag (tip) | **passed** | 34659783676 |

`818eabae` failed twice on 2026-09-11 and passes here on an unchanged tree. Re-sampling the tip five
times gave **3 failures in 5**. There is no first-bad commit: the test was already failing at this
rate before any commit in the window.

The two nightlies the issue cited as passing (`92931c64`, `8b76768c`) were red overall, but on three
*different* tests — `ConversationPageTests` plus two `SessionSurfaceAccessibilityTests` audits. This
test did pass in both.

Ruled out with evidence, not inspection:

- **Flake within a run** — both failed attempts produced byte-identical element frames, and today's
  failing frames match yesterday's exactly. Layout is deterministic; only whether the audit trips varies.
- **The string catalog (#468)** — all ten category-title entries are byte-identical either side of the
  sync (`{}`, or an unchanged auto-generated comment); `sourceLanguage` and `version` unchanged.
- **#470's two files** — every hunk is inside `StatusIndicator`/`BottomControlBar`/`BarButton` and gated
  on `isAccessibilitySize` or `> .large`; this case runs at the default size, and both types are
  referenced only from `VoiceTab.swift`.
- **The runner image** — image `20260907.0351` both passed (`8b76768c`) and failed (`818eabae`).

## Root cause

Unfolding is an animated replacement: the card animates out of Discover while the category animates
into the list above it. The audit ran against whatever was on screen at that moment, and that was not
always the hub.

The card sits under the finger when it is replaced, so the tap that unfolds it can land again on the
row that takes its place and push the category screen. Reproduced locally on an iPhone 16e: the
findings came back as `AI Models`, `Personality`, `How It Behaves`, `Conversation History`,
`Memory Suggestions` — the category's own screen, none of it this case's subject.

So the gate was measuring a screen it does not claim to measure, at a moment when the list was still
moving. No shipped view is at fault, and no accessibility defect is being hidden here.

## The fix

Hold the hub still before measuring it: assert the hub is still on screen, and wait for the card's
pitch — which belongs to the card alone — to disappear, so the replacement has finished. A settle
signal rather than a timer.

**No deferral was added or widened, and no assertion was weakened.** The change adds one assertion.
`OpenGlassesUITests/SettingsAccessibilityTests.swift` is the only file touched.

## Verification

- Local, iPhone 16e: **1 failure in 9** before the fix → **6 of 6 passed** after.
- CI, three full-suite runs on the fix commit: **3 of 3 `** TEST SUCCEEDED **`**
  (34665432830, 34665435808, 34665438466).

### Gates

Unit target (`OpenGlassesTests`, scheme `OpenGlasses`, iPhone 17 Pro / iOS 27.0):

```
	 Executed 5327 tests, with 13 tests skipped and 0 failures (0 unexpected) in 116.624 (122.483) seconds
** TEST SUCCEEDED **
```

Full UI suite (`OpenGlassesUITests`, iPhone 17 Pro / iOS 27.0) — 27 of 27 cases passed:

```
	 Executed 27 tests, with 0 failures (0 unexpected) in 720.167 (720.218) seconds
** TEST SUCCEEDED **
```

Release simulator build (scheme `OpenGlasses`, run alone, `ONLY_ACTIVE_ARCH=YES`):

```
** BUILD SUCCEEDED **
```

Note: the first unit-target attempt failed before any test ran (`Simulator device failed to launch com.openglasses.app`). That was the simulator, not the code; the re-run above passed on the same commit.

### Notes on the bisect runs

The bisect workflow runs at `8b76768c` and `c16fb12d` concluded red overall because of other tests in those revisions. The table reports the result of this test case alone, read from each run's log. The throwaway `ci/bisect-*` and `ci/fix-*` branches used for these runs have been deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
